### PR TITLE
Silence CMake policy warning (CMP0042) on macos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,9 @@ include_directories(src contrib/epee/include external "${CMAKE_BINARY_DIR}/versi
 
 if(APPLE)
   include_directories(SYSTEM /usr/include/malloc)
+  if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW)
+  endif()
 endif()
 
 if(MSVC OR MINGW)

--- a/contrib/otshell_utils/CMakeLists.txt
+++ b/contrib/otshell_utils/CMakeLists.txt
@@ -3,6 +3,10 @@ project (otshell CXX)
 
 # Add executable
 
+if(APPLE AND POLICY CMP0042)
+	cmake_policy(SET CMP0042 NEW)
+endif()
+
 file(GLOB otshell_utils_sources # All files in directory:
 	"*.h"
 	"*.hpp"


### PR DESCRIPTION
Issue: Without this patch, the following CMake warning is generated:

```
Warning:Configuration Debug
Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake --help-policy CMP0042" for policy details.  Use the cmake_policy command to set the policy and suppress this warning.
MACOSX_RPATH is not specified for the following targets:
 blockchain_db  common  crypto  cryptonote_core  cryptonote_protocol  daemonizer  lmdb  mnemonics  p2p  ringct  roc  wallet
```

For more details on the CMake Policy CMP0042, see:
https://cmake.org/cmake/help/v3.0/policy/CMP0042.html
https://cmake.org/cmake/help/v3.0/prop_tgt/MACOSX_RPATH.html#prop_tgt:MACOSX_RPATH