### PR TITLE
updated reccommended Monero version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Dates are provided in the format YYYYMMDD.
 | Date              | Consensus version | Minimum Monero Version | Recommended Monero Version | Details            |  
 | ----------------- | ----------------- | ---------------------- | -------------------------- | ------------------ |
 | 2016-09-21        | v3                | v0.9.4                 | v0.10.0                    | Splits coinbase into denominations  |
-| 2017-01-05        | v4                | v0.10.1                 | v0.10.1                   | Allow normal and RingCT transactions | 
-| 2017-09-21        | v5                | v0.10.1                | v0.10.1                    | Allow only RingCT transactions      |
+| 2017-01-05        | v4                | v0.10.1                 | v0.10.2.2                   | Allow normal and RingCT transactions | 
+| 2017-09-21        | v5                | v0.10.2.2                | v0.10.2.2                    | Allow only RingCT transactions      |
 
 ## Installing Monero from a Package
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Dates are provided in the format YYYYMMDD.
 | ----------------- | ----------------- | ---------------------- | -------------------------- | ------------------ |
 | 2016-09-21        | v3                | v0.9.4                 | v0.10.0                    | Splits coinbase into denominations  |
 | 2017-01-05        | v4                | v0.10.1                 | v0.10.2.2                   | Allow normal and RingCT transactions | 
-| 2017-09-21        | v5                | v0.10.2.2                |                     | Allow only RingCT transactions      |
+| 2017-09-21        | v5                | Not determined as of 2017-03-06                | Not determined as of 2017-03-06                    | Allow only RingCT transactions      |
 
 ## Installing Monero from a Package
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Dates are provided in the format YYYYMMDD.
 | ----------------- | ----------------- | ---------------------- | -------------------------- | ------------------ |
 | 2016-09-21        | v3                | v0.9.4                 | v0.10.0                    | Splits coinbase into denominations  |
 | 2017-01-05        | v4                | v0.10.1                 | v0.10.2.2                   | Allow normal and RingCT transactions | 
-| 2017-09-21        | v5                | v0.10.2.2                | v0.10.2.2                    | Allow only RingCT transactions      |
+| 2017-09-21        | v5                | v0.10.2.2                |                     | Allow only RingCT transactions      |
 
 ## Installing Monero from a Package
 


### PR DESCRIPTION
indicated 0.10.2.2 is the recommended version for running right now and for the upcoming fork