### PR TITLE
ringct: guard against bad data exceptions in worker threads

### DIFF
--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -335,6 +335,8 @@ namespace rct {
     //   mask is a such that C = aG + bH, and b = amount
     //verRange verifies that \sum Ci = C and that each Ci is a commitment to 0 or 2^i
     bool verRange(const key & C, const rangeSig & as) {
+      try
+      {
         PERF_TIMER(verRange);
         key64 CiH;
         int i = 0;
@@ -348,6 +350,9 @@ namespace rct {
         if (!VerASNL(as.Ci, CiH, as.asig))
           return false;
         return true;
+      }
+      // we can get deep throws from ge_frombytes_vartime if input isn't valid
+      catch (...) { return false; }
     }
 
     key get_pre_mlsag_hash(const rctSig &rv)
@@ -513,6 +518,8 @@ namespace rct {
     //This does a simplified version, assuming only post Rct
     //inputs
     bool verRctMGSimple(const key &message, const mgSig &mg, const ctkeyV & pubs, const key & C) {
+        try
+        {
             PERF_TIMER(verRctMGSimple);
             //setup vars
             size_t rows = 1;
@@ -528,6 +535,8 @@ namespace rct {
             }
             //DP(C);
             return MLSAG_Ver(message, M, mg, rows);
+        }
+        catch (...) { return false; }
     }
 
 
@@ -790,6 +799,8 @@ namespace rct {
     //ver RingCT simple
     //assumes only post-rct style inputs (at least for max anonymity)
     bool verRctSimple(const rctSig & rv) {
+      try
+      {
         PERF_TIMER(verRctSimple);
 
         CHECK_AND_ASSERT_MES(rv.type == RCTTypeSimple, false, "verRctSimple called on non simple rctSig");
@@ -860,6 +871,9 @@ namespace rct {
         }
 
         return true;
+      }
+      // we can get deep throws from ge_frombytes_vartime if input isn't valid
+      catch (...) { return false; }
     }
 
     //RingCT protocol

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -259,6 +259,11 @@ namespace rct {
         }
         CHECK_AND_ASSERT_MES(dsRows <= rows, false, "Bad dsRows value");
 
+        for (size_t i = 0; i < rv.ss.size(); ++i)
+          for (size_t j = 0; j < rv.ss[i].size(); ++j)
+            CHECK_AND_ASSERT_MES(sc_check(rv.ss[i][j].bytes) == 0, false, "Bad ss slot");
+        CHECK_AND_ASSERT_MES(sc_check(rv.cc.bytes) == 0, false, "Bad cc");
+
         size_t i = 0, j = 0, ii = 0;
         key c,  L, R, Hi;
         key c_old = copy(rv.cc);


### PR DESCRIPTION
If purported pubkeys aren't actually valid pubkeys, exceptions
will fly. These will terminate if thrown in a worker thread.
Guard against this.