### PR TITLE
reduce max block size to 30kb for getwork

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #define CRYPTONOTE_MAX_BLOCK_NUMBER                     500000000
-#define CRYPTONOTE_MAX_BLOCK_SIZE                       500000000  // block header blob limit, never used!
-#define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE	196608 //size of block (bytes) that is the maximum that miners will produce
+#define CRYPTONOTE_MAX_BLOCK_SIZE                       500000000
+#define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE		30720 //size of block (bytes) that is the maximum that miners will produce
 #define CRYPTONOTE_MAX_TX_SIZE                          1000000000
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX         18 // addresses start with "4"


### PR DESCRIPTION
Temporarily prevent the 514-txes-in-a-block attack
