### PR TITLE
dns_utils: fix infinite recursion when distributing empty dns_urls

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -478,6 +478,9 @@ namespace
 
 bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std::vector<std::string> &dns_urls)
 {
+  // Prevent infinite recursion when distributing
+  if (dns_urls.empty()) return false;
+
   std::vector<std::vector<std::string> > records;
   records.resize(dns_urls.size());
 


### PR DESCRIPTION
load_txt_records_from_dns attempts to distribute `a = 0, b = -1` where
(b = dns_urls.size() - 1) and IntType is signed integer. This results in
an infinite recursion which leads to SIGSEGV.