### PR TITLE
Exception handling while refreshing in rpc wallet (credits to QCN)

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -58,7 +58,11 @@ namespace tools
   bool wallet_rpc_server::run()
   {
     m_net_server.add_idle_handler([this](){
-      m_wallet.refresh();
+      try {
+        m_wallet.refresh();
+      } catch (const std::exception& ex) {
+        LOG_ERROR("Exception at while refreshing, what=" << ex.what());
+      }
       return true;
     }, 20000);
 


### PR DESCRIPTION
Handle exceptions properly while refreshing wallet. With this patch wallet never stuck. Simple and useful. There was some dirty fix proposed before and rejected, I hope Mr. Fluffy could reconsider. <3 <3 <3
