### PR TITLE
signature proving authorship of a tx using its tx private key

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -563,4 +563,22 @@ bool t_command_parser_executor::update(const std::vector<std::string>& args)
   return m_executor.update(args.front());
 }
 
+bool t_command_parser_executor::verify_tx_proof(const std::vector<std::string>& args)
+{
+  if(args.size() != 2)
+  {
+    std::cout << "expected: verify_tx_proof <txid> <signature>" << std::endl;
+    return true;
+  }
+
+  crypto::hash txid;
+  if (!parse_hash256(args[0], txid))
+  {
+    std::cout << "failed to parse tx id" << std::endl;
+    return true;
+  }
+
+  return m_executor.verify_tx_proof(txid, args[1]);
+}
+
 } // namespace daemonize

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -132,6 +132,8 @@ public:
   bool print_blockchain_dynamic_stats(const std::vector<std::string>& args);
 
   bool update(const std::vector<std::string>& args);
+
+  bool verify_tx_proof(const std::vector<std::string>& args);
 };
 
 } // namespace daemonize

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -248,6 +248,11 @@ t_command_server::t_command_server(
     , std::bind(&t_command_parser_executor::update, &m_parser, p::_1)
     , "subcommands: check (check if an update is available), download (download it is there is), update (not implemented)"
     );
+    m_command_lookup.set_handler(
+      "verify_tx_proof"
+    , std::bind(&t_command_parser_executor::verify_tx_proof, &m_parser, p::_1)
+    , "Verify signature proving authorship of given tx"
+    );
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -153,6 +153,8 @@ public:
   bool print_blockchain_dynamic_stats(uint64_t nblocks);
 
   bool update(const std::string &command);
+
+  bool verify_tx_proof(const crypto::hash &txid, const std::string &signature_str);
 };
 
 } // namespace daemonize

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -152,6 +152,7 @@ namespace cryptonote
     bool set_log(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
     bool check_tx_key(const std::vector<std::string> &args);
+    bool gen_tx_proof(const std::vector<std::string> &args);
     bool show_transfers(const std::vector<std::string> &args);
     bool unspent_outputs(const std::vector<std::string> &args);
     bool rescan_blockchain(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5039,6 +5039,19 @@ bool wallet2::verify(const std::string &data, const cryptonote::account_public_a
   return crypto::check_signature(hash, address.m_spend_public_key, s);
 }
 //----------------------------------------------------------------------------------------------------
+std::string wallet2::gen_tx_proof(const crypto::hash &txid) const
+{
+  const std::unordered_map<crypto::hash, crypto::secret_key>::const_iterator i = m_tx_keys.find(txid);
+  if (i == m_tx_keys.end())
+    throw std::runtime_error("no tx key found for this txid");
+  crypto::secret_key tx_key = i->second;
+  crypto::signature sig;
+  crypto::public_key tx_pubkey;
+  crypto::secret_key_to_public_key(tx_key, tx_pubkey);
+  crypto::generate_signature(txid, tx_pubkey, tx_key, sig);
+  return std::string("SigV1") + tools::base58::encode(std::string((const char *)&sig, sizeof(crypto::signature)));
+}
+//----------------------------------------------------------------------------------------------------
 crypto::public_key wallet2::get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const
 {
   std::vector<tx_extra_field> tx_extra_fields;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -574,6 +574,8 @@ namespace tools
     std::string sign(const std::string &data) const;
     bool verify(const std::string &data, const cryptonote::account_public_address &address, const std::string &signature) const;
 
+    std::string gen_tx_proof(const crypto::hash &txid) const;
+
     std::vector<tools::wallet2::transfer_details> export_outputs() const;
     size_t import_outputs(const std::vector<tools::wallet2::transfer_details> &outputs);
 


### PR DESCRIPTION
Currently, the wallet CLI command `check_tx_key <txid> <txkey> <address>` allows the user to decode the transferred amount in a given tx, which can be seen as a proof of payment (i.e., the sender passes the tx secret key to the receiver or whoever). But in some dispute scenarios, the sender may want to prove a payment without revealing the tx secret key.

This PR adds new commands `gen_tx_proof <txid>` / `verify_tx_proof <txid> <signature>` to the wallet CLI / daemon CLI for generating / verifying a signature using the tx key `R=r*G` of a given tx, respectively.

On the wallet CLI:
```
[wallet 4Avpdc]: gen_tx_proof 6d4c9e4b278fa6f29ea3f85b49e3b3ff33842b61dd09a95469e1336e8bfe0d0b
Signature: SigV12gjbsxKan4JSgPbKuhnLkj7iXevBhjR9XHbNb7DM9RF3dH3dXMQJ4z1Tf1CGTAY6fUWyPZ5X28o81dMt8euuiKeq
```

On the daemon CLI:
```
verify_tx_proof 6d4c9e4b278fa6f29ea3f85b49e3b3ff33842b61dd09a95469e1336e8bfe0d0b SigV12gjbsxKan4JSgPbKuhnLkj7iXevBhjR9XHbNb7DM9RF3dH3dXMQJ4z1Tf1CGTAY6fUWyPZ5X28o81dMt8euuiKeq
Good signature
```