### PR TITLE
tests: block reward: disable 64-bit-only tests on 32-bit systems

### DIFF
--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -138,6 +138,7 @@ namespace
     ASSERT_FALSE(m_block_not_too_big);
   }
 
+#ifdef __x86_64__ // For 64-bit systems only, because block size is limited to size_t.
   TEST_F(block_reward_and_current_block_size, fails_on_huge_median_size)
   {
 #if !defined(NDEBUG)
@@ -153,6 +154,7 @@ namespace
     ASSERT_DEATH(do_test(huge_size - 2, huge_size), "");
 #endif
   }
+#endif // __x86_64__
 
   //--------------------------------------------------------------------------------------------------------------------
   class block_reward_and_last_block_sizes : public ::testing::Test


### PR DESCRIPTION
Issue #1008 

__x86_64__ might not be perfect, but hopefully it's fine (tested gcc, didn't test clang). Don't want to do an if condition on sizeof() at runtime because the code in question (that's being disabled) generates a warning about overflow when compiled on 32-bit.