### PR TITLE
wallet cli: viewing and editing address book

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -135,6 +135,7 @@ namespace cryptonote
     );
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool print_integrated_address(const std::vector<std::string> &args = std::vector<std::string>());
+    bool address_book(const std::vector<std::string> &args = std::vector<std::string>());
     bool save(const std::vector<std::string> &args);
     bool save_watch_only(const std::vector<std::string> &args);
     bool set_variable(const std::vector<std::string> &args);


### PR DESCRIPTION
@Jaqueeee I'm confused about the treatment of payment IDs in the address book. It makes sense to me to register and use integrated address in the address book since a 64bit payment ID gets encrypted in a transaction, but it doesn't make sense to me to include 256bit pID in the address book since you don't want to reuse an unencrypted pID which links the new transaction with past transactions.