### PR TITLE
wallet: change priority/fee to ArticMine's recommendation

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -502,10 +502,10 @@ bool simple_wallet::set_default_mixin(const std::vector<std::string> &args/* = s
   }
 }
 
-bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+bool simple_wallet::set_default_priority(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   bool success = false;
-  int fee_multiplier = 0;
+  int priority = 0;
   if (m_wallet->watch_only())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot transfer");
@@ -515,19 +515,19 @@ bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &a
   {
     if (strchr(args[1].c_str(), '-'))
     {
-      fail_msg_writer() << tr("fee multiplier must be 0, 1, 2, or 3 ");
+      fail_msg_writer() << tr("priority must be 0, 1, 2, or 3 ");
       return true;
     }
     if (args[1] == "0")
     {
-      fee_multiplier = 0;
+      priority = 0;
     }
     else
     {
-      fee_multiplier = boost::lexical_cast<int>(args[1]);
-      if (fee_multiplier != 1 && fee_multiplier != 2 && fee_multiplier != 3)
+      priority = boost::lexical_cast<int>(args[1]);
+      if (priority != 1 && priority != 2 && priority != 3)
       {
-        fail_msg_writer() << tr("fee multiplier must be 0, 1, 2, or 3");
+        fail_msg_writer() << tr("priority must be 0, 1, 2, or 3");
         return true;
       }
     }
@@ -548,18 +548,18 @@ bool simple_wallet::set_default_fee_multiplier(const std::vector<std::string> &a
       return true;
     }
 
-    m_wallet->set_default_fee_multiplier(fee_multiplier);
+    m_wallet->set_default_priority(priority);
     m_wallet->rewrite(m_wallet_file, pwd_container.password());
     return true;
   }
   catch(const boost::bad_lexical_cast &)
   {
-    fail_msg_writer() << tr("fee multiplier must be 0, 1, 2 or 3");
+    fail_msg_writer() << tr("priority must be 0, 1, 2 or 3");
     return true;
   }
   catch(...)
   {
-    fail_msg_writer() << tr("could not change default fee multiplier");
+    fail_msg_writer() << tr("could not change default priority");
     return true;
   }
 }
@@ -662,7 +662,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("viewkey", boost::bind(&simple_wallet::viewkey, this, _1), tr("Display private view key"));
   m_cmd_binder.set_handler("spendkey", boost::bind(&simple_wallet::spendkey, this, _1), tr("Display private spend key"));
   m_cmd_binder.set_handler("seed", boost::bind(&simple_wallet::seed, this, _1), tr("Display Electrum-style mnemonic seed"));
-  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("Available options: seed language - set wallet seed language; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-info <1|0> - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin <n> - set default mixin (default default is 4); auto-refresh <1|0> - whether to automatically sync new blocks from the daemon; refresh-type <full|optimize-coinbase|no-coinbase|default> - set wallet refresh behaviour; fee-multiplier [1|2|3] - normal/elevated/priority fee"));
+  m_cmd_binder.set_handler("set", boost::bind(&simple_wallet::set_variable, this, _1), tr("Available options: seed language - set wallet seed language; always-confirm-transfers <1|0> - whether to confirm unsplit txes; store-tx-info <1|0> - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin <n> - set default mixin (default default is 4); auto-refresh <1|0> - whether to automatically sync new blocks from the daemon; refresh-type <full|optimize-coinbase|no-coinbase|default> - set wallet refresh behaviour; priority [1|2|3] - normal/elevated/priority fee"));
   m_cmd_binder.set_handler("rescan_spent", boost::bind(&simple_wallet::rescan_spent, this, _1), tr("Rescan blockchain for spent outputs"));
   m_cmd_binder.set_handler("get_tx_key", boost::bind(&simple_wallet::get_tx_key, this, _1), tr("Get transaction key (r) for a given <txid>"));
   m_cmd_binder.set_handler("check_tx_key", boost::bind(&simple_wallet::check_tx_key, this, _1), tr("Check amount going to <address> in <txid>"));
@@ -688,7 +688,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "default-mixin = " << m_wallet->default_mixin();
     success_msg_writer() << "auto-refresh = " << m_wallet->auto_refresh();
     success_msg_writer() << "refresh-type = " << get_refresh_type_name(m_wallet->get_refresh_type());
-    success_msg_writer() << "fee-multiplier = " << m_wallet->get_default_fee_multiplier();
+    success_msg_writer() << "priority = " << m_wallet->get_default_priority();
     return true;
   }
   else
@@ -784,18 +784,18 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
         return true;
       }
     }
-    else if (args[0] == "fee-multiplier")
+    else if (args[0] == "priority")
     {
       if (args.size() <= 1)
       {
-        fail_msg_writer() << tr("set fee-multiplier: needs an argument: 0, 1, 2, or 3");
+        fail_msg_writer() << tr("set priority: needs an argument: 0, 1, 2, or 3");
         return true;
       }
       else
       {
         std::vector<std::string> local_args = args;
         local_args.erase(local_args.begin(), local_args.begin()+2);
-        set_default_fee_multiplier(local_args);
+        set_default_priority(local_args);
         return true;
       }
     }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -143,7 +143,7 @@ namespace cryptonote
     bool set_tx_note(const std::vector<std::string> &args);
     bool get_tx_note(const std::vector<std::string> &args);
     bool status(const std::vector<std::string> &args);
-    bool set_default_fee_multiplier(const std::vector<std::string> &args);
+    bool set_default_priority(const std::vector<std::string> &args);
     bool sign(const std::vector<std::string> &args);
     bool verify(const std::vector<std::string> &args);
     bool export_key_images(const std::vector<std::string> &args);

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -493,9 +493,8 @@ PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const 
         //std::vector<tools::wallet2::pending_tx> ptx_vector;
 
         try {
-            // priority called "fee_multiplied in terms of underlying wallet interface
             transaction->m_pending_tx = m_wallet->create_transactions_2(dsts, fake_outs_count, 0 /* unlock_time */,
-                                                                      static_cast<uint64_t>(priority),
+                                                                      static_cast<uint32_t>(priority),
                                                                       extra, m_trustedDaemon);
 
         } catch (const tools::error::daemon_busy&) {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -92,10 +92,10 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_default_fee_multiplier(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers (false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
 
   public:
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_default_fee_multiplier(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_restricted(restricted), is_old_file_format(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0) {}
     struct transfer_details
     {
       uint64_t m_block_height;
@@ -305,9 +305,9 @@ namespace tools
 
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
-    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
-    std::vector<wallet2::pending_tx> create_transactions_all(const cryptonote::account_public_address &address, const size_t fake_outs_count, const uint64_t unlock_time, uint64_t fee_multiplier, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t> extra, bool trusted_daemon);
+    std::vector<wallet2::pending_tx> create_transactions_all(const cryptonote::account_public_address &address, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t> extra, bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
     bool check_connection(bool *same_version = NULL);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
@@ -385,8 +385,8 @@ namespace tools
     void store_tx_info(bool store) { m_store_tx_info = store; }
     uint32_t default_mixin() const { return m_default_mixin; }
     void default_mixin(uint32_t m) { m_default_mixin = m; }
-    uint32_t get_default_fee_multiplier() const { return m_default_fee_multiplier; }
-    void set_default_fee_multiplier(uint32_t m) { m_default_fee_multiplier = m; }
+    uint32_t get_default_priority() const { return m_default_priority; }
+    void set_default_priority(uint32_t p) { m_default_priority = p; }
     bool auto_refresh() const { return m_auto_refresh; }
     void auto_refresh(bool r) { m_auto_refresh = r; }
 
@@ -458,7 +458,7 @@ namespace tools
     void parse_block_round(const cryptonote::blobdata &blob, cryptonote::block &bl, crypto::hash &bl_id, bool &error) const;
     uint64_t get_upper_tranaction_size_limit();
     std::vector<uint64_t> get_unspent_amounts_vector();
-    uint64_t sanitize_fee_multiplier(uint64_t fee_multiplier) const;
+    uint64_t get_fee_multiplier(uint32_t priority, bool use_new_fee) const;
     float get_output_relatedness(const transfer_details &td0, const transfer_details &td1) const;
     std::vector<size_t> pick_prefered_rct_inputs(uint64_t needed_money) const;
     void set_spent(transfer_details &td, uint64_t height);
@@ -498,7 +498,7 @@ namespace tools
     bool m_always_confirm_transfers;
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
     uint32_t m_default_mixin;
-    uint32_t m_default_fee_multiplier;
+    uint32_t m_default_priority;
     RefreshType m_refresh_type;
     bool m_auto_refresh;
     uint64_t m_refresh_from_block_height;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -56,7 +56,7 @@ namespace tools
     //       file_read_error
     //       file_save_error
     //       invalid_password
-    //       invalid_fee_multiplier
+    //       invalid_priority
     //       refresh_error *
     //         acc_outs_lookup_error
     //         block_parse_error
@@ -227,10 +227,10 @@ namespace tools
 
       std::string to_string() const { return wallet_logic_error::to_string(); }
     };
-    struct invalid_fee_multiplier : public wallet_logic_error
+    struct invalid_priority : public wallet_logic_error
     {
-      explicit invalid_fee_multiplier(std::string&& loc)
-        : wallet_logic_error(std::move(loc), "invalid fee multiplier")
+      explicit invalid_priority(std::string&& loc)
+        : wallet_logic_error(std::move(loc), "invalid priority")
       {
       }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -239,7 +239,7 @@ namespace tools
         LOG_PRINT_L1("Requested mixin " << req.mixin << " too low for hard fork 2, using 2");
         mixin = 2;
       }
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.priority, extra, req.trusted_daemon);
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.
       if (ptx_vector.size() != 1)
@@ -307,7 +307,7 @@ namespace tools
         mixin = 2;
       }
       std::vector<wallet2::pending_tx> ptx_vector;
-      ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
+      ptx_vector = m_wallet.create_transactions_2(dsts, mixin, req.unlock_time, req.priority, extra, req.trusted_daemon);
 
       m_wallet.commit_tx(ptx_vector);
 
@@ -416,7 +416,7 @@ namespace tools
 
     try
     {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_all(dsts[0].addr, req.mixin, req.unlock_time, req.fee_multiplier, extra, req.trusted_daemon);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet.create_transactions_all(dsts[0].addr, req.mixin, req.unlock_time, req.priority, extra, req.trusted_daemon);
 
       m_wallet.commit_tx(ptx_vector);
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -110,7 +110,7 @@ namespace wallet_rpc
     struct request
     {
       std::list<transfer_destination> destinations;
-      uint64_t fee_multiplier;
+      uint32_t priority;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -119,7 +119,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
-        KV_SERIALIZE(fee_multiplier)
+        KV_SERIALIZE(priority)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
@@ -147,7 +147,7 @@ namespace wallet_rpc
     struct request
     {
       std::list<transfer_destination> destinations;
-      uint64_t fee_multiplier;
+      uint32_t priority;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -156,7 +156,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
-        KV_SERIALIZE(fee_multiplier)
+        KV_SERIALIZE(priority)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)
@@ -225,7 +225,7 @@ namespace wallet_rpc
     struct request
     {
       std::string address;
-      uint64_t fee_multiplier;
+      uint32_t priority;
       uint64_t mixin;
       uint64_t unlock_time;
       std::string payment_id;
@@ -234,7 +234,7 @@ namespace wallet_rpc
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
-        KV_SERIALIZE(fee_multiplier)
+        KV_SERIALIZE(priority)
         KV_SERIALIZE(mixin)
         KV_SERIALIZE(unlock_time)
         KV_SERIALIZE(payment_id)


### PR DESCRIPTION
We keep 1, 2, 3 multipliers till the fee decrase from 0.01/kB
to 0.002/kB, where we start using 1, 20, 166 multipliers.
This ensures the higher multiplier will compensate for the
block reward penalty when pushing past 100% of the past median.

The fee-multiplier wallet setting is now rename to priority,
since it keeps its [0..3] range, but maps to different multiplier
values.