### PR TITLE
Daemon stats for Linux and Mac (untested for Windows)

### DIFF
--- a/src/common/system_stats/system_stats.cpp
+++ b/src/common/system_stats/system_stats.cpp
@@ -28,6 +28,17 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file system_stats.cpp
+ * \brief Contains system stats fetching utilities' implementations.
+ *
+ * Under the namespace `system_stats` it offers functions to fetch:
+ * - Total system memory
+ * - Used system memory
+ * - CPU usage
+ * It works on Linux, Windows and Mac OS.
+ */
+
 #ifdef __linux__
 
 #include "system_stats.h"
@@ -39,6 +50,10 @@
 #include <stdexcept>
 #include <cinttypes>
 
+/*!
+ * \var const int CPU_USAGE_CHECK_WAIT_DURATION
+ * \brief A (static) constant that tells the wait duration between two CPU snapshots for measuring CPU usage.
+ */
 const int CPU_USAGE_CHECK_WAIT_DURATION = 1000000;
 
 namespace
@@ -84,9 +99,13 @@ namespace
   }
 };
 
+/*!
+ * \namespace system_stats
+ * \brief Namespace to hold system stats fetching functions.
+ */
 namespace system_stats
 {
-  /* Returns the total amount of main memory in the system (in Bytes) */
+  /*! \brief Returns total system memory (RAM) in bytes. */
   uint64_t get_total_system_memory()
   {
     struct sysinfo mem_info;
@@ -96,7 +115,7 @@ namespace system_stats
     return total_mem;
   }
 
-  /* Returns the total amount of the memory that is currently being used (in Bytes) */
+  /*! \brief Returns currently used system memory (used RAM) in bytes. */
   uint64_t get_used_system_memory()
   {
     struct sysinfo mem_info;
@@ -106,7 +125,7 @@ namespace system_stats
     return used_mem;
   }
 
-  /* Returns CPU usage percentage */
+  /*! \brief Returns current CPU usage as a percentage. */
   double get_cpu_usage()
   {
     double percent;
@@ -156,9 +175,13 @@ namespace system_stats
 
 CONST PWSTR COUNTER_PATH    = L"\\Processor(0)\\% Processor Time";
 
+/*!
+ * \namespace system_stats
+ * \brief Namespace to hold system stats fetching functions.
+ */
 namespace system_stats
 {
-  /* Returns the total amount of main memory in the system (in Bytes) */
+  /*! \brief Returns total system memory (RAM) in bytes. */
   uint64_t get_total_system_memory()
   {
     DWORDLONG w_total_mem = memInfo.ullTotalPhys;
@@ -166,7 +189,7 @@ namespace system_stats
     return total_mem;
   }
 
-  /* Returns the total amount of the memory that is currently being used (in Bytes) */
+  /*! \brief Returns currently used system memory (used RAM) in bytes. */
   uint64_t get_used_system_memory()
   {
     DWORDLONG w_used_mem = memInfo.ullTotalPhys - memInfo.ullAvailPhys;
@@ -174,7 +197,7 @@ namespace system_stats
     return used_mem;
   }
 
-  /* Returns CPU usage percentage */
+  /*! \brief Returns current CPU usage as a percentage. */
   double get_cpu_usage()
   {
     HQUERY h_query = NULL;
@@ -228,6 +251,10 @@ namespace system_stats
 #include <unistd.h>
 #include <cinttypes>
 
+/*!
+ * \var const int CPU_USAGE_CHECK_WAIT_DURATION
+ * \brief A (static) constant that tells the wait duration between two CPU snapshots for measuring CPU usage.
+ */
 const int CPU_USAGE_CHECK_WAIT_DURATION = 1000000;
 
 namespace
@@ -268,9 +295,13 @@ namespace
   }
 };
 
+/*!
+ * \namespace system_stats
+ * \brief Namespace to hold system stats fetching functions.
+ */
 namespace system_stats
 {
-  /* Returns the total amount of main memory in the system (in Bytes) */
+  /*! \brief Returns total system memory (RAM) in bytes. */
   uint64_t get_total_system_memory()
   {
     int mib[] = {CTL_HW, HW_MEMSIZE};
@@ -280,7 +311,7 @@ namespace system_stats
     return static_cast<uint64_t>(physical_memory);
   }
 
-  /* Returns the total amount of the memory that is currently being used (in Bytes) */
+  /*! \brief Returns currently used system memory (used RAM) in bytes. */
   uint64_t get_used_system_memory()
   {
     vm_size_t page_size;
@@ -310,7 +341,7 @@ namespace system_stats
     return used_mem;
   }
 
-  /* Returns CPU usage percentage */
+  /*! \brief Returns current CPU usage as a percentage. */
   double get_cpu_usage()
   {
     uint64_t total_ticks_1 = 0;

--- a/src/common/system_stats/system_stats.h
+++ b/src/common/system_stats/system_stats.h
@@ -28,15 +28,35 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*! 
+ * \file system_stats.h
+ * \brief Contains system stats fetching utilities' declarations.
+ *
+ * Under the namespace `system_stats` it offers functions to fetch:
+ * - Total system memory
+ * - Used system memory
+ * - CPU usage
+ * It works on Linux, Windows and Mac OS.
+ */
+
 #ifndef SYSTEM_STATS
 #define SYSTEM_STATS
 
 #include <cstdint>
 
+/*! 
+ * \namespace system_stats
+ * \brief Namespace to hold system stats fetching functions.
+ */
 namespace system_stats
 {
+	/*! \brief Returns total system memory (RAM) in bytes. */
   uint64_t get_total_system_memory();
+
+  /*! \brief Returns currently used system memory (used RAM) in bytes. */
   uint64_t get_used_system_memory();
+
+  /*! \brief Returns current CPU usage as a percentage. */
   double get_cpu_usage();
 };
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -28,6 +28,10 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file cryptonote_core.cpp
+ * \brief Source file for core class under cryptonote namespace.
+ */
 #include "include_base_utils.h"
 using namespace epee;
 
@@ -44,6 +48,10 @@ using namespace epee;
 
 DISABLE_VS_WARNINGS(4355)
 
+/*!
+ * \namespace cryptonote
+ * \brief Holds cryptonote related classes and helpers.
+ */
 namespace cryptonote
 {
 
@@ -545,7 +553,12 @@ namespace cryptonote
   uint64_t core::get_target_blockchain_height() const {
     return m_target_blockchain_height;
   }
-  //-----------------------------------------------------------------------------------------------
+  /*!
+   * \brief Returns the time duration for which the core has been running.
+   * 
+   * It returns the difference between the start_time and the current time.
+   * \return time duration for which the core has been running
+   */
   boost::posix_time::time_duration core::time_elapsed() const {
     boost::posix_time::ptime time_now = boost::posix_time::microsec_clock::local_time();
     return time_now - start_time;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -28,6 +28,10 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file cryptonote_core.h
+ * \brief Contains core class under cryptonote namespace.
+ */
 #pragma once
 
 #include <boost/program_options/options_description.hpp>
@@ -48,11 +52,16 @@
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
+/*!
+ * \namespace cryptonote
+ * \brief Holds cryptonote related classes and helpers.
+ */
 namespace cryptonote
 {
-  /************************************************************************/
-  /*                                                                      */
-  /************************************************************************/
+   /*!
+    * \class core
+    * \brief The class that manages the cryptonote algorithm.
+    */
    class core: public i_miner_handler
    {
    public:
@@ -119,6 +128,11 @@ namespace cryptonote
 
      void set_target_blockchain_height(uint64_t target_blockchain_height);
      uint64_t get_target_blockchain_height() const;
+     /*!
+      * \brief Returns the time duration for which the core has been running.
+      * 
+      * It returns the difference between the start_time and the current time.
+      */
      boost::posix_time::time_duration time_elapsed() const;
 
    private:
@@ -157,7 +171,7 @@ namespace cryptonote
      std::atomic<bool> m_starter_message_showed;
 
      uint64_t m_target_blockchain_height;
-     boost::posix_time::ptime start_time;
+     boost::posix_time::ptime start_time; //!< The start time of the core, set during init.
    };
 }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1188,5 +1188,4 @@ namespace nodetool
 
     return true;
   }
-
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -28,6 +28,10 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file core_rpc_server.cpp
+ * \brief Source file for managing RPC server for daemon.
+ */
 #include <boost/foreach.hpp>
 #include "include_base_utils.h"
 using namespace epee;
@@ -43,6 +47,10 @@ using namespace epee;
 #include "common/system_stats/system_stats.h"
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+/*!
+ * \namespace cryptonote
+ * \brief Holds cryptonote related classes and helpers.
+ */
 namespace cryptonote
 {
   namespace
@@ -672,7 +680,15 @@ namespace cryptonote
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }
-  //------------------------------------------------------------------------------------------------------------------------------
+  
+  /*!
+   * \brief Called when 'get_stats' RPC is made.
+   * \param  req        Request object
+   * \param  res        Respose object
+   * \param  error_resp Error response object
+   * \param  cntx       Connection context
+   * \return            Whether the RPC was successful or not.
+   */
   bool core_rpc_server::on_get_stats(const COMMAND_RPC_GET_STATS::request& req, COMMAND_RPC_GET_STATS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx)
   {
     if (!check_core_busy())

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -28,6 +28,10 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file core_rpc_server.h
+ * \brief Header file for managing RPC server for daemon.
+ */
 #pragma  once 
 
 #include <boost/program_options/options_description.hpp>
@@ -39,11 +43,16 @@
 #include "p2p/net_node.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 
+/*!
+ * \namespace cryptonote
+ * \brief Holds cryptonote related classes and helpers.
+ */
 namespace cryptonote
 {
-  /************************************************************************/
-  /*                                                                      */
-  /************************************************************************/
+  /*!
+   * \class core_rpc_server
+   * \brief Manages the RPC API and handlers that the daemon supports.
+   */
   class core_rpc_server: public epee::http_server_impl_base<core_rpc_server>
   {
   public:
@@ -105,6 +114,14 @@ namespace cryptonote
     bool on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
+    /*!
+     * \brief Called when 'get_stats' RPC is made.
+     * \param  req        Request object
+     * \param  res        Respose object
+     * \param  error_resp Error response object
+     * \param  cntx       Connection context
+     * \return            Whether the RPC was successful or not.
+     */
     bool on_get_stats(const COMMAND_RPC_GET_STATS::request& req, COMMAND_RPC_GET_STATS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     //-----------------------
     bool handle_command_line(const boost::program_options::variables_map& vm);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -28,12 +28,20 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+/*!
+ * \file core_rpc_server_commands_defs.h
+ * \brief Contains request response formats for RPCs that the daemon supports.
+ */
 #pragma once
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "cryptonote_core/cryptonote_basic.h"
 #include "cryptonote_core/difficulty.h"
 #include "crypto/hash.h"
 
+/*!
+ * \namespace cryptonote
+ * \brief Holds cryptonote related classes and helpers.
+ */
 namespace cryptonote
 {
   //-----------------------------------------------
@@ -266,7 +274,11 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
-  //-----------------------------------------------
+  
+  /*!
+   * \struct COMMAND_RPC_GET_STATS
+   * \brief Format for request and response of `get_stats` RPC.
+   */
   struct COMMAND_RPC_GET_STATS
   {
     struct request


### PR DESCRIPTION
I've used ifdefs for cross platform support.
After we figure out a good way to integrate this into the build system, we can make separate source files for each platform and let the build system compile what's right.

Windows code is untested atm. I'll get to it soon.
