### PR TITLE
fixed signed-unsigned issue in DNS checkpointing

### DIFF
--- a/src/cryptonote_core/checkpoints_create.cpp
+++ b/src/cryptonote_core/checkpoints_create.cpp
@@ -124,9 +124,9 @@ bool load_checkpoints_from_dns(cryptonote::checkpoints& checkpoints)
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<int> dis(0, dns_urls.size() - 1);
-  int first_index = dis(gen);
+  size_t first_index = dis(gen);
 
-  int cur_index = first_index;
+  size_t cur_index = first_index;
   do
   {
     records = tools::DNSResolver::instance().get_txt_record(dns_urls[cur_index], avail, valid);


### PR DESCRIPTION
Loss of entropy can be discussed at a later time, but is
not deemed a significant issue for now.

resolves #166
