### PR TITLE
db_lmdb: fix bad height saved in tx data

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -130,12 +130,6 @@ uint64_t BlockchainDB::add_block( const block& blk
 
   uint64_t prev_height = height();
 
-  // call out to subclass implementation to add the block & metadata
-  time1 = epee::misc_utils::get_tick_count();
-  add_block(blk, block_size, cumulative_difficulty, coins_generated, blk_hash);
-  TIME_MEASURE_FINISH(time1);
-  time_add_block1 += time1;
-
   // call out to add the transactions
 
   time1 = epee::misc_utils::get_tick_count();
@@ -150,6 +144,12 @@ uint64_t BlockchainDB::add_block( const block& blk
   }
   TIME_MEASURE_FINISH(time1);
   time_add_transaction += time1;
+
+  // call out to subclass implementation to add the block & metadata
+  time1 = epee::misc_utils::get_tick_count();
+  add_block(blk, block_size, cumulative_difficulty, coins_generated, blk_hash);
+  TIME_MEASURE_FINISH(time1);
+  time_add_block1 += time1;
 
   m_hardfork->add(blk, prev_height);
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -628,6 +628,7 @@ void BlockchainLMDB::add_block(const block& blk, const size_t& block_size, const
   CURSOR(blocks)
   CURSOR(block_info)
 
+  // this call to mdb_cursor_put will change height()
   MDB_val_copy<blobdata> blob(block_to_blob(blk));
   result = mdb_cursor_put(m_cur_blocks, &key, &blob, MDB_APPEND);
   if (result)


### PR DESCRIPTION
The recent change to not keep separate track of the blockchain
height caused the reported height to jump early in the lmdb
transaction (when the block data is added to the blocks table),
rather than at the end, after everything succeeded. Since the
block data is added before the transaction data, this caused
the transaction data to be saved with a height one more than
its expected value.

Fix this by saving the block data last. This should have no
side effects.