### PR TITLE
wallet2: fix removal of wrong txes from unconfirmed_payments

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1453,7 +1453,7 @@ void wallet2::update_pool_state()
   std::unordered_map<crypto::hash, wallet2::payment_details>::iterator uit = m_unconfirmed_payments.begin();
   while (uit != m_unconfirmed_payments.end())
   {
-    const crypto::hash &txid = uit->first;
+    const crypto::hash &txid = uit->second.m_tx_hash;
     bool found = false;
     for (const auto &it2: res.tx_hashes)
     {


### PR DESCRIPTION
unconfirmed_payments changed from having the txid as key to
the payment id, and this was not changed to match.