### PR TITLE
compile errors for DEBUG_CREATE_BLOCK_TEMPLATE and PER_BLOCK_CHECKPOINT

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1105,7 +1105,7 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
     }
     else
     {
-      if (cur_tx.fee != cur_tx.tx.txnFee)
+      if (cur_tx.fee != cur_tx.tx.rct_signatures.txnFee)
       {
         LOG_ERROR("Creating block template: error: invalid fee");
       }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2956,8 +2956,8 @@ leave:
   // be a parameter?
   // validate proof_of_work versus difficulty target
   bool precomputed = false;
-#if defined(PER_BLOCK_CHECKPOINT)
   bool fast_check = false;
+#if defined(PER_BLOCK_CHECKPOINT)
   if (m_db->height() < m_blocks_hash_check.size())
   {
     auto hash = get_block_hash(bl);
@@ -3758,6 +3758,7 @@ std::map<uint64_t, uint64_t> Blockchain:: get_output_histogram(const std::vector
   return m_db->get_output_histogram(amounts, unlocked);
 }
 
+#if defined(PER_BLOCK_CHECKPOINT)
 void Blockchain::load_compiled_in_block_hashes()
 {
   if (m_fast_sync && get_blocks_dat_start(m_testnet) != nullptr)
@@ -3800,6 +3801,7 @@ void Blockchain::load_compiled_in_block_hashes()
     }
   }
 }
+#endif
 
 bool Blockchain::for_all_key_images(std::function<bool(const crypto::key_image&)> f) const
 {

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -129,7 +129,7 @@ namespace cryptonote
 
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
     LOG_PRINT_L1("Creating block template: reward " << block_reward <<
-      ", fee " << fee)
+      ", fee " << fee);
 #endif
     block_reward += fee;
 

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -455,8 +455,14 @@ namespace cryptonote
      */
     typedef std::unordered_map<crypto::key_image, std::unordered_set<crypto::hash> > key_images_container;
 
+#if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
+public:
+#endif
     mutable epee::critical_section m_transactions_lock;  //!< lock for the pool
     transactions_container m_transactions;  //!< container for transactions in the pool
+#if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
+private:
+#endif
 
     //! container for spent key images from the transactions in the pool
     key_images_container m_spent_key_images;  


### PR DESCRIPTION
There are some compile errors when DEBUG_CREATE_BLOCK_TEMPLATE is defind and also some when PER_BLOCK_CHECKPOINT is undefined.