### PR TITLE
set USE_LTO_DEFAULT to false

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,7 +559,7 @@ else()
   endif()
 
   if(NOT DEFINED USE_LTO_DEFAULT)
-    set(USE_LTO_DEFAULT true)
+    set(USE_LTO_DEFAULT false)
   endif()
   set(USE_LTO ${USE_LTO_DEFAULT} CACHE BOOL "Use Link-Time Optimization (Release mode only)")
 


### PR DESCRIPTION
at least ubuntu 16.10 seams to fail with USE_LTO=true... so maybe switch it off by default like discussed in  IRC monero-dev