### PR TITLE
Revert "wallet: fix insertion of pool transactions"

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1029,7 +1029,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
     payment.m_unlock_time  = tx.unlock_time;
     payment.m_timestamp    = ts;
     if (pool) {
-      m_unconfirmed_payments.emplace(txid, payment);
+      m_unconfirmed_payments.emplace(payment_id, payment);
       if (0 != m_callback)
         m_callback->on_unconfirmed_money_received(height, txid, tx, payment.m_amount);
     }


### PR DESCRIPTION
This reverts commit d47dac9a88ddd46b88850a899311363b3261c89e.

Callers actually expect the key to be payment id, so this
needs a lot more changes (like storing payment ids in the
structure, and possibly also to other existing structures
which do the same thing).