### PR TITLE
easylogging++: enforce recursive mutex

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -33,7 +33,6 @@
 
 INITIALIZE_EASYLOGGINGPP
 
-//#define MLOG_BASE_FORMAT "%datetime{%Y-%M-%d %H:%m:%s.%g}\t%thread\t%level\t%logger\t%fbase:%line\t%msg"
 #define MLOG_BASE_FORMAT "%datetime{%Y-%M-%d %H:%m:%s.%g}\t%thread\t%level\t%logger\t%loc\t%msg"
 
 using namespace epee;
@@ -83,7 +82,10 @@ void mlog_configure(const std::string &filename_base, bool console)
   el::Configurations c;
   c.setGlobally(el::ConfigurationType::Filename, filename_base);
   c.setGlobally(el::ConfigurationType::ToFile, "true");
-  c.setGlobally(el::ConfigurationType::Format, MLOG_BASE_FORMAT);
+  const char *log_format = getenv("MONERO_LOG_FORMAT");
+  if (!log_format)
+    log_format = MLOG_BASE_FORMAT;
+  c.setGlobally(el::ConfigurationType::Format, log_format);
   c.setGlobally(el::ConfigurationType::ToStandardOutput, console ? "true" : "false");
   c.setGlobally(el::ConfigurationType::MaxLogFileSize, "104850000"); // 100 MB - 7600 bytes
   el::Loggers::setDefaultConfigurations(c, true);

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -1001,7 +1001,11 @@ namespace el {
                                     public:
                                         Mutex(void) {
 #   if ELPP_OS_UNIX
-                                            pthread_mutex_init(&m_underlyingMutex, nullptr);
+                                            pthread_mutexattr_t attr;
+                                            pthread_mutexattr_init(&attr);
+                                            pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+                                            pthread_mutex_init(&m_underlyingMutex, &attr);
+                                            pthread_mutexattr_destroy(&attr);
 #   elif ELPP_OS_WINDOWS
                                             InitializeCriticalSection(&m_underlyingMutex);
 #   endif  // ELPP_OS_UNIX


### PR DESCRIPTION
This fixes a hang when logging something which causes some other
logging code to be called