### PR TITLE
Made error message consistent with other, more helpful, message

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2489,7 +2489,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
       print_money(e.tx_amount() + e.fee())  %
       print_money(e.tx_amount()) %
       print_money(e.fee()));
-    fail_msg_writer() << tr("Failed to find a way to create transactions");
+    fail_msg_writer() << tr("Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees");
   }
   catch (const tools::error::not_enough_outs_to_mix& e)
   {


### PR DESCRIPTION
I encountered this error when attempting to transfer a small amount that was the full account balance. I found a couple examples of this more complete and helpful error message being used when the same error is caught.