### PR TITLE
Change default dust threshold to equal current fee per kb

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -127,7 +127,7 @@ namespace config
 {
   uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 500; // Just a placeholder!  Change me!
   uint8_t const FEE_CALCULATION_MAX_RETRIES = 10;
-  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)10000000000); // pow(10, 10)
+  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)2000000000); // 2 * pow(10, 9)
   uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)
   std::string const P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
 


### PR DESCRIPTION
Currently dust threshold is 0.01, which means often you can end up paying a much higher fee than that the current 0.002 fee per kb.  I suggest bringing the dust threshold down to equal the fee per kb.