### PR TITLE
Add gray peer list housekeeping system

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -229,6 +229,9 @@ namespace nodetool
 
     bool has_too_many_connections(const uint32_t ip);
 
+    bool check_connection_and_handshake_with_peer(const net_address& na, uint64_t last_seen_stamp);
+    bool gray_peerlist_housekeeping();
+
     void kill() { ///< will be called e.g. from deinit()
       _info("Killing the net_node");
       is_closing = true;
@@ -289,6 +292,7 @@ namespace nodetool
     epee::math_helper::once_a_time_seconds<P2P_DEFAULT_HANDSHAKE_INTERVAL> m_peer_handshake_idle_maker_interval;
     epee::math_helper::once_a_time_seconds<1> m_connections_maker_interval;
     epee::math_helper::once_a_time_seconds<60*30, false> m_peerlist_store_interval;
+    epee::math_helper::once_a_time_seconds<60> m_gray_peerlist_housekeeping_interval;
 
     std::string m_bind_ip;
     std::string m_port;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1755,7 +1755,7 @@ namespace nodetool
   {
     peerlist_entry pe = AUTO_VAL_INIT(pe);
 
-    if (!m_peerlist.get_gray_peer_random(pe)) {
+    if (!m_peerlist.get_random_gray_peer(pe)) {
         return false;
     }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1769,7 +1769,7 @@ namespace nodetool
       return true;
     }
 
-    m_peerlist.append_with_peer_white(pe);
+    m_peerlist.set_peer_just_seen(pe.id, pe.adr);
 
     LOG_PRINT_L2("PEER PROMOTED TO WHITE PEER LIST IP address: " << epee::string_tools::get_ip_string_from_int32(pe.adr.ip) << " Peer ID: " << std::hex << pe.id);
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -965,7 +965,7 @@ namespace nodetool
 
     m_net_server.get_config_object().close(con.m_connection_id);
 
-    LOG_PRINT_CC_GREEN(con, "CONNECTION HANDSHAKED OK AND CLOSED.", LOG_LEVEL_2);
+    LOG_DEBUG_CC(con, "CONNECTION HANDSHAKED OK AND CLOSED.");
 
     return true;
   }

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -81,7 +81,7 @@ namespace nodetool
     bool set_peer_just_seen(peerid_type peer, const net_address& addr);
     bool set_peer_unreachable(const peerlist_entry& pr);
     bool is_ip_allowed(uint32_t ip);
-    bool get_gray_peer_random(peerlist_entry& pe);
+    bool get_random_gray_peer(peerlist_entry& pe);
     bool remove_from_peer_gray(const peerlist_entry& pe);
 
     
@@ -399,7 +399,7 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::get_gray_peer_random(peerlist_entry& pe)
+  bool peerlist_manager::get_random_gray_peer(peerlist_entry& pe)
   {
     TRY_ENTRY();
 
@@ -419,7 +419,7 @@ namespace nodetool
 
     return true;
 
-    CATCH_ENTRY_L0("peerlist_manager::get_gray_peer_random()", false);
+    CATCH_ENTRY_L0("peerlist_manager::get_random_gray_peer()", false);
     return true;
   }
   //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A random peer from the gray peer list is selected and a connection is made to check if the peer is alive.

If the connection and handshake are successful the peer is promoted to the white peer list, in case of failure the peer is evicted from the gray peer list.

The connection is closed after the check in either case.

Please, check for:
- Race conditions
- Possible side effects
- That the adequate log levels are being used
- Any other problems and suggestions