### PR TITLE
wallet_api: do not override invalid payment id

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -360,7 +360,7 @@ std::string WalletImpl::integratedAddress(const std::string &payment_id) const
 {
     crypto::hash8 pid;
     if (!tools::wallet2::parse_short_payment_id(payment_id, pid)) {
-        pid = crypto::rand<crypto::hash8>();
+        return "";
     }
     return m_wallet->get_account().get_public_integrated_address_str(pid, m_wallet->testnet());
 }


### PR DESCRIPTION
Instead, return an empty string to mark the error

NOTE: see https://github.com/monero-project/monero-core/issues/64 because it might break assumptions in the GUI code, need mbg033 to reply first.