### PR TITLE
fix CMakeLists.txt to add -lpthread, did not compile boost 1.55

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(MINGW)
 elseif(APPLE)
   set(Boost_LIBRARIES "${Boost_LIBRARIES}")
 elseif(NOT MSVC)
-  set(Boost_LIBRARIES "${Boost_LIBRARIES};rt")
+  set(Boost_LIBRARIES "${Boost_LIBRARIES};rt;pthread")
 endif()
 
 set(COMMIT_ID_IN_VERSION ON CACHE BOOL "Include commit ID in version")


### PR DESCRIPTION
had a couple of compile errors and wasnt able to compile it until i added `LDFLAGS=-lpthread`
