### PR TITLE
Removed all code related to fast_exit

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -300,7 +300,6 @@ namespace net_utils
     boost::thread::id m_main_thread_id;
     critical_section m_threads_lock;
     volatile uint32_t m_thread_index; // TODO change to std::atomic
-    void detach_threads();
 
     t_connection_type m_connection_type;
 

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -827,7 +827,7 @@ POP_WARNINGS
       }
       CRITICAL_REGION_END();
       // Wait for all threads in the pool to exit.
-      if (wait)  // && ! ::cryptonote::core::get_is_stopping()) // TODO fast_exit
+      if (wait)
       {
 		_fact("JOINING all threads");
         for (std::size_t i = 0; i < m_threads.size(); ++i) {
@@ -897,10 +897,6 @@ POP_WARNINGS
   template<class t_protocol_handler>
   void boosted_tcp_server<t_protocol_handler>::send_stop_signal()
   {
-    if (::cryptonote::core::get_fast_exit() == true)
-    {
-		detach_threads();
-	}
     m_stop_signal_sent = true;
     TRY_ENTRY();
     connections_mutex.lock();
@@ -1144,14 +1140,6 @@ POP_WARNINGS
     return true;
     CATCH_ENTRY_L0("boosted_tcp_server<t_protocol_handler>::connect_async", false);
   }
-  //---------------------------------------------------------------------------------
-  template<class t_protocol_handler>
-  void  boosted_tcp_server<t_protocol_handler>::detach_threads()
-  {
-	for (auto thread : m_threads)
-		thread->detach();
-  }
-  
   
 } // namespace
 } // namespace

--- a/contrib/rlwrap/monerocommands_bitmonerod.txt
+++ b/contrib/rlwrap/monerocommands_bitmonerod.txt
@@ -2,7 +2,6 @@ ban
 bans
 diff
 exit
-fast_exit
 flush_txpool
 hard_fork_info
 help

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -433,22 +433,9 @@ namespace cryptonote
   {
     m_miner.stop();
     m_mempool.deinit();
-    if (!m_fast_exit)
-    {
-      m_blockchain_storage.deinit();
-    }
+    m_blockchain_storage.deinit();
     unlock_db_directory();
     return true;
-  }
-  //-----------------------------------------------------------------------------------------------
-    void core::set_fast_exit()
-  {
-    m_fast_exit = true;
-  }
-  //-----------------------------------------------------------------------------------------------
-    bool core::get_fast_exit()
-  {
-    return m_fast_exit;
   }
   //-----------------------------------------------------------------------------------------------
   void core::test_drop_download()
@@ -985,6 +972,4 @@ namespace cryptonote
   {
     raise(SIGTERM);
   }
-
-  std::atomic<bool> core::m_fast_exit(false);
 }

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -230,27 +230,9 @@ namespace cryptonote
       *
       * Uninitializes the miner instance, transaction pool, and Blockchain
       *
-      * if m_fast_exit is set, the call to Blockchain::deinit() is not made.
-      *
       * @return true
       */
      bool deinit();
-
-     /**
-      * @brief sets fast exit flag
-      *
-      * @note see deinit()
-      */
-     static void set_fast_exit();
-
-     /**
-      * @brief gets the current state of the fast exit flag
-      *
-      * @return the fast exit flag
-      *
-      * @note see deinit()
-      */
-     static bool get_fast_exit();
 
      /**
       * @brief sets to drop blocks downloaded (for testing)
@@ -763,8 +745,6 @@ namespace cryptonote
       * @return true
       */
      bool unlock_db_directory();
-
-     static std::atomic<bool> m_fast_exit; //!< whether or not to deinit Blockchain on exit
 
      bool m_test_drop_download = true; //!< whether or not to drop incoming blocks (for testing)
 

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -336,12 +336,6 @@ bool t_command_parser_executor::set_limit_down(const std::vector<std::string>& a
   return m_executor.set_limit_down(limit);
 }
 
-bool t_command_parser_executor::fast_exit(const std::vector<std::string>& args)
-{
-	if (!args.empty()) return false;
-	return m_executor.fast_exit();
-}
-
 bool t_command_parser_executor::out_peers(const std::vector<std::string>& args)
 {
 	if (args.empty()) return false;

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -98,8 +98,6 @@ public:
 
   bool set_limit_down(const std::vector<std::string>& args);
 
-  bool fast_exit(const std::vector<std::string>& args);
-  
   bool out_peers(const std::vector<std::string>& args);
   
   bool start_save_graph(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -171,11 +171,6 @@ t_command_server::t_command_server(
     , "limit <kB/s> - Set download limit"
     );
     m_command_lookup.set_handler(
-      "fast_exit"
-    , std::bind(&t_command_parser_executor::fast_exit, &m_parser, p::_1)
-    , "Exit"
-    );
-    m_command_lookup.set_handler(
       "out_peers"
     , std::bind(&t_command_parser_executor::out_peers, &m_parser, p::_1)
     , "Set max number of out peers"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -989,34 +989,6 @@ bool t_rpc_command_executor::set_limit_down(int limit)
     return true;
 }
 
-bool t_rpc_command_executor::fast_exit()
-{
-	cryptonote::COMMAND_RPC_FAST_EXIT::request req;
-	cryptonote::COMMAND_RPC_FAST_EXIT::response res;
-	
-	std::string fail_message = "Daemon did not stop";
-	
-	if (m_is_rpc)
-	{
-		if (!m_rpc_client->rpc_request(req, res, "/fast_exit", fail_message.c_str()))
-		{
-			return true;
-		}
-	}
-	
-	else
-    {
-		if (!m_rpc_server->on_fast_exit(req, res) || res.status != CORE_RPC_STATUS_OK)
-		{
-			tools::fail_msg_writer() << fail_message.c_str();
-			return true;
-		}
-	}
-
-	tools::success_msg_writer() << "Daemon stopped";
-	return true;
-}
-
 bool t_rpc_command_executor::out_peers(uint64_t limit)
 {
 	cryptonote::COMMAND_RPC_OUT_PEERS::request req;

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -116,8 +116,6 @@ public:
 
   bool set_limit_down(int limit);
 
-  bool fast_exit();
-  
   bool out_peers(uint64_t limit);
   
   bool start_save_graph();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1215,14 +1215,6 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_fast_exit(const COMMAND_RPC_FAST_EXIT::request& req, COMMAND_RPC_FAST_EXIT::response& res)
-  {
-	  cryptonote::core::set_fast_exit();
-	  m_p2p.deinit();
-	  m_core.deinit();
-	  return true;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_out_peers(const COMMAND_RPC_OUT_PEERS::request& req, COMMAND_RPC_OUT_PEERS::response& res)
   {
 	  // TODO

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -94,7 +94,6 @@ namespace cryptonote
       MAP_URI_AUTO_JON2("/get_transaction_pool", on_get_transaction_pool, COMMAND_RPC_GET_TRANSACTION_POOL)
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
-      MAP_URI_AUTO_JON2_IF("/fast_exit", on_fast_exit, COMMAND_RPC_FAST_EXIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/start_save_graph", on_start_save_graph, COMMAND_RPC_START_SAVE_GRAPH, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/stop_save_graph", on_stop_save_graph, COMMAND_RPC_STOP_SAVE_GRAPH, !m_restricted)
@@ -138,7 +137,6 @@ namespace cryptonote
     bool on_set_log_level(const COMMAND_RPC_SET_LOG_LEVEL::request& req, COMMAND_RPC_SET_LOG_LEVEL::response& res);
     bool on_get_transaction_pool(const COMMAND_RPC_GET_TRANSACTION_POOL::request& req, COMMAND_RPC_GET_TRANSACTION_POOL::response& res);
     bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
-    bool on_fast_exit(const COMMAND_RPC_FAST_EXIT::request& req, COMMAND_RPC_FAST_EXIT::response& res);
     bool on_out_peers(const COMMAND_RPC_OUT_PEERS::request& req, COMMAND_RPC_OUT_PEERS::response& res);
     bool on_start_save_graph(const COMMAND_RPC_START_SAVE_GRAPH::request& req, COMMAND_RPC_START_SAVE_GRAPH::response& res);
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);


### PR DESCRIPTION
As per @moneromooo-monero's suggestion way back in #592

Also removed detach_threads() in `contrib/epee/include/net/abstract_tcp_server2.inl` which was only called in response to fast_exit