### PR TITLE
Revert "Do not fall over when refreshing balance fails"

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -309,8 +309,7 @@ void wallet2::refresh(size_t & blocks_fetched, bool& received_money)
       else
       {
         LOG_ERROR("pull_blocks failed, try_count=" << try_count);
-        //throw;
-        return;
+        throw;
       }
     }
   }


### PR DESCRIPTION
Reverts monero-project/bitmonero#54

While this a good idea, a similar change that also addresses various ramifications to this change (such as querying the balance of a wallet that hasn't been refreshed for some time -- this would give a possibly horribly incorrect value for balance/confirmed balance/etc) is already in testing.
