### PR TITLE
Changed ..._HASH_BITS to ..._HASHBITS as expected

### DIFF
--- a/src/crypto/skein.c
+++ b/src/crypto/skein.c
@@ -77,7 +77,7 @@ typedef struct                               /* 1024-bit Skein hash context stru
 } Skein1024_Ctxt_t;
 
 /*   Skein APIs for (incremental) "straight hashing" */
-#if SKEIN_256_NIST_MAX_HASH_BITS
+#if SKEIN_256_NIST_MAX_HASHBITS
 static int  Skein_256_Init  (Skein_256_Ctxt_t *ctx, size_t hashBitLen);
 #endif
 static int  Skein_512_Init  (Skein_512_Ctxt_t *ctx, size_t hashBitLen);
@@ -1941,7 +1941,7 @@ static HashReturn Final (hashState *state,       BitSequence *hashval);
 /* select the context size and init the context */
 static HashReturn Init(hashState *state, int hashbitlen)
 {
-#if SKEIN_256_NIST_MAX_HASH_BITS
+#if SKEIN_256_NIST_MAX_HASHBITS
   if (hashbitlen <= SKEIN_256_NIST_MAX_HASHBITS)
   {
     Skein_Assert(hashbitlen > 0,BAD_HASHLEN);


### PR DESCRIPTION
How much of an issue is it that the 256-bit skein pathway never runs (prior to this PR)?
