### PR TITLE
AddressBook: use unsigned type for row ID's

### DIFF
--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -94,7 +94,7 @@ void AddressBookImpl::refresh()
   
 }
 
-bool AddressBookImpl::deleteRow(int rowId) 
+bool AddressBookImpl::deleteRow(std::size_t rowId)
 {
   LOG_PRINT_L2("Deleting address book row " << rowId);
   bool r = m_wallet->m_wallet->delete_address_book_row(rowId);

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -46,7 +46,7 @@ public:
     void refresh();
     std::vector<AddressBookRow*> getAll() const;
     bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description);
-    bool deleteRow(int rowId);
+    bool deleteRow(std::size_t rowId);
      
     // Error codes. See AddressBook:ErrorCode enum in wallet2_api.h
     std::string errorString() const {return m_errorString;}

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1569,14 +1569,14 @@ bool wallet2::add_address_book_row(const cryptonote::account_public_address &add
   a.m_payment_id = payment_id;
   a.m_description = description;
   
-  int old_size = m_address_book.size();
+  auto old_size = m_address_book.size();
   m_address_book.push_back(a);
   if(m_address_book.size() == old_size+1)
     return true;
   return false;
 }
 
-bool wallet2::delete_address_book_row(int row_id) {
+bool wallet2::delete_address_book_row(std::size_t row_id) {
   if(m_address_book.size() <= row_id)
     return false;
   

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -525,7 +525,7 @@ namespace tools
     */
     std::vector<address_book_row> get_address_book() const { return m_address_book; }
     bool add_address_book_row(const cryptonote::account_public_address &address, const crypto::hash &payment_id, const std::string &description);
-    bool delete_address_book_row(int row_id);
+    bool delete_address_book_row(std::size_t row_id);
         
     uint64_t get_num_rct_outputs();
     const transfer_details &get_transfer_details(size_t idx) const;

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -137,14 +137,14 @@ struct TransactionHistory
  */
 struct AddressBookRow {
 public:
-    AddressBookRow(int _rowId, const std::string &_address, const std::string &_paymentId, const std::string &_description):
+    AddressBookRow(std::size_t _rowId, const std::string &_address, const std::string &_paymentId, const std::string &_description):
         m_rowId(_rowId),
         m_address(_address),
         m_paymentId(_paymentId), 
         m_description(_description) {}
  
 private:
-    int m_rowId;
+    std::size_t m_rowId;
     std::string m_address;
     std::string m_paymentId;
     std::string m_description;
@@ -153,7 +153,7 @@ public:
     std::string getAddress() const {return m_address;} 
     std::string getDescription() const {return m_description;} 
     std::string getPaymentId() const {return m_paymentId;} 
-    int getRowId() const {return m_rowId;} 
+    std::size_t getRowId() const {return m_rowId;}
 };
 
 /**
@@ -171,7 +171,7 @@ struct AddressBook
     virtual ~AddressBook() = 0;
     virtual std::vector<AddressBookRow*> getAll() const = 0;
     virtual bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) = 0;  
-    virtual bool deleteRow(int rowId) = 0;  
+    virtual bool deleteRow(std::size_t rowId) = 0;
     virtual void refresh() = 0;  
     virtual std::string errorString() const = 0;
     virtual int errorCode() const = 0;


### PR DESCRIPTION
Fixes build warnings and may also prevent future headaches.