### PR TITLE
portable serializer: use signed char for size

### DIFF
--- a/external/boost/archive/portable_binary_archive.hpp
+++ b/external/boost/archive/portable_binary_archive.hpp
@@ -14,6 +14,7 @@
 #include <boost/config.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/archive/archive_exception.hpp>
 
 #include <climits>
 #if CHAR_BIT != 8
@@ -37,7 +38,9 @@ enum portable_binary_archive_flags {
 //#endif
 
 inline void
-reverse_bytes(char size, char *address){
+reverse_bytes(signed char size, char *address){
+    if (size <= 0)
+        throw archive_exception(archive_exception::other_exception);
     char * first = address;
     char * last = first + size - 1;
     for(;first < last;++first, --last){

--- a/external/boost/archive/portable_binary_iarchive.hpp
+++ b/external/boost/archive/portable_binary_iarchive.hpp
@@ -234,7 +234,7 @@ namespace boost { namespace archive {
 
 inline void 
 portable_binary_iarchive::load_impl(boost::intmax_t & l, char maxsize){
-    char size;
+    signed char size;
     l = 0;
     this->primitive_base_t::load(size);
 

--- a/external/boost/archive/portable_binary_oarchive.hpp
+++ b/external/boost/archive/portable_binary_oarchive.hpp
@@ -225,7 +225,7 @@ portable_binary_oarchive::save_impl(
     const boost::intmax_t l,
     const char maxsize
 ){
-    char size = 0;
+    signed char size = 0;
 
     if(l == 0){
         this->primitive_base_t::save(size);
@@ -245,7 +245,7 @@ portable_binary_oarchive::save_impl(
     }while(ll != 0);
 
     this->primitive_base_t::save(
-        static_cast<char>(negative ? -size : size)
+        static_cast<signed char>(negative ? -size : size)
     );
 
     if(negative)


### PR DESCRIPTION
See [comment](https://github.com/monero-project/monero/pull/1515#issuecomment-270786333) in PR #1515

I believe this fix doesn't have any real effect on monero with arm7 & armv8 builds, as there is no data to be serialized in Monero that is negative.