### PR TITLE
Add start_time to info commands and uptime to status command

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -250,6 +250,8 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::init(const boost::program_options::variables_map& vm, const cryptonote::test_options *test_options)
   {
+    start_time = std::time(nullptr);
+
     m_fakechain = test_options != NULL;
     bool r = handle_command_line(vm);
 
@@ -1008,6 +1010,11 @@ namespace cryptonote
   uint64_t core::get_target_blockchain_height() const
   {
     return m_target_blockchain_height;
+  }
+  //-----------------------------------------------------------------------------------------------
+  std::time_t core::get_start_time() const
+  {
+    return start_time;
   }
   //-----------------------------------------------------------------------------------------------
   void core::graceful_exit()

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -560,6 +560,12 @@ namespace cryptonote
      uint64_t get_target_blockchain_height() const;
 
      /**
+      * @brief gets start_time
+      *
+      */
+     std::time_t get_start_time() const;
+
+     /**
       * @brief tells the Blockchain to update its checkpoints
       *
       * This function will check if enough time has passed since the last
@@ -813,6 +819,8 @@ namespace cryptonote
      boost::interprocess::file_lock db_lock; //!< a lock object for a file lock in the db directory
 
      size_t block_sync_size;
+
+     time_t start_time;
    };
 }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -363,7 +363,9 @@ bool t_rpc_command_executor::show_status() {
     }
   }
 
-  tools::success_msg_writer() << boost::format("Height: %llu/%llu (%.1f%%) on %s, %s, net hash %s, v%u%s, %s, %u+%u connections")
+  std::time_t uptime = std::time(nullptr) - ires.start_time;
+
+  tools::success_msg_writer() << boost::format("Height: %llu/%llu (%.1f%%) on %s, %s, net hash %s, v%u%s, %s, %u+%u connections, uptime %uh %um %us")
     % (unsigned long long)ires.height
     % (unsigned long long)(ires.target_height >= ires.height ? ires.target_height : ires.height)
     % get_sync_percentage(ires)
@@ -374,6 +376,9 @@ bool t_rpc_command_executor::show_status() {
     % get_fork_extra_info(hfres.earliest_height, ires.height, ires.target)
     % (hfres.state == cryptonote::HardFork::Ready ? "up to date" : hfres.state == cryptonote::HardFork::UpdateNeeded ? "update needed" : "out of date, likely forked")
     % (unsigned)ires.outgoing_connections_count % (unsigned)ires.incoming_connections_count
+    % (unsigned int)floor(uptime / 3600.0)
+    % (unsigned int)floor(fmod(uptime, 3600.0) / 60.0)
+    % (unsigned int)fmod(uptime, 60.0)
   ;
 
   return true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -145,6 +145,7 @@ namespace cryptonote
     res.cumulative_difficulty = m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1);
     res.block_size_limit = m_core.get_blockchain_storage().get_current_cumulative_blocksize_limit();
     res.status = CORE_RPC_STATUS_OK;
+    res.start_time = (uint64_t)m_core.get_start_time();
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -1165,6 +1166,7 @@ namespace cryptonote
     res.cumulative_difficulty = m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1);
     res.block_size_limit = m_core.get_blockchain_storage().get_current_cumulative_blocksize_limit();
     res.status = CORE_RPC_STATUS_OK;
+    res.start_time = (uint64_t)m_core.get_start_time();
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 3
+#define CORE_RPC_VERSION_MINOR 4
 #define CORE_RPC_VERSION (((CORE_RPC_VERSION_MAJOR)<<16)|(CORE_RPC_VERSION_MINOR))
 
   struct COMMAND_RPC_GET_HEIGHT
@@ -513,6 +513,7 @@ namespace cryptonote
       std::string top_block_hash;
       uint64_t cumulative_difficulty;
       uint64_t block_size_limit;
+      uint64_t start_time;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
@@ -531,6 +532,7 @@ namespace cryptonote
         KV_SERIALIZE(top_block_hash)
         KV_SERIALIZE(cumulative_difficulty)
         KV_SERIALIZE(block_size_limit)
+        KV_SERIALIZE(start_time)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
on_get_info and on_get_info_json now includes the field start_time.

status command now report the daemon uptime.

Related to #1382.
