### PR TITLE
easylogging++: default to creating categories by default

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -2095,6 +2095,7 @@ Storage::Storage(const LogBuilderPtr& defaultLogBuilder) :
   sysLogLogger->reconfigure();
 #endif //  defined(ELPP_SYSLOG)
   addFlag(LoggingFlag::AllowVerboseIfModuleNotSpecified);
+  addFlag(LoggingFlag::CreateLoggerAutomatically);
 #if ELPP_ASYNC_LOGGING
   installLogDispatchCallback<base::AsyncLogDispatchCallback>(std::string("AsyncLogDispatchCallback"));
 #else


### PR DESCRIPTION
This avoids error spews from easylogging++ when we try to log
something before easylogging is initialized, which can happen
when errors happen at command line parsing time