### PR TITLE
wallet2 bugfix: store watch_only flag properly with rewrite()

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2139,7 +2139,7 @@ void wallet2::rewrite(const std::string& wallet_name, const std::string& passwor
   prepare_file_names(wallet_name);
   boost::system::error_code ignored_ec;
   THROW_WALLET_EXCEPTION_IF(!boost::filesystem::exists(m_keys_file, ignored_ec), error::file_not_found, m_keys_file);
-  bool r = store_keys(m_keys_file, password, false);
+  bool r = store_keys(m_keys_file, password, m_watch_only);
   THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, m_keys_file);
 }
 /*!


### PR DESCRIPTION
Currently, calling the command `set xxx y` in a watch-only wallet makes it skip storing `watch_only` flag into the .keys file and thus makes it impossible to open it with the same password.