### PR TITLE
wallet-rpc: enable OpenAlias

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -405,21 +405,23 @@ std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec
   return addresses;
 }
 
-std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid)
+std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid, bool cli_confirm)
 {
   // attempt to get address from dns query
   auto addresses = addresses_from_url(url, dnssec_valid);
   if (addresses.empty())
   {
-    std::cout << tr("wrong address: ") << url;
+    LOG_ERROR("wrong address: " << url);
     return {};
   }
   // for now, move on only if one address found
   if (addresses.size() > 1)
   {
-    std::cout << tr("not yet supported: Multiple Monero addresses found for given URL: ") << url;
+    LOG_ERROR("not yet supported: Multiple Monero addresses found for given URL: " << url);
     return {};
   }
+  if (!cli_confirm)
+    return addresses[0];
   // prompt user for confirmation.
   // inform user of DNSSEC validation status as well.
   std::string dnssec_str;

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -163,7 +163,7 @@ namespace dns_utils
 std::string address_from_txt_record(const std::string& s);
 std::vector<std::string> addresses_from_url(const std::string& url, bool& dnssec_valid);
 
-std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid);
+std::string get_account_address_as_str_from_url(const std::string& url, bool& dnssec_valid, bool cli_confirm = true);
 
 bool load_txt_records_from_dns(std::vector<std::string> &records, const std::vector<std::string> &dns_urls);
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -308,12 +308,13 @@ namespace cryptonote {
     , crypto::hash8& payment_id
     , bool testnet
     , const std::string& str_or_url
+    , bool cli_confirm
     )
   {
     if (get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, str_or_url))
       return true;
     bool dnssec_valid;
-    std::string address_str = tools::dns_utils::get_account_address_as_str_from_url(str_or_url, dnssec_valid);
+    std::string address_str = tools::dns_utils::get_account_address_as_str_from_url(str_or_url, dnssec_valid, cli_confirm);
     return !address_str.empty() &&
       get_account_integrated_address_from_str(address, has_payment_id, payment_id, testnet, address_str);
   }
@@ -322,11 +323,12 @@ namespace cryptonote {
       cryptonote::account_public_address& address
     , bool testnet
     , const std::string& str_or_url
+    , bool cli_confirm
     )
   {
     bool has_payment_id;
     crypto::hash8 payment_id;
-    return get_account_address_from_str_or_url(address, has_payment_id, payment_id, testnet, str_or_url);
+    return get_account_address_from_str_or_url(address, has_payment_id, payment_id, testnet, str_or_url, cli_confirm);
   }
   //--------------------------------------------------------------------------------
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b) {

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -107,12 +107,14 @@ namespace cryptonote {
     , crypto::hash8& payment_id
     , bool testnet
     , const std::string& str_or_url
+    , bool cli_confirm = true
     );
 
   bool get_account_address_from_str_or_url(
       cryptonote::account_public_address& address
     , bool testnet
     , const std::string& str_or_url
+    , bool cli_confirm = true
     );
 
   bool is_coinbase(const transaction& tx);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -300,7 +300,7 @@ namespace tools
       cryptonote::tx_destination_entry de;
       bool has_payment_id;
       crypto::hash8 new_payment_id;
-      if(!get_account_integrated_address_from_str(de.addr, has_payment_id, new_payment_id, m_wallet.testnet(), it->address))
+      if(!get_account_address_from_str_or_url(de.addr, has_payment_id, new_payment_id, m_wallet.testnet(), it->address, false))
       {
         er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
         er.message = std::string("WALLET_RPC_ERROR_CODE_WRONG_ADDRESS: ") + it->address;
@@ -945,7 +945,7 @@ namespace tools
     cryptonote::account_public_address address;
     bool has_payment_id;
     crypto::hash8 payment_id;
-    if(!get_account_integrated_address_from_str(address, has_payment_id, payment_id, m_wallet.testnet(), req.address))
+    if(!get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet.testnet(), req.address, false))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "";
@@ -1308,7 +1308,7 @@ namespace tools
     bool has_payment_id;
     crypto::hash8 payment_id8;
     crypto::hash payment_id = cryptonote::null_hash;
-    if(!get_account_integrated_address_from_str(address, has_payment_id, payment_id8, m_wallet.testnet(), req.address))
+    if(!get_account_address_from_str_or_url(address, has_payment_id, payment_id8, m_wallet.testnet(), req.address, false))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = std::string("WALLET_RPC_ERROR_CODE_WRONG_ADDRESS: ") + req.address;


### PR DESCRIPTION
In this patch, the wallet RPC has no ability to confirm the resolved OpenAlias address because it doesn't have access to standard I/O. I'm not sure how/if such a mechanism can/should be implemented.