### PR TITLE
wallet cli: remove redundant password confirm in donate command

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2993,7 +2993,6 @@ bool simple_wallet::sweep_all(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::donate(const std::vector<std::string> &args_)
 {
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   std::vector<std::string> local_args = args_;
   if(local_args.empty() || local_args.size() > 3)
   {


### PR DESCRIPTION
There's already a password confirmation in `transfer_new`. No need to make it more difficult to donate :P