### PR TITLE
make openalias also available for solo miner

### DIFF
--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -25,9 +25,11 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
 
 #include <vector>
 #include <string>
+#include "cryptonote_core/cryptonote_basic.h"
 
 namespace tools
 {
@@ -154,5 +156,22 @@ private:
 
   DNSResolverData *m_data;
 }; // class DNSResolver
+
+namespace dns_utils
+{
+
+std::string address_from_txt_record(const std::string& s);
+std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec_valid);
+
+std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid);
+bool get_account_address_from_str_or_url(
+    cryptonote::account_public_address& address
+  , bool& has_payment_id
+  , crypto::hash8& payment_id
+  , bool testnet
+  , const std::string& str_or_url
+  );
+
+}  // namespace tools::dns_utils
 
 }  // namespace tools

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -162,7 +162,6 @@ namespace cryptonote
     bool accept_loaded_tx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message = std::string());
     bool accept_loaded_tx(const tools::wallet2::unsigned_tx_set &txs);
     bool accept_loaded_tx(const tools::wallet2::signed_tx_set &txs);
-    bool get_address_from_str(const std::string &str, cryptonote::account_public_address &address, bool &has_payment_id, crypto::hash8 &payment_id);
 
     /*!
      * \brief Prints the seed with a nice message

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -32,6 +32,7 @@
 #include "wallet_manager.h"
 #include "wallet.h"
 #include "common_defines.h"
+#include "common/dns_utils.h"
 #include "net/http_client.h"
 
 #include <boost/filesystem.hpp>
@@ -354,7 +355,7 @@ double WalletManagerImpl::miningHashRate() const
 
 std::string WalletManagerImpl::resolveOpenAlias(const std::string &address, bool &dnssec_valid) const
 {
-    std::vector<std::string> addresses = tools::wallet2::addresses_from_url(address, dnssec_valid);
+    std::vector<std::string> addresses = tools::dns_utils::addresses_from_url(address, dnssec_valid);
     if (addresses.empty())
         return "";
     return addresses.front();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -503,10 +503,6 @@ namespace tools
     static bool parse_short_payment_id(const std::string& payment_id_str, crypto::hash8& payment_id);
     static bool parse_payment_id(const std::string& payment_id_str, crypto::hash& payment_id);
 
-    static std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec_valid);
-
-    static std::string address_from_txt_record(const std::string& s);
-
     bool always_confirm_transfers() const { return m_always_confirm_transfers; }
     void always_confirm_transfers(bool always) { m_always_confirm_transfers = always; }
     bool store_tx_info() const { return m_store_tx_info; }

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -31,6 +31,7 @@
 #include "gtest/gtest.h"
 
 #include "wallet/wallet2.h"
+#include "common/dns_utils.h"
 #include <string>
 
 TEST(AddressFromTXT, Success)
@@ -42,7 +43,7 @@ TEST(AddressFromTXT, Success)
   txtr += addr;
   txtr += ";";
 
-  std::string res = tools::wallet2::address_from_txt_record(txtr);
+  std::string res = tools::dns_utils::address_from_txt_record(txtr);
 
   EXPECT_STREQ(addr.c_str(), res.c_str());
 
@@ -52,7 +53,7 @@ TEST(AddressFromTXT, Success)
 
   txtr2 += "more foobar";
 
-  res = tools::wallet2::address_from_txt_record(txtr2);
+  res = tools::dns_utils::address_from_txt_record(txtr2);
 
   EXPECT_STREQ(addr.c_str(), res.c_str());
 
@@ -61,7 +62,7 @@ TEST(AddressFromTXT, Success)
   txtr3 += addr;
   txtr3 += "; foobar";
 
-  res = tools::wallet2::address_from_txt_record(txtr3);
+  res = tools::dns_utils::address_from_txt_record(txtr3);
 
   EXPECT_STREQ(addr.c_str(), res.c_str());
 }
@@ -70,13 +71,13 @@ TEST(AddressFromTXT, Failure)
 {
   std::string txtr = "oa1:xmr recipient_address=not a real address";
 
-  std::string res = tools::wallet2::address_from_txt_record(txtr);
+  std::string res = tools::dns_utils::address_from_txt_record(txtr);
 
   ASSERT_STREQ("", res.c_str());
 
   txtr += ";";
 
-  res = tools::wallet2::address_from_txt_record(txtr);
+  res = tools::dns_utils::address_from_txt_record(txtr);
   ASSERT_STREQ("", res.c_str());
 }
 
@@ -86,7 +87,7 @@ TEST(AddressFromURL, Success)
   
   bool dnssec_result = false;
 
-  std::vector<std::string> addresses = tools::wallet2::addresses_from_url("donate.getmonero.org", dnssec_result);
+  std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("donate.getmonero.org", dnssec_result);
 
   EXPECT_EQ(1, addresses.size());
   if (addresses.size() == 1)
@@ -95,7 +96,7 @@ TEST(AddressFromURL, Success)
   }
 
   // OpenAlias address with an @ instead of first .
-  addresses = tools::wallet2::addresses_from_url("donate@getmonero.org", dnssec_result);
+  addresses = tools::dns_utils::addresses_from_url("donate@getmonero.org", dnssec_result);
   EXPECT_EQ(1, addresses.size());
   if (addresses.size() == 1)
   {
@@ -107,7 +108,7 @@ TEST(AddressFromURL, Failure)
 {
   bool dnssec_result = false;
 
-  std::vector<std::string> addresses = tools::wallet2::addresses_from_url("example.invalid", dnssec_result);
+  std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("example.invalid", dnssec_result);
 
   // for a non-existing domain such as "example.invalid", the non-existence is proved with NSEC records
   ASSERT_TRUE(dnssec_result);


### PR DESCRIPTION
Functions listed below are moved to cryptonote_basic_impl so that monerod can also use OpenAlias:
- `simple_wallet::get_address_from_str`
- `wallet2::addresses_from_url`
- `wallet2::address_from_txt_record`
Now you can easily do solo donation mining by `start_mining getmonero.org` :D