### PR TITLE
Don't check if the request should not be relayed

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -554,7 +554,7 @@ namespace cryptonote
       return true;
     }
 
-    if(!tvc.m_should_be_relayed || req.do_not_relay)
+    if(!tvc.m_should_be_relayed)
     {
       LOG_PRINT_L0("[on_send_raw_tx]: tx accepted, but not relayed");
       res.reason = "Not relayed";


### PR DESCRIPTION
http://monero.stackexchange.com/questions/3048/will-the-experimental-monero-trezor-firmware-continue-to-work-after-january

It seems that this simple fix allows the trezor firmware to work with 0.10.1.

I am not familiar enough with the codebase to determine whether or not this can have damaging effects elsewhere, but I wanted to open up a PR to get conversation around this at the least.