### PR TITLE
moved get_account_address_from_str_or_url from libcommon to libcryptonote_core

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -451,22 +451,6 @@ std::string get_account_address_as_str_from_url(const std::string& url, bool& dn
   return addresses[0];
 }
 
-bool get_account_address_from_str_or_url(
-    cryptonote::account_public_address& address
-  , bool& has_payment_id
-  , crypto::hash8& payment_id
-  , bool testnet
-  , const std::string& str_or_url
-  )
-{
-  if (cryptonote::get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, str_or_url))
-    return true;
-  bool dnssec_valid;
-  std::string address_str = get_account_address_as_str_from_url(str_or_url, dnssec_valid);
-  return !address_str.empty() &&
-          cryptonote::get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, address_str);
-}
-
 }  // namespace tools::dns_utils
 
 }  // namespace tools

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -164,13 +164,6 @@ std::string address_from_txt_record(const std::string& s);
 std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec_valid);
 
 std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid);
-bool get_account_address_from_str_or_url(
-    cryptonote::account_public_address& address
-  , bool& has_payment_id
-  , crypto::hash8& payment_id
-  , bool testnet
-  , const std::string& str_or_url
-  );
 
 }  // namespace tools::dns_utils
 

--- a/src/cryptonote_core/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_core/cryptonote_basic_impl.cpp
@@ -41,6 +41,7 @@ using namespace epee;
 #include "common/base58.h"
 #include "crypto/hash.h"
 #include "common/int-util.h"
+#include "common/dns_utils.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "cn"
@@ -291,7 +292,34 @@ namespace cryptonote {
     crypto::hash8 payment_id;
     return get_account_integrated_address_from_str(adr, has_payment_id, payment_id, testnet, str);
   }
-
+  //--------------------------------------------------------------------------------
+  bool get_account_address_from_str_or_url(
+      cryptonote::account_public_address& address
+    , bool& has_payment_id
+    , crypto::hash8& payment_id
+    , bool testnet
+    , const std::string& str_or_url
+    )
+  {
+    if (get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, str_or_url))
+      return true;
+    bool dnssec_valid;
+    std::string address_str = tools::dns_utils::get_account_address_as_str_from_url(str_or_url, dnssec_valid);
+    return !address_str.empty() &&
+      get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, address_str);
+  }
+  //--------------------------------------------------------------------------------
+  bool get_account_address_from_str_or_url(
+      cryptonote::account_public_address& address
+    , bool testnet
+    , const std::string& str_or_url
+    )
+  {
+    bool has_payment_id;
+    crypto::hash8 payment_id;
+    return get_account_address_from_str_or_url(address, testnet, str_or_url);
+  }
+  //--------------------------------------------------------------------------------
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b) {
     return cryptonote::get_transaction_hash(a) == cryptonote::get_transaction_hash(b);
   }

--- a/src/cryptonote_core/cryptonote_basic_impl.h
+++ b/src/cryptonote_core/cryptonote_basic_impl.h
@@ -100,6 +100,20 @@ namespace cryptonote {
     , const std::string& str
     );
 
+  bool get_account_address_from_str_or_url(
+      cryptonote::account_public_address& address
+    , bool& has_payment_id
+    , crypto::hash8& payment_id
+    , bool testnet
+    , const std::string& str_or_url
+    );
+
+  bool get_account_address_from_str_or_url(
+      cryptonote::account_public_address& address
+    , bool testnet
+    , const std::string& str_or_url
+    );
+
   bool is_coinbase(const transaction& tx);
 
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2143,7 +2143,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     cryptonote::tx_destination_entry de;
     bool has_payment_id;
     crypto::hash8 new_payment_id;
-    if (!tools::dns_utils::get_account_address_from_str_or_url(de.addr, has_payment_id, new_payment_id, m_wallet->testnet(), local_args[i]))
+    if (!cryptonote::get_account_address_from_str_or_url(de.addr, has_payment_id, new_payment_id, m_wallet->testnet(), local_args[i]))
       return true;
 
     if (has_payment_id)
@@ -2636,7 +2636,7 @@ bool simple_wallet::sweep_all(const std::vector<std::string> &args_)
   bool has_payment_id;
   crypto::hash8 new_payment_id;
   cryptonote::account_public_address address;
-  if (!tools::dns_utils::get_account_address_from_str_or_url(address, has_payment_id, new_payment_id, m_wallet->testnet(), local_args[0]))
+  if (!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, new_payment_id, m_wallet->testnet(), local_args[0]))
     return true;
 
   if (has_payment_id)
@@ -3187,7 +3187,7 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
   cryptonote::account_public_address address;
   bool has_payment_id;
   crypto::hash8 payment_id;
-  if(!tools::dns_utils::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), local_args[2]))
+  if(!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), local_args[2]))
   {
     fail_msg_writer() << tr("failed to parse address");
     return true;
@@ -3735,7 +3735,7 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
     cryptonote::account_public_address address;
     bool has_payment_id;
     crypto::hash8 payment_id8;
-    if(!tools::dns_utils::get_account_address_from_str_or_url(address, has_payment_id, payment_id8, m_wallet->testnet(), args[1]))
+    if(!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, payment_id8, m_wallet->testnet(), args[1]))
     {
       fail_msg_writer() << tr("failed to parse address");
       return true;
@@ -3925,7 +3925,7 @@ bool simple_wallet::verify(const std::vector<std::string> &args)
   cryptonote::account_public_address address;
   bool has_payment_id;
   crypto::hash8 payment_id;
-  if(!tools::dns_utils::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), address_string))
+  if(!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), address_string))
   {
     fail_msg_writer() << tr("failed to parse address");
     return true;


### PR DESCRIPTION
Since cryptonote_core depends on common, dns_utils in common shouldn't use functions defined by cryptonote_core. This dependency issue was problematic only for debug build on mac. See PR #1626 