### PR TITLE
Added command_line::is_yes

### DIFF
--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -29,11 +29,22 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "command_line.h"
-#include "string_tools.h"
+#include <boost/algorithm/string/compare.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include "common/i18n.h"
 #include "cryptonote_config.h"
+#include "string_tools.h"
 
 namespace command_line
 {
+  namespace
+  {
+    const char* tr(const char* str)
+    {
+      return i18n_translate(str, "command_line");
+    }
+  }
+
   std::string input_line(const std::string& prompt)
   {
     std::cout << prompt;
@@ -43,6 +54,20 @@ namespace command_line
 
     return epee::string_tools::trim(buf);
 
+  }
+
+  bool is_yes(const std::string& str)
+  {
+    if (str == "y" || str == "Y")
+      return true;
+
+    boost::algorithm::is_iequal ignore_case{};
+    if (boost::algorithm::equals("yes", str, ignore_case))
+      return true;
+    if (boost::algorithm::equals(command_line::tr("yes"), str, ignore_case))
+      return true;
+
+    return false;
   }
 
   const arg_descriptor<bool> arg_help = {"help", "Produce help message"};

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -43,6 +43,9 @@ namespace command_line
 
   std::string input_line(const std::string& prompt);
 
+  //! \return True if `str` is `is_iequal("y" || "yes" || `tr("yes"))`.
+  bool is_yes(const std::string& str);
+
   template<typename T, bool required = false>
   struct arg_descriptor;
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -212,17 +212,17 @@ namespace
     return message_writer(epee::log_space::console_color_red, true, sw::tr("Error: "), LOG_LEVEL_0);
   }
 
-  bool is_it_true(std::string s)
+  bool is_it_true(const std::string& s)
   {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-    if (s == "true")
+    if (s == "1" || command_line::is_yes(s))
       return true;
-    if (s == "1")
+
+    boost::algorithm::is_iequal ignore_case{};
+    if (boost::algorithm::equals("true", s, ignore_case))
       return true;
-    if (s == "y" || s == "yes")
+    if (boost::algorithm::equals(simple_wallet::tr("true"), s, ignore_case))
       return true;
-    if (s == sw::tr("yes"))
-      return true;
+
     return false;
   }
 
@@ -916,7 +916,7 @@ bool simple_wallet::ask_wallet_create_if_needed()
             LOG_ERROR("Unexpected std::cin.eof() - Exited simple_wallet::ask_wallet_create_if_needed()");
             return false;
           }
-          if(is_it_true(confirm_creation))
+          if(command_line::is_yes(confirm_creation))
           {
             success_msg_writer() << tr("Generating new wallet...");
             m_generate_new = wallet_path;
@@ -1977,8 +1977,7 @@ bool simple_wallet::get_address_from_str(const std::string &str, cryptonote::acc
           {
             return false;
           }
-          if (confirm_dns_ok != "Y" && confirm_dns_ok != "y" && confirm_dns_ok != "Yes" && confirm_dns_ok != "yes"
-            && confirm_dns_ok != tr("yes") && confirm_dns_ok != tr("no"))
+          if (!command_line::is_yes(confirm_dns_ok))
           {
             fail_msg_writer() << tr("you have cancelled the transfer request");
             return false;
@@ -2136,7 +2135,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
      std::string accepted = command_line::input_line(tr("No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No)"));
      if (std::cin.eof())
        return true;
-     if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
+     if (!command_line::is_yes(accepted))
      {
        fail_msg_writer() << tr("transaction cancelled.");
 
@@ -2220,7 +2219,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
         std::string accepted = command_line::input_line(prompt.str());
         if (std::cin.eof())
           return true;
-        if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
+        if (!command_line::is_yes(accepted))
         {
           fail_msg_writer() << tr("transaction cancelled.");
 
@@ -2399,7 +2398,7 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
     std::string accepted = command_line::input_line(prompt_str);
     if (std::cin.eof())
       return true;
-    if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
+    if (!command_line::is_yes(accepted))
     {
       fail_msg_writer() << tr("transaction cancelled.");
 
@@ -2613,7 +2612,7 @@ bool simple_wallet::sweep_all(const std::vector<std::string> &args_)
      std::string accepted = command_line::input_line(tr("No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No)"));
      if (std::cin.eof())
        return true;
-     if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
+     if (!command_line::is_yes(accepted))
      {
        fail_msg_writer() << tr("transaction cancelled.");
 
@@ -2658,7 +2657,7 @@ bool simple_wallet::sweep_all(const std::vector<std::string> &args_)
     std::string accepted = command_line::input_line(prompt_str);
     if (std::cin.eof())
       return true;
-    if (accepted != "Y" && accepted != "y" && accepted != "Yes" && accepted != "yes")
+    if (!command_line::is_yes(accepted))
     {
       fail_msg_writer() << tr("transaction cancelled.");
 
@@ -2853,8 +2852,7 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
 
   uint64_t fee = amount - amount_to_dests;
   std::string prompt_str = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No)")) % (unsigned long)get_num_txes() % print_money(amount) % print_money(fee) % dest_string % change_string % (unsigned long)min_mixin % extra_message).str();
-  std::string accepted = command_line::input_line(prompt_str);
-  return is_it_true(accepted);
+  return command_line::is_yes(command_line::input_line(prompt_str));
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::accept_loaded_tx(const tools::wallet2::unsigned_tx_set &txs)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(unit_tests_sources
   canonical_amounts.cpp
   chacha8.cpp
   checkpoints.cpp
+  command_line.cpp
   decompose_amount_into_digits.cpp
   dns_resolver.cpp
   epee_boosted_tcp_server.cpp

--- a/tests/unit_tests/command_line.cpp
+++ b/tests/unit_tests/command_line.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2014-2016, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "gtest/gtest.h"
+#include "common/command_line.h"
+
+TEST(CommandLine, IsYes)
+{
+  EXPECT_TRUE(command_line::is_yes("Y"));
+  EXPECT_TRUE(command_line::is_yes("y"));
+  EXPECT_TRUE(command_line::is_yes("YES"));
+  EXPECT_TRUE(command_line::is_yes("YEs"));
+  EXPECT_TRUE(command_line::is_yes("YeS"));
+  EXPECT_TRUE(command_line::is_yes("yES"));
+  EXPECT_TRUE(command_line::is_yes("Yes"));
+  EXPECT_TRUE(command_line::is_yes("yeS"));
+  EXPECT_TRUE(command_line::is_yes("yEs"));
+  EXPECT_TRUE(command_line::is_yes("yes"));
+
+  EXPECT_FALSE(command_line::is_yes(""));
+  EXPECT_FALSE(command_line::is_yes("yes-"));
+  EXPECT_FALSE(command_line::is_yes("NO"));
+  EXPECT_FALSE(command_line::is_yes("No"));
+  EXPECT_FALSE(command_line::is_yes("nO"));
+  EXPECT_FALSE(command_line::is_yes("no"));
+}

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -32,109 +32,109 @@
 <context>
     <name>Bitmonero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="593"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="604"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="609"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="703"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="629"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="723"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="612"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="706"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="726"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="709"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="635"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="729"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="618"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="712"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="732"/>
         <source>failed to get random outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="625"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="719"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="645"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="739"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="634"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="728"/>
-        <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="643"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="737"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="645"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="739"/>
-        <source>output amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="645"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="739"/>
-        <source>found outputs to mix</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="650"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="744"/>
-        <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="654"/>
         <location filename="../src/wallet/api/wallet.cpp" line="748"/>
-        <source>transaction %s was rejected by daemon with status: </source>
+        <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="661"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="755"/>
-        <source>one of destinations is zero</source>
+        <location filename="../src/wallet/api/wallet.cpp" line="663"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="757"/>
+        <source>not enough outputs for specified mixin_count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="664"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="758"/>
-        <source>failed to find a suitable way to split transactions</source>
+        <location filename="../src/wallet/api/wallet.cpp" line="665"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="759"/>
+        <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="667"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="761"/>
-        <source>unknown transfer error: </source>
+        <location filename="../src/wallet/api/wallet.cpp" line="665"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="759"/>
+        <source>found outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="670"/>
         <location filename="../src/wallet/api/wallet.cpp" line="764"/>
+        <source>transaction was not constructed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="674"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="768"/>
+        <source>transaction %s was rejected by daemon with status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="681"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="775"/>
+        <source>one of destinations is zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="684"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="778"/>
+        <source>failed to find a suitable way to split transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="687"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="781"/>
+        <source>unknown transfer error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="690"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="784"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="673"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="767"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="693"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="787"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="676"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="770"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="696"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="790"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -204,1041 +204,1055 @@
     </message>
 </context>
 <context>
+    <name>command_line</name>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="67"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="272"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="379"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="409"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1491"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="618"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="628"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="415"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="626"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="649"/>
         <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
         <source>Stop mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="653"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="651"/>
         <source>Save current blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="653"/>
         <source>Show current wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="656"/>
         <source>Show blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="665"/>
         <source>Show current wallet public address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Show this help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="725"/>
         <source>set always-confirm-transfers: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wrong number format, use: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wrong number range, use: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1375"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
         <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1223"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1233"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1358"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1363"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1390"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1390"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1413"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
         <source>Use &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1474"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1488"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
         <source>Password for the new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1496"/>
         <source>Enter new password again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1504"/>
         <source>passwords do not match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
         <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;], &lt;number_of_threads&gt; should be from 1 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1556"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1559"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1574"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
         <source>Blockchain saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1605"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
-        <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1606"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1630"/>
-        <source>transaction </source>
+        <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1619"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
+        <source>transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
         <source>received </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1619"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1620"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
         <source>unsupported transaction format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1662"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>failed to get a Monero address from: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1994"/>
         <source>not yet supported: Multiple Monero addresses found for given URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1999"/>
         <source>wrong address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2055"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2067"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2075"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
         <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2594"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2103"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
         <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2207"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2403"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2967"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2183"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2945"/>
+        <source>Sending %s.  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2189"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2206"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2192"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2957"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2217"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2198"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2215"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2217"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
         <source>Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2221"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2416"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2675"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2225"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2679"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2438"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2723"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3017"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2743"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2301"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2496"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2580"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2802"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2819"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
+        <source>Change does to more than one address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2823"/>
-        <source>Loaded %lu transactions, for %s, fee %s, change %s, %s, with min mixin %lu. Is this okay? (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2888"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2894"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <source>Transaction successfully signed to file: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2876"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
         <source>daemon is busy. Please try later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2703"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2997"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1685"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2311"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2489"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2328"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3056"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2333"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3061"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2321"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2499"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3066"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1726"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1784"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1816"/>
         <source>expected at least one payment_id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1874"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2033"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2878"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1947"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="256"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="223"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="252"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="337"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="342"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="487"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="611"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="436"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="471"/>
         <source>mixin must be an integer &gt;= 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="478"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="476"/>
         <source>could not change default mixin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
         <source>priority must be 0, 1, 2, or 3 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="508"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>priority must be 0, 1, 2, or 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="535"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="533"/>
         <source>priority must be 0, 1, 2 or 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="652"/>
         <source>Synchronize transactions and balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="654"/>
         <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="655"/>
         <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="657"/>
         <source>transfer [&lt;mixin_count&gt;] &lt;addr_1&gt; &lt;amount_1&gt; [&lt;addr_2&gt; &lt;amount_2&gt; ... &lt;addr_N&gt; &lt;amount_N&gt;] [payment_id] - Transfer &lt;amount_1&gt;,... &lt;amount_N&gt; to &lt;address_1&gt;,... &lt;address_N&gt;, respectively. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability (from 2 to maximum available)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="658"/>
         <source>Same as transfer_original, but using a new transaction building algorithm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
         <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="660"/>
         <source>Send all unmixable outputs to yourself with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="661"/>
         <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance an address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
         <source>Sign a transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="663"/>
         <source>Submit a signed transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="664"/>
         <source>set_log &lt;level&gt; - Change current log detail level, &lt;0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="668"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="667"/>
         <source>Save wallet data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="670"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="668"/>
         <source>Save a watch-only keys file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
         <source>Display private view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="672"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="670"/>
         <source>Display private spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="671"/>
         <source>Display Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="672"/>
         <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [1|2|3] - normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="675"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="673"/>
         <source>Rescan blockchain for spent outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
         <source>Get transaction key (r) for a given &lt;txid&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="675"/>
         <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="676"/>
         <source>show_transfers [in|out] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="677"/>
         <source>Rescan blockchain from scratch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="678"/>
         <source>Set an arbitrary string note for a txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="681"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
         <source>Get a string note for a txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="682"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Show wallet status information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="681"/>
         <source>Sign the contents of a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="682"/>
         <source>Verify a signature on the contents of a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="683"/>
         <source>Export a signed set of key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="684"/>
         <source>Import signed key images list and verify their spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="685"/>
         <source>Export a set of outputs owned by this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="686"/>
         <source>Import set of outputs owned by this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>set store-tx-info: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="755"/>
         <source>set default-mixin: needs an argument (integer &gt;= 2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="770"/>
         <source>set auto-refresh: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="785"/>
         <source>set refresh-type: needs an argument:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="801"/>
         <source>set priority: needs an argument: 0, 1, 2, or 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="816"/>
         <source>set confirm-missing-payment-id: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="837"/>
         <source>usage: set_log &lt;log_level_number_0-4&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Specify wallet file name (e.g., MyWallet). If the wallet doesn&apos;t exist, it will be created.
 Wallet file name (or Ctrl-C to quit): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="878"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="895"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="901"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="907"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
         <source>No wallet/key file found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
         <source>(y)es/(n)o: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="923"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="957"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="971"/>
         <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="993"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1004"/>
         <source>bad m_restore_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1071"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1088"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1102"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1028"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3685"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1126"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1146"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1092"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1118"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1122"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1153"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1154"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1197"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1204"/>
         <source>Daemon uses a different RPC version that the wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1205"/>
         <source>Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1241"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1246"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1247"/>
         <source>invalid language choice passed. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1303"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1318"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use &quot;refresh&quot; command.
 Use &quot;help&quot; command to see the list of available commands.
@@ -1249,489 +1263,509 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1451"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1895"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1666"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2240"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2694"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2681"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2698"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1774"/>
+        <source>pubkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1774"/>
+        <source>key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1785"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1775"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1784"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1784"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1785"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1964"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1967"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1969"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1971"/>
         <source>Is this OK? (Y/n) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
-        <source>yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
-        <source>no</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3474"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3523"/>
         <source>usage: integrated_address [payment ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
         <source>Integrated address: account %s, payment ID %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3564"/>
         <source>usage: set_tx_note [txid] free text note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3592"/>
         <source>usage: get_tx_note [txid]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3640"/>
         <source>usage: sign &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3645"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3604"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3627"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3653"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3763"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3886"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
         <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>usage: export_key_images &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3858"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3746"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3754"/>
         <source>usage: import_key_images &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3836"/>
         <source>usage: export_outputs &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3869"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3877"/>
         <source>usage: import_outputs &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2124"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>Money successfully sent, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
         <source>no connection to daemon. Please, make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2253"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2952"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3001"/>
         <source>failed to get random outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2452"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2728"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3022"/>
         <source>not enough outputs for specified mixin_count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2277"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2714"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3025"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2277"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2714"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3025"/>
         <source>found outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2460"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2464"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2740"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3034"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2297"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2475"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2993"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2492"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3042"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3046"/>
         <source>Failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2484"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2743"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2647"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2377"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2394"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2653"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2931"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2980"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2848"/>
+        <source>%s change to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2851"/>
+        <source>no change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <source>Transaction successfully signed to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3077"/>
         <source>usage: get_tx_key &lt;txid&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3522"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3550"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3121"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3599"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3110"/>
         <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3137"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3157"/>
         <source>failed to get transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <source>failed to parse transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3175"/>
         <source>failed to validate transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3131"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
         <source>failed to get the right transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3187"/>
         <source>failed to generate key derivation from supplied parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3249"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3249"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3257"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3217"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3266"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3221"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3270"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3407"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>pending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3480"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3530"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,72 +1773,67 @@ your wallet again (your wallet keys are NOT at risk in any case).
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="102"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="103"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="104"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="106"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="107"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="108"/>
         <source>Create non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="109"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="110"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="111"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="131"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="212"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="228"/>
-        <source>yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3994"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1867,81 +1896,81 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="215"/>
+        <location filename="../src/wallet/wallet2.cpp" line="220"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="221"/>
+        <location filename="../src/wallet/wallet2.cpp" line="226"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="228"/>
+        <location filename="../src/wallet/wallet2.cpp" line="233"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="252"/>
-        <location filename="../src/wallet/wallet2.cpp" line="319"/>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
+        <location filename="../src/wallet/wallet2.cpp" line="324"/>
+        <location filename="../src/wallet/wallet2.cpp" line="366"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
-        <location filename="../src/wallet/wallet2.cpp" line="331"/>
-        <location filename="../src/wallet/wallet2.cpp" line="382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
+        <location filename="../src/wallet/wallet2.cpp" line="336"/>
+        <location filename="../src/wallet/wallet2.cpp" line="387"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
+        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="294"/>
+        <location filename="../src/wallet/wallet2.cpp" line="299"/>
         <source>At least one of Electrum-style word list and private view key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="299"/>
+        <location filename="../src/wallet/wallet2.cpp" line="304"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="312"/>
+        <location filename="../src/wallet/wallet2.cpp" line="317"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="328"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
+        <location filename="../src/wallet/wallet2.cpp" line="340"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="344"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
         <source>Cannot create deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="391"/>
+        <location filename="../src/wallet/wallet2.cpp" line="396"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1949,59 +1978,59 @@ your wallet again (your wallet keys are NOT at risk in any case).
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1111"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1115"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1117"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1121"/>
         <source>Must specify --wallet-file or --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1121"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1125"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1146"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1169"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1150"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1173"/>
         <source>Storing wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1148"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1152"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1175"/>
         <source>Stored ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1151"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1155"/>
         <source>Loaded ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1155"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1159"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1160"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1164"/>
         <source>Failed to initialize wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1164"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1168"/>
         <source>Starting wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1166"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1170"/>
         <source>Stopped wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1175"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1179"/>
         <source>Failed to store wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2009,53 +2038,53 @@ your wallet again (your wallet keys are NOT at risk in any case).
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3912"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3961"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1086"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="25"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="56"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="29"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="60"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="51"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="82"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="52"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="83"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="61"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="92"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="75"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>unexpected empty log file name in presence of non-empty file path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="100"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="131"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="147"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="178"/>
         <source>default_log: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="179"/>
         <source>Logging at log level %d to %s</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Code that parsed for "YES/y" now use a single function.  Updated translations file. Useful for `monero-wallet-rpc` - I can include these changes in that request (not yet opened)  if preferred.