### PR TITLE
Bitmonero namespace renamed Monero.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Bitmonero"
+PROJECT_NAME           = "Monero"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -36,7 +36,7 @@
 
 #include <vector>
 
-namespace Bitmonero {
+namespace Monero {
   
 AddressBook::~AddressBook() {}
   
@@ -127,3 +127,5 @@ AddressBookImpl::~AddressBookImpl()
 }
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -31,7 +31,7 @@
 #include "wallet/wallet2_api.h"
 #include "wallet/wallet2.h"
 
-namespace Bitmonero {
+namespace Monero {
     
 class AddressBookRow;
 class WalletImpl;
@@ -64,4 +64,6 @@ private:
 };
 
 }
+
+namespace Bitmonero = Monero;
 

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -43,7 +43,7 @@
 
 using namespace std;
 
-namespace Bitmonero {
+namespace Monero {
 
 PendingTransaction::~PendingTransaction() {}
 
@@ -148,4 +148,6 @@ uint64_t PendingTransactionImpl::txCount() const
 }
 
 }
+
+namespace Bitmonero = Monero;
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -35,7 +35,7 @@
 #include <vector>
 
 
-namespace Bitmonero {
+namespace Monero {
 
 class WalletImpl;
 class PendingTransactionImpl : public PendingTransaction
@@ -64,3 +64,5 @@ private:
 
 
 }
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -42,7 +42,7 @@
 
 using namespace epee;
 
-namespace Bitmonero {
+namespace Monero {
 
 TransactionHistory::~TransactionHistory() {}
 
@@ -209,3 +209,5 @@ void TransactionHistoryImpl::refresh()
 }
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -31,7 +31,7 @@
 #include "wallet/wallet2_api.h"
 #include <boost/thread/shared_mutex.hpp>
 
-namespace Bitmonero {
+namespace Monero {
 
 class TransactionInfo;
 class WalletImpl;
@@ -56,4 +56,6 @@ private:
 };
 
 }
+
+namespace Bitmonero = Monero;
 

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-namespace Bitmonero {
+namespace Monero {
 
 TransactionInfo::~TransactionInfo() {}
 
@@ -110,3 +110,5 @@ const std::vector<TransactionInfo::Transfer> &TransactionInfoImpl::transfers() c
 }
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -32,7 +32,7 @@
 #include <string>
 #include <ctime>
 
-namespace Bitmonero {
+namespace Monero {
 
 class TransactionHistoryImpl;
 
@@ -73,3 +73,5 @@ private:
 };
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-namespace Bitmonero {
+namespace Monero {
 namespace Utils {
 
 
@@ -81,3 +81,5 @@ bool isAddressLocal(const std::string &address)
 
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -43,7 +43,7 @@
 using namespace std;
 using namespace cryptonote;
 
-namespace Bitmonero {
+namespace Monero {
 
 namespace {
     // copy-pasted from simplewallet
@@ -1059,3 +1059,5 @@ void WalletImpl::doInit(const string &daemon_address, uint64_t upper_transaction
 }
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -40,7 +40,7 @@
 #include <boost/thread/condition_variable.hpp>
 
 
-namespace Bitmonero {
+namespace Monero {
 class TransactionHistoryImpl;
 class PendingTransactionImpl;
 class AddressBookImpl;
@@ -155,6 +155,8 @@ private:
 
 
 } // namespace
+
+namespace Bitmonero = Monero;
 
 #endif
 

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -42,7 +42,7 @@ namespace epee {
     unsigned int g_test_dbg_lock_sleep = 0;
 }
 
-namespace Bitmonero {
+namespace Monero {
 
 Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::string &password,
                                     const std::string &language, bool testnet)
@@ -375,3 +375,5 @@ void WalletManagerFactory::setLogLevel(int level)
 
 
 }
+
+namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -32,7 +32,7 @@
 #include "wallet/wallet2_api.h"
 #include <string>
 
-namespace Bitmonero {
+namespace Monero {
 
 class WalletManagerImpl : public WalletManager
 {
@@ -61,3 +61,5 @@ private:
 };
 
 } // namespace
+
+namespace Bitmonero = Monero;

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -37,7 +37,7 @@
 #include <iostream>
 
 //  Public interface for libwallet library
-namespace Bitmonero {
+namespace Monero {
 
     namespace Utils {
         bool isAddressLocal(const std::string &hostaddr);
@@ -575,4 +575,6 @@ struct WalletManagerFactory
 
 
 }
+
+namespace Bitmonero = Monero;
 

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -111,15 +111,15 @@ struct Utils
         boost::filesystem::remove_all(path);
     }
 
-    static void print_transaction(Bitmonero::TransactionInfo * t)
+    static void print_transaction(Monero::TransactionInfo * t)
     {
 
         std::cout << "d: "
-                  << (t->direction() == Bitmonero::TransactionInfo::Direction_In ? "in" : "out")
+                  << (t->direction() == Monero::TransactionInfo::Direction_In ? "in" : "out")
                   << ", pe: " << (t->isPending() ? "true" : "false")
                   << ", bh: " << t->blockHeight()
-                  << ", a: " << Bitmonero::Wallet::displayAmount(t->amount())
-                  << ", f: " << Bitmonero::Wallet::displayAmount(t->fee())
+                  << ", a: " << Monero::Wallet::displayAmount(t->amount())
+                  << ", f: " << Monero::Wallet::displayAmount(t->fee())
                   << ", h: " << t->hash()
                   << ", pid: " << t->paymentId()
                   << std::endl;
@@ -127,8 +127,8 @@ struct Utils
 
     static std::string get_wallet_address(const std::string &filename, const std::string &password)
     {
-        Bitmonero::WalletManager *wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
-        Bitmonero::Wallet * w = wmgr->openWallet(filename, password, true);
+        Monero::WalletManager *wmgr = Monero::WalletManagerFactory::getWalletManager();
+        Monero::Wallet * w = wmgr->openWallet(filename, password, true);
         std::string result = w->address();
         wmgr->closeWallet(w);
         return result;
@@ -138,14 +138,14 @@ struct Utils
 
 struct WalletManagerTest : public testing::Test
 {
-    Bitmonero::WalletManager * wmgr;
+    Monero::WalletManager * wmgr;
 
 
     WalletManagerTest()
     {
         std::cout << __FUNCTION__ << std::endl;
-        wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
-        // Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_4);
+        wmgr = Monero::WalletManagerFactory::getWalletManager();
+        // Monero::WalletManagerFactory::setLogLevel(Monero::WalletManagerFactory::LogLevel_4);
         Utils::deleteWallet(WALLET_NAME);
         Utils::deleteDir(boost::filesystem::path(WALLET_NAME_WITH_DIR).parent_path().string());
     }
@@ -161,13 +161,13 @@ struct WalletManagerTest : public testing::Test
 
 struct WalletManagerMainnetTest : public testing::Test
 {
-    Bitmonero::WalletManager * wmgr;
+    Monero::WalletManager * wmgr;
 
 
     WalletManagerMainnetTest()
     {
         std::cout << __FUNCTION__ << std::endl;
-        wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
+        wmgr = Monero::WalletManagerFactory::getWalletManager();
         Utils::deleteWallet(WALLET_NAME_MAINNET);
     }
 
@@ -181,11 +181,11 @@ struct WalletManagerMainnetTest : public testing::Test
 
 struct WalletTest1 : public testing::Test
 {
-    Bitmonero::WalletManager * wmgr;
+    Monero::WalletManager * wmgr;
 
     WalletTest1()
     {
-        wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
+        wmgr = Monero::WalletManagerFactory::getWalletManager();
     }
 
 
@@ -194,11 +194,11 @@ struct WalletTest1 : public testing::Test
 
 struct WalletTest2 : public testing::Test
 {
-    Bitmonero::WalletManager * wmgr;
+    Monero::WalletManager * wmgr;
 
     WalletTest2()
     {
-        wmgr = Bitmonero::WalletManagerFactory::getWalletManager();
+        wmgr = Monero::WalletManagerFactory::getWalletManager();
     }
 
 };
@@ -206,8 +206,8 @@ struct WalletTest2 : public testing::Test
 TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
 {
 
-    Bitmonero::Wallet * wallet = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
-    ASSERT_TRUE(wallet->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    ASSERT_TRUE(wallet->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(!wallet->seed().empty());
     std::vector<std::string> words;
     std::string seed = wallet->seed();
@@ -223,11 +223,11 @@ TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
 TEST_F(WalletManagerTest, WalletManagerOpensWallet)
 {
 
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
     std::cout << "** seed: " << wallet2->seed() << std::endl;
 }
@@ -235,26 +235,26 @@ TEST_F(WalletManagerTest, WalletManagerOpensWallet)
 
 TEST_F(WalletManagerTest, WalletMaxAmountAsString)
 {
-    LOG_PRINT_L3("max amount: " << Bitmonero::Wallet::displayAmount(
-                     Bitmonero::Wallet::maximumAllowedAmount()));
+    LOG_PRINT_L3("max amount: " << Monero::Wallet::displayAmount(
+                     Monero::Wallet::maximumAllowedAmount()));
 
 }
 
 
 TEST_F(WalletManagerTest, WalletAmountFromString)
 {
-    uint64_t amount = Bitmonero::Wallet::amountFromString("18446740");
+    uint64_t amount = Monero::Wallet::amountFromString("18446740");
     ASSERT_TRUE(amount > 0);
-    amount = Bitmonero::Wallet::amountFromString("11000000000000");
+    amount = Monero::Wallet::amountFromString("11000000000000");
     ASSERT_FALSE(amount > 0);
-    amount = Bitmonero::Wallet::amountFromString("0.0");
+    amount = Monero::Wallet::amountFromString("0.0");
     ASSERT_FALSE(amount > 0);
-    amount = Bitmonero::Wallet::amountFromString("10.1");
+    amount = Monero::Wallet::amountFromString("10.1");
     ASSERT_TRUE(amount > 0);
 
 }
 
-void open_wallet_helper(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wallet, const std::string &pass, std::mutex *mutex)
+void open_wallet_helper(Monero::WalletManager *wmgr, Monero::Wallet **wallet, const std::string &pass, std::mutex *mutex)
 {
     if (mutex)
         mutex->lock();
@@ -275,23 +275,23 @@ void open_wallet_helper(Bitmonero::WalletManager *wmgr, Bitmonero::Wallet **wall
 //    // create password protected wallet
 //    std::string wallet_pass = "password";
 //    std::string wrong_wallet_pass = "1111";
-//    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, wallet_pass, WALLET_LANG, true);
+//    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, wallet_pass, WALLET_LANG, true);
 //    std::string seed1 = wallet1->seed();
 //    ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
-//    Bitmonero::Wallet *wallet2 = nullptr;
-//    Bitmonero::Wallet *wallet3 = nullptr;
+//    Monero::Wallet *wallet2 = nullptr;
+//    Monero::Wallet *wallet3 = nullptr;
 
 //    std::mutex mutex;
 //    std::thread thread1(open_wallet, wmgr, &wallet2, wrong_wallet_pass, &mutex);
 //    thread1.join();
-//    ASSERT_TRUE(wallet2->status() != Bitmonero::Wallet::Status_Ok);
+//    ASSERT_TRUE(wallet2->status() != Monero::Wallet::Status_Ok);
 //    ASSERT_TRUE(wmgr->closeWallet(wallet2));
 
 //    std::thread thread2(open_wallet, wmgr, &wallet3, wallet_pass, &mutex);
 //    thread2.join();
 
-//    ASSERT_TRUE(wallet3->status() == Bitmonero::Wallet::Status_Ok);
+//    ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
 //    ASSERT_TRUE(wmgr->closeWallet(wallet3));
 //}
 
@@ -301,22 +301,22 @@ TEST_F(WalletManagerTest, WalletManagerOpensWalletWithPasswordAndReopen)
     // create password protected wallet
     std::string wallet_pass = "password";
     std::string wrong_wallet_pass = "1111";
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, wallet_pass, WALLET_LANG, true);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, wallet_pass, WALLET_LANG, true);
     std::string seed1 = wallet1->seed();
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
-    Bitmonero::Wallet *wallet2 = nullptr;
-    Bitmonero::Wallet *wallet3 = nullptr;
+    Monero::Wallet *wallet2 = nullptr;
+    Monero::Wallet *wallet3 = nullptr;
     std::mutex mutex;
 
     open_wallet_helper(wmgr, &wallet2, wrong_wallet_pass, nullptr);
     ASSERT_TRUE(wallet2 != nullptr);
-    ASSERT_TRUE(wallet2->status() != Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet2->status() != Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
 
     open_wallet_helper(wmgr, &wallet3, wallet_pass, nullptr);
     ASSERT_TRUE(wallet3 != nullptr);
-    ASSERT_TRUE(wallet3->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wmgr->closeWallet(wallet3));
 }
 
@@ -324,12 +324,12 @@ TEST_F(WalletManagerTest, WalletManagerOpensWalletWithPasswordAndReopen)
 TEST_F(WalletManagerTest, WalletManagerStoresWallet)
 {
 
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     wallet1->store("");
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
 }
 
@@ -337,45 +337,45 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet)
 TEST_F(WalletManagerTest, WalletManagerMovesWallet)
 {
 
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string WALLET_NAME_MOVED = std::string("/tmp/") + WALLET_NAME + ".moved";
     std::string seed1 = wallet1->seed();
     ASSERT_TRUE(wallet1->store(WALLET_NAME_MOVED));
 
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_MOVED, WALLET_PASS);
+    Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_MOVED, WALLET_PASS);
     ASSERT_TRUE(wallet2->filename() == WALLET_NAME_MOVED);
     ASSERT_TRUE(wallet2->keysFilename() == WALLET_NAME_MOVED + ".keys");
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
 }
 
 
 TEST_F(WalletManagerTest, WalletManagerChangesPassword)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     ASSERT_TRUE(wallet1->setPassword(WALLET_PASS2));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS2);
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS2);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
-    Bitmonero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
-    ASSERT_FALSE(wallet3->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
+    ASSERT_FALSE(wallet3->status() == Monero::Wallet::Status_Ok);
 }
 
 
 
 TEST_F(WalletManagerTest, WalletManagerRecoversWallet)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->address();
     ASSERT_FALSE(address1.empty());
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
     Utils::deleteWallet(WALLET_NAME);
-    Bitmonero::Wallet * wallet2 = wmgr->recoveryWallet(WALLET_NAME, seed1);
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet2 = wmgr->recoveryWallet(WALLET_NAME, seed1);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
     ASSERT_TRUE(wallet2->address() == address1);
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
@@ -384,15 +384,15 @@ TEST_F(WalletManagerTest, WalletManagerRecoversWallet)
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet1)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->address();
 
     ASSERT_TRUE(wallet1->store(""));
     ASSERT_TRUE(wallet1->store(WALLET_NAME_COPY));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS);
-    ASSERT_TRUE(wallet2->status() == Bitmonero::Wallet::Status_Ok);
+    Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->seed() == seed1);
     ASSERT_TRUE(wallet2->address() == address1);
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
@@ -401,7 +401,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet1)
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->address();
 
@@ -409,7 +409,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME_WITH_DIR, WALLET_PASS);
-    ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet1->seed() == seed1);
     ASSERT_TRUE(wallet1->address() == address1);
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
@@ -418,7 +418,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->address();
 
@@ -426,13 +426,13 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME_WITH_DIR_NON_WRITABLE, WALLET_PASS);
-    ASSERT_FALSE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_FALSE(wallet1->status() == Monero::Wallet::Status_Ok);
 
     // "close" always returns true;
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
-    ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet1->seed() == seed1);
     ASSERT_TRUE(wallet1->address() == address1);
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
@@ -442,20 +442,20 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet3)
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet4)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG);
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->address();
 
     ASSERT_TRUE(wallet1->store(""));
-    ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::Wallet::Status_Ok);
 
     ASSERT_TRUE(wallet1->store(""));
-    ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::Wallet::Status_Ok);
 
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME, WALLET_PASS);
-    ASSERT_TRUE(wallet1->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet1->seed() == seed1);
     ASSERT_TRUE(wallet1->address() == address1);
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
@@ -477,16 +477,16 @@ TEST_F(WalletManagerTest, WalletManagerFindsWallet)
 
 TEST_F(WalletTest1, WalletGeneratesPaymentId)
 {
-    std::string payment_id = Bitmonero::Wallet::genPaymentId();
+    std::string payment_id = Monero::Wallet::genPaymentId();
     ASSERT_TRUE(payment_id.length() == 16);
 }
 
 
 TEST_F(WalletTest1, WalletGeneratesIntegratedAddress)
 {
-    std::string payment_id = Bitmonero::Wallet::genPaymentId();
+    std::string payment_id = Monero::Wallet::genPaymentId();
 
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     std::string integrated_address = wallet1->integratedAddress(payment_id);
     ASSERT_TRUE(integrated_address.length() == 106);
 }
@@ -494,14 +494,14 @@ TEST_F(WalletTest1, WalletGeneratesIntegratedAddress)
 
 TEST_F(WalletTest1, WalletShowsBalance)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     ASSERT_TRUE(wallet1->balance() > 0);
     ASSERT_TRUE(wallet1->unlockedBalance() > 0);
 
     uint64_t balance1 = wallet1->balance();
     uint64_t unlockedBalance1 = wallet1->unlockedBalance();
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
-    Bitmonero::Wallet * wallet2 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet2 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
 
     ASSERT_TRUE(balance1 == wallet2->balance());
     std::cout << "wallet balance: " << wallet2->balance() << std::endl;
@@ -512,7 +512,7 @@ TEST_F(WalletTest1, WalletShowsBalance)
 
 TEST_F(WalletTest1, WalletReturnsCurrentBlockHeight)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     ASSERT_TRUE(wallet1->blockChainHeight() > 0);
     wmgr->closeWallet(wallet1);
 }
@@ -520,10 +520,10 @@ TEST_F(WalletTest1, WalletReturnsCurrentBlockHeight)
 
 TEST_F(WalletTest1, WalletReturnsDaemonBlockHeight)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // wallet not connected to daemon
     ASSERT_TRUE(wallet1->daemonBlockChainHeight() == 0);
-    ASSERT_TRUE(wallet1->status() != Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet1->status() != Monero::Wallet::Status_Ok);
     ASSERT_FALSE(wallet1->errorString().empty());
     wmgr->closeWallet(wallet1);
 
@@ -540,7 +540,7 @@ TEST_F(WalletTest1, WalletRefresh)
 {
 
     std::cout << "Opening wallet: " << CURRENT_SRC_WALLET << std::endl;
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     std::cout << "connecting to daemon: " << TESTNET_DAEMON_ADDRESS << std::endl;
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
@@ -550,12 +550,12 @@ TEST_F(WalletTest1, WalletRefresh)
 
 TEST_F(WalletTest1, WalletConvertsToString)
 {
-    std::string strAmount = Bitmonero::Wallet::displayAmount(AMOUNT_5XMR);
-    ASSERT_TRUE(AMOUNT_5XMR == Bitmonero::Wallet::amountFromString(strAmount));
+    std::string strAmount = Monero::Wallet::displayAmount(AMOUNT_5XMR);
+    ASSERT_TRUE(AMOUNT_5XMR == Monero::Wallet::amountFromString(strAmount));
 
-    ASSERT_TRUE(AMOUNT_5XMR == Bitmonero::Wallet::amountFromDouble(5.0));
-    ASSERT_TRUE(AMOUNT_10XMR == Bitmonero::Wallet::amountFromDouble(10.0));
-    ASSERT_TRUE(AMOUNT_1XMR == Bitmonero::Wallet::amountFromDouble(1.0));
+    ASSERT_TRUE(AMOUNT_5XMR == Monero::Wallet::amountFromDouble(5.0));
+    ASSERT_TRUE(AMOUNT_10XMR == Monero::Wallet::amountFromDouble(10.0));
+    ASSERT_TRUE(AMOUNT_1XMR == Monero::Wallet::amountFromDouble(1.0));
 
 }
 
@@ -564,23 +564,23 @@ TEST_F(WalletTest1, WalletConvertsToString)
 TEST_F(WalletTest1, WalletTransaction)
 
 {
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet1->refresh());
     uint64_t balance = wallet1->balance();
-    ASSERT_TRUE(wallet1->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::PendingTransaction::Status_Ok);
 
     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
     const int MIXIN_COUNT = 4;
 
 
-    Bitmonero::PendingTransaction * transaction = wallet1->createTransaction(recepient_address,
+    Monero::PendingTransaction * transaction = wallet1->createTransaction(recepient_address,
                                                                              PAYMENT_ID_EMPTY,
                                                                              AMOUNT_10XMR,
                                                                              MIXIN_COUNT,
-                                                                             Bitmonero::PendingTransaction::Priority_Medium);
-    ASSERT_TRUE(transaction->status() == Bitmonero::PendingTransaction::Status_Ok);
+                                                                             Monero::PendingTransaction::Priority_Medium);
+    ASSERT_TRUE(transaction->status() == Monero::PendingTransaction::Status_Ok);
     wallet1->refresh();
 
     ASSERT_TRUE(wallet1->balance() == balance);
@@ -604,25 +604,25 @@ TEST_F(WalletTest1, WalletTransactionWithMixin)
 
     std::string payment_id = "";
 
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
 
 
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet1->refresh());
     uint64_t balance = wallet1->balance();
-    ASSERT_TRUE(wallet1->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::PendingTransaction::Status_Ok);
 
     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
     for (auto mixin : mixins) {
         std::cerr << "Transaction mixin count: " << mixin << std::endl;
-        Bitmonero::PendingTransaction * transaction = wallet1->createTransaction(
+        Monero::PendingTransaction * transaction = wallet1->createTransaction(
                     recepient_address, payment_id, AMOUNT_5XMR, mixin);
 
         std::cerr << "Transaction status: " << transaction->status() << std::endl;
-        std::cerr << "Transaction fee: " << Bitmonero::Wallet::displayAmount(transaction->fee()) << std::endl;
+        std::cerr << "Transaction fee: " << Monero::Wallet::displayAmount(transaction->fee()) << std::endl;
         std::cerr << "Transaction error: " << transaction->errorString() << std::endl;
-        ASSERT_TRUE(transaction->status() == Bitmonero::PendingTransaction::Status_Ok);
+        ASSERT_TRUE(transaction->status() == Monero::PendingTransaction::Status_Ok);
         wallet1->disposeTransaction(transaction);
     }
 
@@ -637,33 +637,33 @@ TEST_F(WalletTest1, WalletTransactionWithPriority)
 
     std::string payment_id = "";
 
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
 
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet1->refresh());
     uint64_t balance = wallet1->balance();
-    ASSERT_TRUE(wallet1->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(wallet1->status() == Monero::PendingTransaction::Status_Ok);
 
     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
     uint32_t mixin = 2;
     uint64_t fee   = 0;
 
-    std::vector<Bitmonero::PendingTransaction::Priority> priorities =  {
-         Bitmonero::PendingTransaction::Priority_Low,
-         Bitmonero::PendingTransaction::Priority_Medium,
-         Bitmonero::PendingTransaction::Priority_High
+    std::vector<Monero::PendingTransaction::Priority> priorities =  {
+         Monero::PendingTransaction::Priority_Low,
+         Monero::PendingTransaction::Priority_Medium,
+         Monero::PendingTransaction::Priority_High
     };
 
     for (auto it = priorities.begin(); it != priorities.end(); ++it) {
         std::cerr << "Transaction priority: " << *it << std::endl;
-        Bitmonero::PendingTransaction * transaction = wallet1->createTransaction(
+        Monero::PendingTransaction * transaction = wallet1->createTransaction(
                     recepient_address, payment_id, AMOUNT_5XMR, mixin, *it);
         std::cerr << "Transaction status: " << transaction->status() << std::endl;
-        std::cerr << "Transaction fee: " << Bitmonero::Wallet::displayAmount(transaction->fee()) << std::endl;
+        std::cerr << "Transaction fee: " << Monero::Wallet::displayAmount(transaction->fee()) << std::endl;
         std::cerr << "Transaction error: " << transaction->errorString() << std::endl;
         ASSERT_TRUE(transaction->fee() > fee);
-        ASSERT_TRUE(transaction->status() == Bitmonero::PendingTransaction::Status_Ok);
+        ASSERT_TRUE(transaction->status() == Monero::PendingTransaction::Status_Ok);
         fee = transaction->fee();
         wallet1->disposeTransaction(transaction);
     }
@@ -676,11 +676,11 @@ TEST_F(WalletTest1, WalletTransactionWithPriority)
 
 TEST_F(WalletTest1, WalletHistory)
 {
-    Bitmonero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet1 = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet1->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet1->refresh());
-    Bitmonero::TransactionHistory * history = wallet1->history();
+    Monero::TransactionHistory * history = wallet1->history();
     history->refresh();
     ASSERT_TRUE(history->count() > 0);
 
@@ -694,11 +694,11 @@ TEST_F(WalletTest1, WalletHistory)
 TEST_F(WalletTest1, WalletTransactionAndHistory)
 {
     return;
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src->refresh());
-    Bitmonero::TransactionHistory * history = wallet_src->history();
+    Monero::TransactionHistory * history = wallet_src->history();
     history->refresh();
     ASSERT_TRUE(history->count() > 0);
     size_t count1 = history->count();
@@ -712,11 +712,11 @@ TEST_F(WalletTest1, WalletTransactionAndHistory)
     std::string wallet4_addr = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
 
 
-    Bitmonero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
+    Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
                                                                        PAYMENT_ID_EMPTY,
                                                                        AMOUNT_10XMR * 5, 1);
 
-    ASSERT_TRUE(tx->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
     history = wallet_src->history();
     history->refresh();
@@ -733,11 +733,11 @@ TEST_F(WalletTest1, WalletTransactionAndHistory)
 TEST_F(WalletTest1, WalletTransactionWithPaymentId)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src->refresh());
-    Bitmonero::TransactionHistory * history = wallet_src->history();
+    Monero::TransactionHistory * history = wallet_src->history();
     history->refresh();
     ASSERT_TRUE(history->count() > 0);
     size_t count1 = history->count();
@@ -750,15 +750,15 @@ TEST_F(WalletTest1, WalletTransactionWithPaymentId)
 
     std::string wallet4_addr = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
 
-    std::string payment_id = Bitmonero::Wallet::genPaymentId();
+    std::string payment_id = Monero::Wallet::genPaymentId();
     ASSERT_TRUE(payment_id.length() == 16);
 
 
-    Bitmonero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
+    Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
                                                                        payment_id,
                                                                        AMOUNT_1XMR, 1);
 
-    ASSERT_TRUE(tx->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
     history = wallet_src->history();
     history->refresh();
@@ -779,10 +779,10 @@ TEST_F(WalletTest1, WalletTransactionWithPaymentId)
 }
 
 
-struct MyWalletListener : public Bitmonero::WalletListener
+struct MyWalletListener : public Monero::WalletListener
 {
 
-    Bitmonero::Wallet * wallet;
+    Monero::Wallet * wallet;
     uint64_t total_tx;
     uint64_t total_rx;
     std::mutex  mutex;
@@ -799,7 +799,7 @@ struct MyWalletListener : public Bitmonero::WalletListener
 
 
 
-    MyWalletListener(Bitmonero::Wallet * wallet)
+    MyWalletListener(Monero::Wallet * wallet)
         : total_tx(0), total_rx(0)
     {
         reset();
@@ -865,7 +865,7 @@ struct MyWalletListener : public Bitmonero::WalletListener
 TEST_F(WalletTest2, WalletCallBackRefreshedSync)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     MyWalletListener * wallet_src_listener = new MyWalletListener(wallet_src);
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src_listener->refresh_triggered);
@@ -882,7 +882,7 @@ TEST_F(WalletTest2, WalletCallBackRefreshedSync)
 TEST_F(WalletTest2, WalletCallBackRefreshedAsync)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     MyWalletListener * wallet_src_listener = new MyWalletListener(wallet_src);
 
     std::chrono::seconds wait_for = std::chrono::seconds(20);
@@ -903,26 +903,26 @@ TEST_F(WalletTest2, WalletCallBackRefreshedAsync)
 TEST_F(WalletTest2, WalletCallbackSent)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src->refresh());
     MyWalletListener * wallet_src_listener = new MyWalletListener(wallet_src);
     uint64_t balance = wallet_src->balance();
     std::cout << "** Balance: " << wallet_src->displayAmount(wallet_src->balance()) <<  std::endl;
-    Bitmonero::Wallet * wallet_dst = wmgr->openWallet(CURRENT_DST_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_dst = wmgr->openWallet(CURRENT_DST_WALLET, TESTNET_WALLET_PASS, true);
 
     uint64_t amount = AMOUNT_1XMR * 5;
-    std::cout << "** Sending " << Bitmonero::Wallet::displayAmount(amount) << " to " << wallet_dst->address();
+    std::cout << "** Sending " << Monero::Wallet::displayAmount(amount) << " to " << wallet_dst->address();
 
 
-    Bitmonero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->address(),
+    Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->address(),
                                                                        PAYMENT_ID_EMPTY,
                                                                        amount, 1);
-    std::cout << "** Committing transaction: " << Bitmonero::Wallet::displayAmount(tx->amount())
-              << " with fee: " << Bitmonero::Wallet::displayAmount(tx->fee());
+    std::cout << "** Committing transaction: " << Monero::Wallet::displayAmount(tx->amount())
+              << " with fee: " << Monero::Wallet::displayAmount(tx->fee());
 
-    ASSERT_TRUE(tx->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
 
     std::chrono::seconds wait_for = std::chrono::seconds(60*3);
@@ -942,13 +942,13 @@ TEST_F(WalletTest2, WalletCallbackSent)
 TEST_F(WalletTest2, WalletCallbackReceived)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(CURRENT_SRC_WALLET, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src->refresh());
     std::cout << "** Balance src1: " << wallet_src->displayAmount(wallet_src->balance()) <<  std::endl;
 
-    Bitmonero::Wallet * wallet_dst = wmgr->openWallet(CURRENT_DST_WALLET, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_dst = wmgr->openWallet(CURRENT_DST_WALLET, TESTNET_WALLET_PASS, true);
     ASSERT_TRUE(wallet_dst->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_dst->refresh());
     uint64_t balance = wallet_dst->balance();
@@ -956,15 +956,15 @@ TEST_F(WalletTest2, WalletCallbackReceived)
     std::unique_ptr<MyWalletListener> wallet_dst_listener (new MyWalletListener(wallet_dst));
 
     uint64_t amount = AMOUNT_1XMR * 5;
-    std::cout << "** Sending " << Bitmonero::Wallet::displayAmount(amount) << " to " << wallet_dst->address();
-    Bitmonero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->address(),
+    std::cout << "** Sending " << Monero::Wallet::displayAmount(amount) << " to " << wallet_dst->address();
+    Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->address(),
                                                                        PAYMENT_ID_EMPTY,
                                                                        amount, 1);
 
-    std::cout << "** Committing transaction: " << Bitmonero::Wallet::displayAmount(tx->amount())
-              << " with fee: " << Bitmonero::Wallet::displayAmount(tx->fee());
+    std::cout << "** Committing transaction: " << Monero::Wallet::displayAmount(tx->amount())
+              << " with fee: " << Monero::Wallet::displayAmount(tx->fee());
 
-    ASSERT_TRUE(tx->status() == Bitmonero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
 
     std::chrono::seconds wait_for = std::chrono::seconds(60*4);
@@ -989,7 +989,7 @@ TEST_F(WalletTest2, WalletCallbackReceived)
 TEST_F(WalletTest2, WalletCallbackNewBlock)
 {
 
-    Bitmonero::Wallet * wallet_src = wmgr->openWallet(TESTNET_WALLET5_NAME, TESTNET_WALLET_PASS, true);
+    Monero::Wallet * wallet_src = wmgr->openWallet(TESTNET_WALLET5_NAME, TESTNET_WALLET_PASS, true);
     // make sure testnet daemon is running
     ASSERT_TRUE(wallet_src->init(TESTNET_DAEMON_ADDRESS, 0));
     ASSERT_TRUE(wallet_src->refresh());
@@ -1016,7 +1016,7 @@ TEST_F(WalletTest2, WalletCallbackNewBlock)
 TEST_F(WalletManagerMainnetTest, CreateOpenAndRefreshWalletMainNetSync)
 {
 
-    Bitmonero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
+    Monero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
     std::unique_ptr<MyWalletListener> wallet_listener (new MyWalletListener(wallet));
     wallet->init(MAINNET_DAEMON_ADDRESS, 0);
     std::cerr << "TEST: waiting on refresh lock...\n";
@@ -1035,7 +1035,7 @@ TEST_F(WalletManagerMainnetTest, CreateAndRefreshWalletMainNetAsync)
     // supposing 120 seconds should be enough for fast refresh
     int SECONDS_TO_REFRESH = 120;
 
-    Bitmonero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
+    Monero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
     std::unique_ptr<MyWalletListener> wallet_listener (new MyWalletListener(wallet));
 
     std::chrono::seconds wait_for = std::chrono::seconds(SECONDS_TO_REFRESH);
@@ -1045,7 +1045,7 @@ TEST_F(WalletManagerMainnetTest, CreateAndRefreshWalletMainNetAsync)
     std::cerr << "TEST: waiting on refresh lock...\n";
     wallet_listener->cv_refresh.wait_for(lock, wait_for);
     std::cerr << "TEST: refresh lock acquired...\n";
-    ASSERT_TRUE(wallet->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet_listener->refresh_triggered);
     ASSERT_TRUE(wallet->connected());
     ASSERT_TRUE(wallet->blockChainHeight() == wallet->daemonBlockChainHeight());
@@ -1058,7 +1058,7 @@ TEST_F(WalletManagerMainnetTest, OpenAndRefreshWalletMainNetAsync)
 
     // supposing 120 seconds should be enough for fast refresh
     int SECONDS_TO_REFRESH = 120;
-    Bitmonero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
+    Monero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
     wmgr->closeWallet(wallet);
     wallet = wmgr->openWallet(WALLET_NAME_MAINNET, "");
 
@@ -1071,7 +1071,7 @@ TEST_F(WalletManagerMainnetTest, OpenAndRefreshWalletMainNetAsync)
     std::cerr << "TEST: waiting on refresh lock...\n";
     wallet_listener->cv_refresh.wait_for(lock, wait_for);
     std::cerr << "TEST: refresh lock acquired...\n";
-    ASSERT_TRUE(wallet->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet_listener->refresh_triggered);
     ASSERT_TRUE(wallet->connected());
     ASSERT_TRUE(wallet->blockChainHeight() == wallet->daemonBlockChainHeight());
@@ -1085,7 +1085,7 @@ TEST_F(WalletManagerMainnetTest, RecoverAndRefreshWalletMainNetAsync)
 
     // supposing 120 seconds should be enough for fast refresh
     int SECONDS_TO_REFRESH = 120;
-    Bitmonero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
+    Monero::Wallet * wallet = wmgr->createWallet(WALLET_NAME_MAINNET, "", WALLET_LANG);
     std::string seed = wallet->seed();
     std::string address = wallet->address();
     wmgr->closeWallet(wallet);
@@ -1095,7 +1095,7 @@ TEST_F(WalletManagerMainnetTest, RecoverAndRefreshWalletMainNetAsync)
     // ..and recovering wallet from seed
 
     wallet = wmgr->recoveryWallet(WALLET_NAME_MAINNET, seed);
-    ASSERT_TRUE(wallet->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet->address() == address);
     std::unique_ptr<MyWalletListener> wallet_listener (new MyWalletListener(wallet));
     std::chrono::seconds wait_for = std::chrono::seconds(SECONDS_TO_REFRESH);
@@ -1108,7 +1108,7 @@ TEST_F(WalletManagerMainnetTest, RecoverAndRefreshWalletMainNetAsync)
     // as it needs much more than 120 seconds for mainnet
 
     wallet_listener->cv_refresh.wait_for(lock, wait_for);
-    ASSERT_TRUE(wallet->status() == Bitmonero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet->status() == Monero::Wallet::Status_Ok);
     ASSERT_FALSE(wallet_listener->refresh_triggered);
     ASSERT_TRUE(wallet->connected());
     ASSERT_FALSE(wallet->blockChainHeight() == wallet->daemonBlockChainHeight());
@@ -1153,6 +1153,6 @@ int main(int argc, char** argv)
     CURRENT_DST_WALLET = TESTNET_WALLET1_NAME;
 
     ::testing::InitGoogleTest(&argc, argv);
-    Bitmonero::WalletManagerFactory::setLogLevel(Bitmonero::WalletManagerFactory::LogLevel_Max);
+    Monero::WalletManagerFactory::setLogLevel(Monero::WalletManagerFactory::LogLevel_Max);
     return RUN_ALL_TESTS();
 }

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -2,7 +2,7 @@
 <!DOCTYPE TS>
 <TS version="2.0">
 <context>
-    <name>Bitmonero::PendingTransactionImpl</name>
+    <name>Monero::PendingTransactionImpl</name>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="95"/>
         <source>daemon is busy. Please try again later.</source>
@@ -30,7 +30,7 @@
     </message>
 </context>
 <context>
-    <name>Bitmonero::WalletImpl</name>
+    <name>Monero::WalletImpl</name>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="609"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
@@ -145,7 +145,7 @@
     </message>
 </context>
 <context>
-    <name>Bitmonero::WalletManagerImpl</name>
+    <name>Monero::WalletManagerImpl</name>
     <message>
         <location filename="../src/wallet/api/wallet_manager.cpp" line="161"/>
         <source>failed to parse txid</source>


### PR DESCRIPTION
Bitmonero namespace renamed Monero. Bitmonero alias added so that third party uses of the wallet can transition to Monero.