### PR TITLE
mlog: direct log category changes to file only

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -33,7 +33,12 @@
 
 INITIALIZE_EASYLOGGINGPP
 
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "logging"
+
 #define MLOG_BASE_FORMAT "%datetime{%Y-%M-%d %H:%m:%s.%g}\t%thread\t%level\t%logger\t%loc\t%msg"
+
+#define MLOG_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x
 
 using namespace epee;
 
@@ -88,10 +93,10 @@ static const char *get_default_categories(int level)
   switch (level)
   {
     case 0:
-      categories = "*:WARNING,net:FATAL,net.p2p:FATAL,net.cn:FATAL,global:INFO,verify:FATAL,stacktrace:INFO";
+      categories = "*:WARNING,net:FATAL,net.p2p:FATAL,net.cn:FATAL,global:INFO,verify:FATAL,stacktrace:INFO,logging:INFO";
       break;
     case 1:
-      categories = "*:WARNING,global:INFO,stacktrace:INFO";
+      categories = "*:WARNING,global:INFO,stacktrace:INFO,logging:INFO";
       break;
     case 2:
       categories = "*:DEBUG";
@@ -142,7 +147,7 @@ void mlog_configure(const std::string &filename_base, bool console)
 void mlog_set_categories(const char *categories)
 {
   el::Loggers::setCategories(categories);
-  MGINFO("New log categories: " << categories);
+  MLOG_LOG("New log categories: " << categories);
 }
 
 // maps epee style log level to new logging system
@@ -150,7 +155,7 @@ void mlog_set_log_level(int level)
 {
   const char *categories = get_default_categories(level);
   el::Loggers::setCategories(categories);
-  MGINFO("New log categories: " << categories);
+  MLOG_LOG("New log categories: " << categories);
 }
 
 void mlog_set_log(const char *log)


### PR DESCRIPTION
Because some people just won't even try to read what is written
and freak out because the word FATAL is in here, despite the
context making it clear it's not an error.