### PR TITLE
Update cryptonote_format_utils.cpp

### DIFF
--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -80,7 +80,7 @@ namespace cryptonote
 #endif
     block_reward += fee;
 
-    std::vector<size_t> out_amounts;
+    std::vector<uint64_t> out_amounts;
     decompose_amount_into_digits(block_reward, DEFAULT_FEE,
       [&out_amounts](uint64_t a_chunk) { out_amounts.push_back(a_chunk); },
       [&out_amounts](uint64_t a_dust) { out_amounts.push_back(a_dust); });
@@ -92,7 +92,7 @@ namespace cryptonote
       out_amounts.resize(out_amounts.size() - 1);
     }
 
-    size_t summary_amounts = 0;
+    uint64_t summary_amounts = 0;
     for (size_t no = 0; no < out_amounts.size(); no++)
     {
       crypto::key_derivation derivation = AUTO_VAL_INIT(derivation);;


### PR DESCRIPTION
Fixed problem with integer saturation when summing summary_amounts and out_amounts in a 32-bit platform.
