### PR TITLE
Refactored password prompting for wallets

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -81,6 +81,9 @@ namespace cryptonote
 
     void wallet_idle_thread();
 
+    //! \return Prompts user for password and verifies against local file. Logs on error and returns `none`
+    boost::optional<tools::password_container> get_and_verify_password() const;
+
     bool new_wallet(const boost::program_options::variables_map& vm, const crypto::secret_key& recovery_key,
         bool recover, bool two_random, const std::string &old_language);
     bool new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,

--- a/src/wallet/password_container.h
+++ b/src/wallet/password_container.h
@@ -31,34 +31,37 @@
 #pragma once
 
 #include <string>
-#include <boost/program_options/variables_map.hpp>
+#include <boost/optional/optional.hpp>
 
 namespace tools
 {
   class password_container
   {
   public:
-    static const size_t max_password_size = 1024;
-    password_container(bool verify);
-    password_container(password_container&& rhs);
-    password_container(std::string&& password);
-    ~password_container();
+    static constexpr const size_t max_password_size = 1024;
 
-    void clear();
-    bool empty() const { return m_empty; }
-    const std::string& password() const { return m_password; }
-    void password(std::string&& val) { m_password = std::move(val); m_empty = false; }
-    bool read_password(const char *message = "Password");
+    //! Empty password
+    password_container() noexcept;
+
+    //! `password` is used as password
+    password_container(std::string&& password) noexcept;
+
+    //! \return A password from stdin TTY prompt or `std::cin` pipe.
+    static boost::optional<password_container> prompt(bool verify, const char *mesage = "Password");
+
+    password_container(const password_container&) = delete;
+    password_container(password_container&& rhs) = default;
+
+    //! Wipes internal password
+    ~password_container() noexcept;
+
+    password_container& operator=(const password_container&) = delete;
+    password_container& operator=(password_container&&) = default;
+
+    const std::string& password() const noexcept { return m_password; }
 
   private:
-    //delete constructor with no parameters
-    password_container();
-    bool read_from_file();
-    bool read_from_tty(std::string & pass);
-    bool read_from_tty_double_check(const char *message);
-
-    bool m_empty;
+    //! TODO Custom allocator that locks to RAM?
     std::string m_password;
-    bool m_verify;
   };
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -174,9 +174,7 @@ boost::optional<tools::password_container> get_password(const boost::program_opt
 
   if (command_line::has_arg(vm, opts.password))
   {
-    tools::password_container pwd(false);
-    pwd.password(command_line::get_arg(vm, opts.password));
-    return {std::move(pwd)};
+    return tools::password_container{command_line::get_arg(vm, opts.password)};
   }
 
   if (command_line::has_arg(vm, opts.password_file))
@@ -192,19 +190,10 @@ boost::optional<tools::password_container> get_password(const boost::program_opt
 
     // Remove line breaks the user might have inserted
     boost::trim_right_if(password, boost::is_any_of("\r\n"));
-    return {tools::password_container(std::move(password))};
+    return {tools::password_container{std::move(password)}};
   }
 
-  //vm is already part of the password container class.  just need to check vm for an already existing wallet
-  //here need to pass in variable map.  This will indicate if the wallet already exists to the read password function
-  tools::password_container pwd(verify);
-  if (pwd.read_password())
-  {
-    return {std::move(pwd)};
-  }
-
-  tools::fail_msg_writer() << tools::wallet2::tr("failed to read wallet password");
-  return boost::none;
+  return tools::wallet2::password_prompt(verify);
 }
 
 std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file, bool testnet, bool restricted)
@@ -431,6 +420,18 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.restricted);
 }
 
+boost::optional<password_container> wallet2::password_prompt(const bool is_new_wallet)
+{
+  auto pwd_container = tools::password_container::prompt(
+    is_new_wallet, (is_new_wallet ? tr("Enter a password for your new wallet") : tr("Wallet password"))
+  );
+  if (!pwd_container)
+  {
+    tools::fail_msg_writer() << tr("failed to read wallet password");
+  }
+  return pwd_container;
+}
+
 std::unique_ptr<wallet2> wallet2::make_from_json(const boost::program_options::variables_map& vm, const std::string& json_file)
 {
   const options opts{};
@@ -444,7 +445,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   auto pwd = get_password(vm, opts, false);
   if (!pwd)
   {
-    return {nullptr, password_container(false)};
+    return {nullptr, password_container{}};
   }
   auto wallet = make_basic(vm, opts);
   if (wallet)
@@ -460,7 +461,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const 
   auto pwd = get_password(vm, opts, true);
   if (!pwd)
   {
-    return {nullptr, password_container(false)};
+    return {nullptr, password_container{}};
   }
   return {make_basic(vm, opts), std::move(*pwd)};
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -104,6 +104,9 @@ namespace tools
     static bool has_testnet_option(const boost::program_options::variables_map& vm);
     static void init_options(boost::program_options::options_description& desc_params);
 
+    //! \return Password retrieved from prompt. Logs error on failure.
+    static boost::optional<password_container> password_prompt(const bool is_new_wallet);
+
     //! Uses stdin and stdout. Returns a wallet2 if no errors.
     static std::unique_ptr<wallet2> make_from_json(const boost::program_options::variables_map& vm, const std::string& json_file);
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -159,9 +159,9 @@ namespace tools
         }
         else
         {
-          tools::password_container pwd(true);
-          pwd.read_password("RPC password");
-          login.password = pwd.password();
+          login.password = tools::password_container::prompt(true, "RPC password").value_or(
+            tools::password_container{}
+          ).password();
         }
 
         if (login.username.empty() || login.password.empty())


### PR DESCRIPTION
[Enabling HTTP auth for `monero-wallet-rpc`](https://github.com/monero-project/monero/pull/1464/files) has one issue - [requesting confirmation for the password automatically displays a message for wallets](https://github.com/monero-project/monero/blob/master/src/wallet/password_container.cpp#L147). So that `password_container` could remain a class for storing passwords:
1. Except for watch-only wallets, all wallet password prompts now call `tools::wallet2::password_prompt` which toggles the same message for new wallets.
2. `tools::password_container` was refactored - instead of a two step construct object then call member function, a single static function was created. Therefore, there is no such thing as an `m_empty` `password_container`. This was done to eliminate confusion when returning a `password_container` object - it is holding a password (which it attempts to wipe from memory) and no member function for retrieving a password needs to be invoked by the caller.
3. `tools::simple_wallet` had the same few lines of code done repeatedly. Since they had to be updated for the interface change, `cryptonote::simple_wallet::get_and_verify_password()` was added