### PR TITLE
initialize timestamp to 0 and check for mktime() error

### DIFF
--- a/src/cryptonote_core/account.cpp
+++ b/src/cryptonote_core/account.cpp
@@ -72,7 +72,7 @@ DISABLE_VS_WARNINGS(4244 4345)
 
     generate_keys(m_keys.m_account_address.m_view_public_key, m_keys.m_view_secret_key, second, two_random ? false : true);
 
-    struct tm timestamp;
+    struct tm timestamp = {0};
     timestamp.tm_year = 2014 - 1900;  // year 2014
     timestamp.tm_mon = 6 - 1;  // month june
     timestamp.tm_mday = 8;  // 8th of june
@@ -82,7 +82,7 @@ DISABLE_VS_WARNINGS(4244 4345)
 
     if (recover)
     {
-      m_creation_timestamp = mktime(&timestamp);
+      m_creation_timestamp = std::max(mktime(&timestamp), (long)0);
     }
     else
     {
@@ -97,7 +97,7 @@ DISABLE_VS_WARNINGS(4244 4345)
     m_keys.m_spend_secret_key = spendkey;
     m_keys.m_view_secret_key = viewkey;
 
-    struct tm timestamp;
+    struct tm timestamp = {0};
     timestamp.tm_year = 2014 - 1900;  // year 2014
     timestamp.tm_mon = 4 - 1;  // month april
     timestamp.tm_mday = 15;  // 15th of april
@@ -105,7 +105,7 @@ DISABLE_VS_WARNINGS(4244 4345)
     timestamp.tm_min = 0;
     timestamp.tm_sec = 0;
 
-    m_creation_timestamp = mktime(&timestamp);
+    m_creation_timestamp = std::max(mktime(&timestamp), (long)0);
   }
   //-----------------------------------------------------------------
   void account_base::create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey)


### PR DESCRIPTION
This fixes #1551, where a bad account creation timestamp was causing transactions to not load in the CLI.

The problem was that on some systems, uninitialized variables in the `tm` struct were causing `mktime()` to return `-1` in `account_base::create_from_keys()`. This is what was being passed to `mktime()`:

    (tm) $0 = {
      tm_sec = 0
      tm_min = 0
      tm_hour = 0
      tm_mday = 15
      tm_mon = 3
      tm_year = 114
      tm_wday = 1606389616
      tm_yday = 32767
      tm_isdst = 1
      tm_gmtoff = 140734799777680
      tm_zone = 0x00007fff5fbf9778 "\x12test.keys"
    }

Initializing the struct to 0 before using fixes it. I also added a check to make sure errors from `mktime()` work predictably by setting `m_creation_timestamp` to 0 (epoch).