### PR TITLE
Fix clang build failure, caused by mixing C and C++

### DIFF
--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -40,11 +40,11 @@
 #include <cinttypes>
 
 extern "C" {
-#include "crypto/generic-ops.h"
 #include "crypto/crypto-ops.h"
 #include "crypto/random.h"
 #include "crypto/keccak.h"
 }
+#include "crypto/generic-ops.h"
 #include "crypto/crypto.h"
 
 #include "serialization/serialization.h"


### PR DESCRIPTION
Easily fixed by moving a C++ header out of 'extern "C" {...}'.

When building with CC=clang CXX=clang++ make,
[ 21%] Building CXX object src/ringct/CMakeFiles/obj_ringct.dir/rctTypes.cpp.o
In file included from /home/tdprime/bitmonero/src/ringct/rctTypes.cpp:31:
In file included from /home/tdprime/bitmonero/src/ringct/rctTypes.h:43:
In file included from /home/tdprime/bitmonero/src/crypto/generic-ops.h:34:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/cstring:100:3: error: conflicting types for 'memchr'
  memchr(void* __s, int __c, size_t __n)
    ^
	/usr/include/string.h:92:14: note: previous declaration is here
	extern void *memchr (const void *__s, int __c, size_t __n)
	             ^
... and 4 more similar errors