### PR TITLE
Removed unused functions

### DIFF
--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -40,22 +40,6 @@ using namespace crypto;
 using namespace std;
 
 namespace rct {
-    namespace {
-      struct verRangeWrapper_ {
-        void operator()(const key & C, const rangeSig & as, bool &result) const {
-          result = verRange(C, as);
-        }
-      };
-      constexpr const verRangeWrapper_ verRangeWrapper{};
-
-      struct verRctMGSimpleWrapper_ {
-        void operator()(const key &message, const mgSig &mg, const ctkeyV & pubs, const key & C, bool &result) const {
-          result = verRctMGSimple(message, mg, pubs, C);
-        }
-      };
-      constexpr const verRctMGSimpleWrapper_ verRctMGSimpleWrapper{};
-    }
-    
     //Borromean (c.f. gmax/andytoshi's paper)
     boroSig genBorromean(const key64 x, const key64 P1, const key64 P2, const bits indices) {
         key64 L[2], alpha;

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -112,8 +112,6 @@ namespace tools
       bool on_make_uri(const wallet_rpc::COMMAND_RPC_MAKE_URI::request& req, wallet_rpc::COMMAND_RPC_MAKE_URI::response& res, epee::json_rpc::error& er);
       bool on_parse_uri(const wallet_rpc::COMMAND_RPC_PARSE_URI::request& req, wallet_rpc::COMMAND_RPC_PARSE_URI::response& res, epee::json_rpc::error& er);
 
-      bool handle_command_line(const boost::program_options::variables_map& vm);
-
       //json rpc v2
       bool on_query_key(const wallet_rpc::COMMAND_RPC_QUERY_KEY::request& req, wallet_rpc::COMMAND_RPC_QUERY_KEY::response& res, epee::json_rpc::error& er);
 


### PR DESCRIPTION
- I removed the definition for `wallet_rpc_server::handle_command_line`, but forgot to remove the declaration ([see comment by @moneromooo-monero](https://github.com/monero-project/monero/pull/1387) ).
- I added some functors to replace `std::bind` by function address, then realized [C++11 lambdas did the same thing](https://github.com/moneromooo-monero/bitmonero/commit/f025198f195516da8654bece64bf7a1fb85be3cd#diff-786279ac0cfa372a81aa13b515b6c24f) with far more readability. They were [unintentionally re-added later](https://github.com/moneromooo-monero/bitmonero/commit/76958fc75abc18c928474eea91ac05fd5e0fcb41#diff-786279ac0cfa372a81aa13b515b6c24f) (probably due to a merge), and are currently unused.