### PR TITLE
cryptonote: uint64_t type for block reward args #1008

### DIFF
--- a/src/cryptonote_core/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_core/cryptonote_basic_impl.cpp
@@ -73,7 +73,7 @@ namespace cryptonote {
     return CRYPTONOTE_MAX_TX_SIZE;
   }
   //-----------------------------------------------------------------------------------------------
-  bool get_block_reward(size_t median_size, size_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version) {
+  bool get_block_reward(uint64_t median_size, uint64_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version) {
     static_assert(DIFFICULTY_TARGET_V2%60==0&&DIFFICULTY_TARGET_V1%60==0,"difficulty targets must be a multiple of 60");
     const int target = version < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
     const int target_minutes = target / 60;

--- a/src/cryptonote_core/cryptonote_basic_impl.h
+++ b/src/cryptonote_core/cryptonote_basic_impl.h
@@ -71,7 +71,7 @@ namespace cryptonote {
   /************************************************************************/
   size_t get_max_block_size();
   size_t get_max_tx_size();
-  bool get_block_reward(size_t median_size, size_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version);
+  bool get_block_reward(uint64_t median_size, uint64_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version);
   uint8_t get_account_address_checksum(const public_address_outer_blob& bl);
   uint8_t get_account_integrated_address_checksum(const public_integrated_address_outer_blob& bl);
 

--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -84,7 +84,7 @@ namespace
       ASSERT_LT(CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1, m_standard_block_reward);
     }
 
-    void do_test(size_t median_block_size, size_t current_block_size)
+    void do_test(uint64_t median_block_size, uint64_t current_block_size)
     {
       m_block_not_too_big = get_block_reward(median_block_size, current_block_size, already_generated_coins, m_block_reward, 1);
     }
@@ -141,7 +141,7 @@ namespace
   TEST_F(block_reward_and_current_block_size, fails_on_huge_median_size)
   {
 #if !defined(NDEBUG)
-    size_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
+    uint64_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
     ASSERT_DEATH(do_test(huge_size, huge_size + 1), "");
 #endif
   }
@@ -149,7 +149,7 @@ namespace
   TEST_F(block_reward_and_current_block_size, fails_on_huge_block_size)
   {
 #if !defined(NDEBUG)
-    size_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
+    uint64_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
     ASSERT_DEATH(do_test(huge_size - 2, huge_size), "");
 #endif
   }
@@ -173,7 +173,7 @@ namespace
       ASSERT_LT(CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1, m_standard_block_reward);
     }
 
-    void do_test(size_t current_block_size)
+    void do_test(uint64_t current_block_size)
     {
       m_block_not_too_big = get_block_reward(epee::misc_utils::median(m_last_block_sizes), current_block_size, already_generated_coins, m_block_reward, 1);
     }


### PR DESCRIPTION
This fixes two failing block reward tests on 32-bit systems
(tested on armv7h). This has no change on 64-bit systems.

Tested: unit_tests pass on armv7h (with #1044) and x86_64.