### PR TITLE
rpc: bump RPC version

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -41,7 +41,7 @@ namespace cryptonote
 #define CORE_RPC_STATUS_BUSY   "BUSY"
 #define CORE_RPC_STATUS_NOT_MINING "NOT MINING"
 
-#define CORE_RPC_VERSION 3
+#define CORE_RPC_VERSION 4
 
   struct COMMAND_RPC_GET_HEIGHT
   {


### PR DESCRIPTION
I forgot to bump it previously when changing RPC, most notably
for the addition of the unlocked field in the histogram RPC.
This causes new wallets to not realize when they're talking to
an older daemon, and get confused trying to get outputs to use
as fake outs. This otherwise gratuitous bump ensures than old
daemons will be detected by wallets using this code.