### PR TITLE
fix undefined reference error when compiling with clang

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -564,10 +564,9 @@ namespace cryptonote
         
         // If we're already mining, then sleep for the miner monitor interval.
         // If we're NOT mining, then sleep for the idle monitor interval
-        boost::this_thread::sleep_for( 
-          m_is_background_mining_started ? 
-            boost::chrono::seconds( BACKGROUND_MINING_MINER_MONITOR_INVERVAL_IN_SECONDS ) :
-            boost::chrono::seconds( get_min_idle_seconds() ) );
+        uint64_t sleep_for_seconds = BACKGROUND_MINING_MINER_MONITOR_INVERVAL_IN_SECONDS;
+        if( !m_is_background_mining_started ) sleep_for_seconds = get_min_idle_seconds();
+        boost::this_thread::sleep_for(boost::chrono::seconds(sleep_for_seconds));
       }
       catch(const boost::thread_interrupted&)
       {


### PR DESCRIPTION
Background mining ( pr #1582 ) compile error
https://build.getmonero.org/builders/monero-static-debian-armv8/builds/640/steps/compile/logs/stdio
