### PR TITLE
core: disable tx/block hash cache

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -658,6 +658,8 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool get_transaction_hash(const transaction& t, crypto::hash& res, size_t* blob_size)
   {
+    return calculate_transaction_hash(t, res, blob_size);
+#if 0
     if (t.is_hash_valid())
     {
 #ifdef ENABLE_HASH_CASH_INTEGRITY_CHECK
@@ -688,6 +690,7 @@ namespace cryptonote
       t.set_blob_size_valid(true);
     }
     return true;
+#endif
   }
   //---------------------------------------------------------------
   bool get_transaction_hash(const transaction& t, crypto::hash& res, size_t& blob_size)
@@ -733,6 +736,8 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool get_block_hash(const block& b, crypto::hash& res)
   {
+    return calculate_block_hash(b, res);
+#if 0
     if (b.is_hash_valid())
     {
 #ifdef ENABLE_HASH_CASH_INTEGRITY_CHECK
@@ -749,6 +754,7 @@ namespace cryptonote
     b.hash = res;
     b.set_hash_valid(true);
     return true;
+#endif
   }
   //---------------------------------------------------------------
   crypto::hash get_block_hash(const block& b)


### PR DESCRIPTION
Looks like it doesn't work on win64