### PR TITLE
cmake: support BUILD_SHARED_LIBS built-in option for dyn linking internal libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
   message(STATUS "Setting default build type: ${CMAKE_BUILD_TYPE}")
 endif()
+string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LOWER)
 
 # ARCH defines the target architecture, either by an explicit identifier or
 # one of the following two keywords. By default, ARCH a value of 'native':
@@ -178,6 +179,17 @@ else()
   set(DEFAULT_STATIC false)
 endif()
 option(STATIC "Link libraries statically" ${DEFAULT_STATIC})
+
+# This is a CMake built-in switch that concerns internal libraries
+if (NOT DEFINED BUILD_SHARED_LIBS AND NOT STATIC AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
+    set(BUILD_SHARED_LIBS ON CACHE STRING "Build internal libs as shared")
+endif()
+if (BUILD_SHARED_LIBS)
+  message(STATUS "Building internal libraries as shared")
+  set(PIC_FLAG "-fPIC")
+else()
+  message(STATUS "Building internal libraries as static")
+endif()
 
 if(MINGW)
   string(REGEX MATCH "^[^/]:/[^/]*" msys2_install_path "${CMAKE_C_COMPILER}")
@@ -365,8 +377,8 @@ else()
     set(COVERAGE_FLAGS "-fprofile-arcs -ftest-coverage --coverage")
   endif()
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_FLAG} ${WARNINGS} ${C_WARNINGS} ${ARCH_FLAG} ${COVERAGE_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_GNU_SOURCE ${MINGW_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG} ${COVERAGE_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_FLAG} ${WARNINGS} ${C_WARNINGS} ${ARCH_FLAG} ${COVERAGE_FLAGS} ${PIC_FLAG}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_GNU_SOURCE ${MINGW_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG} ${COVERAGE_FLAGS} ${PIC_FLAG}")
 
   # With GCC 6.1.1 the compiled binary malfunctions due to aliasing. Until that
   # is fixed in the code (Issue #847), force compiler to be conservative.

--- a/contrib/otshell_utils/CMakeLists.txt
+++ b/contrib/otshell_utils/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB otshell_utils_sources # All files in directory:
 	"*.cpp"
 )
 
-add_library (otshell_utils STATIC ${otshell_utils_sources})
+add_library (otshell_utils ${otshell_utils_sources})
 set_target_properties (otshell_utils PROPERTIES OUTPUT_NAME "otshell_utils")
 #target_link_libraries (upnpc-static ${LDLIBS}) # to add used libs

--- a/external/db_drivers/liblmdb/CMakeLists.txt
+++ b/external/db_drivers/liblmdb/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(lmdb
   ${lmdb_sources})
 target_link_libraries(lmdb
-  LINK_PRIVATE
+  PRIVATE
     ${CMAKE_THREAD_LIBS_INIT})
 if(WIN32)
   target_link_libraries(lmdb

--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -202,13 +202,13 @@ add_library(unbound
   ${compat_src}
   ${libunbound_src})
 target_link_libraries(unbound
-  LINK_PRIVATE
+  PRIVATE
     ${OPENSSL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT})
 
 if (WIN32)
   target_link_libraries(unbound
-    LINK_PRIVATE
+    PRIVATE
       iphlpapi
       ws2_32)
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ function (bitmonero_add_library name)
   # libwallet, which combines multiple components.
   set(objlib obj_${name})
   add_library(${objlib} OBJECT ${ARGN})
-  add_library("${name}" STATIC $<TARGET_OBJECTS:${objlib}>)
+  add_library("${name}" $<TARGET_OBJECTS:${objlib}>)
   set_property(TARGET "${name}"
     PROPERTY
       FOLDER "libs")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ function (bitmonero_add_executable name)
   add_executable("${name}"
     ${ARGN})
   target_link_libraries("${name}"
-    LINK_PRIVATE
+    PRIVATE
       ${EXTRA_LIBRARIES})
   set_property(TARGET "${name}"
     PROPERTY

--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -60,18 +60,12 @@ bitmonero_add_library(blockchain_db
   ${blockchain_db_headers}
   ${blockchain_db_private_headers})
 target_link_libraries(blockchain_db
-  LINK_PUBLIC
+  PUBLIC
     common
     crypto
-    cryptonote_core
-    ${Boost_DATE_TIME_LIBRARY}
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_SERIALIZATION_LIBRARY}
     ${LMDB_LIBRARY}
     ${BDB_LIBRARY}
-  LINK_PRIVATE
     ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+  PRIVATE
     ${EXTRA_LIBRARIES})

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -63,11 +63,15 @@ bitmonero_add_executable(blockchain_import
   ${blockchain_import_private_headers})
 
 target_link_libraries(blockchain_import
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
-	blockchain_db
-	p2p
-    ${CMAKE_THREAD_LIBS_INIT})
+    blockchain_db
+    p2p
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXTRA_LIBRARIES})
 
 if(ARCH_WIDTH)
   target_compile_definitions(blockchain_import
@@ -85,11 +89,15 @@ bitmonero_add_executable(blockchain_export
   ${blockchain_export_private_headers})
 
 target_link_libraries(blockchain_export
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
-	p2p
-	blockchain_db
-    ${CMAKE_THREAD_LIBS_INIT})
+    blockchain_db
+    p2p
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXTRA_LIBRARIES})
 
 add_dependencies(blockchain_export
 	version)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -62,13 +62,15 @@ bitmonero_add_library(common
   ${common_headers}
   ${common_private_headers})
 target_link_libraries(common
-  LINK_PRIVATE
+  PUBLIC
     crypto
     ${UNBOUND_LIBRARY}
     ${LIBUNWIND_LIBRARIES}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+  PRIVATE
     ${EXTRA_LIBRARIES})
 
 #bitmonero_install_headers(common

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -74,6 +74,11 @@ bitmonero_add_library(crypto
   ${crypto_sources}
   ${crypto_headers}
   ${crypto_private_headers})
+target_link_libraries(crypto
+  PUBLIC
+    ${Boost_SYSTEM_LIBRARY}
+  PRIVATE
+    ${EXTRA_LIBRARIES})
 
 if (ARM)
   option(NO_OPTIMIZED_MULTIPLY_ON_ARM

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -939,7 +939,6 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 
 // ND: Some minor optimizations for ARMv7 (raspberrry pi 2), effect seems to be ~40-50% faster.
 //     Needs more work.
-#include "aesb.c"
 
 #ifdef NO_OPTIMIZED_MULTIPLY_ON_ARM
 /* The asm corresponds to this C code */

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -73,7 +73,7 @@ bitmonero_add_library(cryptonote_core
   ${cryptonote_core_headers}
   ${cryptonote_core_private_headers})
 target_link_libraries(cryptonote_core
-  LINK_PUBLIC
+  PUBLIC
     common
     crypto
     otshell_utils
@@ -82,9 +82,9 @@ target_link_libraries(cryptonote_core
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}
-  LINK_PRIVATE
-    ${Blocks}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+  PRIVATE
+    ${Blocks}
     ${EXTRA_LIBRARIES})

--- a/src/cryptonote_protocol/CMakeLists.txt
+++ b/src/cryptonote_protocol/CMakeLists.txt
@@ -32,16 +32,10 @@ project (bitmonero CXX)
 file(GLOB CRYPTONOTE_PROTOCOL *)
 source_group(cryptonote_protocol FILES ${CRYPTONOTE_PROTOCOL})
 
-#add_library(p2p ${P2P})
-
-#bitmonero_private_headers(p2p ${CRYPTONOTE_PROTOCOL})
+#bitmonero_private_headers(cryptonote_protocol ${CRYPTONOTE_PROTOCOL})
 bitmonero_add_library(cryptonote_protocol ${CRYPTONOTE_PROTOCOL})
-#target_link_libraries(p2p)
-#  LINK_PRIVATE
-#    ${Boost_CHRONO_LIBRARY}
-#    ${Boost_REGEX_LIBRARY}
-#    ${Boost_SYSTEM_LIBRARY}
-#    ${Boost_THREAD_LIBRARY}
-#    ${EXTRA_LIBRARIES})
+target_link_libraries(cryptonote_protocol
+  PRIVATE
+    ${EXTRA_LIBRARIES})
 add_dependencies(cryptonote_protocol
   version)

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -83,7 +83,7 @@ bitmonero_add_executable(daemon
   ${blocksdat}
 )
 target_link_libraries(daemon
-  LINK_PRIVATE
+  PRIVATE
     rpc
     blockchain_db
     cryptonote_core
@@ -98,9 +98,7 @@ target_link_libraries(daemon
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${UPNP_LIBRARIES}
     ${EXTRA_LIBRARIES})
 add_dependencies(daemon version)
 set_property(TARGET daemon

--- a/src/daemonizer/CMakeLists.txt
+++ b/src/daemonizer/CMakeLists.txt
@@ -61,14 +61,10 @@ bitmonero_add_library(daemonizer
   ${daemonizer_headers}
   ${daemonizer_private_headers})
 target_link_libraries(daemonizer
-  LINK_PRIVATE
+  PUBLIC
     common
     ${Boost_CHRONO_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_REGEX_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${UPNP_LIBRARIES}
+  PRIVATE
     ${EXTRA_LIBRARIES})

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -51,5 +51,5 @@ bitmonero_add_library(mnemonics
   ${mnemonics_headers}
   ${mnemonics_private_headers})
 target_link_libraries(mnemonics
-  LINK_PRIVATE
-    ${Boost_SYSTEM_LIBRARY})
+  PRIVATE
+    ${EXTRA_LIBRARIES})

--- a/src/p2p/CMakeLists.txt
+++ b/src/p2p/CMakeLists.txt
@@ -36,12 +36,15 @@ source_group(p2p FILES ${P2P})
 
 #bitmonero_private_headers(p2p ${P2P})
 bitmonero_add_library(p2p ${P2P})
-#target_link_libraries(p2p)
-#  LINK_PRIVATE
-#    ${Boost_CHRONO_LIBRARY}
-#    ${Boost_REGEX_LIBRARY}
-#    ${Boost_SYSTEM_LIBRARY}
-#    ${Boost_THREAD_LIBRARY}
-#    ${EXTRA_LIBRARIES})
+target_link_libraries(p2p
+  PUBLIC
+    ${UPNP_LIBRARIES}
+    ${Boost_CHRONO_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+  PRIVATE
+    ${EXTRA_LIBRARIES})
 add_dependencies(p2p
   version)

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -46,14 +46,8 @@ bitmonero_add_library(ringct
   ${ringct_headers}
   ${ringct_private_headers})
 target_link_libraries(ringct
-  LINK_PUBLIC
+  PUBLIC
     common
     crypto
-    ${Boost_DATE_TIME_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_SERIALIZATION_LIBRARY}
-  LINK_PRIVATE
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
+  PRIVATE
     ${EXTRA_LIBRARIES})

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -43,13 +43,11 @@ bitmonero_add_library(rpc
   ${rpc_headers}
   ${rpc_private_headers})
 target_link_libraries(rpc
-  LINK_PRIVATE
+  PUBLIC
     cryptonote_core
     cryptonote_protocol
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_REGEX_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+  PRIVATE
     ${EXTRA_LIBRARIES})
 add_dependencies(rpc
   version)

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -43,7 +43,7 @@ bitmonero_add_executable(simplewallet
   ${simplewallet_headers}
   ${simplewallet_private_headers})
 target_link_libraries(simplewallet
-  LINK_PRIVATE
+  PRIVATE
     wallet
     rpc
     cryptonote_core
@@ -51,8 +51,10 @@ target_link_libraries(simplewallet
     common
     mnemonics
     p2p
-    ${UNBOUND_LIBRARY}
-    ${UPNP_LIBRARIES}
+    ${Boost_CHRONO_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 add_dependencies(simplewallet

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -64,16 +64,18 @@ bitmonero_add_library(wallet
   ${wallet_api_headers}
   ${wallet_private_headers})
 target_link_libraries(wallet
-  LINK_PUBLIC
+  PUBLIC
     cryptonote_core
     mnemonics
-  LINK_PRIVATE
+    p2p
+    ${Boost_CHRONO_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
     ${Boost_REGEX_LIBRARY}
+  PRIVATE
     ${EXTRA_LIBRARIES})
-
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ add_executable(hash-target-tests
   ${hash_targets_sources}
   ${hash_targets_headers})
 target_link_libraries(hash-target-tests
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core)
 set_property(TARGET hash-target-tests
   PROPERTY

--- a/tests/core_proxy/CMakeLists.txt
+++ b/tests/core_proxy/CMakeLists.txt
@@ -36,17 +36,12 @@ add_executable(core_proxy
   ${core_proxy_sources}
   ${core_proxy_headers})
 target_link_libraries(core_proxy
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
     cryptonote_protocol
     p2p
-    ${UPNP_LIBRARIES}
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${EXPAT_LIBRARIES})
+    ${EXTRA_LIBRARIES})
 set_property(TARGET core_proxy
   PROPERTY
     FOLDER "tests")

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -62,14 +62,10 @@ add_executable(coretests
   ${core_tests_sources}
   ${core_tests_headers})
 target_link_libraries(coretests
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
     p2p
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${EXPAT_LIBRARIES}
     ${EXTRA_LIBRARIES})
 set_property(TARGET coretests
   PROPERTY

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -41,7 +41,9 @@ add_executable(crypto-tests
   ${crypto_sources}
   ${crypto_headers})
 target_link_libraries(crypto-tests
-    ${Boost_SYSTEM_LIBRARY})
+  PRIVATE
+    ${Boost_SYSTEM_LIBRARY}
+    ${EXTRA_LIBRARIES})
 set_property(TARGET crypto-tests
   PROPERTY
     FOLDER "tests")

--- a/tests/daemon_tests/CMakeLists.txt
+++ b/tests/daemon_tests/CMakeLists.txt
@@ -35,15 +35,14 @@ add_executable(transfers
   ${transfers_sources}
   ${transfers_headers})
 target_link_libraries(transfers
-  LINK_PRIVATE
+  PRIVATE
     useragent
     rpc
     cryptonote_core
     crypto
     common
     epee
-    ${GTEST_LIBRARIES}
-    ${Boost_LIBRARIES})
+    ${GTEST_LIBRARIES})
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_transfers")
 add_custom_target(test_transfers

--- a/tests/difficulty/CMakeLists.txt
+++ b/tests/difficulty/CMakeLists.txt
@@ -35,8 +35,9 @@ add_executable(difficulty-tests
   ${difficulty_sources}
   ${difficulty_headers})
 target_link_libraries(difficulty-tests
-  LINK_PRIVATE
-    cryptonote_core)
+  PRIVATE
+    cryptonote_core
+    ${EXTRA_LIBRARIES})
 set_property(TARGET difficulty-tests
   PROPERTY
     FOLDER "tests")

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -39,13 +39,13 @@ add_executable(functional_tests
   ${functional_tests_sources}
   ${functional_tests_headers})
 target_link_libraries(functional_tests
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
     wallet
     common
     crypto
-    ${UNBOUND_LIBRARY}
     ${Boost_REGEX_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 set_property(TARGET functional_tests

--- a/tests/hash/CMakeLists.txt
+++ b/tests/hash/CMakeLists.txt
@@ -35,8 +35,9 @@ add_executable(hash-tests
   ${hash_sources}
   ${hash_headers})
 target_link_libraries(hash-tests
-  LINK_PRIVATE
-    crypto)
+  PRIVATE
+    crypto
+    ${EXTRA_LIBRARIES})
 set_property(TARGET hash-tests
   PROPERTY
     FOLDER "tests")

--- a/tests/libwallet_api_tests/CMakeLists.txt
+++ b/tests/libwallet_api_tests/CMakeLists.txt
@@ -38,9 +38,13 @@ add_executable(libwallet_api_tests
   ${libwallet_api_tests_headers})
 
 target_link_libraries(libwallet_api_tests
-  LINK_PRIVATE
+  PRIVATE
     wallet
+    ${Boost_SERIALIZATION_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     ${GTEST_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 
 set_property(TARGET libwallet_api_tests

--- a/tests/net_load_tests/CMakeLists.txt
+++ b/tests/net_load_tests/CMakeLists.txt
@@ -36,16 +36,15 @@ add_executable(net_load_tests_clt
   ${clt_sources}
   ${clt_headers})
 target_link_libraries(net_load_tests_clt
-  LINK_PRIVATE
-	otshell_utils
-	p2p
-	cryptonote_core
+  PRIVATE
+    otshell_utils
+    p2p
+    cryptonote_core
     ${GTEST_LIBRARIES}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 
 set(srv_sources
@@ -58,16 +57,15 @@ add_executable(net_load_tests_srv
   ${srv_sources}
   ${srv_headers})
 target_link_libraries(net_load_tests_srv
-  LINK_PRIVATE
-	otshell_utils
-	p2p
-	cryptonote_core
+  PRIVATE
+    otshell_utils
+    p2p
+    cryptonote_core
     ${GTEST_LIBRARIES}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 
 set_property(TARGET net_load_tests_clt net_load_tests_srv

--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -48,11 +48,10 @@ add_executable(performance_tests
   ${performance_tests_sources}
   ${performance_tests_headers})
 target_link_libraries(performance_tests
-  LINK_PRIVATE
+  PRIVATE
     cryptonote_core
     common
     crypto
-    ${UNBOUND_LIBRARY}
     ${Boost_CHRONO_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(unit_tests
   ${unit_tests_sources}
   ${unit_tests_headers})
 target_link_libraries(unit_tests
-  LINK_PRIVATE
+  PRIVATE
     ringct
     cryptonote_core
     blockchain_db
@@ -70,11 +70,7 @@ target_link_libraries(unit_tests
     wallet
     p2p
     ${GTEST_LIBRARIES}
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_REGEX_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
-    ${UNBOUND_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 set_property(TARGET unit_tests
   PROPERTY


### PR DESCRIPTION
This patchset is to support building internal libs as shared libs via BUILD_SHARED_LIBS cmake built-in option. This speeds up development: changes that don't affect lib interfaces do not require a re-link to run, instead just rebuild the library, for example, `make crypto`, and re-run `./monerod`. Cmake automatically setups up rpath, so no fiddling with paths is necessary, ./monerod is enough to launch.

As a bonus, the link time turned out to be faster: 11sec with BUILD_SHARED_LIBS=ON vs 19sec with BUILD_SHARED_LIBS=OFF. Measured by `rm bin/* && find . -name '.a' -delete && time make -j1` (and ditto for .so).

This patch enables BUILD_SHARED_LIBS by default in debug build, disables in release build or if STATIC=ON.

Tested:
Arch Linux (gcc v6) on x86_64 and i686 chroot (did not test STATIC=ON, though)
Ubuntu 16.04 (gcc v5) on x86_64
Ubuntu 14.04 (gcc v4) on x86_64
Windows mingw64 (tested for any regressions only, shared libs not supported there)
Arch Linux (gcc v6) on armv7 (tested dyn build and STATIC=ON)

commit 06bb6923c3068637af729dd7e7500ce1a6c888b9
    cmake: support BUILD_SHARED_LIBS built-in option
    
    Support building internal libraries as shared. This reduces
    development time by eliminating the need to re-link all
    binaries every time non-interface code in the library changes.
    Instead, can hack on libxyz, then `make libxyz`, and re-run
    monerod.
    
    By default BUILD_SHARED_LIBS is OFF in release build type,
    and ON in debug build type, but can be overriden with -D.

commit e1c7af35d47c6f54628418f67128074c1bcd4858
    cmake: transitive deps and remove deprecated LINK_*
    
    Keep the immediate direct deps at the library that depends on them,
    declare deps as PUBLIC so that targets that link against that library
    get the library's deps as transitive deps.
    
    Break dep cycle between blockchain_db <-> crytonote_core.
    No code refactoring, just hide cycle from cmake so that
    it doesn't complain (cycles are allowed only between
    static libs, not shared libs).
    
    This is in preparation for supproting BUILD_SHARED_LIBS cmake
    built-in option for building internal libs as shared.

commit 54010b97b4739c50f32b3364a88a452625aa31c4
    crypto: armv7: slow-hash: remove redundant source include
    
    aesb.c is already present in libcrypto as a standalone object.
    Tested: builds and runs fine on armv7, static and dynamic.
