### PR TITLE
hmlog: fix default level/category mapping

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -125,10 +125,10 @@ void mlog_set_log_level(int level)
         settings = "*:WARNING,global:INFO";
         break;
       case 2:
-        settings = "*:INFO";
+        settings = "*:DEBUG";
         break;
       case 3:
-        settings = "*:DEBUG";
+        settings = "*:TRACE";
         break;
       case 4:
         settings = "*:TRACE";


### PR DESCRIPTION
It was not matching the LOG_PRINT_Lx mapping for 2/3/4