### PR TITLE
simplewallet: bump output file format version

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -72,7 +72,7 @@ typedef cryptonote::simple_wallet sw;
 #define DEFAULT_MIX 4
 
 #define KEY_IMAGE_EXPORT_FILE_MAGIC "Monero key image export\002"
-#define OUTPUT_EXPORT_FILE_MAGIC "Monero output export\002"
+#define OUTPUT_EXPORT_FILE_MAGIC "Monero output export\003"
 
 #define LOCK_IDLE_SCOPE() \
   bool auto_refresh_enabled = m_auto_refresh_enabled.load(std::memory_order_relaxed); \


### PR DESCRIPTION
The serialization format changed, and while there is code
to load the older serialization format, an older monerod
will not be able to load a file saved by a new monerod,
even though both share the same version. This is not good,
and we prefer a version bump.