### PR TITLE
blockchain: allow marking "tx not found" without an exception

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1020,6 +1020,20 @@ public:
   virtual transaction get_tx(const crypto::hash& h) const = 0;
 
   /**
+   * @brief fetches the transaction with the given hash
+   *
+   * The subclass should return the transaction stored which has the given
+   * hash.
+   *
+   * If the transaction does not exist, the subclass should return false.
+   *
+   * @param h the hash to look for
+   *
+   * @return true iff the transaction was found
+   */
+  virtual bool get_tx(const crypto::hash& h, transaction &tx) const = 0;
+
+  /**
    * @brief fetches the total number of transactions ever
    *
    * The subclass should return a count of all the transactions from

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -209,6 +209,8 @@ public:
 
   virtual transaction get_tx(const crypto::hash& h) const;
 
+  virtual bool get_tx(const crypto::hash& h, transaction &tx) const;
+
   virtual uint64_t get_tx_count() const;
 
   virtual std::vector<transaction> get_tx_list(const std::vector<crypto::hash>& hlist) const;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1894,11 +1894,11 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
   {
     try
     {
-      txs.push_back(m_db->get_tx(tx_hash));
-    }
-    catch (const TX_DNE& e)
-    {
-      missed_txs.push_back(tx_hash);
+      transaction tx;
+      if (m_db->get_tx(tx_hash, tx))
+        txs.push_back(std::move(tx));
+      else
+        missed_txs.push_back(tx_hash);
     }
     catch (const std::exception& e)
     {

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -78,6 +78,7 @@ public:
   virtual bool tx_exists(const crypto::hash& h, uint64_t& tx_index) const { return false; }
   virtual uint64_t get_tx_unlock_time(const crypto::hash& h) const { return 0; }
   virtual transaction get_tx(const crypto::hash& h) const { return transaction(); }
+  virtual bool get_tx(const crypto::hash& h, transaction &tx) const { return false; }
   virtual uint64_t get_tx_count() const { return 0; }
   virtual std::vector<transaction> get_tx_list(const std::vector<crypto::hash>& hlist) const { return std::vector<transaction>(); }
   virtual uint64_t get_tx_block_height(const crypto::hash& h) const { return 0; }


### PR DESCRIPTION
This is a normal occurence in many cases, and there is no need
to spam the log with those when it is.