### PR TITLE
Make get_random_gray_peer distribution uniform

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1023,7 +1023,14 @@ namespace nodetool
     while(rand_count < (max_random_index+1)*3 &&  try_count < 10 && !m_net_server.is_stop_signal_sent())
     {
       ++rand_count;
-      size_t random_index = get_random_index_with_fixed_probability(max_random_index);
+      size_t random_index;
+
+      if (use_white_list) {
+        random_index = get_random_index_with_fixed_probability(max_random_index);
+      } else {
+        random_index = crypto::rand<size_t>() % m_peerlist.get_gray_peers_count();
+      }
+
       CHECK_AND_ASSERT_MES(random_index < local_peers_count, false, "random_starter_index < peers_local.size() failed!!");
 
       if(tried_peers.count(random_index))

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -408,13 +408,10 @@ namespace nodetool
       return false;
     }
 
-    size_t x = crypto::rand<size_t>() % (m_peers_gray.size() + 1);
-    size_t res = (x * x * x) / (m_peers_gray.size() * m_peers_gray.size()); //parabola \/
-
-    LOG_PRINT_L3("Random gray peer index=" << res << "(x="<< x << ", max_index=" << m_peers_gray.size() << ")");
+    size_t random_index = crypto::rand<size_t>() % m_peers_gray.size();
 
     peers_indexed::index<by_time>::type& by_time_index = m_peers_gray.get<by_time>();
-    pe = *epee::misc_utils::move_it_backward(--by_time_index.end(), res);
+    pe = *epee::misc_utils::move_it_backward(--by_time_index.end(), random_index);
 
     return true;
 


### PR DESCRIPTION
```get_random_gray_peer``` should use an uniform distribution. Explained in #1684