### PR TITLE
Revert "Increase the log level for the info about log levels"

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -142,7 +142,7 @@ void mlog_configure(const std::string &filename_base, bool console)
 void mlog_set_categories(const char *categories)
 {
   el::Loggers::setCategories(categories);
-  MDEBUG("New log categories: " << categories);
+  MGINFO("New log categories: " << categories);
 }
 
 // maps epee style log level to new logging system
@@ -150,7 +150,7 @@ void mlog_set_log_level(int level)
 {
   const char *categories = get_default_categories(level);
   el::Loggers::setCategories(categories);
-  MDEBUG("New log categories: " << categories);
+  MGINFO("New log categories: " << categories);
 }
 
 void mlog_set_log(const char *log)


### PR DESCRIPTION
We want to know which log categories are active.

This reverts commit 4f7bce6d20c72a1384289f7c35b7fe0ee796ed41.