### PR TITLE
Lower connection timeout in check_connection()

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2234,7 +2234,7 @@ bool wallet2::check_connection(uint32_t *version)
       u.port = m_testnet ? config::testnet::RPC_DEFAULT_PORT : config::RPC_DEFAULT_PORT;
     }
 
-    if (!m_http_client.connect(u.host, std::to_string(u.port), WALLET_RCP_CONNECTION_TIMEOUT))
+    if (!m_http_client.connect(u.host, std::to_string(u.port), 10000))
       return false;
   }
 


### PR DESCRIPTION
10s timeout should be enough when checking wallet connection status. 
fixes: https://github.com/monero-project/monero-core/issues/172