### PR TITLE
Add server auth to monerod, and client auth to wallet-cli and wallet-rpc

### DIFF
--- a/contrib/epee/include/net/http_base.h
+++ b/contrib/epee/include/net/http_base.h
@@ -29,6 +29,9 @@
 #pragma once
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
+#include <boost/utility/string_ref.hpp>
+#include <string>
+#include <utility>
 
 #include "string_tools.h"
 
@@ -90,6 +93,15 @@ namespace net_utils
 			return std::string();
 		}
 
+		static inline void add_field(std::string& out, const boost::string_ref name, const boost::string_ref value)
+		{
+			out.append(name.data(), name.size()).append(": ");
+			out.append(value.data(), value.size()).append("\r\n");
+		}
+		static inline void add_field(std::string& out, const std::pair<std::string, std::string>& field)
+		{
+			add_field(out, field.first, field.second);
+		}
 
 
 		struct http_header_info

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -30,6 +30,8 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/utility/string_ref.hpp>
 //#include <mbstring.h>
 #include <algorithm>
 #include <cctype>
@@ -45,6 +47,7 @@
 #include "string_tools.h"
 #include "reg_exp_definer.h"
 #include "http_base.h" 
+#include "http_auth.h"
 #include "to_nonconst_iterator.h"
 #include "net_parse_helpers.h"
 
@@ -236,9 +239,6 @@ using namespace std;
 
 		class http_simple_client: public i_target_handler
 		{
-		public:
-			
-
 		private:
 			enum reciev_machine_state
 			{
@@ -263,6 +263,7 @@ using namespace std;
 			blocked_mode_client m_net_client;
 			std::string m_host_buff;
 			std::string m_port;
+			http_client_auth m_auth;
 			std::string m_header_cache;
 			http_response_info m_response_info;
 			size_t m_len_in_summary;
@@ -280,6 +281,7 @@ using namespace std;
 				, m_net_client()
 				, m_host_buff()
 				, m_port()
+				, m_auth()
 				, m_header_cache()
 				, m_response_info()
 				, m_len_in_summary(0)
@@ -291,21 +293,22 @@ using namespace std;
 				, m_lock()
 			{}
 
-			bool set_server(const std::string& address)
+			bool set_server(const std::string& address, boost::optional<login> user)
 			{
 				http::url_content parsed{};
 				const bool r = parse_url(address, parsed);
 				CHECK_AND_ASSERT_MES(r, false, "failed to parse url: " << address);
-				set_server(std::move(parsed.host), std::to_string(parsed.port));
+				set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user));
 				return true;
 			}
 
-			void set_server(std::string host, std::string port)
+			void set_server(std::string host, std::string port, boost::optional<login> user)
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				disconnect();
 				m_host_buff = std::move(host);
 				m_port = std::move(port);
+                                m_auth = user ? http_client_auth{std::move(*user)} : http_client_auth{};
 			}
 
       bool connect(std::chrono::milliseconds timeout)
@@ -335,14 +338,14 @@ using namespace std;
 			}
 			//---------------------------------------------------------------------------
 			inline 
-				bool invoke_get(const std::string& uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
+				bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
 			{
 					CRITICAL_REGION_LOCAL(m_lock);
 					return invoke(uri, "GET", body, timeout, ppresponse_info, additional_params);
 			}
 
 			//---------------------------------------------------------------------------
-			inline bool invoke(const std::string& uri, const std::string& method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
+			inline bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				if(!is_connected())
@@ -354,32 +357,64 @@ using namespace std;
 						return false;
 					}
 				}
-				m_response_info.clear();
-				std::string req_buff = 	method + " ";
-				req_buff += uri + " HTTP/1.1\r\n" + 
-					"Host: "+ m_host_buff +"\r\n" +	"Content-Length: " + boost::lexical_cast<std::string>(body.size()) + "\r\n";
 
+				std::string req_buff{};
+				req_buff.reserve(2048);
+				req_buff.append(method.data(), method.size()).append(" ").append(uri.data(), uri.size()).append(" HTTP/1.1\r\n");
+				add_field(req_buff, "Host", m_host_buff);
+				add_field(req_buff, "Content-Length", std::to_string(body.size()));
 
 				//handle "additional_params"
-				for(fields_list::const_iterator it = additional_params.begin(); it!=additional_params.end(); it++)
-					req_buff += it->first + ": " + it->second + "\r\n";
-				req_buff += "\r\n";
-				//--
+				for(const auto& field : additional_params)
+					add_field(req_buff, field);
 
-				bool res = m_net_client.send(req_buff, timeout);
-				CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
-				if(body.size())
-					res = m_net_client.send(body, timeout);
-				CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
+				for (unsigned sends = 0; sends < 2; ++sends)
+				{
+					const std::size_t initial_size = req_buff.size();
+					const auto auth = m_auth.get_auth_field(method, uri);
+					if (auth)
+						add_field(req_buff, *auth);
 
-				if(ppresponse_info)
-					*ppresponse_info = &m_response_info;
+					req_buff += "\r\n";
+					//--
 
-				m_state = reciev_machine_state_header;
-				return handle_reciev(timeout);
+					bool res = m_net_client.send(req_buff, timeout);
+					CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
+					if(body.size())
+						res = m_net_client.send(body, timeout);
+					CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
+
+
+					m_response_info.clear();
+					m_state = reciev_machine_state_header;
+					if (!handle_reciev(timeout))
+						return false;
+					if (m_response_info.m_response_code != 401)
+					{
+						if(ppresponse_info)
+							*ppresponse_info = std::addressof(m_response_info);
+						return true;
+					}
+
+					switch (m_auth.handle_401(m_response_info))
+					{
+					case http_client_auth::kSuccess:
+						break;
+					case http_client_auth::kBadPassword:
+                                                sends = 2;
+						break;
+					default:
+					case http_client_auth::kParseFailure:
+						LOG_ERROR("Bad server response for authentication");
+						return false;
+					}
+					req_buff.resize(initial_size); // rollback for new auth generation
+				}
+				LOG_ERROR("Client has incorrect username/password for server requiring authentication");
+				return false;
 			}
 			//---------------------------------------------------------------------------
-			inline bool invoke_post(const std::string& uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
+			inline bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list())
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				return invoke(uri, "POST", body, timeout, ppresponse_info, additional_params);
@@ -730,7 +765,7 @@ using namespace std;
 					else if(result[i++].matched)//"User-Agent"
 						body_info.m_user_agent = result[field_val];
 					else if(result[i++].matched)//e.t.c (HAVE TO BE MATCHED!)
-					{;}
+						body_info.m_etc_fields.emplace_back(result[11], result[field_val]);
 					else
 					{CHECK_AND_ASSERT_MES(false, false, "http_stream_filter::parse_cached_header() not matched last entry in:"<<m_cache_to_process);}
 

--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -54,7 +54,6 @@ namespace net_utils
 		struct http_server_config
 		{
 			std::string m_folder;
-			std::string m_required_user_agent;
 			boost::optional<login> m_user;
 			critical_section m_lock;
 		};

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -390,13 +390,6 @@ namespace net_utils
 			return false;
 		}
 
-                if (!m_config.m_required_user_agent.empty() && m_query_info.m_header_info.m_user_agent != m_config.m_required_user_agent)
-                {
-			LOG_ERROR("simple_http_connection_handler<t_connection_context>::analize_cached_request_header_and_invoke_state(): unexpected user agent: " << m_query_info.m_header_info.m_user_agent);
-			m_state = http_state_error;
-			return false;
-                }
-
 		m_cache.erase(0, pos);
 
 		std::string req_command_str = m_query_info.m_full_request_str;

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -56,7 +56,7 @@ namespace epee
     {}
 
     bool init(const std::string& bind_port = "0", const std::string& bind_ip = "0.0.0.0",
-      std::string user_agent = "", boost::optional<net_utils::http::login> user = boost::none)
+      boost::optional<net_utils::http::login> user = boost::none)
     {
 
       //set self as callback handler
@@ -65,8 +65,6 @@ namespace epee
       //here set folder for hosting reqests
       m_net_server.get_config_object().m_folder = "";
 
-      // workaround till we get auth/encryption
-      m_net_server.get_config_object().m_required_user_agent = std::move(user_agent);
       m_net_server.get_config_object().m_user = std::move(user);
 
       LOG_PRINT_L0("Binding on " << bind_ip << ":" << bind_port);

--- a/contrib/epee/include/storages/http_abstract_invoke.h
+++ b/contrib/epee/include/storages/http_abstract_invoke.h
@@ -26,6 +26,9 @@
 // 
 
 #pragma once
+#include <boost/utility/string_ref.hpp>
+#include <chrono>
+#include <string>
 #include "portable_storage_template_helper.h"
 #include "net/http_base.h"
 #include "net/http_server_handlers_map2.h"
@@ -35,7 +38,7 @@ namespace epee
   namespace net_utils
   {
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_json(const std::string& uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const std::string& method = "GET")
+    bool invoke_http_json(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const boost::string_ref method = "GET")
     {
       std::string req_param;
       if(!serialization::store_t_to_json(out_struct, req_param))
@@ -66,7 +69,7 @@ namespace epee
 
 
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_bin(const std::string& uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const std::string& method = "GET")
+    bool invoke_http_bin(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const boost::string_ref method = "GET")
     {
       std::string req_param;
       if(!serialization::store_t_to_binary(out_struct, req_param))
@@ -95,7 +98,7 @@ namespace epee
     }
 
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_json_rpc(const std::string& uri, std::string method_name, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const std::string& http_method = "GET", const std::string& req_id = "0")
+    bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
     {
       epee::json_rpc::request<t_request> req_t = AUTO_VAL_INIT(req_t);
       req_t.jsonrpc = "2.0";
@@ -117,7 +120,7 @@ namespace epee
     }
 
     template<class t_command, class t_transport>
-    bool invoke_http_json_rpc(const std::string& uri, typename t_command::request& out_struct, typename t_command::response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const std::string& http_method = "GET", const std::string& req_id = "0")
+    bool invoke_http_json_rpc(const boost::string_ref uri, typename t_command::request& out_struct, typename t_command::response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(5), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
     {
       return invoke_http_json_rpc(uri, t_command::methodname(), out_struct, result_struct, transport, timeout, http_method, req_id);
     }

--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -362,7 +362,7 @@ namespace
 
       server_parameters best{};
 
-      const std::list<field>& fields = response.m_additional_fields;
+      const std::list<field>& fields = response.m_header_info.m_etc_fields;
       auto current = fields.begin();
       const auto end = fields.end();
       while (true)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -32,6 +32,7 @@ set(common_sources
   dns_utils.cpp
   util.cpp
   i18n.cpp
+  password.cpp
   perf_timer.cpp
   task_region.cpp
   thread_group.cpp)
@@ -46,6 +47,7 @@ set(common_private_headers
   base58.h
   boost_serialization_helper.h
   command_line.h
+  common_fwd.h
   dns_utils.h
   http_connection.h
   int-util.h
@@ -56,6 +58,7 @@ set(common_private_headers
   util.h
   varint.h
   i18n.h
+  password.h
   perf_timer.h
   stack_trace.h
   task_region.h

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -76,7 +76,6 @@ namespace command_line
   const arg_descriptor<bool> arg_version = {"version", "Output version information"};
   const arg_descriptor<std::string> arg_data_dir = {"data-dir", "Specify data directory"};
   const arg_descriptor<std::string> arg_testnet_data_dir = {"testnet-data-dir", "Specify testnet data directory"};
-  const arg_descriptor<std::string> arg_user_agent = {"user-agent", "Restrict RPC use to clients using this user agent"};
   const arg_descriptor<bool>		arg_test_drop_download  		= {"test-drop-download", "For net tests: in download, discard ALL blocks instead checking/saving them (very fast)"};
   const arg_descriptor<uint64_t>	arg_test_drop_download_height  	= {"test-drop-download-height", "Like test-drop-download but disards only after around certain height", 0};
   const arg_descriptor<int> 		arg_test_dbg_lock_sleep = {"test-dbg-lock-sleep", "Sleep time in ms, defaults to 0 (off), used to debug before/after locking mutex. Values 100 to 1000 are good for tests."};

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -207,7 +207,6 @@ namespace command_line
   extern const arg_descriptor<bool> arg_version;
   extern const arg_descriptor<std::string> arg_data_dir;
   extern const arg_descriptor<std::string> arg_testnet_data_dir;
-  extern const arg_descriptor<std::string> arg_user_agent;
   extern const arg_descriptor<bool>		arg_test_drop_download;
   extern const arg_descriptor<uint64_t>	arg_test_drop_download_height;
   extern const arg_descriptor<int> 		arg_test_dbg_lock_sleep;

--- a/src/common/common_fwd.h
+++ b/src/common/common_fwd.h
@@ -1,32 +1,21 @@
-/**
-@file
-@details
-
-
-Passing RPC commands:
-
-@image html images/other/runtime-commands.png
-
-*/
-
-// Copyright (c) 2014-2016, The Monero Project
-// 
+// Copyright (c) 2014-2017, The Monero Project
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -36,43 +25,17 @@ Passing RPC commands:
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include <boost/optional/optional_fwd.hpp>
-#include "common/common_fwd.h"
-#include "console_handler.h"
-#include "daemon/command_parser_executor.h"
-
-namespace daemonize {
-
-class t_command_server {
-private:
-  t_command_parser_executor m_parser;
-  epee::console_handlers_binder m_command_lookup;
-  bool m_is_rpc;
-
-public:
-  t_command_server(
-      uint32_t ip
-    , uint16_t port
-    , const boost::optional<tools::login>& login
-    , bool is_rpc = true
-    , cryptonote::core_rpc_server* rpc_server = NULL
-    );
-
-  bool process_command_str(const std::string& cmd);
-
-  bool process_command_vec(const std::vector<std::string>& cmd);
-
-  bool start_handling(std::function<void(void)> exit_handler = NULL);
-
-  void stop_handling();
-
-private:
-  bool help(const std::vector<std::string>& args);
-
-  std::string get_commands_str();
-};
-
-} // namespace daemonize
+namespace tools
+{
+  class DNSResolver;
+  struct login;
+  class password_container;
+  class t_http_connection;
+  class task_region;
+  class thread_group;
+}

--- a/src/common/password.cpp
+++ b/src/common/password.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Monero Project
+// Copyright (c) 2014-2017, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -28,7 +28,7 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#include "password_container.h"
+#include "password.h"
 
 #include <iostream>
 #include <memory.h>
@@ -244,5 +244,28 @@ namespace tools
       return {std::move(pass1)};
 
     return boost::none;
+  }
+
+  boost::optional<login> login::parse(std::string&& userpass, bool verify, const char* message)
+  {
+    login out{};
+    password_container wipe{std::move(userpass)};
+
+    const auto loc = wipe.password().find(':');
+    if (loc == std::string::npos)
+    {
+      auto result = tools::password_container::prompt(verify, message);
+      if (!result)
+        return boost::none;
+
+      out.password = std::move(*result);
+    }
+    else
+    {
+      out.password = password_container{wipe.password().substr(loc + 1)};
+    }
+
+    out.username = wipe.password().substr(0, loc);
+    return {std::move(out)};
   }
 } 

--- a/src/common/password.h
+++ b/src/common/password.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, The Monero Project
+// Copyright (c) 2014-2017, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -63,5 +63,34 @@ namespace tools
   private:
     //! TODO Custom allocator that locks to RAM?
     std::string m_password;
+  };
+
+  struct login
+  {
+    login() = default;
+
+    /*!
+       Extracts username and password from the format `username:password`. A
+       blank username or password is allowed. If the `:` character is not
+       present, `password_container::prompt` will be called by forwarding the
+       `verify` and `message` arguments.
+
+       \param userpass Is "consumed", and the memory contents are wiped.
+       \param verify is passed to `password_container::prompt` if necessary.
+       \param message is passed to `password_container::prompt` if necessary.
+
+       \return The username and password, or boost::none if
+         `password_container::prompt` fails.
+     */
+    static boost::optional<login> parse(std::string&& userpass, bool verify, const char* message = "Password");
+
+    login(const login&) = delete;
+    login(login&&) = default;
+    ~login() = default;
+    login& operator=(const login&) = delete;
+    login& operator=(login&&) = default;
+
+    std::string username;
+    password_container password;
   };
 }

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -28,10 +28,13 @@
 
 #pragma once
 
+#include <boost/optional/optional.hpp>
+
 #include "common/http_connection.h"
 #include "common/scoped_message_writer.h"
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "storages/http_abstract_invoke.h"
+#include "net/http_auth.h"
 #include "net/http_client.h"
 #include "string_tools.h"
 
@@ -45,11 +48,12 @@ namespace tools
     t_rpc_client(
         uint32_t ip
       , uint16_t port
+      , boost::optional<epee::net_utils::http::login> user
       )
       : m_http_client{}
     {
       m_http_client.set_server(
-        epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port)
+        epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user)
       );
     }
 

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -37,11 +37,11 @@ namespace daemonize {
 t_command_parser_executor::t_command_parser_executor(
     uint32_t ip
   , uint16_t port
-  , const std::string &user_agent
+  , const boost::optional<tools::login>& login
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
-  : m_executor(ip, port, user_agent, is_rpc, rpc_server)
+  : m_executor(ip, port, login, is_rpc, rpc_server)
 {}
 
 bool t_command_parser_executor::print_peer_list(const std::vector<std::string>& args)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -36,7 +36,10 @@
 
 #pragma once
 
+#include <boost/optional/optional_fwd.hpp>
+
 #include "daemon/rpc_command_executor.h"
+#include "common/common_fwd.h"
 #include "rpc/core_rpc_server.h"
 
 namespace daemonize {
@@ -49,7 +52,7 @@ public:
   t_command_parser_executor(
       uint32_t ip
     , uint16_t port
-    , const std::string &user_agent
+    , const boost::optional<tools::login>& login
     , bool is_rpc
     , cryptonote::core_rpc_server* rpc_server = NULL
     );

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -40,11 +40,11 @@ namespace p = std::placeholders;
 t_command_server::t_command_server(
     uint32_t ip
   , uint16_t port
-  , const std::string &user_agent
+  , const boost::optional<tools::login>& login
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
-  : m_parser(ip, port, user_agent, is_rpc, rpc_server)
+  : m_parser(ip, port, login, is_rpc, rpc_server)
   , m_command_lookup()
   , m_is_rpc(is_rpc)
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -33,6 +33,7 @@
 #include "misc_log_ex.h"
 #include "daemon/daemon.h"
 
+#include "common/password.h"
 #include "common/util.h"
 #include "daemon/core.h"
 #include "daemon/p2p.h"
@@ -127,7 +128,8 @@ bool t_daemon::run(bool interactive)
 
     if (interactive)
     {
-      rpc_commands = new daemonize::t_command_server(0, 0, "", false, mp_internals->rpc.get_server());
+      // The first three variables are not used when the fourth is false
+      rpc_commands = new daemonize::t_command_server(0, 0, boost::none, false, mp_internals->rpc.get_server());
       rpc_commands->start_handling(std::bind(&daemonize::t_daemon::stop_p2p, this));
     }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "string_tools.h"
+#include "common/password.h"
 #include "common/scoped_message_writer.h"
 #include "daemon/rpc_command_executor.h"
 #include "rpc/core_rpc_server_commands_defs.h"
@@ -95,7 +96,7 @@ namespace {
 t_rpc_command_executor::t_rpc_command_executor(
     uint32_t ip
   , uint16_t port
-  , const std::string &user_agent
+  , const boost::optional<tools::login>& login
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
@@ -103,7 +104,10 @@ t_rpc_command_executor::t_rpc_command_executor(
 {
   if (is_rpc)
   {
-    m_rpc_client = new tools::t_rpc_client(ip, port);
+    boost::optional<epee::net_utils::http::login> http_login{};
+    if (login)
+      http_login.emplace(login->username, login->password.password());
+    m_rpc_client = new tools::t_rpc_client(ip, port, std::move(http_login));
   }
   else
   {

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -38,6 +38,9 @@
 
 #pragma once
 
+#include <boost/optional/optional_fwd.hpp>
+
+#include "common/common_fwd.h"
 #include "common/rpc_client.h"
 #include "misc_log_ex.h"
 #include "cryptonote_core/cryptonote_core.h"
@@ -60,7 +63,7 @@ public:
   t_rpc_command_executor(
       uint32_t ip
     , uint16_t port
-    , const std::string &user_agent
+    , const boost::optional<tools::login>& user
     , bool is_rpc = true
     , cryptonote::core_rpc_server* rpc_server = NULL
     );

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -27,9 +27,11 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(rpc_sources
-  core_rpc_server.cpp)
+  core_rpc_server.cpp
+  rpc_args.cpp)
 
-set(rpc_headers)
+set(rpc_headers
+  rpc_args.h)
 
 set(rpc_private_headers
   core_rpc_server.h
@@ -44,6 +46,7 @@ monero_add_library(rpc
   ${rpc_private_headers})
 target_link_libraries(rpc
   PUBLIC
+    common
     cryptonote_core
     cryptonote_protocol
     epee

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -52,11 +52,9 @@ namespace cryptonote
   {
   public:
 
-    static const command_line::arg_descriptor<std::string> arg_rpc_bind_ip;
     static const command_line::arg_descriptor<std::string> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_testnet_rpc_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
-    static const command_line::arg_descriptor<std::string> arg_user_agent;
 
     typedef epee::net_utils::connection_context_base connection_context;
 
@@ -175,10 +173,6 @@ namespace cryptonote
     //-----------------------
 
 private:
-
-    bool handle_command_line(
-        const boost::program_options::variables_map& vm
-      );
     bool check_core_busy();
     bool check_core_ready();
     
@@ -188,8 +182,6 @@ private:
     
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& m_p2p;
-    std::string m_port;
-    std::string m_bind_ip;
     bool m_testnet;
     bool m_restricted;
   };

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2014-2017, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "rpc_args.h"
+
+#include <boost/asio/ip/address.hpp>
+#include "common/command_line.h"
+#include "common/i18n.h"
+
+namespace cryptonote
+{
+  rpc_args::descriptors::descriptors()
+     : rpc_bind_ip({"rpc-bind-ip", rpc_args::tr("Specify ip to bind rpc server"), "127.0.0.1"})
+     , rpc_login({"rpc-login", rpc_args::tr("Specify username[:password] required for RPC server"), "", true})
+     , confirm_external_bind({"confirm-external-bind", rpc_args::tr("Confirm rcp-bind-ip value is NOT a loopback (local) IP")})
+  {}
+
+  const char* rpc_args::tr(const char* str) { return i18n_translate(str, "cryptonote::rpc_args"); }
+
+  void rpc_args::init_options(boost::program_options::options_description& desc)
+  {
+    const descriptors arg{};
+    command_line::add_arg(desc, arg.rpc_bind_ip);
+    command_line::add_arg(desc, arg.rpc_login);
+    command_line::add_arg(desc, arg.confirm_external_bind);
+  }
+
+  boost::optional<rpc_args> rpc_args::process(const boost::program_options::variables_map& vm)
+  {
+    const descriptors arg{};
+    rpc_args config{};
+    
+    config.bind_ip = command_line::get_arg(vm, arg.rpc_bind_ip);
+    if (!config.bind_ip.empty())
+    {
+      // always parse IP here for error consistency
+      boost::system::error_code ec{};
+      const auto parsed_ip = boost::asio::ip::address::from_string(config.bind_ip, ec);
+      if (ec)
+      {
+        LOG_ERROR(tr("Invalid IP address given for --") << arg.rpc_bind_ip.name);
+        return boost::none;
+      }
+
+      if (!parsed_ip.is_loopback() && !command_line::get_arg(vm, arg.confirm_external_bind))
+      {
+        LOG_ERROR(
+          "--" << arg.rpc_bind_ip.name <<
+          tr(" permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --") <<
+          arg.confirm_external_bind.name
+        );
+        return boost::none;
+      }
+    }
+
+    if (command_line::has_arg(vm, arg.rpc_login))
+    {
+      config.login = tools::login::parse(command_line::get_arg(vm, arg.rpc_login), true, "RPC server password");
+      if (!config.login)
+        return boost::none;
+
+      if (config.login->username.empty())
+      {
+        LOG_ERROR(tr("Username specified with --") << arg.rpc_login.name << tr(" cannot be empty"));
+        return boost::none;
+      }
+    }
+
+    return {std::move(config)};
+  }
+}

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -1,32 +1,21 @@
-/**
-@file
-@details
-
-
-Passing RPC commands:
-
-@image html images/other/runtime-commands.png
-
-*/
-
-// Copyright (c) 2014-2016, The Monero Project
-// 
+// Copyright (c) 2014-2017, The Monero Project
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -36,43 +25,43 @@ Passing RPC commands:
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+//
 #pragma once
 
-#include <boost/optional/optional_fwd.hpp>
-#include "common/common_fwd.h"
-#include "console_handler.h"
-#include "daemon/command_parser_executor.h"
+#include <boost/optional/optional.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <string>
 
-namespace daemonize {
+#include "common/command_line.h"
+#include "common/password.h"
 
-class t_command_server {
-private:
-  t_command_parser_executor m_parser;
-  epee::console_handlers_binder m_command_lookup;
-  bool m_is_rpc;
+namespace cryptonote
+{
+  //! Processes command line arguments related to server-side RPC
+  struct rpc_args
+  {
+    // non-static construction prevents initialization order issues
+    struct descriptors
+    {
+      descriptors();
+      descriptors(const descriptors&) = delete;
+      descriptors(descriptors&&) = delete;
+      descriptors& operator=(const descriptors&) = delete;
+      descriptors& operator=(descriptors&&) = delete;
 
-public:
-  t_command_server(
-      uint32_t ip
-    , uint16_t port
-    , const boost::optional<tools::login>& login
-    , bool is_rpc = true
-    , cryptonote::core_rpc_server* rpc_server = NULL
-    );
+      const command_line::arg_descriptor<std::string> rpc_bind_ip;
+      const command_line::arg_descriptor<std::string> rpc_login;
+      const command_line::arg_descriptor<bool> confirm_external_bind;
+    };
 
-  bool process_command_str(const std::string& cmd);
+    static const char* tr(const char* str);
+    static void init_options(boost::program_options::options_description& desc);
 
-  bool process_command_vec(const std::vector<std::string>& cmd);
+    //! \return Arguments specified by user, or `boost::none` if error
+    static boost::optional<rpc_args> process(const boost::program_options::variables_map& vm);
 
-  bool start_handling(std::function<void(void)> exit_handler = NULL);
-
-  void stop_handling();
-
-private:
-  bool help(const std::vector<std::string>& args);
-
-  std::string get_commands_str();
-};
-
-} // namespace daemonize
+    std::string bind_ip;
+    boost::optional<tools::login> login; // currently `boost::none` if unspecified by user
+  };
+}

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1192,7 +1192,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
   }
   catch (const std::exception &e) { }
 
-  m_http_client.set_server(m_wallet->get_daemon_address());
+  m_http_client.set_server(m_wallet->get_daemon_address(), m_wallet->get_daemon_login());
   m_wallet->callback(this);
   return true;
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -44,7 +44,7 @@
 #include "cryptonote_core/cryptonote_basic_impl.h"
 #include "wallet/wallet2.h"
 #include "console_handler.h"
-#include "wallet/password_container.h"
+#include "common/password.h"
 #include "crypto/crypto.h"  // for definition of crypto::secret_key
 
 #undef MONERO_DEFAULT_LOG_CATEGORY

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -31,7 +31,6 @@
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set(wallet_sources
-  password_container.cpp
   wallet2.cpp
   wallet_args.cpp
   node_rpc_proxy.cpp
@@ -49,7 +48,6 @@ set(wallet_api_headers
     
 
 set(wallet_private_headers
-  password_container.h
   wallet2.h
   wallet_args.h
   wallet_errors.h
@@ -74,6 +72,7 @@ monero_add_library(wallet
   ${wallet_private_headers})
 target_link_libraries(wallet
   PUBLIC
+    common
     cryptonote_core
     mnemonics
     p2p

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1364,7 +1364,7 @@ bool WalletImpl::isNewWallet() const
 
 bool WalletImpl::doInit(const string &daemon_address, uint64_t upper_transaction_size_limit)
 {
-    if (!m_wallet->init(daemon_address, upper_transaction_size_limit))
+    if (!m_wallet->init(daemon_address, boost::none, upper_transaction_size_limit))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -48,7 +48,7 @@ namespace {
     bool connect_and_invoke(const std::string& address, const std::string& path, const Request& request, Response& response)
     {
         epee::net_utils::http::http_simple_client client{};
-        return client.set_server(address) && epee::net_utils::invoke_http_json(path, request, response, client);
+        return client.set_server(address, boost::none) && epee::net_utils::invoke_http_json(path, request, response, client);
     }
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -53,7 +53,7 @@
 #include "ringct/rctOps.h"
 
 #include "wallet_errors.h"
-#include "password_container.h"
+#include "common/password.h"
 #include "node_rpc_proxy.h"
 
 #include <iostream>
@@ -343,7 +343,8 @@ namespace tools
     // into account the current median block size rather than
     // the minimum block size.
     bool deinit();
-    bool init(std::string daemon_address = "http://localhost:8080", uint64_t upper_transaction_size_limit = 0);
+    bool init(std::string daemon_address = "http://localhost:8080",
+      boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_size_limit = 0);
 
     void stop() { m_run.store(false, std::memory_order_relaxed); }
 
@@ -527,6 +528,7 @@ namespace tools
     std::string get_wallet_file() const;
     std::string get_keys_file() const;
     std::string get_daemon_address() const;
+    const boost::optional<epee::net_utils::http::login>& get_daemon_login() const { return m_daemon_login; }
     uint64_t get_daemon_blockchain_height(std::string& err);
     uint64_t get_daemon_blockchain_target_height(std::string& err);
    /*!
@@ -619,6 +621,7 @@ namespace tools
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
 
     cryptonote::account_base m_account;
+    boost::optional<epee::net_utils::http::login> m_daemon_login;
     std::string m_daemon_address;
     std::string m_wallet_file;
     std::string m_keys_file;

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -159,7 +159,7 @@ bool transactions_flow_test(std::string& working_folder,
   epee::net_utils::http::http_simple_client http_client;
   COMMAND_RPC_STOP_MINING::request daemon1_req = AUTO_VAL_INIT(daemon1_req);
   COMMAND_RPC_STOP_MINING::response daemon1_rsp = AUTO_VAL_INIT(daemon1_rsp);
-  bool r = http_client.set_server(daemon_addr_a) && net_utils::invoke_http_json("/stop_mine", daemon1_req, daemon1_rsp, http_client, std::chrono::seconds(10));
+  bool r = http_client.set_server(daemon_addr_a, boost::none) && net_utils::invoke_http_json("/stop_mine", daemon1_req, daemon1_rsp, http_client, std::chrono::seconds(10));
   CHECK_AND_ASSERT_MES(r, false, "failed to stop mining");
 
   COMMAND_RPC_START_MINING::request daemon_req = AUTO_VAL_INIT(daemon_req);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -42,7 +42,7 @@ set(unit_tests_sources
   epee_levin_protocol_handler_async.cpp
   fee.cpp
   get_xtype_from_string.cpp
-  http_auth.cpp
+  http.cpp
   main.cpp
   mnemonics.cpp
   mul_div.cpp


### PR DESCRIPTION
Summary:
- `monerod` now has a `--rpc-login` option which requires HTTP digest authentication on all RPC connections
- `monero-wallet-cli` and `monero-wallet-rpc` now have a `--daemon-rpc-login` option which connects to a `monerod` that has authentication enabled
- `password_container` was moved to common. It is used by the wallets and monerod to optionally prompt user for RPC client/server password.
- Client code had to be updated for auth - so I also snuck in some tweaks that reduce the number of allocations for temporary strings
- HTTP client now tracks all unknown fields like the server.

Support needs to be added to the GUI, and possibly figure out how to enable authentication by default (or whether it should be enabled by default).

I some quick analysis with callgrind to see the effects of the changes to the HTTP client. I can post some more detail information for anyone interested, but obviously the string manipulation reduction should be a net improvement.