### PR TITLE
wallet_api: add address validation functions

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -162,6 +162,26 @@ bool Wallet::paymentIdValid(const string &paiment_id)
     return tools::wallet2::parse_short_payment_id(paiment_id, pid);
 }
 
+bool Wallet::addressValid(const std::string &str, bool testnet)
+{
+  bool has_payment_id;
+  cryptonote::account_public_address address;
+  crypto::hash8 pid;
+  return get_account_integrated_address_from_str(address, has_payment_id, pid, testnet, str);
+}
+
+std::string Wallet::paymentIdFromAddress(const std::string &str, bool testnet)
+{
+  bool has_payment_id;
+  cryptonote::account_public_address address;
+  crypto::hash8 pid;
+  if (!get_account_integrated_address_from_str(address, has_payment_id, pid, testnet, str))
+    return "";
+  if (!has_payment_id)
+    return "";
+  return epee::string_tools::pod_to_hex(pid);
+}
+
 uint64_t Wallet::maximumAllowedAmount()
 {
     return std::numeric_limits<uint64_t>::max();

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -280,6 +280,8 @@ struct Wallet
     static uint64_t amountFromDouble(double amount);
     static std::string genPaymentId();
     static bool paymentIdValid(const std::string &paiment_id);
+    static bool addressValid(const std::string &str, bool testnet);
+    static std::string paymentIdFromAddress(const std::string &str, bool testnet);
     static uint64_t maximumAllowedAmount();
 
     /**


### PR DESCRIPTION
The payment id from integrated addresses is also parsed