### PR TITLE
prompt for seed language and error handling

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -207,6 +207,13 @@ bool simple_wallet::viewkey(const std::vector<std::string> &args/* = std::vector
 bool simple_wallet::seed(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   std::string electrum_words;
+
+  if (m_wallet->get_seed_language().empty())
+  {
+    std::string mnemonic_language = get_mnemonic_language();
+    m_wallet->set_seed_language(mnemonic_language);
+  }
+
   bool success = m_wallet->get_seed(electrum_words);
   
   if (success) 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -91,6 +91,12 @@ void wallet2::init(const std::string& daemon_address, uint64_t upper_transaction
 //----------------------------------------------------------------------------------------------------
 bool wallet2::get_seed(std::string& electrum_words)
 {
+  if (seed_language.empty())
+  {
+    std::cout << "seed_language not set" << std::endl;
+    return false;
+  }
+
   crypto::ElectrumWords::bytes_to_words(get_account().get_keys().m_spend_secret_key, electrum_words, seed_language);
 
   crypto::secret_key second;
@@ -99,6 +105,13 @@ bool wallet2::get_seed(std::string& electrum_words)
   sc_reduce32((uint8_t *)&second);
   
   return memcmp(second.data,get_account().get_keys().m_view_secret_key.data, sizeof(crypto::secret_key)) == 0;
+}
+/*!
+ * \brief Gets the seed language
+ */
+const std::string wallet2::get_seed_language()
+{
+  return seed_language;
 }
 /*!
  * \brief Sets the seed language

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -170,6 +170,10 @@ namespace tools
 
     bool get_seed(std::string& electrum_words);
     /*!
+     * \brief Gets the seed language
+     */
+    const std::string get_seed_language();
+    /*!
      * \brief Sets the seed language
      */
     void set_seed_language(const std::string &language);


### PR DESCRIPTION
"seed" simplewallet command was only displaying seed if wallet was newly generated.
If seed language was unset, it failed silently.
