### PR TITLE
Separate data per P2P port

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -42,6 +42,7 @@ using namespace epee;
 #include "cryptonote_format_utils.h"
 #include "misc_language.h"
 #include <csignal>
+#include <p2p/net_node.h>
 #include "cryptonote_core/checkpoints.h"
 #include "ringct/rctTypes.h"
 #include "blockchain_db/blockchain_db.h"
@@ -259,8 +260,17 @@ namespace cryptonote
 
     m_fakechain = test_options != NULL;
     bool r = handle_command_line(vm);
+    bool testnet = command_line::get_arg(vm, command_line::arg_testnet_on);
+    auto p2p_bind_arg = testnet ? nodetool::arg_testnet_p2p_bind_port : nodetool::arg_p2p_bind_port;
+    std::string m_port = command_line::get_arg(vm, p2p_bind_arg);
+    std::string m_config_folder_mempool = m_config_folder;
 
-    r = m_mempool.init(m_fakechain ? std::string() : m_config_folder);
+    if ((!testnet && m_port != std::to_string(::config::P2P_DEFAULT_PORT))
+        || (testnet && m_port != std::to_string(::config::testnet::P2P_DEFAULT_PORT))) {
+      m_config_folder_mempool = m_config_folder_mempool + "/" + m_port;
+    }
+
+    r = m_mempool.init(m_fakechain ? std::string() : m_config_folder_mempool);
     CHECK_AND_ASSERT_MES(r, false, "Failed to initialize memory pool");
 
     std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -505,6 +505,11 @@ namespace nodetool
     auto config_arg = testnet ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
     m_config_folder = command_line::get_arg(vm, config_arg);
 
+    if ((!testnet && m_port != std::to_string(::config::P2P_DEFAULT_PORT))
+        || (testnet && m_port != std::to_string(::config::testnet::P2P_DEFAULT_PORT))) {
+      m_config_folder = m_config_folder + "/" + m_port;
+    }
+
     res = init_config();
     CHECK_AND_ASSERT_MES(res, false, "Failed to init config.");
 


### PR DESCRIPTION
poolstate.bin and p2pstate.bin are stored in .bitmonero/ if the default P2P port is being used.

If another port is used both files are stored in .bitmonero/PORTNUMBER/.