### PR TITLE
Fix "wallet->close()" deadlock

### DIFF
--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -77,6 +77,11 @@ public:
     uint64_t unlockedBalance() const;
     bool refresh();
     void refreshAsync();
+    void setAutoRefreshInterval(int seconds);
+    int autoRefreshInterval() const;
+
+
+
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                         uint64_t amount, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low);

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -223,10 +223,25 @@ struct Wallet
      * @return - true if refreshed successfully;
      */
     virtual bool refresh() = 0;
+
     /**
      * @brief refreshAsync - refreshes wallet asynchronously.
      */
     virtual void refreshAsync() = 0;
+
+    /**
+     * @brief setAutoRefreshInterval - setup interval for automatic refresh.
+     * @param seconds - interval in seconds. if zero or less than zero - automatic refresh disabled;
+     */
+    virtual void setAutoRefreshInterval(int seconds) = 0;
+
+    /**
+     * @brief autoRefreshInterval - returns automatic refresh interval in seconds
+     * @return
+     */
+    virtual int autoRefreshInterval() const = 0;
+
+
     /*!
      * \brief createTransaction creates transaction. if dst_addr is an integrated address, payment_id is ignored
      * \param dst_addr          destination address as string

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -36,6 +36,8 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/asio.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <iostream>
 #include <vector>
@@ -181,6 +183,7 @@ struct WalletTest2 : public testing::Test
 
 
 };
+
 
 
 TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
@@ -394,6 +397,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 }
 
+
 TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
 {
     Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
@@ -406,7 +410,8 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
     wallet1 = wmgr->openWallet(WALLET_NAME_WITH_DIR_NON_WRITABLE, WALLET_PASS);
     ASSERT_FALSE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
 
-    ASSERT_FALSE(wmgr->closeWallet(wallet1));
+    // "close" always returns true;
+    ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
     ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
@@ -415,6 +420,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
 }
+
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet4)
 {
@@ -792,6 +798,7 @@ struct MyWalletListener : public Bitmonero::WalletListener
 };
 
 
+/*
 TEST_F(WalletTest2, WalletCallBackRefreshedSync)
 {
 
@@ -800,11 +807,12 @@ TEST_F(WalletTest2, WalletCallBackRefreshedSync)
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src_listener->refresh_triggered);
     ASSERT_TRUE(wallet_src->connected());
-//    std::chrono::seconds wait_for = std::chrono::seconds(60*3);
-//    std::unique_lock<std::mutex> lock (wallet_src_listener->mutex);
-//    wallet_src_listener->cv_refresh.wait_for(lock, wait_for);
+    std::chrono::seconds wait_for = std::chrono::seconds(60*3);
+    std::unique_lock<std::mutex> lock (wallet_src_listener->mutex);
+    wallet_src_listener->cv_refresh.wait_for(lock, wait_for);
     wmgr->closeWallet(wallet_src);
 }
+*/
 
 
 TEST_F(WalletTest2, WalletCallBackRefreshedAsync)
@@ -908,10 +916,9 @@ TEST_F(WalletTest2, WalletCallbackReceived)
 }
 
 
-
 int main(int argc, char** argv)
 {
-
     ::testing::InitGoogleTest(&argc, argv);
+    // Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_Max);
     return RUN_ALL_TESTS();
 }

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -65,9 +65,8 @@ const char * WALLET_PASS = "password";
 const char * WALLET_PASS2 = "password22";
 const char * WALLET_LANG = "English";
 
-// change this according your environment
 
-const std::string WALLETS_ROOT_DIR = "/home/mbg033/dev/monero/testnet/";
+const std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt/";
 
 const std::string TESTNET_WALLET1_NAME = WALLETS_ROOT_DIR + "wallet_01.bin";
 const std::string TESTNET_WALLET2_NAME = WALLETS_ROOT_DIR + "wallet_02.bin";
@@ -78,10 +77,11 @@ const std::string TESTNET_WALLET6_NAME = WALLETS_ROOT_DIR + "wallet_06.bin";
 
 const char * TESTNET_WALLET_PASS = "";
 
-const std::string CURRENT_SRC_WALLET = TESTNET_WALLET1_NAME;
-const std::string CURRENT_DST_WALLET = TESTNET_WALLET6_NAME;
+const std::string CURRENT_SRC_WALLET = TESTNET_WALLET6_NAME;
+const std::string CURRENT_DST_WALLET = TESTNET_WALLET1_NAME;
 
 const char * TESTNET_DAEMON_ADDRESS = "localhost:38081";
+
 const uint64_t AMOUNT_10XMR =  10000000000000L;
 const uint64_t AMOUNT_5XMR  =  5000000000000L;
 const uint64_t AMOUNT_1XMR  =  1000000000000L;
@@ -181,10 +181,7 @@ struct WalletTest2 : public testing::Test
         wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
     }
 
-
 };
-
-
 
 TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
 {
@@ -222,6 +219,7 @@ TEST_F(WalletManagerTest, WalletMaxAmountAsString)
                      Bitmonero::Wallet::maximumAllowedAmount()));
 
 }
+
 
 TEST_F(WalletManagerTest, WalletAmountFromString)
 {
@@ -457,14 +455,14 @@ TEST_F(WalletManagerTest, WalletManagerFindsWallet)
 }
 
 
-TEST_F(WalletManagerTest, WalletGeneratesPaymentId)
+TEST_F(WalletTest1, WalletGeneratesPaymentId)
 {
     std::string payment_id = Bitmonero::Wallet::genPaymentId();
     ASSERT_TRUE(payment_id.length() == 16);
 }
 
 
-TEST_F(WalletManagerTest, WalletGeneratesIntegratedAddress)
+TEST_F(WalletTest1, WalletGeneratesIntegratedAddress)
 {
     std::string payment_id = Bitmonero::Wallet::genPaymentId();
 
@@ -503,7 +501,6 @@ TEST_F(WalletTest1, WalletRefresh)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 }
 
-
 TEST_F(WalletTest1, WalletConvertsToString)
 {
     std::string strAmount = Bitmonero::Wallet::displayAmount(AMOUNT_5XMR);
@@ -518,6 +515,7 @@ TEST_F(WalletTest1, WalletConvertsToString)
 
 
 TEST_F(WalletTest1, WalletTransaction)
+
 {
     Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
@@ -543,6 +541,8 @@ TEST_F(WalletTest1, WalletTransaction)
     ASSERT_FALSE(wallet1->balance() == balance);
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 }
+
+
 
 TEST_F(WalletTest1, WalletTransactionWithMixin)
 {
@@ -798,7 +798,8 @@ struct MyWalletListener : public Bitmonero::WalletListener
 };
 
 
-/*
+
+
 TEST_F(WalletTest2, WalletCallBackRefreshedSync)
 {
 
@@ -812,7 +813,8 @@ TEST_F(WalletTest2, WalletCallBackRefreshedSync)
     wallet_src_listener->cv_refresh.wait_for(lock, wait_for);
     wmgr->closeWallet(wallet_src);
 }
-*/
+
+
 
 
 TEST_F(WalletTest2, WalletCallBackRefreshedAsync)

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -65,28 +65,27 @@ const char * WALLET_PASS = "password";
 const char * WALLET_PASS2 = "password22";
 const char * WALLET_LANG = "English";
 
-
-const std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt/";
-
-const std::string TESTNET_WALLET1_NAME = WALLETS_ROOT_DIR + "wallet_01.bin";
-const std::string TESTNET_WALLET2_NAME = WALLETS_ROOT_DIR + "wallet_02.bin";
-const std::string TESTNET_WALLET3_NAME = WALLETS_ROOT_DIR + "wallet_03.bin";
-const std::string TESTNET_WALLET4_NAME = WALLETS_ROOT_DIR + "wallet_04.bin";
-const std::string TESTNET_WALLET5_NAME = WALLETS_ROOT_DIR + "wallet_05.bin";
-const std::string TESTNET_WALLET6_NAME = WALLETS_ROOT_DIR + "wallet_06.bin";
+std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt";
+std::string TESTNET_WALLET1_NAME;
+std::string TESTNET_WALLET2_NAME;
+std::string TESTNET_WALLET3_NAME;
+std::string TESTNET_WALLET4_NAME;
+std::string TESTNET_WALLET5_NAME;
+std::string TESTNET_WALLET6_NAME;
 
 const char * TESTNET_WALLET_PASS = "";
 
-const std::string CURRENT_SRC_WALLET = TESTNET_WALLET6_NAME;
-const std::string CURRENT_DST_WALLET = TESTNET_WALLET1_NAME;
-
-const char * TESTNET_DAEMON_ADDRESS = "localhost:38081";
+std::string CURRENT_SRC_WALLET;
+std::string CURRENT_DST_WALLET;
 
 const uint64_t AMOUNT_10XMR =  10000000000000L;
 const uint64_t AMOUNT_5XMR  =  5000000000000L;
 const uint64_t AMOUNT_1XMR  =  1000000000000L;
 
 const std::string PAYMENT_ID_EMPTY = "";
+
+std::string TESTNET_DAEMON_ADDRESS = "localhost:38081";
+
 
 }
 
@@ -494,6 +493,7 @@ TEST_F(WalletTest1, WalletShowsBalance)
 
 TEST_F(WalletTest1, WalletRefresh)
 {
+
     Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
@@ -920,6 +920,29 @@ TEST_F(WalletTest2, WalletCallbackReceived)
 
 int main(int argc, char** argv)
 {
+    // we can override default values for "TESTNET_DAEMON_ADDRESS" and "WALLETS_ROOT_DIR"
+
+    const char * monero_daemon_addr = std::getenv("TESTNET_DAEMON_ADDRESS");
+    if (monero_daemon_addr) {
+        TESTNET_DAEMON_ADDRESS = monero_daemon_addr;
+    }
+
+    const char * wallets_root_dir = std::getenv("WALLETS_ROOT_DIR");
+    if (wallets_root_dir) {
+        WALLETS_ROOT_DIR = wallets_root_dir;
+    }
+
+
+    TESTNET_WALLET1_NAME = WALLETS_ROOT_DIR + "/wallet_01.bin";
+    TESTNET_WALLET2_NAME = WALLETS_ROOT_DIR + "/wallet_02.bin";
+    TESTNET_WALLET3_NAME = WALLETS_ROOT_DIR + "/wallet_03.bin";
+    TESTNET_WALLET4_NAME = WALLETS_ROOT_DIR + "/wallet_04.bin";
+    TESTNET_WALLET5_NAME = WALLETS_ROOT_DIR + "/wallet_05.bin";
+    TESTNET_WALLET6_NAME = WALLETS_ROOT_DIR + "/wallet_06.bin";
+
+    CURRENT_SRC_WALLET = TESTNET_WALLET6_NAME;
+    CURRENT_DST_WALLET = TESTNET_WALLET5_NAME;
+
     ::testing::InitGoogleTest(&argc, argv);
     // Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_Max);
     return RUN_ALL_TESTS();

--- a/tests/libwallet_api_tests/scripts/README.md
+++ b/tests/libwallet_api_tests/scripts/README.md
@@ -1,0 +1,24 @@
+# Running libwallet_api tests
+
+## Environment for the tests
+* Running monero node, linked to private/public testnet. 
+  By default, tests expect daemon running at ```localhost:38081```,
+  can we overriden with enviroment variable ```TESTNET_DAEMON_ADDRESS=<your_daemon_address>```
+  [Manual](https://github.com/moneroexamples/private-testnet) explaining how to run private testnet.
+
+* Directory with pre-generated wallets
+  (wallet_01.bin, wallet_02.bin,...,wallet_06.bin, some of these wallets might not be used in the tests currently). 
+  By default, tests expect these wallets to be in ```/var/monero/testnet_pvt```. 
+  Directory can be overriden with environment variable ```WALLETS_ROOT_DIR=<your_directory_with_wallets>```.
+  Directory and files should be writable for the user running tests.
+
+
+## Generating test wallets
+* ```create_wallets.sh``` - this script will create wallets (wallet_01.bin, wallet_02.bin,...,wallet_06.bin) in current directory. 
+  when running first time, please uncomment line ```#create_wallet wallet_m``` to create miner wallet as well. 
+  This wallet should be used for mining and all test wallets supposed to be seed from this miner wallet
+
+* ```mining_start.sh``` and ```mining_stop.sh``` - helper scripts to start and stop mining on miner waller
+
+* ```send_funds.sh``` - script for seeding test wallets. Please run this script when you have ehough money on miner wallet
+

--- a/tests/libwallet_api_tests/scripts/create_wallets.sh
+++ b/tests/libwallet_api_tests/scripts/create_wallets.sh
@@ -6,7 +6,6 @@ function create_wallet {
 }
 
 
-
 create_wallet wallet_01.bin
 create_wallet wallet_02.bin
 create_wallet wallet_03.bin
@@ -14,7 +13,6 @@ create_wallet wallet_04.bin
 create_wallet wallet_05.bin
 create_wallet wallet_06.bin
 
-
-#create_wallet wallet_m
+# create_wallet wallet_m
 
 


### PR DESCRIPTION
- fixed deadlock happened in "Wallet::close()" (introduced in https://github.com/monero-project/monero/commit/8a274eab3feab820f38503f98a3caecb5dded4a5, wait_for() was replaced to wait()), referred in issue: https://github.com/monero-project/monero-core/issues/25
- introduced getter and setter for "refresh interval"
- improved tests