### PR TITLE
fixes #1660 depency on libepee.a for debug-test build

### DIFF
--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(cryptonote_core
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+    epee
   PRIVATE
     ${Blocks}
     ${EXTRA_LIBRARIES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(hash-target-tests
   ${hash_targets_headers})
 target_link_libraries(hash-target-tests
   PRIVATE
+    epee
     cryptonote_core)
 set_property(TARGET hash-target-tests
   PROPERTY

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,7 +93,6 @@ add_executable(hash-target-tests
   ${hash_targets_headers})
 target_link_libraries(hash-target-tests
   PRIVATE
-    epee
     cryptonote_core)
 set_property(TARGET hash-target-tests
   PROPERTY


### PR DESCRIPTION
Before change, make debug-test does,
```
../src/cryptonote_core/libcryptonote_core.so: undefined reference to `el::base::utils::s_currentHost[abi:cxx11]'
../src/cryptonote_core/libcryptonote_core.so: undefined reference to `el::base::utils::s_currentUser[abi:cxx11]'
../src/cryptonote_core/libcryptonote_core.so: undefined reference to `el::base::elStorage'
collect2: error: ld returned 1 exit status
tests/CMakeFiles/hash-target-tests.dir/build.make:110: recipe for target 'tests/hash-target-tests' failed
```

Tried to add "epee" dependency to PUBLIC part of
src/cryptonote_core/CMakeLists.txt.  But, that adds libepee.a to
libcryptonote_core.so and to libwallet.so -- not necessary.