### PR TITLE
Wallet API: Catch error from tools::is_local_address

### DIFF
--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -39,8 +39,13 @@ namespace Monero {
 namespace Utils {
 
 bool isAddressLocal(const std::string &address)
-{
-  return tools::is_local_address(address);
+{ 
+    try {
+        return tools::is_local_address(address);
+    } catch (const std::exception &e) {
+        MERROR("error: " << e.what());
+        return false;
+    }
 }
 
 }


### PR DESCRIPTION
Not sure where this throws, but it does, with error: `resolve: Host not found (authoritative)`
Related to changes made in #1629? 

Causing GUI to crash when switching to a daemon address that doesn't resolve.


