### PR TITLE
Honor depth in get_peerlist_head method

### DIFF
--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -285,9 +285,11 @@ namespace nodetool
     {
       if(!vl.last_seen)
         continue;
-      bs_head.push_back(vl);      
-      if(cnt++ > depth)
+
+      if(cnt++ >= depth)
         break;
+
+      bs_head.push_back(vl);
     }
     return true;
   }


### PR DESCRIPTION
The method returned depth + 2 because:

- push_back was executed before the condition.
- \> instead of >= causing one more iteration.