### PR TITLE
tx_pool: silence use of uninitialized warning

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -614,7 +614,7 @@ namespace cryptonote
 
     CRITICAL_REGION_LOCAL(m_transactions_lock);
 
-    uint64_t best_coinbase = 0, coinbase;
+    uint64_t best_coinbase = 0, coinbase = 0;
     total_size = 0;
     fee = 0;
     


### PR DESCRIPTION
The result is not actually used when uninitialized