### PR TITLE
Spelling in epee

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,8 @@ find_package(Boost 1.58 QUIET REQUIRED COMPONENTS system filesystem thread date_
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${OLD_LIB_SUFFIXES})
 if(NOT Boost_FOUND)
   die("Could not find Boost libraries, please make sure you have installed Boost or libboost-all-dev (1.58) or the equivalent")
+elseif(Boost_FOUND)
+  message(STATUS "Found Boost Version: ${Boost_VERSION}")
 endif()
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -281,7 +281,7 @@ namespace epee
 
 
 #define END_INVOKE_MAP2() \
-  LOG_ERROR("Unkonown command:" << command); \
+  LOG_ERROR("Unknown command:" << command); \
   return LEVIN_ERROR_CONNECTION_HANDLER_NOT_DEFINED; \
   }
   }


### PR DESCRIPTION
We're going to see more of these 'Unknown error: 1007' as Fluffy block nodes become more common and this little spelling error was making my eye twitch every time I saw it... 