### PR TITLE
wallet2::rewrite update to not require bin file

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -616,11 +616,9 @@ void wallet2::rewrite(const std::string& wallet_name, const std::string& passwor
 {
   prepare_file_names(wallet_name);
   boost::system::error_code ignored_ec;
-  THROW_WALLET_EXCEPTION_IF(!boost::filesystem::exists(m_wallet_file, ignored_ec), error::file_not_found, m_wallet_file);
   THROW_WALLET_EXCEPTION_IF(!boost::filesystem::exists(m_keys_file, ignored_ec), error::file_not_found, m_keys_file);
   bool r = store_keys(m_keys_file, password);
   THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, m_keys_file);
-  store();
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::wallet_exists(const std::string& file_path, bool& keys_file_exists, bool& wallet_file_exists)


### PR DESCRIPTION
Allow pre-JSON wallet format to load without depending on existing bin
file.

Don't write bin file while inside keys rewrite, so bin file write
behavior here matches that of regular wallet load.
