### PR TITLE
Fixed undefined behavior in TestDB

### DIFF
--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -117,15 +117,15 @@ public:
     blocks.push_back(blk);
   }
   virtual block get_block_from_height(const uint64_t& height) const {
-    return blocks[height];
+    return blocks.at(height);
   }
   virtual void set_hard_fork_version(uint64_t height, uint8_t version) {
-    if (versions.size() <= height) 
-      versions.resize(height+1); 
+    if (versions.size() <= height)
+      versions.resize(height+1);
     versions[height] = version;
   }
   virtual uint8_t get_hard_fork_version(uint64_t height) const {
-    return versions[height];
+    return versions.at(height);
   }
   virtual void check_hard_fork_info() {}
 


### PR DESCRIPTION
BSD and OSX build bots should stop complaining now.