### PR TITLE
Revert "Fix fake 'network synchronized, begin using' messages"

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -965,10 +965,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   void core::set_target_blockchain_height(uint64_t target_blockchain_height)
   {
-    if (target_blockchain_height > m_target_blockchain_height)
-    {
-      m_target_blockchain_height = target_blockchain_height;
-    }
+    m_target_blockchain_height = target_blockchain_height;
   }
   //-----------------------------------------------------------------------------------------------
   uint64_t core::get_target_blockchain_height() const

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -263,7 +263,7 @@ namespace cryptonote
     if(context.m_state == cryptonote_connection_context::state_synchronizing)
       return true;
 
-    if(m_core.have_block(hshd.top_id) && !(hshd.current_height < m_core.get_target_blockchain_height()))
+    if(m_core.have_block(hshd.top_id))
     {
       context.m_state = cryptonote_connection_context::state_normal;
       if(is_inital)


### PR DESCRIPTION
This reverts commit 78035d2b6c9922f4cd730df0766aa74f4854ccb2.

The patch doesn't work, and causes constant SYNCHRONIZED OK spam.