### PR TITLE
cryptonote_protocol: drop connection when find_blockchain_supplement …

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -622,6 +622,7 @@ namespace cryptonote
     if(!m_core.find_blockchain_supplement(arg.block_ids, r))
     {
       LOG_ERROR_CCONTEXT("Failed to handle NOTIFY_REQUEST_CHAIN.");
+      m_p2p->drop_connection(context);
       return 1;
     }
     LOG_PRINT_CCONTEXT_L2("-->>NOTIFY_RESPONSE_CHAIN_ENTRY: m_start_height=" << r.start_height << ", m_total_height=" << r.total_height << ", m_block_ids.size()=" << r.m_block_ids.size());


### PR DESCRIPTION
…fails

This will be when we can't find common ground between the peer's
short chain history and our blockchain.

This fixes bad peers claiming a higher blockchain height from never
dropped, and keeping the node in synchronizing state forever, since
we will never get blocks from that peer.