### PR TITLE
cmake: split BUILD_GUI_DEPS option into two

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,11 @@ if(BUILD_DOCUMENTATION)
   endif()
 endif()
 
-# when ON - will install libunbound and libwallet_merged into "lib"
+# when ON - will install libwallet_merged into "lib"
 option(BUILD_GUI_DEPS "Build GUI dependencies." OFF)
+
+# This is not nice, distribution packagers should not enable this, but depend
+# on libunbound shipped with their distribution instead
+option(INSTALL_VENDORED_LIBUNBOUND "Install libunbound binary built from source vendored with this repo." OFF)
 
 

--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -230,7 +230,7 @@ if (MINGW)
 endif ()
 
 
-if (BUILD_GUI_DEPS)
+if (INSTALL_VENDORED_LIBUNBOUND)
     install(TARGETS unbound
         ARCHIVE DESTINATION lib)
 endif()    


### PR DESCRIPTION
The split is to make this software more packageable. 'make install'
is used by the package building scripts, and should not be installing
vendored dependencies onto the system.

After that point, I might PR a minor rename of BUILD_GUI_DEPS to both repos, although that might be more trouble than it's worth.