### PR TITLE
fixes #1688 protect make debug-test from gtest 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,24 +43,30 @@ if (GTest_FOUND)
   include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 else ()
   message(STATUS "GTest not found on the system: will use GTest bundled with this source")
-  add_subdirectory(gtest)
-  include_directories(SYSTEM "${gtest_SOURCE_DIR}/include" "${gtest_SOURCE_DIR}")
+
+  include(ExternalProject)
+  ExternalProject_Add(googletest
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gtest
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/gtest
+    DOWNLOAD_COMMAND ""
+    UPDATE_COMMAND ""
+    INSTALL_COMMAND ""
+  )
+  add_library(gtest      UNKNOWN IMPORTED)
+  add_library(gtest_main UNKNOWN IMPORTED)
+  set_target_properties(gtest PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gtest/libgtest.a
+  )
+  set_target_properties(gtest_main PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gtest/libgtest_main.a
+  )
+  add_dependencies(gtest      googletest)
+  add_dependencies(gtest_main googletest)
 
   # Emulate the FindGTest module's variable.
-  set(GTEST_LIBRARIES gtest)
-
-  # Ignore some warnings when building gtest binaries.
-  if(NOT MSVC)
-    set_property(TARGET gtest
-      APPEND_STRING
-      PROPERTY
-        COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
-  endif()
-
-  set_property(TARGET gtest
-      PROPERTY
-        FOLDER "${folder}")
-endif ()
+  set(GTEST_LIBRARIES gtest gtest_main)
+  include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest/include")
+endif (GTest_FOUND)
 
 file(COPY
   data/wallet_9svHk1.keys

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,10 +55,10 @@ else ()
   add_library(gtest      UNKNOWN IMPORTED)
   add_library(gtest_main UNKNOWN IMPORTED)
   set_target_properties(gtest PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gtest/libgtest.a
+    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
   set_target_properties(gtest_main PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gtest/libgtest_main.a
+    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
   add_dependencies(gtest      googletest)
   add_dependencies(gtest_main googletest)


### PR DESCRIPTION
In simple terms, add_subdirectory() is replaced with ExternalProject_Add().

This change is inspired by https://crascit.com/2015/07/25/cmake-gtest/
with one difference, no download, using the source we already have.

Before this change, make debug-test must be preceded by make clean.
Otherwise, a subsequent build would be polluted by cmake options made
by tests/gtest/.

Also removed the changed compiler flags.  My test build did not have
the affected warnings.