### PR TITLE
Android64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,10 @@ if (ARM_TEST STREQUAL "arm")
   endif()
 endif()
 
-if (ARM_ID STREQUAL "aarch64" OR ARM_ID STREQUAL "arm64")
+if (ARM_ID STREQUAL "aarch64" OR ARM_ID STREQUAL "arm64" OR ARM_ID STREQUAL "armv8-a")
   set(ARM 1)
   set(ARM8 1)
+  set(ARCH "armv8-a")
 endif()
 
 if(WIN32 OR ARM)

--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -137,7 +137,7 @@ typedef SSIZE_T	ssize_t;
 #include <unistd.h>
 #endif
 
-#if defined(__sun) || defined(ANDROID)
+#if defined(__sun) || defined(__ANDROID__)
 /* Most platforms have posix_memalign, older may only have memalign */
 #define HAVE_MEMALIGN	1
 #include <malloc.h>
@@ -153,7 +153,7 @@ typedef SSIZE_T	ssize_t;
 # define MDB_USE_SYSV_SEM	1
 # endif
 # define MDB_FDATASYNC		fsync
-#elif defined(ANDROID)
+#elif defined(__ANDROID__)
 # define MDB_FDATASYNC		fsync
 #endif
 
@@ -298,7 +298,7 @@ union semun {
  */
 #ifndef MDB_USE_ROBUST
 /* Android currently lacks Robust Mutex support. So does glibc < 2.4. */
-# if defined(MDB_USE_POSIX_MUTEX) && (defined(ANDROID) || \
+# if defined(MDB_USE_POSIX_MUTEX) && (defined(__ANDROID__) || \
 	(defined(__GLIBC__) && GLIBC_VER < 0x020004))
 #  define MDB_USE_ROBUST	0
 # else

--- a/external/unbound/validator/val_secalgo.c
+++ b/external/unbound/validator/val_secalgo.c
@@ -345,7 +345,11 @@ setup_key_digest(int algo, EVP_PKEY** evp_key, const EVP_MD** digest_type,
 					"EVP_PKEY_assign_DSA failed");
 				return 0;
 			}
+#ifdef HAVE_EVP_DSS1
 			*digest_type = EVP_dss1();
+#else
+			*digest_type = EVP_sha1();
+#endif
 
 			break;
 		case LDNS_RSASHA1:

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3665,6 +3665,8 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::list<block_complete_e
     std::vector<std::unordered_map<crypto::hash, crypto::hash>> maps(threads);
     std::vector < std::vector < block >> blocks(threads);
     auto it = blocks_entry.begin();
+    boost::thread::attributes attrs;
+    attrs.set_stack_size(THREAD_STACK_SIZE);
 
     for (uint64_t i = 0; i < threads; i++)
     {
@@ -3724,7 +3726,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::list<block_complete_e
       m_blocks_longhash_table.clear();
       for (uint64_t i = 0; i < threads; i++)
       {
-        thread_list.push_back(new boost::thread(&Blockchain::block_longhash_worker, this, height + (i * batches), std::cref(blocks[i]), std::ref(maps[i])));
+        thread_list.push_back(new boost::thread(attrs, boost::bind(&Blockchain::block_longhash_worker, this, height + (i * batches), std::cref(blocks[i]), std::ref(maps[i]))));
       }
 
       for (size_t j = 0; j < thread_list.size(); j++)


### PR DESCRIPTION
A bunch of minor tweaks required to get a successful build with the Android NDK for ARM64.
~~Note that there are still glitches to work out - crypto/slow-hash.c only works correctly when compiled with gcc, not clang. Each compiler (gcc, g++, clang, clang++) has its own weird quirks and it doesn't look like we can satisfy one consistent set, yet.~~ Works fine with clang now.

This also depends on PR #1966 ...