### PR TITLE
Wallet API: Do not refresh while daemon is syncing

### DIFF
--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -107,14 +107,15 @@ public:
     virtual std::string getTxKey(const std::string &txid) const;
     virtual std::string signMessage(const std::string &message);
     virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const;
+    virtual void startRefresh();
+    virtual void pauseRefresh();
 
 private:
     void clearStatus();
     void refreshThreadFunc();
     void doRefresh();
-    void startRefresh();
+    bool daemonSynced() const;
     void stopRefresh();
-    void pauseRefresh();
     bool isNewWallet() const;
     void doInit(const std::string &daemon_address, uint64_t upper_transaction_size_limit);
 
@@ -151,6 +152,8 @@ private:
     bool                m_recoveringFromSeed;
     std::atomic<bool>   m_synchronized;
     bool                m_rebuildWalletCache;
+    // cache connection status to avoid unnecessary RPC calls
+    mutable bool                m_is_connected;
 };
 
 

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -364,6 +364,15 @@ struct Wallet
     static std::string paymentIdFromAddress(const std::string &str, bool testnet);
     static uint64_t maximumAllowedAmount();
 
+   /**
+    * @brief StartRefresh - Start/resume refresh thread (refresh every 10 seconds)
+    */
+    virtual void startRefresh() = 0;
+   /**
+    * @brief pauseRefresh - pause refresh thread
+    */
+    virtual void pauseRefresh() = 0;
+
     /**
      * @brief refresh - refreshes the wallet, updating transactions from daemon
      * @return - true if refreshed successfully;


### PR DESCRIPTION
Syncing daemon and refreshing wallet simultaneously is very resource intensive.

+ pause/startRefresh() changed to public. 