### PR TITLE
Fixed console handler not properly exiting on SIGINT and such

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -233,6 +233,7 @@ namespace epee
 
     void stop()
     {
+      m_running = false;
       m_stdin_reader.stop();
     }
 
@@ -244,6 +245,10 @@ namespace epee
       bool continue_handle = true;
       while(continue_handle)
       {
+        if (!m_running)
+        {
+          break;
+        }
         if (!prompt.empty())
         {
           epee::log_space::set_console_color(epee::log_space::console_color_yellow, true);
@@ -257,7 +262,7 @@ namespace epee
         std::string command;
         if(!m_stdin_reader.get_line(command))
         {
-          LOG_PRINT("Failed to read line. Ignoring and continuing to run, exiting daemon may require a SIGTERM kill.", LOG_LEVEL_0);
+          LOG_PRINT("Failed to read line.", LOG_LEVEL_0);
         }
         string_tools::trim(command);
 
@@ -285,6 +290,7 @@ namespace epee
 
   private:
     async_stdin_reader m_stdin_reader;
+    bool m_running = true;
   };
 
 


### PR DESCRIPTION
The console handler was not correctly killing the read loop when its stop() method was invoked.  This fixes that.
