### PR TITLE
core: add p2p bind port options from net_node

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -151,6 +151,10 @@ namespace cryptonote
     command_line::add_arg(desc, command_line::arg_show_time_stats);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
     command_line::add_arg(desc, command_line::arg_check_updates);
+
+    // we now also need some of net_node's options (p2p bind arg, for separate data dir)
+    command_line::add_arg(desc, nodetool::arg_testnet_p2p_bind_port, false);
+    command_line::add_arg(desc, nodetool::arg_p2p_bind_port, false);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_command_line(const boost::program_options::variables_map& vm)

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -108,8 +108,8 @@ namespace nodetool
   void node_server<t_payload_net_handler>::init_options(boost::program_options::options_description& desc)
   {
     command_line::add_arg(desc, arg_p2p_bind_ip);
-    command_line::add_arg(desc, arg_p2p_bind_port);
-    command_line::add_arg(desc, arg_testnet_p2p_bind_port);
+    command_line::add_arg(desc, arg_p2p_bind_port, false);
+    command_line::add_arg(desc, arg_testnet_p2p_bind_port, false);
     command_line::add_arg(desc, arg_p2p_external_port);
     command_line::add_arg(desc, arg_p2p_allow_local_ip);
     command_line::add_arg(desc, arg_p2p_add_peer);


### PR DESCRIPTION
They're now used by core to determine the data directory to use
for the txpool directory.

This fixes an assert in the core tests, which don't use the RPC
server, which normally initializes the P2P code.