### PR TITLE
Prevent users naming wallets 'quit', 'logout' or 'exit'

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -885,6 +885,11 @@ bool simple_wallet::ask_wallet_create_if_needed()
     {
       return false;
     }
+    bool protected_name = tools::wallet2::wallet_protected_name(wallet_path);
+    if (protected_name)
+    {
+      return false;
+    }
     valid_path = tools::wallet2::wallet_valid_path_format(wallet_path);
     if (!valid_path)
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1758,6 +1758,18 @@ bool wallet2::wallet_valid_path_format(const std::string& file_path)
   return !file_path.empty();
 }
 //----------------------------------------------------------------------------------------------------
+bool wallet2::wallet_protected_name(const std::string& file_path)
+{
+  std::string s = file_path;
+  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+  if(s == "exit" || s == "logout" || s == "quit" || s == "")
+  {
+    LOG_PRINT_L1("Terminating monero-wallet-cli after " << s << " command received");
+    return true;
+  }
+  return false;
+}
+//----------------------------------------------------------------------------------------------------
 bool wallet2::parse_long_payment_id(const std::string& payment_id_str, crypto::hash& payment_id)
 {
   cryptonote::blobdata payment_id_data;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -423,6 +423,12 @@ namespace tools
      * \return                Whether path is valid format
      */
     static bool wallet_valid_path_format(const std::string& file_path);
+    /*!
+     * \brief  Check if wallet file name is protected i.e. 'logout' or 'exit'
+     * \param  file_path      Wallet file path
+     * \return                Whether the value is one of the protected values
+     */
+    static bool wallet_protected_name(const std::string& file_path);
 
     static bool parse_long_payment_id(const std::string& payment_id_str, crypto::hash& payment_id);
     static bool parse_short_payment_id(const std::string& payment_id_str, crypto::hash8& payment_id);


### PR DESCRIPTION
Quits to command line if the user types 'quit', 'logout' or 'exit' when asked for a wallet name.

Would be nice to abstract this behaviour into an 'isProtected()' function which could check any user entries against a master word/address list to check we're not overwriting wallet files with log file names or naming our wallets after monero files or other stupid behaviour.

Never underestimate the value of protecting the user against themselves ;)