### PR TITLE
Convert m_testnet to int before passing to C functions

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3765,14 +3765,14 @@ std::map<uint64_t, std::tuple<uint64_t, uint64_t, uint64_t>> Blockchain:: get_ou
 #if defined(PER_BLOCK_CHECKPOINT)
 void Blockchain::load_compiled_in_block_hashes()
 {
-  if (m_fast_sync && get_blocks_dat_start(m_testnet) != nullptr)
+  if (m_fast_sync && get_blocks_dat_start((int)m_testnet) != nullptr)
   {
-    if (get_blocks_dat_size(m_testnet) > 4)
+    if (get_blocks_dat_size((int)m_testnet) > 4)
     {
-      const unsigned char *p = get_blocks_dat_start(m_testnet);
+      const unsigned char *p = get_blocks_dat_start((int)m_testnet);
       const uint32_t nblocks = *p | ((*(p+1))<<8) | ((*(p+2))<<16) | ((*(p+3))<<24);
       const size_t size_needed = 4 + nblocks * sizeof(crypto::hash);
-      if(nblocks > 0 && nblocks > m_db->height() && get_blocks_dat_size(m_testnet) >= size_needed)
+      if(nblocks > 0 && nblocks > m_db->height() && get_blocks_dat_size((int)m_testnet) >= size_needed)
       {
         LOG_PRINT_L0("Loading precomputed blocks: " << nblocks);
         p += sizeof(uint32_t);


### PR DESCRIPTION
Bit of a hacky change to try to address #1256 and #1131 by converting the `bool m_testnet` to an `int` before passing into the C functions of `blockexports.c`

If this solves it for people on RPi 2's & other ARMv7 devices, perhaps someone more skilled could try to address this code portability issue and #355 at the same time?