### PR TITLE
wallet: fix pre-rct cold wallet signing not splitting change

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3246,7 +3246,7 @@ bool simple_wallet::submit_transfer(const std::vector<std::string> &args_)
         if (dust_in_fee != 0) prompt << boost::format(tr(", of which %s is dust from change")) % print_money(dust_in_fee);
         if (dust_not_in_fee != 0)  prompt << tr(".") << ENDL << boost::format(tr("A total of %s from dust change will be sent to dust address"))
                                                    % print_money(dust_not_in_fee);
-        prompt << tr(".") << ENDL << tr("Is this okay?  (Y/Yes/N/No)");
+        prompt << tr(".") << ENDL << "Full transaction details are available in the log file" << ENDL << tr("Is this okay?  (Y/Yes/N/No)");
 
         std::string accepted = command_line::input_line(prompt.str());
         if (std::cin.eof())

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2706,7 +2706,8 @@ bool wallet2::load_tx(const std::string &signed_filename, std::vector<tools::wal
     LOG_PRINT_L0("Failed to parse data from " << signed_filename);
     return false;
   }
-  LOG_PRINT_L1("Loaded signed tx data from binary: " << signed_txs.ptx.size() << " transactions");
+  LOG_PRINT_L0("Loaded signed tx data from binary: " << signed_txs.ptx.size() << " transactions");
+  for (auto &ptx: signed_txs.ptx) LOG_PRINT_L0(cryptonote::obj_to_json_str(ptx.tx));
 
   ptx = signed_txs.ptx;
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -154,16 +154,18 @@ namespace tools
     struct tx_construction_data
     {
       std::vector<cryptonote::tx_source_entry> sources;
-      std::vector<cryptonote::tx_destination_entry> destinations;
       cryptonote::tx_destination_entry change_dts;
+      std::vector<cryptonote::tx_destination_entry> splitted_dsts;
+      std::list<size_t> selected_transfers;
       std::vector<uint8_t> extra;
       uint64_t unlock_time;
       bool use_rct;
 
       BEGIN_SERIALIZE_OBJECT()
         FIELD(sources)
-        FIELD(destinations)
         FIELD(change_dts)
+        FIELD(splitted_dsts)
+        FIELD(selected_transfers)
         FIELD(extra)
         VARINT_FIELD(unlock_time)
         FIELD(use_rct)
@@ -930,8 +932,9 @@ namespace tools
     ptx.tx_key = tx_key;
     ptx.dests = dsts;
     ptx.construction_data.sources = sources;
-    ptx.construction_data.destinations = dsts;
     ptx.construction_data.change_dts = change_dts;
+    ptx.construction_data.splitted_dsts = splitted_dsts;
+    ptx.construction_data.selected_transfers = selected_transfers;
     ptx.construction_data.extra = tx.extra;
     ptx.construction_data.unlock_time = unlock_time;
     ptx.construction_data.use_rct = false;


### PR DESCRIPTION
Re-creating the transaction on the cold wallet was not splitting
the change, causing the transaction to be rejected by the network.
This worked on testnet since amounts do not have to be split.