### PR TITLE
blockchain: fix reorganizations past a hard fork boundary

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -759,6 +759,9 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
     pop_block_from_blockchain();
   }
 
+  // make sure the hard fork object updates its current version
+  m_hardfork->reorganize_from_chain_height(rollback_height);
+
   //return back original chain
   for (auto& bl : original_chain)
   {


### PR DESCRIPTION
After popping blocks from the old chain, the hard fork object's
notion of the current version was not in line with the new height,
causing the first blocks from the new chain to be rejected due
to a false expection of a newer version.