### PR TITLE
boost portable binary archive: account for API difference between 1.58 & 1.59

### DIFF
--- a/external/boost/archive/portable_binary_oarchive.hpp
+++ b/external/boost/archive/portable_binary_oarchive.hpp
@@ -22,6 +22,7 @@
 //  See http://www.boost.org for updates, documentation, and revision history.
 
 #include <ostream>
+#include <boost/version.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/archive/archive_exception.hpp>
 #include <boost/archive/basic_binary_oprimitive.hpp>
@@ -133,6 +134,7 @@ protected:
     // extra stuff to get it passed borland compilers
     typedef boost::archive::detail::common_oarchive<portable_binary_oarchive> 
         detail_common_oarchive;
+#if BOOST_VERSION > 105800
     template<class T>
     void save_override(T & t){
         this->detail_common_oarchive::save_override(t);
@@ -146,6 +148,21 @@ protected:
     void save_override(
         const boost::archive::class_id_optional_type & /* t */
     ){}
+#else
+    template<class T>
+    void save_override(T & t, int){
+        this->detail_common_oarchive::save_override(t, 0);
+    }
+    // explicitly convert to char * to avoid compile ambiguities
+    void save_override(const boost::archive::class_name_type & t, int){
+        const std::string s(t);
+        * this << s;
+    }
+    // binary files don't include the optional information 
+    void save_override(
+        const boost::archive::class_id_optional_type & /* t */, int
+    ){}
+#endif
 
     void init(unsigned int flags);
 public:


### PR DESCRIPTION
@danrmiller Could you confirm the issue in PR #1462 is fixed by this?