### PR TITLE
Add snap packaging.

### DIFF
--- a/contrib/snap/daemon.bash
+++ b/contrib/snap/daemon.bash
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+export LD_LIBRARY_PATH=${SNAP_LIBRARY_PATH}:${SNAP}/usr/lib/x86_64-linux-gnu
 export HOME=${SNAP_DATA}
 cd ${SNAP_DATA}
 

--- a/contrib/snap/daemon.bash
+++ b/contrib/snap/daemon.bash
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+export HOME=${SNAP_DATA}
+cd ${SNAP_DATA}
+
+ARGS=
+if [ -e "${SNAP_DATA}/etc/monerod.conf" ]; then
+	ARGS="--config-file ${SNAP_DATA}/etc/monerod.conf"
+fi
+
+exec ${SNAP}/bin/monerod --detach $ARGS

--- a/contrib/snap/log.bash
+++ b/contrib/snap/log.bash
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec tail -c +0 -F ${SNAP_DATA}/.bitmonero/bitmonero.log

--- a/contrib/snap/wallet.bash
+++ b/contrib/snap/wallet.bash
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+export LD_LIBRARY_PATH=${SNAP_LIBRARY_PATH}:${SNAP}/usr/lib/x86_64-linux-gnu
 export HOME=${SNAP_USER_DATA}
 cd ${SNAP_USER_DATA}
 

--- a/contrib/snap/wallet.bash
+++ b/contrib/snap/wallet.bash
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+export HOME=${SNAP_USER_DATA}
+cd ${SNAP_USER_DATA}
+
+exec ${SNAP}/usr/bin/rlwrap ${SNAP}/bin/monero-wallet-cli "$@"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,9 @@ parts:
             - doxygen
             - graphviz
         stage-packages:
+            - libminiupnpc10
             - libunbound2
+            - libunwind8
         snap:
             - bin
             - usr

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,62 @@
+name: monero
+version: 0  # TODO: change this to release version in CI builds
+summary: "Monero: the secure, private, untraceable cryptocurrency https://getmonero.org"
+description: |
+    Monero is a private, secure, untraceable, decentralised digital currency.
+    You are your bank, you control your funds, and nobody can trace your transfers
+    unless you allow them to do so.
+grade: devel
+confinement: strict
+
+apps:
+    d:
+        daemon: forking
+        command: daemon.bash
+        plugs:
+            - network
+            - network-bind
+
+    log:
+        command: log.bash
+
+    monero:
+        command: wallet.bash
+        plugs:
+            - network
+
+parts:
+    wrapper:
+        plugin: dump
+        source: .
+        stage-packages:
+            - rlwrap
+        organize:
+            contrib/snap/daemon.bash: daemon.bash
+            contrib/snap/log.bash: log.bash
+            contrib/snap/wallet.bash: wallet.bash
+        snap:
+            - daemon.bash
+            - log.bash
+            - wallet.bash
+            - usr/bin/rlwrap
+ 
+    cmake-build:
+        plugin: cmake
+        source: .
+        build-packages:
+            - gcc
+            - cmake
+            - pkg-config
+            - libunbound-dev
+            - libevent-dev
+            - libboost-all-dev
+            - libdb-dev
+            - libunwind-dev
+            - libminiupnpc-dev
+            - libldns-dev
+            - libexpat1-dev
+            - bison
+            - doxygen
+            - graphviz
+        snap:
+            - bin

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,6 +42,12 @@ parts:
  
     cmake-build:
         plugin: cmake
+        configflags:
+            - -DBDB_STATIC=1
+            - -DUPNP_STATIC=1
+            - -DBoost_USE_STATIC_LIBS=1
+            - -DBoost_USE_STATIC_RUNTIME=1
+            - -DARCH=default
         source: .
         build-packages:
             - gcc
@@ -58,5 +64,8 @@ parts:
             - bison
             - doxygen
             - graphviz
+        stage-packages:
+            - libunbound2
         snap:
             - bin
+            - usr

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -106,3 +106,4 @@ add_dependencies(daemon version)
 set_property(TARGET daemon
   PROPERTY
     OUTPUT_NAME "monerod")
+install(TARGETS daemon DESTINATION bin)

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -60,3 +60,4 @@ add_dependencies(simplewallet
 set_property(TARGET simplewallet
   PROPERTY
     OUTPUT_NAME "monero-wallet-cli")
+install(TARGETS simplewallet DESTINATION bin)


### PR DESCRIPTION
This adds [snap](https://snapcraft.io) packaging to the project. See the
link for more information on snaps, but basically, snap packages install on all Linux
distributions. On Ubuntu, snap confinement with apparmor and seccomp
provide an additional layer of security.

This snap sets up monerod as a systemd service, which should start
immediately on install. To access the wallet CLI, simply run `monero`
(/snap/bin/monero). I think it's a really quick & easy way to get
started with monero.

I've made some opinionated decisions in the packaging just to kick this
off, but I'm happy to iterate on this stuff.