### PR TITLE
wallet: fix output collision detection for view wallets

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -236,6 +236,6 @@ namespace crypto {
   }
 }
 
-CRYPTO_MAKE_COMPARABLE(public_key)
+CRYPTO_MAKE_HASHABLE(public_key)
 CRYPTO_MAKE_HASHABLE(key_image)
 CRYPTO_MAKE_COMPARABLE(signature)


### PR DESCRIPTION
GIVE LUIGI TIME TO DOUBLE CHECK FIRST PLEASE

View wallets do not have the spend secret key, and are thus
unable to derive key images for incoming outputs. Moreover,
a previous patch set key images to zero as a means to mark
an output as having an unknown key image, so they could be
filled in when importing key images at a later time. That
later patch caused spurious collisions. We now use public
keys to detect duplicate outputs. Public keys obtained from
the blockchain are checked to be identical to the ones
derived locally, so can't be spoofed.