### PR TITLE
Problem: misleading information about LMDB storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ if(STATIC)
   endif()
 endif()
 
-# default database:
-# should be lmdb for testing, memory for production still
+# Set default blockchain storage location:
+# memory was the default in Cryptonote before Monero implimented LMDB, it still works but is unneccessary.
 # set(DATABASE memory)
 set(DATABASE lmdb)
 


### PR DESCRIPTION
Solution: updated the comments to reflect the current situation in terms of LMDB implementation and no longer recommend 'memory' for blockchain storage in production use.