### PR TITLE
Revert forcing -fPIC for all ARMv8 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ endif()
 if (ARM_ID STREQUAL "aarch64")
   set(ARM 1)
   set(ARM8 1)
-  set(BUILD_SHARED_LIBS ON)
 endif()
 
 if(WIN32 OR ARM)


### PR DESCRIPTION
Never achieved what it set out to do, looking at the failure logs for the ARMv8 builds.

Just seems to increase compile time.