### PR TITLE
fixed 'typo' in flag for aarch64/armv8

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ By default, in either dynamically or statically linked builds, binaries target t
 
 * ```make release-static-64``` builds binaries on Linux on x86_64 portable across POSIX systems on x86_64 processors
 * ```make release-static-32``` builds binaries on Linux on x86_64 or i686 portable across POSIX systems on i686 processors
-* ```make release-static-arm8``` builds binaries on Linux on armv8 portable across POSIX systems on armv8 processors
+* ```make release-static-armv8``` builds binaries on Linux on armv8 portable across POSIX systems on armv8 processors
 * ```make release-static-arm7``` builds binaries on Linux on armv7 portable across POSIX systems on armv7 processors
 * ```make release-static-arm6``` builds binaries on Linux on armv7 or armv6 portable across POSIX systems on armv6 processors, such as the Raspberry Pi
 * ```make release-static-win64``` builds binaries on 64-bit Windows portable across 64-bit Windows systems


### PR DESCRIPTION
There is no make rule for 'arm8' - the rule is for 'armv8'.

This is however inconsistent with the other ARM build rules, but those are technically incorrectly named since ARM6, ARM7, and ARM8 are architectures from the 90s and the modern ARM chips that comprise the Cortex product line are named ARMv6, ARMv7 and ARMv8.

https://en.wikipedia.org/wiki/List_of_ARM_microarchitectures

Suggest also renaming rules for ARMv6 and ARMv7 to maintain consistency with ARM's naming scheme.