### PR TITLE
Locking

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -1010,7 +1010,7 @@ POP_WARNINGS
     boost::unique_lock<boost::mutex> lock(local_shared_context->connect_mut);
     auto connect_callback = [](boost::system::error_code ec_, boost::shared_ptr<local_async_context> shared_context)
     {
-      shared_context->connect_mut.lock(); shared_context->ec = ec_; shared_context->connect_mut.unlock(); shared_context->cond.notify_one(); 
+      shared_context->connect_mut.lock(); shared_context->ec = ec_; shared_context->cond.notify_one(); shared_context->connect_mut.unlock();
     };
 
     sock_.async_connect(remote_endpoint, boost::bind<void>(connect_callback, _1, local_shared_context));

--- a/contrib/valgrind/monero.supp
+++ b/contrib/valgrind/monero.supp
@@ -8,3 +8,12 @@
    fun:_ULx86_64_step
    ...
 }
+
+{
+   boost unlocks before signalling cond var
+   Helgrind:Misc
+   ...
+   fun:pthread_cond_signal@*
+   fun:maybe_unlock_and_signal_one<boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex> >
+   ...
+}


### PR DESCRIPTION
I looked at helgrind for a bit, and it's super spammy. A lot of the warnings are signal-after-unlock, which I think is fine, though non canonical. So I think these reduce the spam a little, but if someone with in depth knowledge can double check the change is correct, it'd be great :)