### PR TITLE
core: fix integrated addresses breaking with auto zero change

### DIFF
--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -443,6 +443,8 @@ namespace cryptonote
     {
       if (!memcmp(&destinations[n].addr, &sender_keys.m_account_address, sizeof(destinations[0].addr)))
         continue;
+      if (destinations[n].amount == 0)
+        continue;
       if (memcmp(&destinations[n].addr, &destinations[0].addr, sizeof(destinations[0].addr)))
         return null_pkey;
     }


### PR DESCRIPTION
Zero change is sent to a random address, which confuses the code
which determines which key to use to encrypt the payment id.
Ignore zero amounts for this purpose, so the payment id gets
encrypted with the real destination's key.