### PR TITLE
p2p: always recreate a new peer id on startup

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -110,7 +110,12 @@ namespace nodetool
     void serialize(Archive &a,  const t_version_type ver)
     {
       a & m_peerlist;
-      a & m_config.m_peer_id;
+      if (ver == 0)
+      {
+        // from v1, we do not store the peer id anymore
+        peerid_type peer_id;
+        a & peer_id;
+      }
     }
     // debug functions
     bool log_peerlist();
@@ -162,6 +167,7 @@ namespace nodetool
 #endif
     int handle_get_support_flags(int command, COMMAND_REQUEST_SUPPORT_FLAGS::request& arg, COMMAND_REQUEST_SUPPORT_FLAGS::response& rsp, p2p_connection_context& context);
     bool init_config();
+    bool make_default_peer_id();
     bool make_default_config();
     bool store_config();
     bool check_trust(const proof_of_trust& tr);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -173,6 +173,9 @@ namespace nodetool
       make_default_config();
     }
 
+    // always recreate a new peer id
+    make_default_peer_id();
+
     //at this moment we have hardcoded config
     m_config.m_net_config.handshake_interval = P2P_DEFAULT_HANDSHAKE_INTERVAL;
     m_config.m_net_config.packet_max_size = P2P_DEFAULT_PACKET_MAX_SIZE; //20 MB limit
@@ -212,10 +215,16 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::make_default_config()
+  bool node_server<t_payload_net_handler>::make_default_peer_id()
   {
     m_config.m_peer_id  = crypto::rand<uint64_t>();
     return true;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::make_default_config()
+  {
+    return make_default_peer_id();
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -194,3 +194,5 @@ private:
     bool m_restricted;
   };
 }
+
+BOOST_CLASS_VERSION(nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >, 1);


### PR DESCRIPTION
This prevents easy fingerprinting when you change IPs, and
will be a must when kovri gets used.