### PR TITLE
Fixed generate-from-json bug introduced in 358e068

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1134,7 +1134,8 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     else if (!m_generate_from_json.empty())
     {
       m_wallet_file = m_generate_from_json;
-      if (!tools::wallet2::make_from_json(vm, m_wallet_file))
+      m_wallet = tools::wallet2::make_from_json(vm, m_wallet_file);
+      if (!m_wallet)
         return false;
     }
     else


### PR DESCRIPTION
Title says it all. It would be nice to unit test some these portions, but they could be difficult to add with the amount of reads from `stdin` ...