### PR TITLE
Add per transaction fee to transfer command

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -101,6 +101,7 @@ enum TransferType {
 
 namespace
 {
+  const auto allowed_priority_strings = {"default", "unimportant", "normal", "elevated", "priority"};
   const auto arg_wallet_file = wallet_args::arg_wallet_file();
   const command_line::arg_descriptor<std::string> arg_generate_new_wallet = {"generate-new-wallet", sw::tr("Generate new wallet and save it to <arg>"), ""};
   const command_line::arg_descriptor<std::string> arg_generate_from_view_key = {"generate-from-view-key", sw::tr("Generate incoming-only wallet from view key"), ""};
@@ -685,7 +686,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("payments", boost::bind(&simple_wallet::show_payments, this, _1), tr("payments <PID_1> [<PID_2> ... <PID_N>] - Show payments for given payment ID[s]"));
   m_cmd_binder.set_handler("bc_height", boost::bind(&simple_wallet::show_blockchain_height, this, _1), tr("Show blockchain height"));
   m_cmd_binder.set_handler("transfer_original", boost::bind(&simple_wallet::transfer, this, _1), tr("Same as transfer, but using an older transaction building algorithm"));
-  m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::transfer_new, this, _1), tr("transfer [<mixin_count>] <address> <amount> [<payment_id>] - Transfer <amount> to <address>. <mixin_count> is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
+  m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::transfer_new, this, _1), tr("transfer [<priority>] [<mixin_count>] <address> <amount> [<payment_id>] - Transfer <amount> to <address>. <priority> is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <mixin_count> is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
   m_cmd_binder.set_handler("locked_transfer", boost::bind(&simple_wallet::locked_transfer, this, _1), tr("locked_transfer [<mixin_count>] <addr> <amount> <lockblocks>(Number of blocks to lock the transaction for, max 1000000) [<payment_id>]"));
   m_cmd_binder.set_handler("sweep_unmixable", boost::bind(&simple_wallet::sweep_unmixable, this, _1), tr("Send all unmixable outputs to yourself with mixin 0"));
   m_cmd_binder.set_handler("sweep_all", boost::bind(&simple_wallet::sweep_all, this, _1), tr("sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address"));
@@ -2205,6 +2206,18 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
 
   std::vector<std::string> local_args = args_;
 
+  int priority = 0;
+  if(local_args.size() > 0) {
+    auto priority_pos = std::find(
+      allowed_priority_strings.begin(),
+      allowed_priority_strings.end(),
+      local_args[0]);
+    if(priority_pos != allowed_priority_strings.end()) {
+      local_args.erase(local_args.begin());
+      priority = std::distance(allowed_priority_strings.begin(), priority_pos);
+    }
+  }
+
   size_t fake_outs_count;
   if(local_args.size() > 0) {
     if(!epee::string_tools::get_xtype_from_string(fake_outs_count, local_args[0]))
@@ -2356,15 +2369,15 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
           return true;
         }
         unlock_block = bc_height + locked_blocks;
-        ptx_vector = m_wallet->create_transactions_2(dsts, fake_outs_count, unlock_block /* unlock_time */, 0 /* unused fee arg*/, extra, m_trusted_daemon);
+        ptx_vector = m_wallet->create_transactions_2(dsts, fake_outs_count, unlock_block /* unlock_time */, priority, extra, m_trusted_daemon);
       break;
       case TransferNew:
-        ptx_vector = m_wallet->create_transactions_2(dsts, fake_outs_count, 0 /* unlock_time */, 0 /* unused fee arg*/, extra, m_trusted_daemon);
+        ptx_vector = m_wallet->create_transactions_2(dsts, fake_outs_count, 0 /* unlock_time */, priority, extra, m_trusted_daemon);
       break;
       default:
         LOG_ERROR("Unknown transfer method, using original");
       case TransferOriginal:
-        ptx_vector = m_wallet->create_transactions(dsts, fake_outs_count, 0 /* unlock_time */, 0 /* unused fee arg*/, extra, m_trusted_daemon);
+        ptx_vector = m_wallet->create_transactions(dsts, fake_outs_count, 0 /* unlock_time */, priority, extra, m_trusted_daemon);
         break;
     }
 

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -1,1249 +1,1606 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.1">
+<context>
+    <name>Monero::AddressBookImpl</name>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="55"/>
+        <source>Invalid destination address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="65"/>
+        <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="72"/>
+        <source>Invalid payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="79"/>
+        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="95"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="90"/>
+        <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="97"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="114"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="117"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="102"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="105"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="126"/>
+        <source>. Reason: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="108"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="131"/>
         <source>Unhandled exception</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Monero::UnsignedTransactionImpl</name>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
+        <source>This is a watch only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
+        <source>Failed to sign transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="134"/>
+        <source>Claimed change does not go to a paid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="140"/>
+        <source>Claimed change is larger than payment to the change address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="146"/>
+        <source>Change does to more than one address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="158"/>
+        <source>sending %s to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="164"/>
+        <source>with no destinations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="170"/>
+        <source>%s change to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="173"/>
+        <source>no change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="175"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="609"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="926"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="619"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="936"/>
         <source>Failed to add short payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="645"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="739"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="962"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1056"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="648"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="742"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="965"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1059"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="651"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="745"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="968"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1062"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="654"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="748"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1065"/>
         <source>failed to get random outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="661"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="755"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="978"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1072"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="670"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="764"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="403"/>
+        <source>failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="415"/>
+        <source>failed to parse secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="425"/>
+        <source>No view key supplied, cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="432"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="442"/>
+        <source>failed to verify secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="447"/>
+        <source>spend key does not match address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="453"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="458"/>
+        <source>view key does not match address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="476"/>
+        <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="783"/>
+        <source>Failed to load unsigned transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="804"/>
+        <source>Failed to load transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="822"/>
+        <source>Wallet is view only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="831"/>
+        <source>failed to save file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="858"/>
+        <source>Failed to import key images: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="971"/>
+        <source>failed to get random outputs to mix: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="987"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1081"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="996"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1090"/>
         <source>not enough outputs for specified mixin_count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="681"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="775"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="998"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="681"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="775"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="998"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
         <source>found outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="780"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1003"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1097"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="690"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="784"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1007"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1101"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="791"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="700"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="794"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1017"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="703"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="797"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1020"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1114"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="706"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="800"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1023"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1117"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="709"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="803"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1026"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1120"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="712"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="806"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1029"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1123"/>
         <source>unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1403"/>
+        <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletManagerImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="161"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="192"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="168"/>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="175"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="199"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="206"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="186"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="217"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="197"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
         <source>failed to get transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="208"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="238"/>
         <source>failed to parse transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="215"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="245"/>
         <source>failed to validate transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="220"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="250"/>
         <source>failed to get the right transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="257"/>
         <source>failed to generate key derivation from supplied parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="283"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="313"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="289"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="289"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="293"/>
+        <location filename="../src/wallet/api/wallet_manager.cpp" line="323"/>
         <source>received nothing in txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wallet</name>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="212"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="219"/>
+        <source>Failed to parse key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="227"/>
+        <source>failed to verify key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="237"/>
+        <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="67"/>
+        <location filename="../src/common/command_line.cpp" line="69"/>
         <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>cryptonote::rpc_args</name>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="38"/>
+        <source>Specify ip to bind rpc server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="39"/>
+        <source>Specify username[:password] required for RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="66"/>
+        <source>Invalid IP address given for --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="74"/>
+        <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <source>Username specified with --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="280"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="381"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="411"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="457"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1659"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="419"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="527"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="563"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1417"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="653"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="681"/>
         <source>Stop mining in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="682"/>
         <source>Save current blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="684"/>
         <source>Show current wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Show blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="697"/>
         <source>Show current wallet public address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="723"/>
         <source>Show this help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="752"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
         <source>set always-confirm-transfers: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="847"/>
-        <source>wrong number format, use: set_log &lt;log_level_number_0-4&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="852"/>
-        <source>wrong number range, use: set_log &lt;log_level_number_0-4&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1544"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1033"/>
         <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1353"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1361"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1227"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1380"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1389"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1446"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1304"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1527"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1393"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1559"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1393"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1559"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1402"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1433"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
         <source>Use &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <source>Password for the new watch-only wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
-        <source>Enter new password again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1507"/>
-        <source>passwords do not match</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1551"/>
-        <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;], &lt;number_of_threads&gt; should be from 1 to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1711"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1713"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1730"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
         <source>transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
         <source>received </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1779"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1791"/>
         <source>unsupported transaction format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1821"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
-        <source>you have cancelled the transfer request</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
-        <source>failed to get a Monero address from: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1997"/>
-        <source>not yet supported: Multiple Monero addresses found for given URL: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2002"/>
-        <source>wrong address: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2799"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2293"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2118"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2615"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2143"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2227"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2894"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2417"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2426"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2429"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2213"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2430"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2213"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2430"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
-        <source>Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2241"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2419"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2463"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2907"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2245"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2682"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2911"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2280"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2717"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2681"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3233"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3242"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2487"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2531"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2975"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2321"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2499"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2987"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2807"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
-        <source>No outputs found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2817"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2827"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
         <source>Change does to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3111"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3117"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2923"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3213"/>
         <source>daemon is busy. Please try later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2949"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2670"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3222"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2331"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
-        <source>internal error: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2773"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3013"/>
-        <source>unexpected error: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="380"/>
+        <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2341"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2778"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3018"/>
-        <source>unknown error</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="394"/>
+        <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1704"/>
-        <source>refresh failed: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="490"/>
+        <source>priority must be 0, 1, 2, 3, or 4 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1704"/>
-        <source>Blocks received: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="502"/>
+        <source>priority must be 0, 1, 2, 3,or 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1729"/>
-        <source>unlocked balance: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="517"/>
+        <source>priority must be 0, 1, 2 3,or 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
-        <source>amount</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="606"/>
+        <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
-        <source>spent</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="624"/>
+        <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
-        <source>global index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
-        <source>tx id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1800"/>
-        <source>No incoming transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1804"/>
-        <source>No incoming available transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
-        <source>No incoming unavailable transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1819"/>
-        <source>expected at least one payment_id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
-        <source>payment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
-        <source>transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
-        <source>height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
-        <source>unlock time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
-        <source>No payments with id </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
-        <source>failed to get blockchain height: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2036"/>
-        <source>wrong number of arguments</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <source>This is a watch only wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
-        <source>DNSSEC validation passed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="223"/>
-        <source>true</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="252"/>
-        <source>failed to parse refresh type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="309"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="331"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="346"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="491"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="615"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="440"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="446"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
-        <source>mixin must be an integer &gt;= 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
-        <source>could not change default mixin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
-        <source>priority must be 0, 1, 2, or 3 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
-        <source>priority must be 0, 1, 2, or 3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
-        <source>priority must be 0, 1, 2 or 3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="542"/>
-        <source>could not change default priority</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="656"/>
-        <source>Synchronize transactions and balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="658"/>
-        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
-        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="661"/>
-        <source>transfer [&lt;mixin_count&gt;] &lt;addr_1&gt; &lt;amount_1&gt; [&lt;addr_2&gt; &lt;amount_2&gt; ... &lt;addr_N&gt; &lt;amount_N&gt;] [payment_id] - Transfer &lt;amount_1&gt;,... &lt;amount_N&gt; to &lt;address_1&gt;,... &lt;address_N&gt;, respectively. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability (from 2 to maximum available)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
-        <source>Same as transfer_original, but using a new transaction building algorithm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="663"/>
-        <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="664"/>
-        <source>Send all unmixable outputs to yourself with mixin 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="665"/>
-        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance an address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
-        <source>Sign a transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="667"/>
-        <source>Submit a signed transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="668"/>
-        <source>set_log &lt;level&gt; - Change current log detail level, &lt;0-4&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="670"/>
-        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="671"/>
-        <source>Save wallet data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="672"/>
-        <source>Save a watch-only keys file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="673"/>
-        <source>Display private view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
-        <source>Display private spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="675"/>
-        <source>Display Electrum-style mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="676"/>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [1|2|3] - normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="677"/>
-        <source>Rescan blockchain for spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="678"/>
-        <source>Get transaction key (r) for a given &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
-        <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
-        <source>show_transfers [in|out] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="681"/>
-        <source>Rescan blockchain from scratch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="682"/>
-        <source>Set an arbitrary string note for a txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="683"/>
-        <source>Get a string note for a txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="684"/>
-        <source>Show wallet status information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="685"/>
-        <source>Sign the contents of a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="686"/>
-        <source>Verify a signature on the contents of a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
-        <source>Export a signed set of key images</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="642"/>
+        <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="688"/>
-        <source>Import signed key images list and verify their spent status</source>
+        <source>Same as transfer, but using an older transaction building algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="692"/>
+        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="693"/>
+        <source>donate [&lt;mixin_count&gt;] &lt;amount&gt; [payment_id] - Donate &lt;amount&gt; to the development team (donate.getmonero.org)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="696"/>
+        <source>set_log &lt;level&gt;|&lt;categories&gt; - Change current log detail (level must be &lt;0-4&gt;)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="699"/>
+        <source>address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)] - Print all entries in the address book, optionally adding/deleting an entry to/from it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
+        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-output-count [n] - try to keep at least that many outputs of value at least min-output-value; min-output-value [n] - try to keep at least min-output-count outputs of at least that value - merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
+        <source>show_transfers [in|out|pending|failed|pool] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
+        <source>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Show unspent outputs within an optional amount range)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
+        <source>Show information about a transfer to/from this address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="722"/>
+        <source>Change wallet password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="778"/>
+        <source>set print-ring-members: needs an argument (0 or 1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="844"/>
+        <source>set priority: needs an argument: 0, 1, 2, 3, or 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
+        <source>set ask-password: needs an argument (0 or 1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
+        <source>set unit: needs an argument (monero, millinero, micronero, nanop, piconero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="896"/>
+        <source>set min-outputs-count: needs an argument (unsigned integer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="909"/>
+        <source>set min-outputs-value: needs an argument (unsigned integer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
+        <source>set merge-destinations: needs an argument (0 or 1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="941"/>
+        <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <source>(Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1281"/>
+        <source>bad m_restore_height parameter: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1259"/>
+        <source>date format must be YYYY-MM-DD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>Restore height is: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1273"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2442"/>
+        <source>Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
+        <source>Daemon is local, assuming trusted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <source>Password for new watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1702"/>
+        <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
+        <source>internal error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3286"/>
+        <source>unexpected error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3291"/>
+        <source>unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1860"/>
+        <source>refresh failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1860"/>
+        <source>Blocks received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1885"/>
+        <source>unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <source>amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
+        <source>spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
+        <source>global index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
+        <source>tx id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
+        <source>No incoming transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
+        <source>No incoming available transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1964"/>
+        <source>No incoming unavailable transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
+        <source>expected at least one payment_id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <source>payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <source>transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <source>height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
+        <source>unlock time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1994"/>
+        <source>No payments with id </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2374"/>
+        <source>failed to get blockchain height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2102"/>
+        <source>failed to connect to the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2130"/>
+        <source>
+Input %llu/%llu: amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2146"/>
+        <source>failed to get output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2158"/>
+        <source>
+Originating block heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2173"/>
+        <source>
+|</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
+        <source>|
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2190"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2192"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3019"/>
+        <source>wrong number of arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
+        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2862"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2674"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3226"/>
+        <source>failed to get random outputs to mix: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2879"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <source>Donating </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3129"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3153"/>
+        <source>This is a watch only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4316"/>
+        <source>usage: show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <source>Transaction ID not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="227"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="256"/>
+        <source>failed to parse refresh type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="352"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="343"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="444"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="565"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="473"/>
+        <source>mixin must be an integer &gt;= 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="478"/>
+        <source>could not change default mixin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
+        <source>could not change default priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="683"/>
+        <source>Synchronize transactions and balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="685"/>
+        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="686"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="689"/>
-        <source>Export a set of outputs owned by this wallet</source>
+        <source>transfer [&lt;priority&gt;] [&lt;mixin_count&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;] - Transfer &lt;amount&gt; to &lt;address&gt;. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
+        <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="691"/>
+        <source>Send all unmixable outputs to yourself with mixin 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="694"/>
+        <source>Sign a transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Submit a signed transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
+        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <source>Save wallet data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="701"/>
+        <source>Save a watch-only keys file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="702"/>
+        <source>Display private view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="703"/>
+        <source>Display private spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
+        <source>Display Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="706"/>
+        <source>Rescan blockchain for spent outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
+        <source>Get transaction key (r) for a given &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="708"/>
+        <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
+        <source>Rescan blockchain from scratch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <source>Set an arbitrary string note for a txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="713"/>
+        <source>Get a string note for a txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
+        <source>Show wallet status information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>Sign the contents of a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
+        <source>Verify a signature on the contents of a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>Export a signed set of key images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="718"/>
+        <source>Import signed key images list and verify their spent status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="719"/>
+        <source>Export a set of outputs owned by this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
         <source>Import set of outputs owned by this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="791"/>
         <source>set store-tx-info: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="759"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
         <source>set default-mixin: needs an argument (integer &gt;= 2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
         <source>set auto-refresh: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="830"/>
         <source>set refresh-type: needs an argument:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="831"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="805"/>
-        <source>set priority: needs an argument: 0, 1, 2, or 3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="857"/>
         <source>set confirm-missing-payment-id: needs an argument (0 or 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
-        <source>usage: set_log &lt;log_level_number_0-4&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="872"/>
-        <source>Specify wallet file name (e.g., MyWallet). If the wallet doesn&apos;t exist, it will be created.
-Wallet file name (or Ctrl-C to quit): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="995"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
-        <source>No wallet/key file found with that name. Confirm creation of new wallet named: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
-        <source>(y)es/(n)o: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1015"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1049"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1065"/>
         <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="993"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1083"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1008"/>
-        <source>bad m_restore_height parameter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1038"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1029"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4112"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1118"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1186"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1204"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1208"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1063"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1138"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1151"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1225"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1170"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1296"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1403"/>
         <source>invalid language choice passed. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1487"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use &quot;refresh&quot; command.
 Use &quot;help&quot; command to see the list of available commands.
@@ -1254,509 +1611,623 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1594"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1620"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1898"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1672"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2054"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2438"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2697"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2482"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2264"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2486"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1884"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1934"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1943"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1943"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2015"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1967"/>
-        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2298"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
-        <source>For URL: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1972"/>
-        <source> Monero Address = </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1974"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3475"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3867"/>
         <source>usage: integrated_address [payment ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3890"/>
         <source>Integrated address: account %s, payment ID %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3508"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3911"/>
+        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>failed to parse payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3961"/>
+        <source>failed to parse index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3969"/>
+        <source>Address book is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3975"/>
+        <source>Index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3976"/>
+        <source>Address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
+        <source>Payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3978"/>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3988"/>
         <source>usage: set_tx_note [txid] free text note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
         <source>usage: get_tx_note [txid]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
         <source>usage: sign &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4071"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3840"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4247"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3619"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4092"/>
         <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4132"/>
         <source>usage: export_key_images &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4137"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3812"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4219"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4158"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4166"/>
         <source>usage: import_key_images &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>usage: export_outputs &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>usage: import_outputs &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2474"/>
         <source>Money successfully sent, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3217"/>
         <source>no connection to daemon. Please, make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
-        <source>failed to get random outputs to mix</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3247"/>
         <source>not enough outputs for specified mixin_count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2297"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2475"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2297"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2475"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
         <source>found outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2703"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3255"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2484"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2743"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3259"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2317"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2539"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2718"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2983"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3267"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3271"/>
         <source>Failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2326"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2504"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2763"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3276"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2689"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2653"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3123"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3181"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
         <source>usage: get_tx_key &lt;txid&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3347"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4323"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3321"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3052"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3336"/>
         <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3363"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3383"/>
         <source>failed to get transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>failed to parse transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
         <source>failed to validate transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>failed to get the right transaction from daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3413"/>
         <source>failed to generate key derivation from supplied parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3475"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3475"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3479"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3483"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3492"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
         <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3575"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3587"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3359"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3397"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3671"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3397"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3671"/>
         <source>failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3397"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3671"/>
         <source>pending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3682"/>
+        <source>usage: unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
+        <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3729"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3729"/>
+        <source>, number of keys: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3734"/>
+        <source> </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3739"/>
+        <source>
+Min block height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3740"/>
+        <source>
+Max block height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3741"/>
+        <source>
+Min amount found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <source>
+Max amount found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3743"/>
+        <source>
+Total count: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3783"/>
+        <source>
+Bin size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3784"/>
+        <source>
+Outputs per *: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3786"/>
+        <source>count
+  ^
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
+        <source>  |</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3790"/>
+        <source>  +</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3790"/>
+        <source>+--&gt; block height
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <source>   ^</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <source>^
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3792"/>
+        <source>  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3842"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3873"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3482"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3874"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1764,274 +2235,348 @@ your wallet again (your wallet keys are NOT at risk in any case).
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="106"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="107"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="108"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="110"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="111"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="112"/>
         <source>Create non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="113"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="114"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="131"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="216"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>Failed to initialize wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>tools::dns_utils</name>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="430"/>
+        <source>DNSSEC validation passed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="434"/>
+        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="437"/>
+        <source>For URL: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="439"/>
+        <source> Monero Address = </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="441"/>
+        <source>Is this OK? (Y/n) </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/dns_utils.cpp" line="451"/>
+        <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="102"/>
+        <location filename="../src/wallet/wallet2.cpp" line="106"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="103"/>
+        <location filename="../src/wallet/wallet2.cpp" line="107"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="104"/>
+        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="458"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="105"/>
+        <location filename="../src/wallet/wallet2.cpp" line="109"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="106"/>
+        <location filename="../src/wallet/wallet2.cpp" line="110"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="107"/>
+        <location filename="../src/wallet/wallet2.cpp" line="112"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
         <source>Restricts to view-only commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="147"/>
+        <location filename="../src/wallet/wallet2.cpp" line="152"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="188"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="458"/>
+        <source>Enter new wallet password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="462"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="219"/>
+        <location filename="../src/wallet/wallet2.cpp" line="225"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="111"/>
+        <source>Specify username[:password] for daemon RPC client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="231"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="232"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
-        <location filename="../src/wallet/wallet2.cpp" line="365"/>
+        <location filename="../src/wallet/wallet2.cpp" line="262"/>
+        <location filename="../src/wallet/wallet2.cpp" line="329"/>
+        <location filename="../src/wallet/wallet2.cpp" line="371"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="274"/>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
+        <location filename="../src/wallet/wallet2.cpp" line="280"/>
+        <location filename="../src/wallet/wallet2.cpp" line="341"/>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
+        <location filename="../src/wallet/wallet2.cpp" line="293"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="298"/>
+        <location filename="../src/wallet/wallet2.cpp" line="304"/>
         <source>At least one of Electrum-style word list and private view key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="303"/>
+        <location filename="../src/wallet/wallet2.cpp" line="309"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="316"/>
+        <location filename="../src/wallet/wallet2.cpp" line="322"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="327"/>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="345"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="348"/>
+        <location filename="../src/wallet/wallet2.cpp" line="354"/>
         <source>Cannot create deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="395"/>
+        <location filename="../src/wallet/wallet2.cpp" line="401"/>
         <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="5167"/>
+        <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="100"/>
-        <source>Invalid IP address given for rpc-bind-ip argument</source>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="122"/>
+        <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="107"/>
-        <source>The rpc-bind-ip value is listening for unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --confirm-external-bind</source>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="132"/>
+        <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1161"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="132"/>
+        <source> and --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="159"/>
+        <source>Failed to create file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="159"/>
+        <source>. Check permissions or remove file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="170"/>
+        <source>Error writing to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="173"/>
+        <source>RPC username/password is stored in file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1517"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1167"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1523"/>
         <source>Must specify --wallet-file or --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1527"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1196"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1219"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1552"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1575"/>
         <source>Storing wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1198"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1221"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1554"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1577"/>
         <source>Stored ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1201"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1557"/>
         <source>Loaded ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1561"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1210"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1566"/>
         <source>Failed to initialize wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1214"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1570"/>
         <source>Starting wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1216"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1572"/>
         <source>Stopped wallet rpc server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1581"/>
         <source>Failed to store wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2039,54 +2584,59 @@ your wallet again (your wallet keys are NOT at risk in any case).
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1131"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1486"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="56"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="59"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="60"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="63"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="82"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="87"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="83"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="88"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="92"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="89"/>
+        <source>Config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="98"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
-        <source>unexpected empty log file name in presence of non-empty file path</source>
+        <location filename="../src/wallet/wallet_args.cpp" line="128"/>
+        <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="131"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="172"/>
+        <source>Logging to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
+        <source>Logging to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="153"/>
         <source>Usage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="178"/>
-        <source>default_log: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="179"/>
-        <source>Logging at log level %d to %s</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Allows fee argument default/unimportant/normal/elevated/priority to be used per transaction in CLI wallet's transfer command. Resolves #1913.