### PR TITLE
mnemonics: fix language detection with checksum word

### DIFF
--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -148,3 +148,22 @@ TEST(mnemonics, all_languages)
     test_language(*(*it));
   }
 }
+
+TEST(mnemonics, language_detection_with_bad_checksum)
+{
+    crypto::secret_key key;
+    std::string language_name;
+    bool res;
+
+    // This Portuguese (4-prefix) seed has all its words with 3-prefix that's also present in English
+    const std::string base_seed = "cinzento luxuriante leonardo gnostico digressao cupula fifa broxar iniquo louvor ovario dorsal ideologo besuntar decurso rosto susto lemure unheiro pagodeiro nitroglicerina eclusa mazurca bigorna";
+    const std::string real_checksum = "gnostico";
+
+    res = crypto::ElectrumWords::words_to_bytes(base_seed, key, language_name);
+    ASSERT_EQ(true, res);
+    ASSERT_STREQ(language_name.c_str(), "Portuguese");
+
+    res = crypto::ElectrumWords::words_to_bytes(base_seed + " " + real_checksum, key, language_name);
+    ASSERT_EQ(true, res);
+    ASSERT_STREQ(language_name.c_str(), "Portuguese");
+}


### PR DESCRIPTION
If a checksum word is present, language detection would use
just the word prefixes. However, a set of word prefixes may
be found in more than one language, and so the wrong language
may be found first, which could then fail the checksum, since
the check may be done with a different unique prefix length
from the one it was created from.

We now make a checksum test when we we detect a language from
prefixes only, to make sure we have the correct one.