### PR TITLE
wallet2: fix large reorgs failing

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1632,7 +1632,7 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
       process_blocks(blocks_start_height, blocks, o_indices, added_blocks);
       blocks_fetched += added_blocks;
       pull_thread.join();
-      if(!added_blocks)
+      if(blocks_start_height == next_blocks_start_height)
         break;
 
       // switch to the new blocks from the daemon


### PR DESCRIPTION
If a reorg was large enough that a full 1000 block chunk
from the daemon was all known blocks, refresh would stop,
and no reorg would happen.