### PR TITLE
Stripped BerkeleyDB references from CMakeLists.txt and changed README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,59 +212,10 @@ if(STATIC)
   endif()
 endif()
 
-# default database:
-# should be lmdb for testing, memory for production still
-# set(DATABASE memory)
-set(DATABASE lmdb)
-
-if (DEFINED ENV{DATABASE})
-  set(DATABASE $ENV{DATABASE})
-  message(STATUS "DATABASE set: ${DATABASE}")
-else()
-  message(STATUS "Could not find DATABASE in env (not required unless you want to change database type from default: ${DATABASE})")
-endif()
-
-set(BERKELEY_DB_OVERRIDE 0)
-if (DEFINED ENV{BERKELEY_DB})
-  set(BERKELEY_DB_OVERRIDE 1)
-  set(BERKELEY_DB $ENV{BERKELEY_DB})
-elseif()
-  set(BERKELEY_DB 0)
-endif()
-
-if (DATABASE STREQUAL "lmdb")
-  message(STATUS "Using LMDB as default DB type")
-  set(BLOCKCHAIN_DB DB_LMDB)
-  add_definitions("-DDEFAULT_DB_TYPE=\"lmdb\"")
-elseif (DATABASE STREQUAL "berkeleydb")
-  find_package(BerkeleyDB)
-  if(NOT BERKELEY_DB)
-      die("Found BerkeleyDB includes, but could not find BerkeleyDB library. Please make sure you have installed libdb and libdb-dev / libdb++-dev or the equivalent.")
-  else()
-    message(STATUS "Found BerkeleyDB include (db.h) in ${BERKELEY_DB_INCLUDE_DIR}")
-    if(BERKELEY_DB_LIBRARIES)
-      message(STATUS "Found BerkeleyDB shared library")
-      set(BDB_STATIC false CACHE BOOL "BDB Static flag")
-      set(BDB_INCLUDE ${BERKELEY_DB_INCLUDE_DIR} CACHE STRING "BDB include path")
-      set(BDB_LIBRARY ${BERKELEY_DB_LIBRARIES} CACHE STRING "BDB library name")
-      set(BDB_LIBRARY_DIRS "" CACHE STRING "BDB Library dirs")
-      set(BERKELEY_DB 1)
-    else()
-      die("Found BerkeleyDB includes, but could not find BerkeleyDB library. Please make sure you have installed libdb and libdb-dev / libdb++-dev or the equivalent.")
-    endif()
-  endif()
-
-  message(STATUS "Using Berkeley DB as default DB type")
-  add_definitions("-DDEFAULT_DB_TYPE=\"berkeley\"")
-else()
-  die("Invalid database type: ${DATABASE}")
-endif()
-
-if(BERKELEY_DB)
-  add_definitions("-DBERKELEY_DB")
-endif()
-
-add_definitions("-DBLOCKCHAIN_DB=${BLOCKCHAIN_DB}")
+#The database type is LMDB
+message(STATUS "Using LMDB for the blockchain database")
+add_definitions("-DDEFAULT_DB_TYPE=\"lmdb\"")
+add_definitions("-DBLOCKCHAIN_DB=DB_LMDB")
 
 find_package(Libunwind)
 # Can't install hook in static build on OSX, because OSX linker does not support --wrap
@@ -309,11 +260,6 @@ include_directories(external/rapidjson)
 
 # Final setup for liblmdb
 include_directories(${LMDB_INCLUDE})
-
-# Final setup for Berkeley DB
-if (BERKELEY_DB)
-  include_directories(${BDB_INCLUDE})
-endif()
 
 # Final setup for libunwind
 include_directories(${LIBUNWIND_INCLUDE})

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ library archives (`.a`).
 | CMake          | 3.0.0         | NO       | `cmake`            | `cmake`        | NO       |                |
 | pkg-config     | any           | NO       | `pkg-config`       | `base-devel`   | NO       |                |
 | Boost          | 1.58          | NO       | `libboost-all-dev` | `boost`        | NO       |                |
-| BerkeleyDB     | 4.8           | NO       | `libdb{,++}-dev`   | `db`           | NO       |                |
 | libevent       | 2.0           | NO       | `libevent-dev`     | `libevent`     | NO       |                |
 | libunbound     | 1.4.16        | YES      | `libunbound-dev`   | `unbound`      | NO       |                |
 | libminiupnpc   | 2.0           | YES      | `libminiupnpc-dev` | `miniupnpc`    | YES      | NAT punching   |
@@ -143,6 +142,7 @@ library archives (`.a`).
 | GTest          | 1.5           | YES      | `libgtest-dev`^    | `gtest`        | YES      | test suite     |
 | Doxygen        | any           | NO       | `doxygen`          | `doxygen`      | YES      | documentation  |
 | Graphviz       | any           | NO       | `graphviz`         | `graphviz`     | YES      | documentation  |
+| BerkeleyDB     | 4.8           | NO       | `libdb{,++}-dev`   | `db`           | YES      | Historic DB    |
 
 [^] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
 build the library binary manually.


### PR DESCRIPTION
We're not going to switch from LMDB, so lets remove some cruft here.

Next step is to strip Berkeley DB from elsewhere in the codebase

I've also updated README.md because I don't see the need for Berkeley DB in `blockchain_import`'s header files, but please let me know if I'm wrong here and BDB code is actually needed somewhere...

