### PR TITLE
wallet cli: print originating block heights of mixin keys when making transfer

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1778,7 +1778,7 @@ bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMA
     tx_out_index toi = m_db->get_output_tx_and_index(i.amount, i.index);
     bool unlocked = is_tx_spendtime_unlocked(m_db->get_tx_unlock_time(toi.first));
 
-    res.outs.push_back({od.pubkey, od.commitment, unlocked});
+    res.outs.push_back({od.pubkey, od.commitment, unlocked, od.height, toi.first});
   }
   return true;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -300,6 +300,8 @@ namespace cryptonote
       outkey.key = epee::string_tools::pod_to_hex(i.key);
       outkey.mask = epee::string_tools::pod_to_hex(i.mask);
       outkey.unlocked = i.unlocked;
+      outkey.height = i.height;
+      outkey.txid = epee::string_tools::pod_to_hex(i.txid);
     }
 
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 3
+#define CORE_RPC_VERSION_MINOR 4
 #define CORE_RPC_VERSION (((CORE_RPC_VERSION_MAJOR)<<16)|(CORE_RPC_VERSION_MINOR))
 
   struct COMMAND_RPC_GET_HEIGHT
@@ -329,11 +329,15 @@ namespace cryptonote
       crypto::public_key key;
       rct::key mask;
       bool unlocked;
+      uint64_t height;
+      crypto::hash txid;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_VAL_POD_AS_BLOB(key)
         KV_SERIALIZE_VAL_POD_AS_BLOB(mask)
         KV_SERIALIZE(unlocked)
+        KV_SERIALIZE(height)
+        KV_SERIALIZE_VAL_POD_AS_BLOB(txid)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -365,11 +369,15 @@ namespace cryptonote
       std::string key;
       std::string mask;
       bool unlocked;
+      uint64_t height;
+      std::string txid;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(key)
         KV_SERIALIZE(mask)
         KV_SERIALIZE(unlocked)
+        KV_SERIALIZE(height)
+        KV_SERIALIZE(txid)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -106,6 +106,7 @@ namespace cryptonote
      */
     bool seed_set_language(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_always_confirm_transfers(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_print_ring_members(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_store_tx_info(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_default_mixin(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_auto_refresh(const std::vector<std::string> &args = std::vector<std::string>());
@@ -160,11 +161,12 @@ namespace cryptonote
     bool show_transfer(const std::vector<std::string> &args);
 
     uint64_t get_daemon_blockchain_height(std::string& err);
-    bool try_connect_to_daemon(bool silent = false);
+    bool try_connect_to_daemon(bool silent = false, uint32_t* version = nullptr);
     bool ask_wallet_create_if_needed();
     bool accept_loaded_tx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message = std::string());
     bool accept_loaded_tx(const tools::wallet2::unsigned_tx_set &txs);
     bool accept_loaded_tx(const tools::wallet2::signed_tx_set &txs);
+    bool print_ring_members(const std::vector<tools::wallet2::pending_tx>& ptx_vector, std::ostream& ostr);
 
     /*!
      * \brief Prints the seed with a nice message

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1808,6 +1808,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const std::string& p
   value2.SetInt(m_always_confirm_transfers ? 1 :0);
   json.AddMember("always_confirm_transfers", value2, json.GetAllocator());
 
+  value2.SetInt(m_print_ring_members ? 1 :0);
+  json.AddMember("print_ring_members", value2, json.GetAllocator());
+
   value2.SetInt(m_store_tx_info ? 1 :0);
   json.AddMember("store_tx_info", value2, json.GetAllocator());
 
@@ -1890,6 +1893,7 @@ bool wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     is_old_file_format = true;
     m_watch_only = false;
     m_always_confirm_transfers = false;
+    m_print_ring_members = false;
     m_default_mixin = 0;
     m_default_priority = 0;
     m_auto_refresh = true;
@@ -1920,6 +1924,8 @@ bool wallet2::load_keys(const std::string& keys_file_name, const std::string& pa
     m_watch_only = field_watch_only;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, always_confirm_transfers, int, Int, false, true);
     m_always_confirm_transfers = field_always_confirm_transfers;
+    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, print_ring_members, int, Int, false, true);
+    m_print_ring_members = field_print_ring_members;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, store_tx_keys, int, Int, false, true);
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, store_tx_info, int, Int, false, true);
     m_store_tx_info = ((field_store_tx_keys != 0) || (field_store_tx_info != 0));

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -98,7 +98,7 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true) {}
 
   public:
     static const char* tr(const char* str);// { return i18n_translate(str, "cryptonote::simple_wallet"); }
@@ -119,7 +119,7 @@ namespace tools
     //! Uses stdin and stdout. Returns a wallet2 and password for wallet with no file if no errors.
     static std::pair<std::unique_ptr<wallet2>, password_container> make_new(const boost::program_options::variables_map& vm);
 
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_restricted(restricted), is_old_file_format(false) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_restricted(restricted), is_old_file_format(false) {}
     struct transfer_details
     {
       uint64_t m_block_height;
@@ -476,6 +476,8 @@ namespace tools
 
     bool always_confirm_transfers() const { return m_always_confirm_transfers; }
     void always_confirm_transfers(bool always) { m_always_confirm_transfers = always; }
+    bool print_ring_members() const { return m_print_ring_members; }
+    void print_ring_members(bool value) { m_print_ring_members = value; }
     bool store_tx_info() const { return m_store_tx_info; }
     void store_tx_info(bool store) { m_store_tx_info = store; }
     uint32_t default_mixin() const { return m_default_mixin; }
@@ -624,6 +626,7 @@ namespace tools
     bool is_old_file_format; /*!< Whether the wallet file is of an old file format */
     bool m_watch_only; /*!< no spend key */
     bool m_always_confirm_transfers;
+    bool m_print_ring_members;
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
     uint32_t m_default_mixin;
     uint32_t m_default_priority;


### PR DESCRIPTION
Example:

    [wallet 43TYdU]: sweep_all 44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A
    No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): y
    
    Transaction 1/1: txid=<c5f2895d281dc4849a2443cc6d27df804d433a496741539e13ebb569e50f43cc>
    Input 1/4: amount=0.010000000000
    Originating block heights:  81677 86003 784180 1207815 *1208310
    |_____o_____________________________________________o__________________________*|
    
    Input 2/4: amount=0.100000000000
    Originating block heights:  95691 143843 146187 477755 *1208313
    |______o__o_____________________o______________________________________________*|
    
    Input 3/4: amount=0.000300000000
    Originating block heights:  57255 73895 87661 1181392 *1208310
    |___ooo_______________________________________________________________________o*|
    
    Input 4/4: amount=0.002000000000
    Originating block heights:  1099394 1182448 1194534 1208148 *1208310
    |_______________________________________________________________________o_____o*|
    
    Warning: Some input keys being spent are from the same transaction, which can break the anonymity of ring signature. Make sure this is intentional!
    Sweeping 0.112300000000 for a total fee of 0.004000000000.  Is this okay?  (Y/Yes/N/No)n
    Error: transaction cancelled.
    [wallet 43TYdU]: donate 0.1
    No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): y
    Sending 0.100000000000.  The transaction fee is 0.004300000000, of which 0.000300000000 is dust from change
    Transaction 1/1: txid=<ca90d7cfc4434845fd4a6be1e7aa90f13ee64207cca3b2312ebc3265edb1c39a>
    Input 1/3: amount=0.000300000000
    Originating block heights:  54968 1025744 1168859 1186961 *1208310
    |___o_______________________________________________________________o________oo*|
    
    Input 2/3: amount=0.100000000000
    Originating block heights:  134127 277801 323224 513905 *1208313
    |________o_________o__o___________o____________________________________________*|
    
    Input 3/3: amount=0.010000000000
    Originating block heights:  183801 416254 951312 1207920 *1208310
    |____________o______________o__________________________________o_______________*|
    
    Warning: Some input keys being spent are from blocks that are temporally very close, which can break the anonymity of ring signature. Make sure this is intentional!
    
    Is this okay?  (Y/Yes/N/No):

Credit: https://github.com/moneroexamples/onion-monero-viewer