### PR TITLE
fluffy-blocks-p2p-bit-flags

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -111,6 +111,9 @@
 #define P2P_IP_FAILS_BEFORE_BLOCK                       10
 #define P2P_IDLE_CONNECTION_KILL_INTERVAL               (5*60) //5 minutes
 
+#define P2P_SUPPORT_FLAG_FLUFFY_BLOCKS                  0x01
+#define P2P_SUPPORT_FLAGS                               P2P_SUPPORT_FLAG_FLUFFY_BLOCKS
+
 #define ALLOW_DEBUG_COMMANDS
 
 #define CRYPTONOTE_NAME                         "bitmonero"

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -915,6 +915,11 @@ namespace cryptonote
     m_mempool.get_transactions(txs);
     return true;
   }
+  //-----------------------------------------------------------------------------------------------  
+  bool core::get_pool_transaction(const crypto::hash &id, transaction& tx) const
+  {
+    return m_mempool.get_transaction(id, tx);
+  }  
   //-----------------------------------------------------------------------------------------------
   bool core::get_pool_transactions_and_spent_keys_info(std::vector<tx_info>& tx_infos, std::vector<spent_key_image_info>& key_image_infos) const
   {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -379,6 +379,13 @@ namespace cryptonote
       * @note see tx_memory_pool::get_transactions
       */
      bool get_pool_transactions(std::list<transaction>& txs) const;
+     
+     /**
+      * @copydoc tx_memory_pool::get_transaction
+      *
+      * @note see tx_memory_pool::get_transaction
+      */
+     bool get_pool_transaction(const crypto::hash& id, transaction& tx) const;     
 
      /**
       * @copydoc tx_memory_pool::get_pool_transactions_and_spent_keys_info
@@ -611,6 +618,13 @@ namespace cryptonote
       * @return the number of blocks to sync in one go
       */
      std::pair<uint64_t, uint64_t> get_coinbase_tx_sum(const uint64_t start_offset, const size_t count);
+     
+     /**
+      * @brief get whether we're on testnet or not
+      *
+      * @return are we on testnet?
+      */     
+     bool get_testnet() const { return m_testnet; };
 
    private:
 

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -69,6 +69,8 @@ namespace cryptonote
 	
 	uint64_t avg_upload;
 	uint64_t current_upload;
+  
+	uint32_t support_flags;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(incoming)
@@ -87,6 +89,7 @@ namespace cryptonote
       KV_SERIALIZE(current_download)
       KV_SERIALIZE(avg_upload)
       KV_SERIALIZE(current_upload)
+      KV_SERIALIZE(support_flags)
     END_KV_SERIALIZE_MAP()
   };
 
@@ -223,5 +226,49 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+  
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_NEW_FLUFFY_BLOCK
+  {
+    const static int ID = BC_COMMANDS_POOL_BASE + 8;
 
+    struct request
+    {
+      block_complete_entry b;
+      uint64_t current_blockchain_height;
+      uint32_t hop;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(b)
+        KV_SERIALIZE(current_blockchain_height)
+        KV_SERIALIZE(hop)
+      END_KV_SERIALIZE_MAP()
+    };
+  };  
+
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_REQUEST_FLUFFY_MISSING_TX
+  {
+    const static int ID = BC_COMMANDS_POOL_BASE + 9;
+
+    struct request
+    {
+      block_complete_entry b;
+      uint64_t current_blockchain_height;      
+      std::vector<size_t> missing_tx_indices;
+      uint32_t hop;
+      
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(b)
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(missing_tx_indices)        
+        KV_SERIALIZE(hop)   
+        KV_SERIALIZE(current_blockchain_height)     
+      END_KV_SERIALIZE_MAP()
+    };
+  }; 
+    
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -91,6 +91,8 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_GET_OBJECTS, &cryptonote_protocol_handler::handle_response_get_objects)
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_CHAIN, &cryptonote_protocol_handler::handle_request_chain)
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_CHAIN_ENTRY, &cryptonote_protocol_handler::handle_response_chain_entry)
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)			
+      HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)						
     END_INVOKE_MAP2()
 
     bool on_idle();
@@ -115,8 +117,9 @@ namespace cryptonote
     int handle_response_get_objects(int command, NOTIFY_RESPONSE_GET_OBJECTS::request& arg, cryptonote_connection_context& context);
     int handle_request_chain(int command, NOTIFY_REQUEST_CHAIN::request& arg, cryptonote_connection_context& context);
     int handle_response_chain_entry(int command, NOTIFY_RESPONSE_CHAIN_ENTRY::request& arg, cryptonote_connection_context& context);
-
-
+    int handle_notify_new_fluffy_block(int command, NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& context);
+    int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
+		
     //----------------- i_bc_protocol_layout ---------------------------------------
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -404,6 +404,7 @@ bool t_rpc_command_executor::print_connections() {
 
   tools::msg_writer() << std::setw(30) << std::left << "Remote Host"
       << std::setw(20) << "Peer id"
+      << std::setw(20) << "Support Flags"      
       << std::setw(30) << "Recv/Sent (inactive,sec)"
       << std::setw(25) << "State"
       << std::setw(20) << "Livetime(sec)"
@@ -422,6 +423,7 @@ bool t_rpc_command_executor::print_connections() {
      //<< std::setw(30) << std::left << in_out
      << std::setw(30) << std::left << address
      << std::setw(20) << info.peer_id
+     << std::setw(20) << info.support_flags
      << std::setw(30) << std::to_string(info.recv_count) + "("  + std::to_string(info.recv_idle_time) + ")/" + std::to_string(info.send_count) + "(" + std::to_string(info.send_idle_time) + ")"
      << std::setw(25) << info.state
      << std::setw(20) << info.live_time

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -63,6 +63,7 @@ namespace nodetool
   struct p2p_connection_context_t: base_type //t_payload_net_handler::connection_context //public net_utils::connection_context_base
   {
     peerid_type peer_id;
+    uint32_t support_flags;
   };
 
   template<class t_payload_net_handler>
@@ -146,6 +147,7 @@ namespace nodetool
       HANDLE_INVOKE_T2(COMMAND_REQUEST_NETWORK_STATE, &node_server::handle_get_network_state)
       HANDLE_INVOKE_T2(COMMAND_REQUEST_PEER_ID, &node_server::handle_get_peer_id)
 #endif
+      HANDLE_INVOKE_T2(COMMAND_REQUEST_SUPPORT_FLAGS, &node_server::handle_get_support_flags)
       CHAIN_INVOKE_MAP_TO_OBJ_FORCE_CONTEXT(m_payload_handler, typename t_payload_net_handler::connection_context&)
     END_INVOKE_MAP2()
 
@@ -158,6 +160,7 @@ namespace nodetool
     int handle_get_network_state(int command, COMMAND_REQUEST_NETWORK_STATE::request& arg, COMMAND_REQUEST_NETWORK_STATE::response& rsp, p2p_connection_context& context);
     int handle_get_peer_id(int command, COMMAND_REQUEST_PEER_ID::request& arg, COMMAND_REQUEST_PEER_ID::response& rsp, p2p_connection_context& context);
 #endif
+    int handle_get_support_flags(int command, COMMAND_REQUEST_SUPPORT_FLAGS::request& arg, COMMAND_REQUEST_SUPPORT_FLAGS::response& rsp, p2p_connection_context& context);
     bool init_config();
     bool make_default_config();
     bool store_config();
@@ -174,7 +177,7 @@ namespace nodetool
     virtual bool invoke_notify_to_peer(int command, const std::string& req_buff, const epee::net_utils::connection_context_base& context);
     virtual bool drop_connection(const epee::net_utils::connection_context_base& context);
     virtual void request_callback(const epee::net_utils::connection_context_base& context);
-    virtual void for_each_connection(std::function<bool(typename t_payload_net_handler::connection_context&, peerid_type)> f);
+    virtual void for_each_connection(std::function<bool(typename t_payload_net_handler::connection_context&, peerid_type, uint32_t)> f);
     virtual bool add_ip_fail(uint32_t address);
     //----------------- i_connection_filter  --------------------------------------------------------
     virtual bool is_remote_ip_allowed(uint32_t adress);
@@ -204,6 +207,7 @@ namespace nodetool
     bool is_addr_connected(const net_address& peer);
     template<class t_callback>
     bool try_ping(basic_node_data& node_data, p2p_connection_context& context, t_callback cb);
+    bool try_get_support_flags(const p2p_connection_context& context, std::function<void(p2p_connection_context&, const uint32_t&)> f);
     bool make_expected_connections_count(bool white_list, size_t expected_connections);
     void cache_connect_fail_info(const net_address& addr);
     bool is_addr_recently_failed(const net_address& addr);
@@ -240,10 +244,12 @@ namespace nodetool
     {
       network_config m_net_config;
       uint64_t m_peer_id;
+      uint32_t m_support_flags;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(m_net_config)
         KV_SERIALIZE(m_peer_id)
+        KV_SERIALIZE(m_support_flags)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -49,7 +49,7 @@ namespace nodetool
     virtual bool drop_connection(const epee::net_utils::connection_context_base& context)=0;
     virtual void request_callback(const epee::net_utils::connection_context_base& context)=0;
     virtual uint64_t get_connections_count()=0;
-    virtual void for_each_connection(std::function<bool(t_connection_context&, peerid_type)> f)=0;
+    virtual void for_each_connection(std::function<bool(t_connection_context&, peerid_type, uint32_t)> f)=0;
     virtual bool block_ip(uint32_t adress, time_t seconds = 0)=0;
     virtual bool unblock_ip(uint32_t adress)=0;
     virtual std::map<uint32_t, time_t> get_blocked_ips()=0;
@@ -79,7 +79,7 @@ namespace nodetool
     {
 
     }
-    virtual void for_each_connection(std::function<bool(t_connection_context&,peerid_type)> f)
+    virtual void for_each_connection(std::function<bool(t_connection_context&,peerid_type,uint32_t)> f)
     {
 
     }

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -332,6 +332,29 @@ namespace nodetool
     };
   };
 
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct COMMAND_REQUEST_SUPPORT_FLAGS
+  {
+    const static int ID = P2P_COMMANDS_POOL_BASE + 7;
+
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()    
+    };
+
+    struct response
+    {
+      uint32_t support_flags;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(support_flags)
+      END_KV_SERIALIZE_MAP()    
+    };
+  };
+  
 #endif
 
 


### PR DESCRIPTION
Pretty much same as #1242, but fixed up the p2p stuff so that it works with current release nodes. In the previous version I altered the existing handshake, etc structs to send extra data, so it didn't play nice with current nodes. The new one has an extra trip/call for support flags on handshake. If you run this against current release nodes you will see a bunch of errors, but it should be fine, it's just the "get_support_flags" command failing since release nodes don't have it. 
