### PR TITLE
Revert attempt to write to console on daemon shutdown

### DIFF
--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -79,7 +79,6 @@ public:
       m_protocol.deinit();
       m_protocol.set_p2p_endpoint(nullptr);
       MGINFO("Cryptonote protocol stopped successfully");
-      tools::success_msg_writer() << "Daemon stopped successfully";
     } catch (...) {
       LOG_ERROR("Failed to stop cryptonote protocol!");
     }


### PR DESCRIPTION
Would have been nice to have clear console output on daemon shutdown and not need to check the logs or `top`, but this method didn't work.