### PR TITLE
wallet: keep change dest separate from other dests

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3063,16 +3063,18 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
     ++out_index;
   }
 
+  // we still keep a copy, since we want to keep dsts free of change for user feedback purposes
+  std::vector<cryptonote::tx_destination_entry> splitted_dsts = dsts;
   cryptonote::tx_destination_entry change_dts = AUTO_VAL_INIT(change_dts);
   if (needed_money < found_money)
   {
     change_dts.addr = m_account.get_keys().m_account_address;
     change_dts.amount = found_money - needed_money;
-    dsts.push_back(change_dts);
+    splitted_dsts.push_back(change_dts);
   }
 
   crypto::secret_key tx_key;
-  bool r = cryptonote::construct_tx_and_get_tx_key(m_account.get_keys(), sources, dsts, extra, tx, unlock_time, tx_key, true);
+  bool r = cryptonote::construct_tx_and_get_tx_key(m_account.get_keys(), sources, splitted_dsts, extra, tx, unlock_time, tx_key, true);
   THROW_WALLET_EXCEPTION_IF(!r, error::tx_not_constructed, sources, dsts, unlock_time, m_testnet);
   THROW_WALLET_EXCEPTION_IF(upper_transaction_size_limit <= get_object_blobsize(tx), error::tx_too_big, tx, upper_transaction_size_limit);
 


### PR DESCRIPTION
This fixes misreporting of amount/fee in rct txes, as the rct
tx construction code was lumping all dests (whether change or
not) in the same dests vector, while the pre-rct code was
keeping it separate.