### PR TITLE
Added (not yet enabled) HTTP client authentication

### DIFF
--- a/contrib/epee/include/net/http_auth.h
+++ b/contrib/epee/include/net/http_auth.h
@@ -28,10 +28,13 @@
 #pragma once
 
 #include <boost/optional/optional.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <cstdint>
-#include "http_base.h"
+#include <functional>
 #include <string>
 #include <utility>
+
+#include "http_base.h"
 
 namespace epee
 {
@@ -39,21 +42,21 @@ namespace net_utils
 {
   namespace http
   {
+    struct login
+    {
+      login() : username(), password() {}
+      login(std::string username_, std::string password_)
+        : username(std::move(username_)), password(std::move(password_))
+      {}
+
+      std::string username;
+      std::string password;
+    };
+
     //! Implements RFC 2617 digest auth. Digests from RFC 7616 can be added.
-    class http_auth
+    class http_server_auth
     {
     public:
-      struct login
-      {
-        login() : username(), password() {}
-        login(std::string username_, std::string password_)
-          : username(std::move(username_)), password(std::move(password_))
-        {}
-
-        std::string username;
-        std::string password;
-      };
-
       struct session
       {
         session(login credentials_)
@@ -65,21 +68,97 @@ namespace net_utils
         std::uint32_t counter;
       };
 
-      http_auth() : user() {}
-      http_auth(login credentials);
+      http_server_auth() : user() {}
+      http_server_auth(login credentials);
 
       //! \return Auth response, or `boost::none` iff `request` had valid auth.
       boost::optional<http_response_info> get_response(const http_request_info& request)
       {
         if (user)
+          return do_get_response(request);
+        return boost::none;
+      }
+    private:
+      boost::optional<http_response_info> do_get_response(const http_request_info& request);
+
+      boost::optional<session> user;
+    };
+
+    //! Implements RFC 2617 digest auth. Digests from RFC 7616 can be added.
+    class http_client_auth
+    {
+    public:
+      enum status : std::uint8_t { kSuccess = 0, kBadPassword, kParseFailure };
+
+      struct session
+      {
+        session(login credentials_)
+          : credentials(std::move(credentials_)), server(), counter(0)
+        {}
+
+        struct keys
         {
-          return process(request);
-        }
+          using algorithm =
+            std::function<std::string(const session&, boost::string_ref, boost::string_ref)>;
+
+          keys() : nonce(), opaque(), realm(), generator() {}
+          keys(std::string nonce_, std::string opaque_, std::string realm_, algorithm generator_)
+            : nonce(std::move(nonce_))
+            , opaque(std::move(opaque_))
+            , realm(std::move(realm_))
+            , generator(std::move(generator_))
+          {}
+
+          std::string nonce;
+          std::string opaque;
+          std::string realm;
+          algorithm generator;
+        };
+
+        login credentials;
+        keys server;
+        std::uint32_t counter;
+      };
+
+      http_client_auth() : user() {}
+      http_client_auth(login credentials);
+
+      /*!
+        Clients receiving a 401 response code from the server should call this
+        function to process the server auth. Then, before every client request,
+        `get_auth_field()` should be called to retrieve the newest
+        authorization request.
+
+        \return `kBadPassword` if client will never be able to authenticate,
+          `kParseFailure` if all server authentication responses were invalid,
+          and `kSuccess` if `get_auth_field` is ready to generate authorization
+          fields.
+      */
+      status handle_401(const http_response_info& response)
+      {
+        if (user)
+          return do_handle_401(response);
+        return kBadPassword;
+      }
+
+      /*!
+        After calling `handle_401`, clients should call this function to
+        generate an authentication field for every request.
+
+        \return A HTTP "Authorization" field if `handle_401(...)` previously
+          returned `kSuccess`.
+      */
+      boost::optional<std::pair<std::string, std::string>> get_auth_field(
+        const boost::string_ref method, const boost::string_ref uri)
+      {
+        if (user)
+          return do_get_auth_field(method, uri);
         return boost::none;
       }
 
     private:
-      boost::optional<http_response_info> process(const http_request_info& request);
+      status do_handle_401(const http_response_info&);
+      boost::optional<std::pair<std::string, std::string>> do_get_auth_field(boost::string_ref, boost::string_ref);
 
       boost::optional<session> user;
     };

--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -52,7 +52,7 @@ namespace net_utils
 		{
 			std::string m_folder;
 			std::string m_required_user_agent;
-			boost::optional<http_auth::login> m_user;
+			boost::optional<login> m_user;
 			critical_section m_lock;
 		};
 
@@ -173,7 +173,7 @@ namespace net_utils
 				: simple_http_connection_handler<t_connection_context>(psnd_hndlr, config),
 					m_config(config),
 					m_conn_context(conn_context),
-					m_auth(m_config.m_user ? http_auth{*m_config.m_user} : http_auth{})
+					m_auth(m_config.m_user ? http_server_auth{*m_config.m_user} : http_server_auth{})
 			{}
 			inline bool handle_request(const http_request_info& query_info, http_response_info& response)
 			{
@@ -214,7 +214,7 @@ namespace net_utils
 			//simple_http_connection_handler::config_type m_stub_config;
 			config_type& m_config;
 			t_connection_context& m_conn_context;
-			http_auth m_auth;
+			http_server_auth m_auth;
 		};
 	}
 }

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -53,7 +53,7 @@ namespace epee
     {}
 
     bool init(const std::string& bind_port = "0", const std::string& bind_ip = "0.0.0.0",
-      std::string user_agent = "", boost::optional<net_utils::http::http_auth::login> user = boost::none)
+      std::string user_agent = "", boost::optional<net_utils::http::login> user = boost::none)
     {
 
       //set self as callback handler

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -125,7 +125,7 @@ namespace tools
       }
     }
 
-    epee::net_utils::http::http_auth::login login{};
+    epee::net_utils::http::login login{};
 
     const bool disable_auth = command_line::get_arg(vm, arg_disable_rpc_login);
     const std::string user_pass = command_line::get_arg(vm, arg_rpc_login);

--- a/tests/unit_tests/http_auth.cpp
+++ b/tests/unit_tests/http_auth.cpp
@@ -61,6 +61,7 @@
 #include "string_tools.h"
 
 namespace {
+namespace http = epee::net_utils::http;
 using fields = std::unordered_map<std::string, std::string>;
 using auth_responses = std::vector<fields>;
 
@@ -71,22 +72,48 @@ std::string quoted(std::string str)
   return str;
 }
 
-epee::net_utils::http::http_request_info make_request(const fields& args)
+void write_fields(std::string& out, const fields& args)
 {
   namespace karma = boost::spirit::karma;
-
-  std::string out{"   DIGEST   "};
   karma::generate(
     std::back_inserter(out),
     (karma::string << " = " << karma::string) % " , ", 
     args);
+}
 
-  epee::net_utils::http::http_request_info request{};
+std::string write_fields(const fields& args)
+{
+  std::string out{};
+  write_fields(out, args);
+  return out;
+}
+
+http::http_request_info make_request(const fields& args)
+{
+  std::string out{"   DIGEST   "};
+  write_fields(out, args);
+
+  http::http_request_info request{};
   request.m_http_method_str = "NOP";
   request.m_header_info.m_etc_fields.push_back(
     std::make_pair(u8"authorization", std::move(out))
   );
   return request;
+}
+
+http::http_response_info make_response(const auth_responses& choices)
+{
+  http::http_response_info response{};
+  for (const auto& choice : choices)
+  {
+    std::string out{"   DIGEST   "};
+    write_fields(out, choice);
+
+    response.m_additional_fields.push_back(
+      std::make_pair(u8"WWW-authenticate", std::move(out))
+    );
+  }
+  return response;
 }
 
 bool has_same_fields(const auth_responses& in)
@@ -113,7 +140,7 @@ bool has_same_fields(const auth_responses& in)
   return true;
 }
 
-bool is_unauthorized(const epee::net_utils::http::http_response_info& response)
+bool is_unauthorized(const http::http_response_info& response)
 {
   EXPECT_EQ(401, response.m_response_code);
   EXPECT_STREQ(u8"Unauthorized", response.m_response_comment.c_str());
@@ -123,39 +150,44 @@ bool is_unauthorized(const epee::net_utils::http::http_response_info& response)
     response.m_mime_tipe == u8"text/html";
 }
 
-
-auth_responses parse_response(const epee::net_utils::http::http_response_info& response)
+fields parse_fields(const std::string& value)
 {
   namespace qi = boost::spirit::qi;
 
+  fields out{};
+  const bool rc = qi::parse(
+    value.begin(), value.end(),
+    qi::lit(u8"Digest ") >> ((
+        +qi::ascii::alpha >>
+        qi::lit('=') >> (
+          (qi::lit('"') >> +(qi::ascii::char_ - '"') >> qi::lit('"')) |
+          +(qi::ascii::graph - qi::ascii::char_(u8"()<>@,;:\\\"/[]?={}"))
+        )
+      ) % ','
+    ) >> qi::eoi,
+    out
+  );
+  if (!rc)
+    throw std::runtime_error{"Bad field given in HTTP header"};
+
+  return out;
+}
+
+auth_responses parse_response(const http::http_response_info& response)
+{
   auth_responses result{};
 
   const auto end = response.m_additional_fields.end();
-  for (auto current = response.m_additional_fields.begin(); current != end; ++current)
+  for (auto current = response.m_additional_fields.begin();; ++current)
   {
     current = std::find_if(current, end, [] (const std::pair<std::string, std::string>& field) {
-        return boost::iequals(u8"www-authenticate", field.first);
+        return boost::equals(u8"WWW-authenticate", field.first);
     });
 
     if (current == end)
       return result;
 
-    std::unordered_map<std::string, std::string> fields{};
-    const bool rc = qi::parse(
-      current->second.begin(), current->second.end(),
-      qi::lit(u8"Digest ") >> ((
-          +qi::ascii::alpha >>
-          qi::lit('=') >> (
-            (qi::lit('"') >> +(qi::ascii::char_ - '"') >> qi::lit('"')) | 
-            +(qi::ascii::graph - qi::ascii::char_(u8"()<>@,;:\\\"/[]?={}"))
-          )
-        ) % ','
-      ) >> qi::eoi,
-      fields
-    );
-
-    if (rc)
-      result.push_back(std::move(fields));
+    result.push_back(parse_fields(current->second));
   }
   return result;
 }
@@ -175,15 +207,20 @@ std::string md5_hex(const std::string& in)
   return epee::string_tools::pod_to_hex(digest);
 }
 
-std::string get_a1(const epee::net_utils::http::http_auth::login& user, const auth_responses& responses)
+std::string get_a1(const http::login& user, const fields& src)
 {
-  const std::string& realm = responses.at(0).at(u8"realm");
+  const std::string& realm = src.at(u8"realm");
   return boost::join(
     std::vector<std::string>{user.username, realm, user.password}, u8":"
   );
 }
 
-std::string get_a1_sess(const epee::net_utils::http::http_auth::login& user, const std::string& cnonce, const auth_responses& responses)
+std::string get_a1(const http::login& user, const auth_responses& responses)
+{
+  return get_a1(user, responses.at(0));
+}
+
+std::string get_a1_sess(const http::login& user, const std::string& cnonce, const auth_responses& responses)
 {
   const std::string& nonce = responses.at(0).at(u8"nonce");
   return boost::join(
@@ -210,36 +247,36 @@ std::string get_nc(std::uint32_t count)
 }
 }
 
-TEST(HTTP_Auth, NotRequired)
+TEST(HTTP_Server_Auth, NotRequired)
 {
-  epee::net_utils::http::http_auth auth{};
-  EXPECT_FALSE(auth.get_response(epee::net_utils::http::http_request_info{}));
+  http::http_server_auth auth{};
+  EXPECT_FALSE(auth.get_response(http::http_request_info{}));
 }
 
-TEST(HTTP_Auth, MissingAuth)
+TEST(HTTP_Server_Auth, MissingAuth)
 {
-  epee::net_utils::http::http_auth auth{{"foo", "bar"}};
-  EXPECT_TRUE(bool(auth.get_response(epee::net_utils::http::http_request_info{})));
+  http::http_server_auth auth{{"foo", "bar"}};
+  EXPECT_TRUE(bool(auth.get_response(http::http_request_info{})));
   {
-    epee::net_utils::http::http_request_info request{};
+    http::http_request_info request{};
     request.m_header_info.m_etc_fields.push_back({"\xFF", "\xFF"});
     EXPECT_TRUE(bool(auth.get_response(request)));
   }
 }
 
-TEST(HTTP_Auth, BadSyntax)
+TEST(HTTP_Server_Auth, BadSyntax)
 {
-  epee::net_utils::http::http_auth auth{{"foo", "bar"}};
+  http::http_server_auth auth{{"foo", "bar"}};
   EXPECT_TRUE(bool(auth.get_response(make_request({{u8"algorithm", "fo\xFF"}}))));
   EXPECT_TRUE(bool(auth.get_response(make_request({{u8"cnonce", "\"000\xFF\""}}))));
   EXPECT_TRUE(bool(auth.get_response(make_request({{u8"cnonce \xFF =", "\"000\xFF\""}}))));
   EXPECT_TRUE(bool(auth.get_response(make_request({{u8" \xFF cnonce", "\"000\xFF\""}}))));
 }
 
-TEST(HTTP_Auth, MD5)
+TEST(HTTP_Server_Auth, MD5)
 {
-  epee::net_utils::http::http_auth::login user{"foo", "bar"};
-  epee::net_utils::http::http_auth auth{user};
+  http::login user{"foo", "bar"};
+  http::http_server_auth auth{user};
 
   const auto response = auth.get_response(make_request(fields{}));
   ASSERT_TRUE(bool(response));
@@ -283,12 +320,12 @@ TEST(HTTP_Auth, MD5)
   EXPECT_STREQ(u8"true", fields2[0].at(u8"stale").c_str());
 }
 
-TEST(HTTP_Auth, MD5_sess)
+TEST(HTTP_Server_Auth, MD5_sess)
 {
   constexpr const char cnonce[] = "not a good cnonce";
 
-  epee::net_utils::http::http_auth::login user{"foo", "bar"};
-  epee::net_utils::http::http_auth auth{user};
+  http::login user{"foo", "bar"};
+  http::http_server_auth auth{user};
 
   const auto response = auth.get_response(make_request(fields{}));
   ASSERT_TRUE(bool(response));
@@ -334,13 +371,13 @@ TEST(HTTP_Auth, MD5_sess)
   EXPECT_STREQ(u8"true", fields2[0].at(u8"stale").c_str());
 }
 
-TEST(HTTP_Auth, MD5_auth)
+TEST(HTTP_Server_Auth, MD5_auth)
 {
   constexpr const char cnonce[] = "not a nonce";
   constexpr const char qop[] = "auth";
 
-  epee::net_utils::http::http_auth::login user{"foo", "bar"};
-  epee::net_utils::http::http_auth auth{user};
+  http::login user{"foo", "bar"};
+  http::http_server_auth auth{user};
 
   const auto response = auth.get_response(make_request(fields{}));
   ASSERT_TRUE(bool(response));
@@ -402,13 +439,13 @@ TEST(HTTP_Auth, MD5_auth)
   EXPECT_STREQ(u8"true", parsed_replay[0].at(u8"stale").c_str());
 }
 
-TEST(HTTP_Auth, MD5_sess_auth)
+TEST(HTTP_Server_Auth, MD5_sess_auth)
 {
   constexpr const char cnonce[] = "not a nonce";
   constexpr const char qop[] = "auth";
 
-  epee::net_utils::http::http_auth::login user{"foo", "bar"};
-  epee::net_utils::http::http_auth auth{user};
+  http::login user{"foo", "bar"};
+  http::http_server_auth auth{user};
 
   const auto response = auth.get_response(make_request(fields{}));
   ASSERT_TRUE(bool(response));
@@ -469,3 +506,219 @@ TEST(HTTP_Auth, MD5_sess_auth)
   EXPECT_NE(nonce, parsed_replay[0].at(u8"nonce"));
   EXPECT_STREQ(u8"true", parsed_replay[0].at(u8"stale").c_str());
 }
+
+
+TEST(HTTP_Auth, DogFood)
+{
+  const auto add_field = [] (http::http_request_info& request, http::http_client_auth& client)
+  {
+    auto field = client.get_auth_field(request.m_http_method_str, request.m_URI);
+    EXPECT_TRUE(bool(field));
+    if (!field)
+      return false;
+    request.m_header_info.m_etc_fields.push_back(std::move(*field));
+    return true;
+  };
+
+  const http::login user{"some_user", "ultimate password"};
+
+  http::http_server_auth server{user};
+  http::http_client_auth client{user};
+
+  http::http_request_info request{};
+  request.m_http_method_str = "GET";
+  request.m_URI = "/FOO";
+
+  const auto response = server.get_response(request);
+  ASSERT_TRUE(bool(response));
+  EXPECT_TRUE(is_unauthorized(*response));
+
+  EXPECT_EQ(http::http_client_auth::kSuccess, client.handle_401(*response));
+  EXPECT_TRUE(add_field(request, client));
+  EXPECT_FALSE(bool(server.get_response(request)));
+
+  for (unsigned i = 0; i < 1000; ++i)
+  {
+    request.m_http_method_str += std::to_string(i);
+    request.m_header_info.m_etc_fields.clear();
+    EXPECT_TRUE(add_field(request, client));
+    EXPECT_FALSE(bool(server.get_response(request)));
+  }
+
+  // resetting counter should be rejected by server
+  request.m_header_info.m_etc_fields.clear();
+  client = http::http_client_auth{user};
+  EXPECT_EQ(http::http_client_auth::kSuccess, client.handle_401(*response));
+  EXPECT_TRUE(add_field(request, client));
+
+  const auto response2 = server.get_response(request);
+  ASSERT_TRUE(bool(response2));
+  EXPECT_TRUE(is_unauthorized(*response2));
+
+  const auth_responses parsed1 = parse_response(*response);
+  const auth_responses parsed2 = parse_response(*response2);
+  ASSERT_LE(1u, parsed1.size());
+  ASSERT_LE(1u, parsed2.size());
+  EXPECT_NE(parsed1[0].at(u8"nonce"), parsed2[0].at(u8"nonce"));
+
+  // with stale=true client should reset
+  request.m_header_info.m_etc_fields.clear();
+  EXPECT_EQ(http::http_client_auth::kSuccess, client.handle_401(*response2));
+  EXPECT_TRUE(add_field(request, client));
+  EXPECT_FALSE(bool(server.get_response(request)));
+
+  // client should give up if stale=false
+  EXPECT_EQ(http::http_client_auth::kBadPassword, client.handle_401(*response));
+}
+
+TEST(HTTP_Client_Auth, Unavailable)
+{
+  http::http_client_auth auth{};
+  EXPECT_EQ(http::http_client_auth::kBadPassword, auth.handle_401(http::http_response_info{}));
+  EXPECT_FALSE(bool(auth.get_auth_field("GET", "/file")));
+}
+
+TEST(HTTP_Client_Auth, MissingAuthenticate)
+{
+  http::http_client_auth auth{{"foo", "bar"}};
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(http::http_response_info{}));
+  EXPECT_FALSE(bool(auth.get_auth_field("POST", "/\xFFname")));
+  {
+    http::http_response_info response{};
+    response.m_additional_fields.push_back({"\xFF", "\xFF"});
+    EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(response));
+  }
+  EXPECT_FALSE(bool(auth.get_auth_field("DELETE", "/file/does/not/exist")));
+}
+
+TEST(HTTP_Client_Auth, BadSyntax)
+{
+  http::http_client_auth auth{{"foo", "bar"}};
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(make_response({{{u8"realm", "fo\xFF"}}})));
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(make_response({{{u8"domain", "fo\xFF"}}})));
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(make_response({{{u8"nonce", "fo\xFF"}}})));
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(make_response({{{u8"nonce \xFF =", "fo\xFF"}}})));
+  EXPECT_EQ(http::http_client_auth::kParseFailure, auth.handle_401(make_response({{{u8" \xFF nonce", "fo\xFF"}}})));
+}
+
+TEST(HTTP_Client_Auth, MD5)
+{
+  constexpr char method[] = "NOP";
+  constexpr char nonce[] = "some crazy nonce";
+  constexpr char realm[] = "the only realm";
+  constexpr char uri[] = "/some_file";
+
+  const http::login user{"foo", "bar"};
+  http::http_client_auth auth{user};
+
+  auto response = make_response({
+    {
+      {u8"domain", quoted("ignored")},
+      {u8"nonce", quoted(nonce)},
+      {u8"REALM", quoted(realm)}
+    },
+    {
+      {u8"algorithm", "null"},
+      {u8"domain", quoted("ignored")},
+      {u8"nonce", quoted(std::string{"e"} + nonce)},
+      {u8"realm", quoted(std::string{"e"} + realm)}
+    },
+  });
+
+  EXPECT_EQ(http::http_client_auth::kSuccess, auth.handle_401(response));
+  const auto auth_field = auth.get_auth_field(method, uri);
+  ASSERT_TRUE(bool(auth_field));
+
+  const auto parsed = parse_fields(auth_field->second);
+  EXPECT_STREQ(u8"Authorization", auth_field->first.c_str());
+  EXPECT_EQ(parsed.end(), parsed.find(u8"opaque"));
+  EXPECT_EQ(parsed.end(), parsed.find(u8"qop"));
+  EXPECT_EQ(parsed.end(), parsed.find(u8"nc"));
+  EXPECT_STREQ(u8"MD5", parsed.at(u8"algorithm").c_str());
+  EXPECT_STREQ(nonce, parsed.at(u8"nonce").c_str());
+  EXPECT_STREQ(uri, parsed.at(u8"uri").c_str());
+  EXPECT_EQ(user.username, parsed.at(u8"username"));
+  EXPECT_STREQ(realm, parsed.at(u8"realm").c_str());
+
+  const std::string a1 = get_a1(user, parsed);
+  const std::string a2 = get_a2(uri);
+  const std::string auth_code = md5_hex(
+    boost::join(std::vector<std::string>{md5_hex(a1), nonce, md5_hex(a2)}, u8":")
+  );
+  EXPECT_TRUE(boost::iequals(auth_code, parsed.at(u8"response")));
+  {
+    const auto auth_field_dup = auth.get_auth_field(method, uri);
+    ASSERT_TRUE(bool(auth_field_dup));
+    EXPECT_EQ(*auth_field, *auth_field_dup);
+  }
+
+
+  EXPECT_EQ(http::http_client_auth::kBadPassword, auth.handle_401(response));
+  response.m_additional_fields.front().second.append(u8"," + write_fields({{u8"stale", u8"TRUE"}}));
+  EXPECT_EQ(http::http_client_auth::kSuccess, auth.handle_401(response));
+}
+
+TEST(HTTP_Client_Auth, MD5_auth)
+{
+  constexpr char cnonce[] = "";
+  constexpr char method[] = "NOP";
+  constexpr char nonce[] = "some crazy nonce";
+  constexpr char opaque[] = "this is the opaque";
+  constexpr char qop[] = u8"ignore,auth,ignore";
+  constexpr char realm[] = "the only realm";
+  constexpr char uri[] = "/some_file";
+
+  const http::login user{"foo", "bar"};
+  http::http_client_auth auth{user};
+
+  auto response = make_response({
+    {
+      {u8"algorithm", u8"MD5"},
+      {u8"domain", quoted("ignored")},
+      {u8"nonce", quoted(std::string{"e"} + nonce)},
+      {u8"realm", quoted(std::string{"e"} + realm)},
+      {u8"qop", quoted("some,thing,to,ignore")}
+    },
+    {
+      {u8"algorIthm", quoted(u8"md5")},
+      {u8"domain", quoted("ignored")},
+      {u8"noNce", quoted(nonce)},
+      {u8"opaque", quoted(opaque)},
+      {u8"realm", quoted(realm)},
+      {u8"QoP", quoted(qop)}
+    }
+  });
+
+  EXPECT_EQ(http::http_client_auth::kSuccess, auth.handle_401(response));
+
+  for (unsigned i = 1; i < 1000; ++i)
+  {
+    const std::string nc = get_nc(i);
+
+    const auto auth_field = auth.get_auth_field(method, uri);
+    ASSERT_TRUE(bool(auth_field));
+
+    const auto parsed = parse_fields(auth_field->second);
+    EXPECT_STREQ(u8"Authorization", auth_field->first.c_str());
+    EXPECT_STREQ(u8"MD5", parsed.at(u8"algorithm").c_str());
+    EXPECT_STREQ(nonce, parsed.at(u8"nonce").c_str());
+    EXPECT_STREQ(opaque, parsed.at(u8"opaque").c_str());
+    EXPECT_STREQ(u8"auth", parsed.at(u8"qop").c_str());
+    EXPECT_STREQ(uri, parsed.at(u8"uri").c_str());
+    EXPECT_EQ(user.username, parsed.at(u8"username"));
+    EXPECT_STREQ(realm, parsed.at(u8"realm").c_str());
+    EXPECT_EQ(nc, parsed.at(u8"nc"));
+
+    const std::string a1 = get_a1(user, parsed);
+    const std::string a2 = get_a2(uri);
+    const std::string auth_code = md5_hex(
+      boost::join(std::vector<std::string>{md5_hex(a1), nonce, nc, cnonce, u8"auth", md5_hex(a2)}, u8":")
+    );
+    EXPECT_TRUE(boost::iequals(auth_code, parsed.at(u8"response")));
+  }
+
+  EXPECT_EQ(http::http_client_auth::kBadPassword, auth.handle_401(response));
+  response.m_additional_fields.back().second.append(u8"," + write_fields({{u8"stale", u8"trUe"}}));
+  EXPECT_EQ(http::http_client_auth::kSuccess, auth.handle_401(response));
+}
+


### PR DESCRIPTION
This adds HTTP client "authorization" field generation to the same library that contains the HTTP server authentication. This does not add the "hooks" to the epee code to generate the authorization field. Client authentication will be necessary in the wallets if HTTP auth is added to the `monerod` RPC daemon.

Client authorization uses the exact same parsing framework that the server code uses. I apologize for the renaming spam - I did not plan _completely_ ahead of time.

This supercedes [PR 1514](https://github.com/monero-project/monero/pull/1514), which I will leave up because I expect this will have more discussion.