### PR TITLE
signature proving payment to given destination using tx secret key

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -111,6 +111,8 @@ namespace crypto {
     friend bool check_key(const public_key &);
     static bool secret_key_to_public_key(const secret_key &, public_key &);
     friend bool secret_key_to_public_key(const secret_key &, public_key &);
+    static bool secret_key_mult_public_key(const secret_key &, const public_key &, public_key &);
+    friend bool secret_key_mult_public_key(const secret_key &, const public_key &, public_key &);
     static bool generate_key_derivation(const public_key &, const secret_key &, key_derivation &);
     friend bool generate_key_derivation(const public_key &, const secret_key &, key_derivation &);
     static void derivation_to_scalar(const key_derivation &derivation, size_t output_index, ec_scalar &res);
@@ -123,6 +125,10 @@ namespace crypto {
     friend void generate_signature(const hash &, const public_key &, const secret_key &, signature &);
     static bool check_signature(const hash &, const public_key &, const signature &);
     friend bool check_signature(const hash &, const public_key &, const signature &);
+    static void generate_signature_custom_base(const hash &, const public_key &, const secret_key &, const public_key &, signature &);
+    friend void generate_signature_custom_base(const hash &, const public_key &, const secret_key &, const public_key &, signature &);
+    static bool check_signature_custom_base(const hash &, const public_key &, const public_key &, const signature &);
+    friend bool check_signature_custom_base(const hash &, const public_key &, const public_key &, const signature &);
     static void generate_key_image(const public_key &, const secret_key &, key_image &);
     friend void generate_key_image(const public_key &, const secret_key &, key_image &);
     static void generate_ring_signature(const hash &, const key_image &,
@@ -170,6 +176,12 @@ namespace crypto {
     return crypto_ops::secret_key_to_public_key(sec, pub);
   }
 
+  /* Multiply secret key to public key
+   */
+  inline bool secret_key_mult_public_key(const secret_key &sec, const public_key &pub, public_key &result) {
+    return crypto_ops::secret_key_mult_public_key(sec, pub, result);
+  }
+
   /* To generate an ephemeral key used to send money to:
    * * The sender generates a new key pair, which becomes the transaction key. The public transaction key is included in "extra" field.
    * * Both the sender and the receiver generate key derivation from the transaction key, the receivers' "view" key and the output index.
@@ -198,6 +210,17 @@ namespace crypto {
   }
   inline bool check_signature(const hash &prefix_hash, const public_key &pub, const signature &sig) {
     return crypto_ops::check_signature(prefix_hash, pub, sig);
+  }
+
+  /* Generation and checking of a signature using 'custom base'; i.e. instead of using the standard basepoint G and 
+   * proving the knowledge of x such that P=x*G, we introduce another pubkey A as the 'custom basepoint' and prove the 
+   * knowledge of x such that P=x*A
+   */
+  inline void generate_signature_custom_base(const hash &prefix_hash, const public_key &pub, const secret_key &sec, const public_key &custom_base, signature &sig) {
+    crypto_ops::generate_signature_custom_base(prefix_hash, pub, sec, custom_base, sig);
+  }
+  inline bool check_signature_custom_base(const hash &prefix_hash, const public_key &pub, const public_key &custom_base, const signature &sig) {
+    return crypto_ops::check_signature_custom_base(prefix_hash, pub, custom_base, sig);
   }
 
   /* To send money to a key:

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -47,6 +47,7 @@
 #include "common/command_line.h"
 #include "common/util.h"
 #include "common/dns_utils.h"
+#include "common/base58.h"
 #include "p2p/net_node.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 #include "simplewallet.h"
@@ -705,6 +706,8 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("rescan_spent", boost::bind(&simple_wallet::rescan_spent, this, _1), tr("Rescan blockchain for spent outputs"));
   m_cmd_binder.set_handler("get_tx_key", boost::bind(&simple_wallet::get_tx_key, this, _1), tr("Get transaction key (r) for a given <txid>"));
   m_cmd_binder.set_handler("check_tx_key", boost::bind(&simple_wallet::check_tx_key, this, _1), tr("Check amount going to <address> in <txid>"));
+  m_cmd_binder.set_handler("get_tx_proof", boost::bind(&simple_wallet::get_tx_proof, this, _1), tr("Generate a signature to prove payment to <address> in <txid> using the transaction secret key (r) without revealing it"));
+  m_cmd_binder.set_handler("check_tx_proof", boost::bind(&simple_wallet::check_tx_proof, this, _1), tr("Check tx proof for payment going to <address> in <txid>"));
   m_cmd_binder.set_handler("show_transfers", boost::bind(&simple_wallet::show_transfers, this, _1), tr("show_transfers [in|out|pending|failed|pool] [<min_height> [<max_height>]] - Show incoming/outgoing transfers within an optional height range"));
   m_cmd_binder.set_handler("unspent_outputs", boost::bind(&simple_wallet::unspent_outputs, this, _1), tr("unspent_outputs [<min_amount> <max_amount>] - Show unspent outputs within an optional amount range)"));
   m_cmd_binder.set_handler("rescan_bc", boost::bind(&simple_wallet::rescan_blockchain, this, _1), tr("Rescan blockchain from scratch"));
@@ -3309,6 +3312,58 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
   }
 }
 //----------------------------------------------------------------------------------------------------
+bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)
+{
+  if(args.size() != 2) {
+    fail_msg_writer() << tr("usage: get_tx_proof <txid> <address>");
+    return true;
+  }
+  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  cryptonote::blobdata txid_data;
+  if(!epee::string_tools::parse_hexstr_to_binbuff(args[0], txid_data) || txid_data.size() != sizeof(crypto::hash))
+  {
+    fail_msg_writer() << tr("failed to parse txid");
+    return false;
+  }
+  crypto::hash txid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
+
+  cryptonote::account_public_address address;
+  bool has_payment_id;
+  crypto::hash8 payment_id;
+  if(!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), args[1]))
+  {
+    fail_msg_writer() << tr("failed to parse address");
+    return true;
+  }
+
+  LOCK_IDLE_SCOPE();
+
+  crypto::secret_key tx_key;
+  std::vector<crypto::secret_key> amount_keys;
+  if (m_wallet->get_tx_key(txid, tx_key))
+  {
+    success_msg_writer() << tr("Tx key: ") << epee::string_tools::pod_to_hex(tx_key);
+
+    crypto::public_key rA;
+    crypto::secret_key_mult_public_key(tx_key, address.m_view_public_key, rA);
+    crypto::signature sig;
+    crypto::generate_signature_custom_base(txid, rA, tx_key, address.m_view_public_key, sig);
+
+    std::string sig_str = std::string("SigV1") +
+      tools::base58::encode(std::string((const char *)&rA, sizeof(crypto::public_key))) +
+      tools::base58::encode(std::string((const char *)&sig, sizeof(crypto::signature)));
+
+    success_msg_writer() << tr("Signature: ") << sig_str;
+    return true;
+  }
+  else
+  {
+    fail_msg_writer() << tr("no tx keys found for this txid");
+    return true;
+  }
+}
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
 {
   std::vector<std::string> local_args = args_;
@@ -3355,6 +3410,18 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
     return true;
   }
 
+  crypto::key_derivation derivation;
+  if (!crypto::generate_key_derivation(address.m_view_public_key, tx_key, derivation))
+  {
+    fail_msg_writer() << tr("failed to generate key derivation from supplied parameters");
+    return true;
+  }
+
+  return check_tx_key_helper(txid, address, derivation);
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::check_tx_key_helper(const crypto::hash &txid, const cryptonote::account_public_address &address, const crypto::key_derivation &derivation)
+{
   COMMAND_RPC_GET_TRANSACTIONS::request req;
   COMMAND_RPC_GET_TRANSACTIONS::response res;
   req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
@@ -3388,13 +3455,6 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
     return true;
   }
 
-  crypto::key_derivation derivation;
-  if (!crypto::generate_key_derivation(address.m_view_public_key, tx_key, derivation))
-  {
-    fail_msg_writer() << tr("failed to generate key derivation from supplied parameters");
-    return true;
-  }
-
   uint64_t received = 0;
   try {
     for (size_t n = 0; n < tx.vout.size(); ++n)
@@ -3417,14 +3477,6 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
           {
             rct::key Ctmp;
             //rct::key amount_key = rct::hash_to_scalar(rct::scalarmultKey(rct::pk2rct(address.m_view_public_key), rct::sk2rct(tx_key)));
-            crypto::key_derivation derivation;
-            bool r = crypto::generate_key_derivation(address.m_view_public_key, tx_key, derivation);
-            if (!r)
-            {
-              LOG_ERROR("Failed to generate key derivation to decode rct output " << n);
-              amount = 0;
-            }
-            else
             {
               crypto::secret_key scalar1;
               crypto::derivation_to_scalar(derivation, n, scalar1);
@@ -3479,6 +3531,94 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
   }
 
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
+{
+  if(args.size() != 3) {
+    fail_msg_writer() << tr("usage: check_tx_proof <txid> <address> <signature>");
+    return true;
+  }
+
+  if (!try_connect_to_daemon())
+    return true;
+
+  // parse txid
+  assert(m_wallet);
+  cryptonote::blobdata txid_data;
+  if(!epee::string_tools::parse_hexstr_to_binbuff(args[0], txid_data) || txid_data.size() != sizeof(crypto::hash))
+  {
+    fail_msg_writer() << tr("failed to parse txid");
+    return true;
+  }
+  crypto::hash txid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
+
+  LOCK_IDLE_SCOPE();
+
+  // parse address
+  cryptonote::account_public_address address;
+  bool has_payment_id;
+  crypto::hash8 payment_id;
+  if(!cryptonote::get_account_address_from_str_or_url(address, has_payment_id, payment_id, m_wallet->testnet(), args[1]))
+  {
+    fail_msg_writer() << tr("failed to parse address");
+    return true;
+  }
+
+  // parse pubkey r*A & signature
+  std::string sig_str = args[2];
+  const size_t header_len = strlen("SigV1");
+  if (sig_str.size() < header_len || sig_str.substr(0, header_len) != "SigV1")
+  {
+    fail_msg_writer() << tr("Signature header check error");
+    return true;
+  }
+  crypto::public_key rA;
+  crypto::signature sig;
+  const size_t rA_len = tools::base58::encode(std::string((const char *)&rA, sizeof(crypto::public_key))).size();
+  const size_t sig_len = tools::base58::encode(std::string((const char *)&sig, sizeof(crypto::signature))).size();
+  std::string rA_decoded;
+  std::string sig_decoded;
+  if (!tools::base58::decode(sig_str.substr(header_len, rA_len), rA_decoded))
+  {
+    fail_msg_writer() << tr("Signature decoding error");
+    return true;
+  }
+  if (!tools::base58::decode(sig_str.substr(header_len + rA_len, sig_len), sig_decoded))
+  {
+    fail_msg_writer() << tr("Signature decoding error");
+    return true;
+  }
+  if (sizeof(crypto::public_key) != rA_decoded.size() || sizeof(crypto::signature) != sig_decoded.size())
+  {
+    fail_msg_writer() << tr("Signature decoding error");
+    return true;
+  }
+  memcpy(&rA, rA_decoded.data(), sizeof(crypto::public_key));
+  memcpy(&sig, sig_decoded.data(), sizeof(crypto::signature));
+
+  // check signature
+  if (crypto::check_signature_custom_base(txid, rA, address.m_view_public_key, sig))
+  {
+    success_msg_writer() << tr("Good signature");
+  }
+  else
+  {
+    fail_msg_writer() << tr("Bad signature");
+    return true;
+  }
+
+  // obtain key derivation by multiplying scalar 1 to the pubkey r*A included in the signature
+  crypto::secret_key one = AUTO_VAL_INIT(one);
+  one.data[0] = 1;
+  crypto::key_derivation derivation;
+  if (!crypto::generate_key_derivation(rA, one, derivation))
+  {
+    fail_msg_writer() << tr("failed to generate key derivation");
+    return true;
+  }
+
+  return check_tx_key_helper(txid, address, derivation);
 }
 //----------------------------------------------------------------------------------------------------
 static std::string get_human_readable_timestamp(uint64_t ts)

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -152,6 +152,9 @@ namespace cryptonote
     bool set_log(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
     bool check_tx_key(const std::vector<std::string> &args);
+    bool check_tx_key_helper(const crypto::hash &txid, const cryptonote::account_public_address &address, const crypto::key_derivation &derivation);
+    bool get_tx_proof(const std::vector<std::string> &args);
+    bool check_tx_proof(const std::vector<std::string> &args);
     bool show_transfers(const std::vector<std::string> &args);
     bool unspent_outputs(const std::vector<std::string> &args);
     bool rescan_blockchain(const std::vector<std::string> &args);


### PR DESCRIPTION
This is an alternative to #1935 with the difference being the ability to check the amount sent to a given destination address. A slightly modified version of the Schnorr signature scheme is introduced, where the signer proves the knowledge of a secret key `x` that is the discrete log of a pubkey `P` with respect to what I call a 'custom basepoint' `A`, i.e. `P=x*A`. Below is the pseudocode:

```
[Signature Generation]
input: Msg, x (where P=x*A), A
    k = random_scalar()
    c = Hs(Msg || k*A)
    r = k - c*x
    return (c, r)

[Signature Checking]
input: Msg, P, c, r, A
    R = c*P + r*A
    c' = Hs(Msg || R)
    return c == c'
```

They're implemented as `generate_signature_custom_base` & `check_signature_custom_base ` in `src/crypto/crypto.cpp`.

The signature string contains, in addition to the pair of scalars `(c, r)` as before, a pubkey `Q=r*A` where `r` is the tx secret key and `A` is the recipient's view public key, thus proving the knowledge of `r` and also the fact that the fund was indeed transferred to the destination `(A,B)`. 

Since `Q` is also the key derivation, it's possible for anyone not knowing `r` to compute the output pubkey

```
P_i = Hs(Q || i)*G + B
```
and decode the transferred amount.

Two new commands are introduced to `monero-wallet-cli`:
```
get_tx_proof <txid> <address>
check_tx_proof <txid> <address> <signature>
```

Example:
```
get_tx_proof 272da4daad30c24acb9b22f358b19c7f613e30f5da36da35c873edada6c0ef6f 44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A
Wallet password: ***************
Tx key: 267db02ffc27554ecf06fe1f756d6bc3b79af80201e49fdcab3a3b47e086a40f
Signature: SigV1JJGctHjqL9PDACX79pzDjpgLTkdfdSCycDsqdn3ULg3p6VGtKGKsbwTWqG9AuTiQZqGU4XXpAnyshTyL67GCDCCBUcv8kWr17meE4dfwgKXQ6T7T92nZrhdJfVbzmE2MHr7g

check_tx_proof 272da4daad30c24acb9b22f358b19c7f613e30f5da36da35c873edada6c0ef6f 44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A SigV1JJGctHjqL9PDACX79pzDjpgLTkdfdSCycDsqdn3ULg3p6VGtKGKsbwTWqG9AuTiQZqGU4XXpAnyshTyL67GCDCCBUcv8kWr17meE4dfwgKXQ6T7T92nZrhdJfVbzmE2MHr7g
Good signature
44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A received 0.500000000000 in txid <272da4daad30c24acb9b22f358b19c7f613e30f5da36da35c873edada6c0ef6f>
This transaction has 14 confirmations
```

Conveniently, this scheme also works well with the sub-address scheme in #1753 without modification.

Thanks in advance for reviewing!
CC: @luigi1111