### PR TITLE
Improve daemon RPC version handling

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -41,7 +41,16 @@ namespace cryptonote
 #define CORE_RPC_STATUS_BUSY   "BUSY"
 #define CORE_RPC_STATUS_NOT_MINING "NOT MINING"
 
-#define CORE_RPC_VERSION 5
+// When making *any* change here, bump minor
+// If the change is incompatible, then bump major and set minor to 0
+// This ensures CORE_RPC_VERSION always increases, that every change
+// has its own version, and that clients can just test major to see
+// whether they can talk to a given daemon without having to know in
+// advance which version they will stop working with
+// Don't go over 32767 for any of these
+#define CORE_RPC_VERSION_MAJOR 1
+#define CORE_RPC_VERSION_MINOR 0
+#define CORE_RPC_VERSION (((CORE_RPC_VERSION_MAJOR)<<16)|(CORE_RPC_VERSION_MINOR))
 
   struct COMMAND_RPC_GET_HEIGHT
   {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -906,11 +906,11 @@ bool WalletImpl::connectToDaemon()
 
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
-    bool same_version = false;
-    bool is_connected = m_wallet->check_connection(&same_version);
+    uint32_t version = 0;
+    bool is_connected = m_wallet->check_connection(&version);
     if (!is_connected)
         return Wallet::ConnectionStatus_Disconnected;
-    if (!same_version)
+    if ((version >> 16) != CORE_RPC_VERSION_MAJOR)
         return Wallet::ConnectionStatus_WrongVersion;
     return Wallet::ConnectionStatus_Connected;
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2221,7 +2221,7 @@ bool wallet2::prepare_file_names(const std::string& file_path)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::check_connection(bool *same_version)
+bool wallet2::check_connection(uint32_t *version)
 {
   boost::lock_guard<boost::mutex> lock(m_daemon_rpc_mutex);
 
@@ -2239,7 +2239,7 @@ bool wallet2::check_connection(bool *same_version)
       return false;
   }
 
-  if (same_version)
+  if (version)
   {
     epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req_t = AUTO_VAL_INIT(req_t);
     epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
@@ -2248,9 +2248,9 @@ bool wallet2::check_connection(bool *same_version)
     req_t.method = "get_version";
     bool r = net_utils::invoke_http_json_remote_command2(m_daemon_address + "/json_rpc", req_t, resp_t, m_http_client);
     if (!r || resp_t.result.status != CORE_RPC_STATUS_OK)
-      *same_version = false;
+      *version = 0;
     else
-      *same_version = resp_t.result.version == CORE_RPC_VERSION;
+      *version = resp_t.result.version;
   }
 
   return true;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -408,7 +408,7 @@ namespace tools
     std::vector<wallet2::pending_tx> create_transactions_all(const cryptonote::account_public_address &address, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t> extra, bool trusted_daemon);
     std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t> extra, bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
-    bool check_connection(bool *same_version = NULL);
+    bool check_connection(uint32_t *version = NULL);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0) const;
     void get_payments(std::list<std::pair<crypto::hash,wallet2::payment_details>>& payments, uint64_t min_height, uint64_t max_height = (uint64_t)-1) const;


### PR DESCRIPTION
Daemon RPC version is now composed of a major and minor number,
so that incompatible changes bump the major version, while
compatible changes can still bump the minor version without
causing clients to unnecessarily complain.