### PR TITLE
fix build on gcc 4.8.4

### DIFF
--- a/contrib/epee/include/net/http_auth.h
+++ b/contrib/epee/include/net/http_auth.h
@@ -45,14 +45,12 @@ namespace net_utils
     public:
       struct login
       {
-        login() = delete;
         std::string username;
         std::string password;
       };
 
       struct session
       {
-        session() = delete;
         const login credentials;
         std::string nonce;
         std::uint32_t counter;


### PR DESCRIPTION
This fixes build on GCC 4.8.4 but i'm not sure if it's safe to delete those lines here as well? See https://github.com/monero-project/monero/issues/1373#issuecomment-263783721

@vtnerd needs to confirm this. 