### PR TITLE
Update log messages - no need to type 'exit' to save DB

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1020,12 +1020,11 @@ namespace cryptonote
       MGINFO_YELLOW(ENDL << "**********************************************************************" << ENDL
         << "The daemon will start synchronizing with the network. It may take up to several hours." << ENDL
         << ENDL
-        << "You can set the level of process detailization* through \"set_log <level|categories>\" command*, where <level> is between 0 (no details) and 4 (very verbose), or custom category based levels (eg, *:WARNING)" << ENDL
+        << "You can set the level of process detailization* through \"set_log <level|categories>\" command*," << ENDL
+        << "where <level> is between 0 (no details) and 4 (very verbose), or custom category based levels (eg, *:WARNING)" << ENDL
         << ENDL
-        << "Use \"help\" command to see the list of available commands." << ENDL
-        << ENDL
-        << "Note: in case you need to interrupt the process, use \"exit\" command. Otherwise, the current progress won't be saved." << ENDL
-        << "**********************************************************************");
+        << "Use the \"help\" command to see the list of available commands." << ENDL
+        << "**********************************************************************" << ENDL);
       m_starter_message_showed = true;
     }
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1022,13 +1022,10 @@ namespace cryptonote
     bool val_expected = false;
     if(m_synchronized.compare_exchange_strong(val_expected, true))
     {
-      MGINFO_GREEN(ENDL << "**********************************************************************" << ENDL
+      MGINFO_YELLOW(ENDL << "**********************************************************************" << ENDL
         << "You are now synchronized with the network. You may now start monero-wallet-cli." << ENDL
         << ENDL
-        << "Please note, that the blockchain will be saved only after you quit the daemon with \"exit\" command or if you use \"save\" command." << ENDL
-        << "Otherwise, you will possibly need to synchronize the blockchain again." << ENDL
-        << ENDL
-        << "Use \"help\" command to see the list of available commands." << ENDL
+        << "Use the \"help\" command to see the list of available commands." << ENDL
         << "**********************************************************************");
       m_core.on_synchronized();
     }


### PR DESCRIPTION
LMDB means we no longer need to type `exit` or `save` before quitting. Have updated the user messages to reflect this change. Have also made the green message orange to stand out from the rest of the log traffic and match the other.