### PR TITLE
Fix race in setThreadName/getThreadName

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -3988,10 +3988,12 @@ inline void FUNCTION_NAME(const T&);
             }
 
             void setThreadName(const std::string &name) {
+                const base::threading::ScopedLock scopedLock(lock());
                 m_threadNames[base::threading::getCurrentThreadId()] = name;
             }
             
             std::string getThreadName(const std::string& name) {
+                const base::threading::ScopedLock scopedLock(lock());
                 std::map<std::string, std::string>::const_iterator it = m_threadNames.find(name);
                 if (it == m_threadNames.end())
                     return name;


### PR DESCRIPTION
`-fsanitize=thread` did the hard work of catching the race. @hyc @moneromooo-monero This is likely some of the strange issues being reported in various places on the trunk build. The trunk branch of easylogging adds the lock to `setThreadName`, but not `getThreadName`. Guess its time to send some patches that way.