### PR TITLE
Fix core_tests breaking on startup

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -155,6 +155,8 @@ namespace cryptonote
     // we now also need some of net_node's options (p2p bind arg, for separate data dir)
     command_line::add_arg(desc, nodetool::arg_testnet_p2p_bind_port, false);
     command_line::add_arg(desc, nodetool::arg_p2p_bind_port, false);
+
+    miner::init_options(desc);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_command_line(const boost::program_options::variables_map& vm)

--- a/src/daemon/core.h
+++ b/src/daemon/core.h
@@ -45,7 +45,6 @@ public:
   static void init_options(boost::program_options::options_description & option_spec)
   {
     cryptonote::core::init_options(option_spec);
-    cryptonote::miner::init_options(option_spec);
   }
 private:
   typedef cryptonote::t_cryptonote_protocol_handler<cryptonote::core> t_protocol_raw;


### PR DESCRIPTION
You're wondering how this fixes core tests, aren't you...

It prevents the miner (initialized by cryptonote::core) from
breaking trying to access arguments that were not added.
Since the tests don't use the miner directly, it makes more
sense to have cryptonote_core add those, since it also uses
the miner.