### PR TITLE
Don't define stdc++ on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,11 +512,6 @@ else()
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # There is a clang bug that does not allow to compile code that uses AES-NI intrinsics if -flto is enabled, so explicitly disable
     set(USE_LTO false)
-    # explicitly define stdlib for older versions of clang
-    if(CMAKE_C_COMPILER_VERSION VERSION_LESS 3.7 AND NOT FREEBSD)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
-    endif()
   endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,7 @@ else()
     # There is a clang bug that does not allow to compile code that uses AES-NI intrinsics if -flto is enabled, so explicitly disable
     set(USE_LTO false)
     # explicitly define stdlib for older versions of clang
-    if(CMAKE_C_COMPILER_VERSION VERSION_LESS 3.7)
+    if(CMAKE_C_COMPILER_VERSION VERSION_LESS 3.7 AND NOT FREEBSD)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
     endif()


### PR DESCRIPTION
With this it now builds and runs on FreeBSD 10.1 which uses clang version 3.4.1. Otherwise I get errors for 'iostream' file not found and stdc++ not found.