### PR TITLE
Increase the log level for the info about log levels

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -142,7 +142,7 @@ void mlog_configure(const std::string &filename_base, bool console)
 void mlog_set_categories(const char *categories)
 {
   el::Loggers::setCategories(categories);
-  MGINFO("New log categories: " << categories);
+  MDEBUG("New log categories: " << categories);
 }
 
 // maps epee style log level to new logging system
@@ -150,7 +150,7 @@ void mlog_set_log_level(int level)
 {
   const char *categories = get_default_categories(level);
   el::Loggers::setCategories(categories);
-  MGINFO("New log categories: " << categories);
+  MDEBUG("New log categories: " << categories);
 }
 
 void mlog_set_log(const char *log)


### PR DESCRIPTION
Reduces the following unnecessary information about log levels after every command-line action:

```
nodey@odroidc2:~$ monerod status
2017-02-25 13:53:31.307	      7fa109a000	INFO 	global	contrib/epee/src/mlog.cpp:145	New log categories: *:WARNING,net:FATAL,net.p2p:FATAL,global:INFO,verify:FATAL,stacktrace:INFO
2017-02-25 13:53:31.308	      7fa109a000	INFO 	global	contrib/epee/src/mlog.cpp:153	New log categories: *:WARNING,net:FATAL,net.p2p:FATAL,global:INFO,verify:FATAL,stacktrace:INFO
Height: 1253096/1253866 (99.9%) on mainnet, not mining, net hash 63.30 MH/s, v4, up to date, 29(out)+12(in) connections, uptime 0d 0h 26m 59s
```