### PR TITLE
Enabled HTTP auth support for monero-wallet-rpc

### DIFF
--- a/src/common/boost_serialization_helper.h
+++ b/src/common/boost_serialization_helper.h
@@ -53,8 +53,8 @@ namespace tools
       return false;
     }
 
-    FILE* data_file_file = _fdopen(data_file_descriptor, "wb");
-    if (0 == data_file_file)
+    const std::unique_ptr<FILE, tools::close_file> data_file_file{_fdopen(data_file_descriptor, "wb")};
+    if (nullptr == data_file_file)
     {
       // Call CloseHandle is not necessary
       _close(data_file_descriptor);
@@ -62,11 +62,10 @@ namespace tools
     }
 
     // HACK: undocumented constructor, this code may not compile
-    std::ofstream data_file(data_file_file);
+    std::ofstream data_file(data_file_file.get());
     if (data_file.fail())
     {
       // Call CloseHandle and _close are not necessary
-      fclose(data_file_file);
       return false;
     }
 #else
@@ -85,7 +84,6 @@ namespace tools
 #if defined(_MSC_VER)
     // To make sure the file is fully stored on disk
     ::FlushFileBuffers(data_file_handle);
-    fclose(data_file_file);
 #endif
 
     return true;

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -30,13 +30,15 @@
 
 #pragma once 
 
-#include <mutex>
-#include <system_error>
-#include <boost/filesystem.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
+#include <csignal>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <string>
 
-#include "crypto/crypto.h"
 #include "crypto/hash.h"
-#include "misc_language.h"
 #include "p2p/p2p_protocol_defs.h"
 
 /*! \brief Various Tools
@@ -46,6 +48,21 @@
  */
 namespace tools
 {
+  //! Functional class for closing C file handles.
+  struct close_file
+  {
+    void operator()(std::FILE* handle) const noexcept
+    {
+      if (handle)
+      {
+        std::fclose(handle);
+      }
+    }
+  };
+
+  //! \return File only readable by owner. nullptr if `filename` exists.
+  std::unique_ptr<std::FILE, close_file> create_private_file(const std::string& filename);
+
   /*! \brief Returns the default data directory.
    *
    * \details Windows < Vista: C:\\Documents and Settings\\Username\\Application Data\\CRYPTONOTE_NAME

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -32,6 +32,7 @@
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <string>
 #include "net/http_server_impl_base.h"
 #include "wallet_rpc_server_commands_defs.h"
 #include "wallet2.h"
@@ -48,6 +49,7 @@ namespace tools
     static const char* tr(const char* str);
 
     wallet_rpc_server(wallet2& cr);
+    ~wallet_rpc_server();
 
     bool init(const boost::program_options::variables_map& vm);
     bool run();
@@ -118,6 +120,7 @@ namespace tools
       bool on_query_key(const wallet_rpc::COMMAND_RPC_QUERY_KEY::request& req, wallet_rpc::COMMAND_RPC_QUERY_KEY::response& res, epee::json_rpc::error& er);
 
       wallet2& m_wallet;
+      std::string rpc_login_filename;
       std::atomic<bool> m_stop;
   };
 }


### PR DESCRIPTION
This does **not** make the program options for user selected username/password or disabled authentication hidden. That did not feel "right" - although it would prevent people from shooting themselves in the foot more quickly. Thoughts?

And I added code for some gross Win32 ACL code - a file containing the username/password for HTTP authentication is restricted to only readable by the owner of the process in Posix and Win32 (umask does this by default for Posix, but now we are really sure!). This should fail if the user is running `monero-wallet-rpc` in Windows from a FAT32 partition. Thoughts?