### PR TITLE
mlog: default net.cn to FATAL

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -88,7 +88,7 @@ static const char *get_default_categories(int level)
   switch (level)
   {
     case 0:
-      categories = "*:WARNING,net:FATAL,net.p2p:FATAL,global:INFO,verify:FATAL,stacktrace:INFO";
+      categories = "*:WARNING,net:FATAL,net.p2p:FATAL,net.cn:FATAL,global:INFO,verify:FATAL,stacktrace:INFO";
       break;
     case 1:
       categories = "*:WARNING,global:INFO,stacktrace:INFO";


### PR DESCRIPTION
Errors in this layer depend on how peers behave, and thus errors
are expected