### PR TITLE
monero-wallet-cli: one-time address using unencrypted payment ID

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -2897,6 +2897,12 @@ void sc_mulsub(unsigned char *s, const unsigned char *a, const unsigned char *b,
   s[30] = s11 >> 9;
   s[31] = s11 >> 17;
 }
+void sc_mul(unsigned char *s, const unsigned char *a, const unsigned char *b) {
+  unsigned char zero[32], neg[32];
+  sc_0(zero);
+  sc_mulsub(neg, a, b, zero);
+  sc_sub(s, zero, neg);
+}
 
 /* Assumes that a != INT64_MIN */
 static int64_t signum(int64_t a) {

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -141,6 +141,7 @@ void sc_reduce32(unsigned char *);
 void sc_add(unsigned char *, const unsigned char *, const unsigned char *);
 void sc_sub(unsigned char *, const unsigned char *, const unsigned char *);
 void sc_mulsub(unsigned char *, const unsigned char *, const unsigned char *, const unsigned char *);
+void sc_mul(unsigned char *, const unsigned char *, const unsigned char *);
 int sc_check(const unsigned char *);
 int sc_isnonzero(const unsigned char *); /* Doesn't normalize */
 

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -135,6 +135,17 @@ namespace crypto {
     ge_p3_tobytes(&pub, &point);
     return true;
   }
+  bool crypto_ops::secret_key_mult_public_key(const secret_key &sec, const public_key &pub, public_key &result) {
+    ge_p3 point;
+    ge_p2 point2;
+    assert(sc_check(&sec) == 0);
+    if (ge_frombytes_vartime(&point, &pub) != 0) {
+      return false;
+    }
+    ge_scalarmult(&point2, &sec, &point);
+    ge_tobytes(&result, &point2);
+    return true;
+  }
 
   bool crypto_ops::generate_key_derivation(const public_key &key1, const secret_key &key2, key_derivation &derivation) {
     ge_p3 point;

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -88,7 +88,7 @@ namespace crypto {
     memcpy(&res, tmp, 32);
   }
 
-  static inline void hash_to_scalar(const void *data, size_t length, ec_scalar &res) {
+  void hash_to_scalar(const void *data, size_t length, ec_scalar &res) {
     cn_fast_hash(data, length, reinterpret_cast<hash &>(res));
     sc_reduce32(&res);
   }

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -94,6 +94,8 @@ namespace crypto {
   };
 #pragma pack(pop)
 
+  void hash_to_scalar(const void *data, size_t length, ec_scalar &res);
+
   static_assert(sizeof(ec_point) == 32 && sizeof(ec_scalar) == 32 &&
     sizeof(public_key) == 32 && sizeof(secret_key) == 32 &&
     sizeof(key_derivation) == 32 && sizeof(key_image) == 32 &&

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -111,6 +111,8 @@ namespace crypto {
     friend bool check_key(const public_key &);
     static bool secret_key_to_public_key(const secret_key &, public_key &);
     friend bool secret_key_to_public_key(const secret_key &, public_key &);
+    static bool secret_key_mult_public_key(const secret_key &, const public_key &, public_key &);
+    friend bool secret_key_mult_public_key(const secret_key &, const public_key &, public_key &);
     static bool generate_key_derivation(const public_key &, const secret_key &, key_derivation &);
     friend bool generate_key_derivation(const public_key &, const secret_key &, key_derivation &);
     static void derivation_to_scalar(const key_derivation &derivation, size_t output_index, ec_scalar &res);
@@ -168,6 +170,12 @@ namespace crypto {
    */
   inline bool secret_key_to_public_key(const secret_key &sec, public_key &pub) {
     return crypto_ops::secret_key_to_public_key(sec, pub);
+  }
+
+  /* Checks a private key and multiplies it to the given public key.
+   */
+  inline bool secret_key_mult_public_key(const secret_key &sec, const public_key &pub, public_key &result) {
+    return crypto_ops::secret_key_mult_public_key(sec, pub, result);
   }
 
   /* To generate an ephemeral key used to send money to:

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -217,9 +217,9 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
+  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, uint64_t received, crypto::secret_key* onetime_h, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
   {
-    if (onetime_h)
+    if (received == 2)
     {
       account_keys ack2;
       sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h);

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -217,6 +217,19 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
+  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
+  {
+    if (generate_key_image_helper(ack, tx_public_key, real_output_index, in_ephemeral, ki))
+      return true;
+    if (onetime_h_a_k) {
+      account_keys ack2;
+      sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h_a_k);
+      sc_mul((unsigned char*)&ack2.m_spend_secret_key, (const unsigned char*)&ack.m_spend_secret_key, (const unsigned char*)onetime_h_a_k);
+      crypto::secret_key_to_public_key(ack2.m_spend_secret_key, ack2.m_account_address.m_spend_public_key);
+      return generate_key_image_helper(ack2, tx_public_key, real_output_index, in_ephemeral, ki);
+    }
+  }
+  //---------------------------------------------------------------
   uint64_t power_integral(uint64_t a, uint64_t b)
   {
     if(b == 0)

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -219,16 +219,18 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
   {
-    if (generate_key_image_helper(ack, tx_public_key, real_output_index, in_ephemeral, ki))
-      return true;
-    if (onetime_h_a_k) {
+    if (onetime_h_a_k)
+    {
       account_keys ack2;
       sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h_a_k);
       sc_mul((unsigned char*)&ack2.m_spend_secret_key, (const unsigned char*)&ack.m_spend_secret_key, (const unsigned char*)onetime_h_a_k);
       crypto::secret_key_to_public_key(ack2.m_spend_secret_key, ack2.m_account_address.m_spend_public_key);
       return generate_key_image_helper(ack2, tx_public_key, real_output_index, in_ephemeral, ki);
     }
-    return false;
+    else
+    {
+      return generate_key_image_helper(ack, tx_public_key, real_output_index, in_ephemeral, ki);
+    }
   }
   //---------------------------------------------------------------
   uint64_t power_integral(uint64_t a, uint64_t b)

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -228,6 +228,7 @@ namespace cryptonote
       crypto::secret_key_to_public_key(ack2.m_spend_secret_key, ack2.m_account_address.m_spend_public_key);
       return generate_key_image_helper(ack2, tx_public_key, real_output_index, in_ephemeral, ki);
     }
+    return false;
   }
   //---------------------------------------------------------------
   uint64_t power_integral(uint64_t a, uint64_t b)

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -217,13 +217,13 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
+  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
   {
-    if (onetime_h_a_k)
+    if (onetime_h)
     {
       account_keys ack2;
-      sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h_a_k);
-      sc_mul((unsigned char*)&ack2.m_spend_secret_key, (const unsigned char*)&ack.m_spend_secret_key, (const unsigned char*)onetime_h_a_k);
+      sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h);
+      sc_mul((unsigned char*)&ack2.m_spend_secret_key, (const unsigned char*)&ack.m_spend_secret_key, (const unsigned char*)onetime_h);
       crypto::secret_key_to_public_key(ack2.m_spend_secret_key, ack2.m_account_address.m_spend_public_key);
       return generate_key_image_helper(ack2, tx_public_key, real_output_index, in_ephemeral, ki);
     }

--- a/src/cryptonote_core/cryptonote_format_utils.h
+++ b/src/cryptonote_core/cryptonote_format_utils.h
@@ -121,6 +121,7 @@ namespace cryptonote
   bool get_tx_fee(const transaction& tx, uint64_t & fee);
   uint64_t get_tx_fee(const transaction& tx);
   bool generate_key_image_helper(const account_keys& ack, const crypto::public_key& tx_public_key, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki);
+  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki);
   void get_blob_hash(const blobdata& blob, crypto::hash& res);
   crypto::hash get_blob_hash(const blobdata& blob);
   std::string short_hash_str(const crypto::hash& h);

--- a/src/cryptonote_core/cryptonote_format_utils.h
+++ b/src/cryptonote_core/cryptonote_format_utils.h
@@ -121,7 +121,7 @@ namespace cryptonote
   bool get_tx_fee(const transaction& tx, uint64_t & fee);
   uint64_t get_tx_fee(const transaction& tx);
   bool generate_key_image_helper(const account_keys& ack, const crypto::public_key& tx_public_key, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki);
-  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki);
+  bool generate_key_image_helper_onetime(const account_keys& ack, const crypto::public_key& tx_public_key, uint64_t received, crypto::secret_key* onetime_h_a_k, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki);
   void get_blob_hash(const blobdata& blob, crypto::hash& res);
   crypto::hash get_blob_hash(const blobdata& blob);
   std::string short_hash_str(const crypto::hash& h);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3529,6 +3529,31 @@ bool simple_wallet::print_onetime_address(const std::vector<std::string> &args/*
     crypto::generate_key_derivation(AB.m_view_public_key , h_a_k, reinterpret_cast<crypto::key_derivation&>(CD.m_view_public_key ));
     crypto::generate_key_derivation(AB.m_spend_public_key, h_a_k, reinterpret_cast<crypto::key_derivation&>(CD.m_spend_public_key));
     success_msg_writer() << tr("One-time address: ") << cryptonote::get_account_address_as_str(m_wallet->testnet(), CD);
+    ////////
+    // generate_key_image_helper(const account_keys& ack, const crypto::public_key& tx_public_key, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki)
+    // account_keys ack2;
+    // sc_mul((unsigned char*)&ack2.m_view_secret_key , (const unsigned char*)&ack.m_view_secret_key , (const unsigned char*)onetime_h_a_k);
+    // sc_mul((unsigned char*)&ack2.m_spend_secret_key, (const unsigned char*)&ack.m_spend_secret_key, (const unsigned char*)onetime_h_a_k);
+    // crypto::secret_key_to_public_key(ack2.m_spend_secret_key, ack2.m_account_address.m_spend_public_key);
+    // return generate_key_image_helper(ack2, tx_public_key, real_output_index, in_ephemeral, ki);
+    ////////
+    // check_acc_out_precomp(const crypto::public_key &spend_public_key, const tx_out &o, const crypto::key_derivation &derivation, size_t i, bool &received, uint64_t &money_transfered, bool &error)
+    // crypto::key_derivation derivation2, spend_public_key2;
+    // crypto::generate_key_derivation(reinterpret_cast<const crypto::public_key&>(derivation), *onetime_h_a_k, derivation2);
+    // crypto::generate_key_derivation(spend_public_key, *onetime_h_a_k, spend_public_key2);
+    // check_acc_out_precomp(reinterpret_cast<crypto::public_key&>(spend_public_key2), o, derivation2, i, received, money_transfered, error);
+    crypto::secret_key* onetime_h_a_k = &h_a_k;
+    ////////
+    crypto::secret_key spend_secret_key2;
+    sc_mul((unsigned char*)&spend_secret_key2, (const unsigned char*)&account_keys.m_spend_secret_key, (const unsigned char*)onetime_h_a_k);
+    sc_reduce32((unsigned char*)&spend_secret_key2);
+    crypto::public_key spend_public_key2;
+    crypto::secret_key_to_public_key(spend_secret_key2, spend_public_key2);
+    success_msg_writer() << tr("[debug] spend_public_key2: ") << spend_public_key2;
+    ////////
+    crypto::public_key spend_public_key3;
+    crypto::generate_key_derivation(account_keys.m_account_address.m_spend_public_key, *onetime_h_a_k, reinterpret_cast<crypto::key_derivation&>(spend_public_key3));
+    success_msg_writer() << tr("[debug] spend_public_key3: ") << spend_public_key3;
     return true;
   }
   fail_msg_writer() << tr("failed to generate valid one-time address after 65536 attempts");

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -662,6 +662,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("set_log", boost::bind(&simple_wallet::set_log, this, _1), tr("set_log <level> - Change current log detail level, <0-4>"));
   m_cmd_binder.set_handler("address", boost::bind(&simple_wallet::print_address, this, _1), tr("Show current wallet public address"));
   m_cmd_binder.set_handler("integrated_address", boost::bind(&simple_wallet::print_integrated_address, this, _1), tr("integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID"));
+  m_cmd_binder.set_handler("onetime_address", boost::bind(&simple_wallet::print_onetime_address, this, _1), tr("One-time address with random unencrypted payment ID"));
   m_cmd_binder.set_handler("save", boost::bind(&simple_wallet::save, this, _1), tr("Save wallet data"));
   m_cmd_binder.set_handler("save_watch_only", boost::bind(&simple_wallet::save_watch_only, this, _1), tr("Save a watch-only keys file"));
   m_cmd_binder.set_handler("viewkey", boost::bind(&simple_wallet::viewkey, this, _1), tr("Display private view key"));
@@ -3504,6 +3505,33 @@ bool simple_wallet::print_integrated_address(const std::vector<std::string> &arg
     }
   }
   fail_msg_writer() << tr("failed to parse payment ID or address");
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::print_onetime_address(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  for (int i = 0; i < 65536; ++i) {
+    crypto::hash k = crypto::rand<crypto::hash>();
+    const auto& account_keys = m_wallet->get_account().get_keys();
+    char data[2 * HASH_SIZE];
+    memcpy(data, &account_keys.m_view_secret_key, HASH_SIZE);
+    memcpy(data + HASH_SIZE, &k, HASH_SIZE);
+    crypto::secret_key h_a_k;
+    // somehow crypto::hash_to_scalar(const void *data, size_t length, ec_scalar &res) is not accessible from outside crypto.cpp
+      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(h_a_k));
+      sc_reduce32(reinterpret_cast<unsigned char *>(h_a_k.data));
+    // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
+    if (k.data[0] != h_a_k.data[0])
+      continue;
+    success_msg_writer() << tr("Random payment ID satisfying the equation (H(viewkey, pID) - pID) mod 256 == 0:\n") << k << tr("\n(found after ") << i << tr(" attempts)");
+    const auto& AB = account_keys.m_account_address;
+    cryptonote::account_public_address CD;
+    crypto::generate_key_derivation(AB.m_view_public_key , h_a_k, reinterpret_cast<crypto::key_derivation&>(CD.m_view_public_key ));
+    crypto::generate_key_derivation(AB.m_spend_public_key, h_a_k, reinterpret_cast<crypto::key_derivation&>(CD.m_spend_public_key));
+    success_msg_writer() << tr("One-time address: ") << cryptonote::get_account_address_as_str(m_wallet->testnet(), CD);
+    return true;
+  }
+  fail_msg_writer() << tr("failed to generate valid one-time address after 65536 attempts");
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3531,20 +3531,6 @@ bool simple_wallet::print_onetime_address(const std::vector<std::string> &args/*
     crypto::secret_key_mult_public_key(h, AB.m_view_public_key , CD.m_view_public_key );
     crypto::secret_key_mult_public_key(h, AB.m_spend_public_key, CD.m_spend_public_key);
     success_msg_writer() << tr("One-time address: \n") << cryptonote::get_account_address_as_str(m_wallet->testnet(), CD);
-    //////// debug ////////
-    crypto::public_key B = AB.m_spend_public_key;
-    //////// case 1: multiply scalars first, then derive
-    crypto::secret_key ha;
-    sc_mul((unsigned char*)&ha, (const unsigned char*)&h, (const unsigned char*)&a);
-    crypto::key_derivation haB_1;
-    crypto::generate_key_derivation(B, ha, haB_1);
-    success_msg_writer() << tr("[debug] haB_1: ") << haB_1;
-    //////// case 2: derive first, then multiply point by scalar
-    crypto::key_derivation aB;
-    crypto::generate_key_derivation(B, a, aB);
-    crypto::key_derivation haB_2;
-    crypto::secret_key_mult_public_key(h, reinterpret_cast<const crypto::public_key&>(aB), reinterpret_cast<crypto::public_key&>(haB_2));
-    success_msg_writer() << tr("[debug] haB_2: ") << haB_2;
     return true;
   }
   fail_msg_writer() << tr("failed to generate valid one-time address after 65536 attempts");

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3519,9 +3519,7 @@ bool simple_wallet::print_onetime_address(const std::vector<std::string> &args/*
     memcpy(data            , &a, HASH_SIZE);
     memcpy(data + HASH_SIZE, &k, HASH_SIZE);
     crypto::secret_key h;
-    // somehow crypto::hash_to_scalar(const void *data, size_t length, ec_scalar &res) is not accessible from outside crypto.cpp
-      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash&>(h));
-      sc_reduce32(reinterpret_cast<unsigned char *>(h.data));
+    crypto::hash_to_scalar(data, 2 * HASH_SIZE, reinterpret_cast<crypto::ec_scalar&>(h));
     // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
     if (k.data[0] != h.data[0])
       continue;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -131,6 +131,7 @@ namespace cryptonote
     );
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool print_integrated_address(const std::vector<std::string> &args = std::vector<std::string>());
+    bool print_onetime_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool save(const std::vector<std::string> &args);
     bool save_watch_only(const std::vector<std::string> &args);
     bool set_variable(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -559,15 +559,15 @@ void wallet2::check_acc_out_precomp(const crypto::public_key &spend_public_key, 
   error = false;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::check_acc_out_precomp_onetime(const crypto::public_key &spend_public_key, const tx_out &o, const crypto::key_derivation &derivation, crypto::secret_key* onetime_h_a_k, size_t i, bool &received, uint64_t &money_transfered, bool &error) const
+void wallet2::check_acc_out_precomp_onetime(const crypto::public_key &spend_public_key, const tx_out &o, const crypto::key_derivation &derivation, crypto::secret_key* onetime_h, size_t i, bool &received, uint64_t &money_transfered, bool &error) const
 {
   check_acc_out_precomp(spend_public_key, o, derivation, i, received, money_transfered, error);
-  if (!received && onetime_h_a_k)
+  if (!received && onetime_h)
   {
     crypto::public_key spend_public_key2;
     crypto::key_derivation derivation2;
-    crypto::secret_key_mult_public_key(*onetime_h_a_k, spend_public_key, spend_public_key2);
-    crypto::secret_key_mult_public_key(*onetime_h_a_k, reinterpret_cast<const crypto::public_key&>(derivation), reinterpret_cast<crypto::public_key&>(derivation2));
+    crypto::secret_key_mult_public_key(*onetime_h, spend_public_key, spend_public_key2);
+    crypto::secret_key_mult_public_key(*onetime_h, reinterpret_cast<const crypto::public_key&>(derivation), reinterpret_cast<crypto::public_key&>(derivation2));
     check_acc_out_precomp(spend_public_key2, o, derivation2, i, received, money_transfered, error);
   }
 }
@@ -641,18 +641,18 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
   find_tx_extra_field_by_type(tx_extra_fields, extra_nonce);
   crypto::hash payment_id = null_hash;
   bool has_unencrypted_payment_id = get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id);
-  crypto::secret_key onetime_h_a_k;
-  crypto::secret_key* onetime_h_a_k_ptr = nullptr;
+  crypto::secret_key onetime_h;
+  crypto::secret_key* onetime_h_ptr = nullptr;
   if (has_unencrypted_payment_id)
   {
     char data[2 * HASH_SIZE];
     memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
     memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-    crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h_a_k));
-    sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h_a_k.data));
+    crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
+    sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
     // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
-    if (payment_id.data[0] == onetime_h_a_k.data[0])
-      onetime_h_a_k_ptr = &onetime_h_a_k;
+    if (payment_id.data[0] == onetime_h.data[0])
+      onetime_h_ptr = &onetime_h;
   }
   
   // Don't try to extract tx public key if tx has no ouputs
@@ -663,7 +663,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
     {
       LOG_PRINT_L0("Public key wasn't found in the transaction extra. Skipping transaction " << txid());
       if(0 != m_callback)
-	m_callback->on_skip_transaction(height, tx);
+        m_callback->on_skip_transaction(height, tx);
       return;
     }
 
@@ -686,7 +686,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
     {
       uint64_t money_transfered = 0;
       bool error = false, received = false;
-      check_acc_out_precomp_onetime(keys.m_account_address.m_spend_public_key, tx.vout[0], derivation, onetime_h_a_k_ptr, 0, received, money_transfered, error);
+      check_acc_out_precomp_onetime(keys.m_account_address.m_spend_public_key, tx.vout[0], derivation, onetime_h_ptr, 0, received, money_transfered, error);
       if (error)
       {
         r = false;
@@ -696,7 +696,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
         // this assumes that the miner tx pays a single address
         if (received)
         {
-          cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_a_k_ptr, 0, in_ephemeral[0], ki[0]);
+          cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_ptr, 0, in_ephemeral[0], ki[0]);
           THROW_WALLET_EXCEPTION_IF(in_ephemeral[0].pub != boost::get<cryptonote::txout_to_key>(tx.vout[0].target).key,
               error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key");
 
@@ -724,7 +724,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
           // the first one was already checked
           for (size_t i = 1; i < tx.vout.size(); ++i)
           {
-            ioservice.dispatch(boost::bind(&wallet2::check_acc_out_precomp_onetime, this, std::cref(keys.m_account_address.m_spend_public_key), std::cref(tx.vout[i]), std::cref(derivation), std::ref(onetime_h_a_k_ptr), i,
+            ioservice.dispatch(boost::bind(&wallet2::check_acc_out_precomp_onetime, this, std::cref(keys.m_account_address.m_spend_public_key), std::cref(tx.vout[i]), std::cref(derivation), std::ref(onetime_h_ptr), i,
               std::ref(received[i]), std::ref(money_transfered[i]), std::ref(error[i])));
           }
           KILL_IOSERVICE();
@@ -737,7 +737,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
             }
             if (received[i])
             {
-              cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_a_k_ptr, i, in_ephemeral[i], ki[i]);
+              cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_ptr, i, in_ephemeral[i], ki[i]);
               THROW_WALLET_EXCEPTION_IF(in_ephemeral[i].pub != boost::get<cryptonote::txout_to_key>(tx.vout[i].target).key,
                   error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key");
 
@@ -769,7 +769,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
       std::deque<bool> received(tx.vout.size());
       for (size_t i = 0; i < tx.vout.size(); ++i)
       {
-        ioservice.dispatch(boost::bind(&wallet2::check_acc_out_precomp_onetime, this, std::cref(keys.m_account_address.m_spend_public_key), std::cref(tx.vout[i]), std::cref(derivation), std::ref(onetime_h_a_k_ptr), i,
+        ioservice.dispatch(boost::bind(&wallet2::check_acc_out_precomp_onetime, this, std::cref(keys.m_account_address.m_spend_public_key), std::cref(tx.vout[i]), std::cref(derivation), std::ref(onetime_h_ptr), i,
           std::ref(received[i]), std::ref(money_transfered[i]), std::ref(error[i])));
       }
       KILL_IOSERVICE();
@@ -783,7 +783,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
         }
         if (received[i])
         {
-          cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_a_k_ptr, i, in_ephemeral[i], ki[i]);
+          cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_ptr, i, in_ephemeral[i], ki[i]);
           THROW_WALLET_EXCEPTION_IF(in_ephemeral[i].pub != boost::get<cryptonote::txout_to_key>(tx.vout[i].target).key,
               error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key");
 
@@ -804,7 +804,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
       {
         uint64_t money_transfered = 0;
         bool error = false, received = false;
-        check_acc_out_precomp_onetime(keys.m_account_address.m_spend_public_key, tx.vout[i], derivation, onetime_h_a_k_ptr, i, received, money_transfered, error);
+        check_acc_out_precomp_onetime(keys.m_account_address.m_spend_public_key, tx.vout[i], derivation, onetime_h_ptr, i, received, money_transfered, error);
         if (error)
         {
           r = false;
@@ -814,7 +814,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
         {
           if (received)
           {
-            cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_a_k_ptr, i, in_ephemeral[i], ki[i]);
+            cryptonote::generate_key_image_helper_onetime(keys, tx_pub_key, onetime_h_ptr, i, in_ephemeral[i], ki[i]);
             THROW_WALLET_EXCEPTION_IF(in_ephemeral[i].pub != boost::get<cryptonote::txout_to_key>(tx.vout[i].target).key,
                 error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key");
 
@@ -845,11 +845,11 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
 
       BOOST_FOREACH(size_t o, outs)
       {
-	THROW_WALLET_EXCEPTION_IF(tx.vout.size() <= o, error::wallet_internal_error, "wrong out in transaction: internal index=" +
-				  std::to_string(o) + ", total_outs=" + std::to_string(tx.vout.size()));
+        THROW_WALLET_EXCEPTION_IF(tx.vout.size() <= o, error::wallet_internal_error, "wrong out in transaction: internal index=" +
+                                  std::to_string(o) + ", total_outs=" + std::to_string(tx.vout.size()));
 
         auto kit = m_pub_keys.find(in_ephemeral[o].pub);
-	THROW_WALLET_EXCEPTION_IF(kit != m_pub_keys.end() && kit->second >= m_transfers.size(),
+        THROW_WALLET_EXCEPTION_IF(kit != m_pub_keys.end() && kit->second >= m_transfers.size(),
             error::wallet_internal_error, std::string("Unexpected transfer index from public key: ")
             + "got " + (kit == m_pub_keys.end() ? "<none>" : boost::lexical_cast<std::string>(kit->second))
             + ", m_transfers.size() is " + boost::lexical_cast<std::string>(m_transfers.size()));
@@ -857,13 +857,13 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
         {
           if (!pool)
           {
-	    m_transfers.push_back(boost::value_initialized<transfer_details>());
-	    transfer_details& td = m_transfers.back();
-	    td.m_block_height = height;
-	    td.m_internal_output_index = o;
-	    td.m_global_output_index = o_indices[o];
-	    td.m_tx = (const cryptonote::transaction_prefix&)tx;
-	    td.m_txid = txid();
+            m_transfers.push_back(boost::value_initialized<transfer_details>());
+            transfer_details& td = m_transfers.back();
+            td.m_block_height = height;
+            td.m_internal_output_index = o;
+            td.m_global_output_index = o_indices[o];
+            td.m_tx = (const cryptonote::transaction_prefix&)tx;
+            td.m_txid = txid();
             td.m_key_image = ki[o];
             td.m_key_image_known = !m_watch_only;
             td.m_amount = tx.vout[o].amount;
@@ -883,24 +883,24 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
               td.m_mask = rct::identity();
               td.m_rct = false;
             }
-	    set_unspent(m_transfers.size()-1);
-	    m_key_images[td.m_key_image] = m_transfers.size()-1;
-	    m_pub_keys[in_ephemeral[o].pub] = m_transfers.size()-1;
-	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid());
-	    if (0 != m_callback)
-	      m_callback->on_money_received(height, tx, td.m_amount);
+            set_unspent(m_transfers.size()-1);
+            m_key_images[td.m_key_image] = m_transfers.size()-1;
+            m_pub_keys[in_ephemeral[o].pub] = m_transfers.size()-1;
+            LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid());
+            if (0 != m_callback)
+              m_callback->on_money_received(height, tx, td.m_amount);
           }
         }
-	else if (m_transfers[kit->second].m_spent || m_transfers[kit->second].amount() >= tx.vout[o].amount)
+        else if (m_transfers[kit->second].m_spent || m_transfers[kit->second].amount() >= tx.vout[o].amount)
         {
-	  LOG_ERROR("Public key " << epee::string_tools::pod_to_hex(kit->first)
+          LOG_ERROR("Public key " << epee::string_tools::pod_to_hex(kit->first)
               << " from received " << print_money(tx.vout[o].amount) << " output already exists with "
               << (m_transfers[kit->second].m_spent ? "spent" : "unspent") << " "
               << print_money(m_transfers[kit->second].amount()) << ", received output ignored");
         }
         else
         {
-	  LOG_ERROR("Public key " << epee::string_tools::pod_to_hex(kit->first)
+          LOG_ERROR("Public key " << epee::string_tools::pod_to_hex(kit->first)
               << " from received " << print_money(tx.vout[o].amount) << " output already exists with "
               << print_money(m_transfers[kit->second].amount()) << ", replacing with new output");
           // The new larger output replaced a previous smaller one
@@ -909,11 +909,11 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
           if (!pool)
           {
             transfer_details &td = m_transfers[kit->second];
-	    td.m_block_height = height;
-	    td.m_internal_output_index = o;
-	    td.m_global_output_index = o_indices[o];
-	    td.m_tx = (const cryptonote::transaction_prefix&)tx;
-	    td.m_txid = txid();
+            td.m_block_height = height;
+            td.m_internal_output_index = o;
+            td.m_global_output_index = o_indices[o];
+            td.m_tx = (const cryptonote::transaction_prefix&)tx;
+            td.m_txid = txid();
             td.m_amount = tx.vout[o].amount;
             if (td.m_amount == 0)
             {
@@ -932,11 +932,11 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
               td.m_rct = false;
             }
             THROW_WALLET_EXCEPTION_IF(td.get_public_key() != in_ephemeral[o].pub, error::wallet_internal_error, "Inconsistent public keys");
-	    THROW_WALLET_EXCEPTION_IF(td.m_spent, error::wallet_internal_error, "Inconsistent spent status");
+            THROW_WALLET_EXCEPTION_IF(td.m_spent, error::wallet_internal_error, "Inconsistent spent status");
 
-	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid());
-	    if (0 != m_callback)
-	      m_callback->on_money_received(height, tx, td.m_amount);
+            LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid());
+            if (0 != m_callback)
+              m_callback->on_money_received(height, tx, td.m_amount);
           }
         }
       }
@@ -3200,14 +3200,14 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions(std::vector<crypto
         cryptonote::transaction tx;
         pending_tx ptx;
 
-	// loop until fee is met without increasing tx size to next KB boundary.
-	uint64_t needed_fee = 0;
-	do
-	{
-	  transfer(dst_vector, fake_outs_count, unused_transfers_indices, unlock_time, needed_fee, extra, tx, ptx, trusted_daemon);
-	  auto txBlob = t_serializable_object_to_blob(ptx.tx);
+        // loop until fee is met without increasing tx size to next KB boundary.
+        uint64_t needed_fee = 0;
+        do
+        {
+          transfer(dst_vector, fake_outs_count, unused_transfers_indices, unlock_time, needed_fee, extra, tx, ptx, trusted_daemon);
+          auto txBlob = t_serializable_object_to_blob(ptx.tx);
           needed_fee = calculate_fee(fee_per_kb, txBlob, fee_multiplier);
-	} while (ptx.fee < needed_fee);
+        } while (ptx.fee < needed_fee);
 
         ptx_vector.push_back(ptx);
 
@@ -4678,24 +4678,24 @@ std::vector<std::pair<crypto::key_image, crypto::signature>> wallet2::export_key
     find_tx_extra_field_by_type(tx_extra_fields, extra_nonce);
     crypto::hash payment_id = null_hash;
     bool has_unencrypted_payment_id = get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id);
-    crypto::secret_key onetime_h_a_k;
-    crypto::secret_key* onetime_h_a_k_ptr = nullptr;
+    crypto::secret_key onetime_h;
+    crypto::secret_key* onetime_h_ptr = nullptr;
     if (has_unencrypted_payment_id)
     {
       char data[2 * HASH_SIZE];
       memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
       memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h_a_k));
-      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h_a_k.data));
+      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
+      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
       // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
-      if (payment_id.data[0] == onetime_h_a_k.data[0])
-        onetime_h_a_k_ptr = &onetime_h_a_k;
+      if (payment_id.data[0] == onetime_h.data[0])
+        onetime_h_ptr = &onetime_h;
     }
 
     // generate ephemeral secret key
     crypto::key_image ki;
     cryptonote::keypair in_ephemeral;
-    cryptonote::generate_key_image_helper_onetime(m_account.get_keys(), tx_pub_key, onetime_h_a_k_ptr, td.m_internal_output_index, in_ephemeral, ki);
+    cryptonote::generate_key_image_helper_onetime(m_account.get_keys(), tx_pub_key, onetime_h_ptr, td.m_internal_output_index, in_ephemeral, ki);
 
     THROW_WALLET_EXCEPTION_IF(td.m_key_image_known && ki != td.m_key_image,
         error::wallet_internal_error, "key_image generated not matched with cached key image");
@@ -4826,21 +4826,21 @@ size_t wallet2::import_outputs(const std::vector<tools::wallet2::transfer_detail
     find_tx_extra_field_by_type(tx_extra_fields, extra_nonce);
     crypto::hash payment_id = null_hash;
     bool has_unencrypted_payment_id = get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id);
-    crypto::secret_key onetime_h_a_k;
-    crypto::secret_key* onetime_h_a_k_ptr = nullptr;
+    crypto::secret_key onetime_h;
+    crypto::secret_key* onetime_h_ptr = nullptr;
     if (has_unencrypted_payment_id)
     {
       char data[2 * HASH_SIZE];
       memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
       memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h_a_k));
-      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h_a_k.data));
+      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
+      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
       // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
-      if (payment_id.data[0] == onetime_h_a_k.data[0])
-        onetime_h_a_k_ptr = &onetime_h_a_k;
+      if (payment_id.data[0] == onetime_h.data[0])
+        onetime_h_ptr = &onetime_h;
     }
     
-    cryptonote::generate_key_image_helper_onetime(m_account.get_keys(), pub_key_field.pub_key, onetime_h_a_k_ptr, td.m_internal_output_index, in_ephemeral, td.m_key_image);
+    cryptonote::generate_key_image_helper_onetime(m_account.get_keys(), pub_key_field.pub_key, onetime_h_ptr, td.m_internal_output_index, in_ephemeral, td.m_key_image);
     td.m_key_image_known = true;
     THROW_WALLET_EXCEPTION_IF(in_ephemeral.pub != boost::get<cryptonote::txout_to_key>(td.m_tx.vout[td.m_internal_output_index].target).key,
         error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key at index " + i);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -603,6 +603,20 @@ static uint64_t decodeRct(const rct::rctSig & rv, const crypto::public_key pub, 
   }
 }
 //----------------------------------------------------------------------------------------------------
+static uint64_t decodeRct_onetime(const rct::rctSig & rv, const crypto::public_key pub, const crypto::secret_key &sec, crypto::secret_key* onetime_h, unsigned int i, rct::key & mask)
+{
+  if (onetime_h)
+  {
+    crypto::secret_key sec2;
+    sc_mul((unsigned char*)&sec2, (const unsigned char*)&sec, (const unsigned char*)onetime_h);
+    return decodeRct(rv, pub, sec2, i, mask);
+  }
+  else
+  {
+    return decodeRct(rv, pub, sec, i, mask);
+  }
+}
+//----------------------------------------------------------------------------------------------------
 void wallet2::process_new_transaction(const cryptonote::transaction& tx, const std::vector<uint64_t> &o_indices, uint64_t height, uint64_t ts, bool miner_tx, bool pool)
 {
   class lazy_txid_getter
@@ -703,7 +717,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
           outs.push_back(0);
           if (money_transfered == 0)
           {
-            money_transfered = tools::decodeRct(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, 0, mask[0]);
+            money_transfered = tools::decodeRct_onetime(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, onetime_h_ptr, 0, mask[0]);
           }
           amount[0] = money_transfered;
           tx_money_got_in_outs = money_transfered;
@@ -744,7 +758,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
               outs.push_back(i);
               if (money_transfered[i] == 0)
               {
-                money_transfered[i] = tools::decodeRct(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, i, mask[i]);
+                money_transfered[i] = tools::decodeRct_onetime(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, onetime_h_ptr, i, mask[i]);
               }
               tx_money_got_in_outs += money_transfered[i];
               amount[i] = money_transfered[i];
@@ -790,7 +804,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
           outs.push_back(i);
           if (money_transfered[i] == 0)
           {
-            money_transfered[i] = tools::decodeRct(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, i, mask[i]);
+            money_transfered[i] = tools::decodeRct_onetime(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, onetime_h_ptr, i, mask[i]);
           }
           tx_money_got_in_outs += money_transfered[i];
           amount[i] = money_transfered[i];
@@ -821,7 +835,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
             outs.push_back(i);
             if (money_transfered == 0)
             {
-              money_transfered = tools::decodeRct(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, i, mask[i]);
+              money_transfered = tools::decodeRct_onetime(tx.rct_signatures, pub_key_field.pub_key, keys.m_view_secret_key, onetime_h_ptr, i, mask[i]);
             }
             amount[i] = money_transfered;
             tx_money_got_in_outs += money_transfered;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -662,8 +662,7 @@ void wallet2::process_new_transaction(const cryptonote::transaction& tx, const s
     char data[2 * HASH_SIZE];
     memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
     memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-    crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
-    sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
+    crypto::hash_to_scalar(data, 2 * HASH_SIZE, reinterpret_cast<crypto::ec_scalar&>(onetime_h));
     // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
     if (payment_id.data[0] == onetime_h.data[0])
       onetime_h_ptr = &onetime_h;
@@ -4699,8 +4698,7 @@ std::vector<std::pair<crypto::key_image, crypto::signature>> wallet2::export_key
       char data[2 * HASH_SIZE];
       memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
       memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
-      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
+      crypto::hash_to_scalar(data, 2 * HASH_SIZE, reinterpret_cast<crypto::ec_scalar&>(onetime_h));
       // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
       if (payment_id.data[0] == onetime_h.data[0])
         onetime_h_ptr = &onetime_h;
@@ -4847,8 +4845,7 @@ size_t wallet2::import_outputs(const std::vector<tools::wallet2::transfer_detail
       char data[2 * HASH_SIZE];
       memcpy(data, &m_account.get_keys().m_view_secret_key, HASH_SIZE);
       memcpy(data + HASH_SIZE, &payment_id, HASH_SIZE);
-      crypto::cn_fast_hash(data, 2 * HASH_SIZE, reinterpret_cast<crypto::hash &>(onetime_h));
-      sc_reduce32(reinterpret_cast<unsigned char *>(onetime_h.data));
+      crypto::hash_to_scalar(data, 2 * HASH_SIZE, reinterpret_cast<crypto::ec_scalar&>(onetime_h));
       // check if the following equation holds: (H(viewkey, pID) - pID) mod 256 == 0
       if (payment_id.data[0] == onetime_h.data[0])
         onetime_h_ptr = &onetime_h;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -556,6 +556,7 @@ namespace tools
     bool generate_chacha8_key_from_secret_keys(crypto::chacha8_key &key) const;
     crypto::hash get_payment_id(const pending_tx &ptx) const;
     void check_acc_out_precomp(const crypto::public_key &spend_public_key, const cryptonote::tx_out &o, const crypto::key_derivation &derivation, size_t i, bool &received, uint64_t &money_transfered, bool &error) const;
+    void check_acc_out_precomp_onetime(const crypto::public_key &spend_public_key, const cryptonote::tx_out &o, const crypto::key_derivation &derivation, crypto::secret_key* onetime_h_a_k, size_t i, bool &received, uint64_t &money_transfered, bool &error) const;
     void parse_block_round(const cryptonote::blobdata &blob, cryptonote::block &bl, crypto::hash &bl_id, bool &error) const;
     uint64_t get_upper_tranaction_size_limit();
     std::vector<uint64_t> get_unspent_amounts_vector();
@@ -568,7 +569,6 @@ namespace tools
     void set_unspent(size_t idx);
     template<typename entry>
     void get_outs(std::vector<std::vector<entry>> &outs, const std::list<size_t> &selected_transfers, size_t fake_outputs_count);
-    bool wallet_generate_key_image_helper(const cryptonote::account_keys& ack, const crypto::public_key& tx_public_key, size_t real_output_index, cryptonote::keypair& in_ephemeral, crypto::key_image& ki);
 
     cryptonote::account_base m_account;
     std::string m_daemon_address;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -556,7 +556,7 @@ namespace tools
     bool generate_chacha8_key_from_secret_keys(crypto::chacha8_key &key) const;
     crypto::hash get_payment_id(const pending_tx &ptx) const;
     void check_acc_out_precomp(const crypto::public_key &spend_public_key, const cryptonote::tx_out &o, const crypto::key_derivation &derivation, size_t i, bool &received, uint64_t &money_transfered, bool &error) const;
-    void check_acc_out_precomp_onetime(const crypto::public_key &spend_public_key, const cryptonote::tx_out &o, const crypto::key_derivation &derivation, crypto::secret_key* onetime_h_a_k, size_t i, bool &received, uint64_t &money_transfered, bool &error) const;
+    void check_acc_out_precomp_onetime(const crypto::public_key &spend_public_key, const cryptonote::tx_out &o, const crypto::key_derivation &derivation, crypto::secret_key* onetime_h_a_k, size_t i, uint64_t &received, uint64_t &money_transfered, bool &error) const;
     void parse_block_round(const cryptonote::blobdata &blob, cryptonote::block &bl, crypto::hash &bl_id, bool &error) const;
     uint64_t get_upper_tranaction_size_limit();
     std::vector<uint64_t> get_unspent_amounts_vector();


### PR DESCRIPTION
This is an implementation of the **one-time receiving address** idea discussed earlier in [Reddit](https://www.reddit.com/r/Monero/comments/58oizb/). My personal motivation of this feature primarily comes from the fact that I must tell my wallet address `(A,B)` to ShapeShift every single time I buy Monero there. To prevent ShapeShift from knowing the total amount of XMR I bought through them, the idea of this proposal is to give ShapeShift a one-time address `(C,D)=(hA,hB)` along with an unencrypted payment ID `k` where `h=hash(a,k)`. The two addresses `(A,B)` and `(C,D)` cannot be linked without knowing the secret viewkey `a`. When the wallet holder processes a new transaction having an unencrypted payment ID, he performs the output key derivation also against `(C,D)` to receive the fund. To reduce the additional computational cost incurred in processing new transactions, the wallet holder generates a one-time address with `k` such that the following equation holds: `(hash(a,k)-k) mod 256 == 0` by iterative random picking; this way, he can ignore all payment IDs not satisfying this equation. This trick reduces the performance impact to roughly 1/256 or 0.4% increase.

A new command `onetime_address` is added to `monero-wallet-cli` which presents a pair of payment ID and an address. As is the case for the standard payments, it's definitely discouraged to reuse the same one-time address (i.e. same unencrypted payment ID) which leads to transactions being linked.
