### PR TITLE
Do not fall over when refreshing balance fails

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -309,7 +309,8 @@ void wallet2::refresh(size_t & blocks_fetched, bool& received_money)
       else
       {
         LOG_ERROR("pull_blocks failed, try_count=" << try_count);
-        throw;
+        //throw;
+        return;
       }
     }
   }


### PR DESCRIPTION
In daemon mode, the wallet polls the blockchain daemon every 20 seconds to refresh the balance. If the blockchain daemon happens to be in "core is busy" mode then the polling fails and the wallet daemon falls over. It never tries to sync again and doesn't respond to RPC requests - its useless until restarted.

This fix lets the sync fail gracefully and retry next time. 
