### PR TITLE
Fix building the GUI after libcryptonote_core was split

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)
-    set(libs_to_merge wallet cryptonote_core mnemonics common crypto ringct)
+    set(libs_to_merge wallet cryptonote_core cryptonote_basic mnemonics common crypto ringct)
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt


### PR DESCRIPTION
This fixes undefined references when linking the GUI after PR #1626 was merged. Tested on Ubuntu 14.04 and MSYS2 on Windows 10. 