### PR TITLE
Show available types in db-type and remove db-auto-remove-logs

### DIFF
--- a/src/blockchain_db/db_types.h
+++ b/src/blockchain_db/db_types.h
@@ -34,7 +34,6 @@ namespace cryptonote
 
   const std::unordered_set<std::string> blockchain_db_types = 
   { "lmdb"
-  , "berkeley"
   };
 
 } // namespace cryptonote

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -31,6 +31,8 @@
 #include "command_line.h"
 #include <boost/algorithm/string/compare.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <unordered_set>
+#include "blockchain_db/db_types.h"
 #include "common/i18n.h"
 #include "cryptonote_config.h"
 #include "string_tools.h"
@@ -88,9 +90,10 @@ namespace command_line
   , "checkpoints from DNS server will be enforced"
   , false
   };
+  std::string arg_db_type_description = "Specify database type, available: " + boost::algorithm::join(cryptonote::blockchain_db_types, ", ");
   const command_line::arg_descriptor<std::string> arg_db_type = {
     "db-type"
-  , "Specify database type"
+  , arg_db_type_description.c_str()
   , DEFAULT_DB_TYPE
   };
   const command_line::arg_descriptor<std::string> arg_db_sync_mode = {

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -111,11 +111,6 @@ namespace command_line
   , "Max number of threads to use when preparing block hashes in groups."
   , 4
   };
-  const command_line::arg_descriptor<uint64_t> arg_db_auto_remove_logs  = {
-    "db-auto-remove-logs"
-  , "For BerkeleyDB only. Remove transactions logs automatically."
-  , 1
-  };
   const command_line::arg_descriptor<uint64_t> arg_show_time_stats  = {
     "show-time-stats"
   , "Show time-stats when processing blocks/txs and disk synchronization."

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -217,7 +217,6 @@ namespace command_line
   extern const arg_descriptor<std::string> arg_db_sync_mode;
   extern const arg_descriptor<uint64_t> arg_fast_block_sync;
   extern const arg_descriptor<uint64_t> arg_prep_blocks_threads;
-  extern const arg_descriptor<uint64_t> arg_db_auto_remove_logs;
   extern const arg_descriptor<uint64_t> arg_show_time_stats;
   extern const arg_descriptor<size_t> arg_block_sync_size;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -141,7 +141,6 @@ namespace cryptonote
     command_line::add_arg(desc, command_line::arg_fast_block_sync);
     command_line::add_arg(desc, command_line::arg_db_sync_mode);
     command_line::add_arg(desc, command_line::arg_show_time_stats);
-    command_line::add_arg(desc, command_line::arg_db_auto_remove_logs);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
   }
   //-----------------------------------------------------------------------------------------------
@@ -368,8 +367,6 @@ namespace cryptonote
           blocks_per_sync = bps;
       }
 
-      bool auto_remove_logs = command_line::get_arg(vm, command_line::arg_db_auto_remove_logs) != 0;
-      db->set_auto_remove_logs(auto_remove_logs);
       db->open(filename, db_flags);
       if(!db->m_open)
         return false;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -301,18 +301,6 @@ namespace cryptonote
       DBS_FAST_MODE = MDB_NORDAHEAD | MDB_NOSYNC;
       DBS_FASTEST_MODE = MDB_NORDAHEAD | MDB_NOSYNC | MDB_WRITEMAP | MDB_MAPASYNC;
     }
-    else if (db_type == "berkeley")
-    {
-#if defined(BERKELEY_DB)
-      db = new BlockchainBDB();
-      DBS_FAST_MODE = DB_TXN_WRITE_NOSYNC;
-      DBS_FASTEST_MODE = DB_TXN_NOSYNC;
-      DBS_SAFE_MODE = DB_TXN_SYNC;
-#else
-      LOG_ERROR("BerkeleyDB support disabled.");
-      return false;
-#endif
-    }
     else
     {
       LOG_ERROR("Attempted to use non-existent database type");


### PR DESCRIPTION
Not needed anymore since the complete switch to LMDB.

Related to #1533.