### PR TITLE
Dockerfile command separation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,13 @@ RUN set -x \
       pkg-config \
   ' \
   && apt-get -qq update \
-  && apt-get -qq --no-install-recommends install $buildDeps \
-  \
-  && git clone https://github.com/monero-project/monero.git $SRC_DIR \
-  && cd $SRC_DIR \
-  && make -j$(nproc) release-static \
-  && cp build/release/bin/* /usr/local/bin/ \
+  && apt-get -qq --no-install-recommends install $buildDeps
+
+RUN git clone https://github.com/monero-project/monero.git $SRC_DIR
+WORKDIR $SRC_DIR
+RUN make -j$(nproc) release-static
+
+RUN cp build/release/bin/* /usr/local/bin/ \
   \
   && rm -r $SRC_DIR \
   && apt-get -qq --auto-remove purge $buildDeps


### PR DESCRIPTION
Dependency installation, clone and build are all currently part of a single RUN command. If any of these steps fail, they all have to be run again.

Worst case, `make` fails and you have to fetch all the dependencies again and clone the repo. This can be especially painful on a limited network connection.
By separating the steps as per this PR, they can each be cached and massively reduce build times upon failure.