### PR TITLE
daemon: fix missing close parenthesis in alt_chain_info output

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1482,7 +1482,7 @@ bool t_rpc_command_executor::alt_chain_info()
   {
     uint64_t start_height = (chain.height - chain.length + 1);
     tools::msg_writer() << chain.length << " blocks long, from height " << start_height << " (" << (ires.height - start_height - 1)
-        << " deep, diff " << chain.difficulty << ": " << chain.block_hash;
+        << " deep), diff " << chain.difficulty << ": " << chain.block_hash;
   }
   return true;
 }


### PR DESCRIPTION
Reported by assylias_ on IRC