### PR TITLE
Make a log entry when the cryptonote protocol terminates

### DIFF
--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -75,7 +75,7 @@ public:
       m_protocol.set_p2p_endpoint(nullptr);
       LOG_PRINT_L0("Cryptonote protocol stopped successfully.");
     } catch (...) {
-      LOG_PRINT_L0("Failed to stop cryptonote protocol...");
+      LOG_PRINT_RED("Failed to stop cryptonote protocol.");
     }
   }
 };

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -75,7 +75,7 @@ public:
       m_protocol.set_p2p_endpoint(nullptr);
       LOG_PRINT_L0("Cryptonote protocol stopped successfully.");
     } catch (...) {
-      LOG_PRINT_RED("Failed to stop cryptonote protocol.");
+      LOG_ERROR("Failed to stop cryptonote protocol!");
     }
   }
 };

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -69,12 +69,13 @@ public:
 
   ~t_protocol()
   {
-    LOG_PRINT_L0("Deinitializing cryptonote_protocol...");
+    LOG_PRINT_L0("Stopping cryptonote protocol...");
     try {
       m_protocol.deinit();
       m_protocol.set_p2p_endpoint(nullptr);
+      LOG_PRINT_L0("Cryptonote protocol stopped successfully.");
     } catch (...) {
-      LOG_PRINT_L0("Failed to deinitialize protocol...");
+      LOG_PRINT_L0("Failed to stop cryptonote protocol...");
     }
   }
 };


### PR DESCRIPTION
I'd also like to add a final 'daemon stopped' message at log level 0 but can't figure out the right place to do it

I also want to add more explicit logging at higher levels for each of the shutdown steps in `core::deinit()` in `cryptonote_core.cpp` so you can tell when each component stops - if someone could suggest which log level these should be active at?

Finally, I'm going to try to have a look at stripping out the 'fast exit' stuff as suggested way back in issue #592 
