### PR TITLE
Noticed two spellings of the word 'response' in the codebase

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -57,7 +57,7 @@ namespace {
     tools::msg_writer() << boost::format("%-10s %-25s %-25s %s") % prefix % id_str % addr_str % elapsed;
   }
 
-  void print_block_header(cryptonote::block_header_responce const & header)
+  void print_block_header(cryptonote::block_header_response const & header)
   {
     tools::success_msg_writer()
       << "timestamp: " << boost::lexical_cast<std::string>(header.timestamp) << std::endl

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -830,19 +830,19 @@ namespace cryptonote
     return reward;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::fill_block_header_responce(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_responce& responce)
+  bool core_rpc_server::fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response)
   {
-    responce.major_version = blk.major_version;
-    responce.minor_version = blk.minor_version;
-    responce.timestamp = blk.timestamp;
-    responce.prev_hash = string_tools::pod_to_hex(blk.prev_id);
-    responce.nonce = blk.nonce;
-    responce.orphan_status = orphan_status;
-    responce.height = height;
-    responce.depth = m_core.get_current_blockchain_height() - height - 1;
-    responce.hash = string_tools::pod_to_hex(hash);
-    responce.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
-    responce.reward = get_block_reward(blk);
+    response.major_version = blk.major_version;
+    response.minor_version = blk.minor_version;
+    response.timestamp = blk.timestamp;
+    response.prev_hash = string_tools::pod_to_hex(blk.prev_id);
+    response.nonce = blk.nonce;
+    response.orphan_status = orphan_status;
+    response.height = height;
+    response.depth = m_core.get_current_blockchain_height() - height - 1;
+    response.hash = string_tools::pod_to_hex(hash);
+    response.difficulty = m_core.get_blockchain_storage().block_difficulty(height);
+    response.reward = get_block_reward(blk);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -871,8 +871,8 @@ namespace cryptonote
       error_resp.message = "Internal error: can't get last block.";
       return false;
     }
-    bool responce_filled = fill_block_header_responce(last_block, false, last_block_height, last_block_hash, res.block_header);
-    if (!responce_filled)
+    bool response_filled = fill_block_header_response(last_block, false, last_block_height, last_block_hash, res.block_header);
+    if (!response_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: can't produce valid response.";
@@ -912,8 +912,8 @@ namespace cryptonote
       return false;
     }
     uint64_t block_height = boost::get<txin_gen>(blk.miner_tx.vin.front()).height;
-    bool responce_filled = fill_block_header_responce(blk, false, block_height, block_hash, res.block_header);
-    if (!responce_filled)
+    bool response_filled = fill_block_header_response(blk, false, block_height, block_hash, res.block_header);
+    if (!response_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: can't produce valid response.";
@@ -945,8 +945,8 @@ namespace cryptonote
       error_resp.message = "Internal error: can't get block by height. Height = " + std::to_string(req.height) + '.';
       return false;
     }
-    bool responce_filled = fill_block_header_responce(blk, false, req.height, block_hash, res.block_header);
-    if (!responce_filled)
+    bool response_filled = fill_block_header_response(blk, false, req.height, block_hash, res.block_header);
+    if (!response_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: can't produce valid response.";
@@ -999,8 +999,8 @@ namespace cryptonote
       return false;
     }
     uint64_t block_height = boost::get<txin_gen>(blk.miner_tx.vin.front()).height;
-    bool responce_filled = fill_block_header_responce(blk, false, block_height, block_hash, res.block_header);
-    if (!responce_filled)
+    bool response_filled = fill_block_header_response(blk, false, block_height, block_hash, res.block_header);
+    if (!response_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: can't produce valid response.";

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -172,7 +172,7 @@ private:
     
     //utils
     uint64_t get_block_reward(const block& blk);
-    bool fill_block_header_responce(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_responce& responce);
+    bool fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response);
     
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& m_p2p;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -631,7 +631,7 @@ namespace cryptonote
     };
   };
   
-  struct block_header_responce
+  struct block_header_response
   {
       uint8_t major_version;
       uint8_t minor_version;
@@ -671,7 +671,7 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
@@ -695,7 +695,7 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
@@ -719,7 +719,7 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
@@ -745,7 +745,7 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       std::vector<std::string> tx_hashes;
       std::string blob;
       std::string json;
@@ -940,7 +940,7 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      std::vector<block_header_responce> headers;
+      std::vector<block_header_response> headers;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)


### PR DESCRIPTION
Sometimes spelled 'responce'. 

Fixed to the standard spelling 'response'. 

This may fix some functionality - some calls had mixed spellings, particularly the creation of the ```response``` struct in ```contrib/epee/include/net/jsonrpc_structs.h ``` where it's later referred to as ```responce``` in other functions.