### PR TITLE
Removed --confirm-external-bind from monerod and monero-wallet-rpc

### DIFF
--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -37,7 +37,6 @@ namespace cryptonote
   rpc_args::descriptors::descriptors()
      : rpc_bind_ip({"rpc-bind-ip", rpc_args::tr("Specify ip to bind rpc server"), "127.0.0.1"})
      , rpc_login({"rpc-login", rpc_args::tr("Specify username[:password] required for RPC server"), "", true})
-     , confirm_external_bind({"confirm-external-bind", rpc_args::tr("Confirm rpc-bind-ip value is NOT a loopback (local) IP")})
   {}
 
   const char* rpc_args::tr(const char* str) { return i18n_translate(str, "cryptonote::rpc_args"); }
@@ -47,7 +46,6 @@ namespace cryptonote
     const descriptors arg{};
     command_line::add_arg(desc, arg.rpc_bind_ip);
     command_line::add_arg(desc, arg.rpc_login);
-    command_line::add_arg(desc, arg.confirm_external_bind);
   }
 
   boost::optional<rpc_args> rpc_args::process(const boost::program_options::variables_map& vm)
@@ -60,20 +58,10 @@ namespace cryptonote
     {
       // always parse IP here for error consistency
       boost::system::error_code ec{};
-      const auto parsed_ip = boost::asio::ip::address::from_string(config.bind_ip, ec);
+      boost::asio::ip::address::from_string(config.bind_ip, ec);
       if (ec)
       {
         LOG_ERROR(tr("Invalid IP address given for --") << arg.rpc_bind_ip.name);
-        return boost::none;
-      }
-
-      if (!parsed_ip.is_loopback() && !command_line::get_arg(vm, arg.confirm_external_bind))
-      {
-        LOG_ERROR(
-          "--" << arg.rpc_bind_ip.name <<
-          tr(" permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --") <<
-          arg.confirm_external_bind.name
-        );
         return boost::none;
       }
     }

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -52,7 +52,6 @@ namespace cryptonote
 
       const command_line::arg_descriptor<std::string> rpc_bind_ip;
       const command_line::arg_descriptor<std::string> rpc_login;
-      const command_line::arg_descriptor<bool> confirm_external_bind;
     };
 
     static const char* tr(const char* str);


### PR DESCRIPTION
As per the discussion started by @hyc in https://github.com/monero-project/monero/pull/1689 . The intent was to remind people that the new HTTP auth scheme was unsuitable to be exposed directly to the internet since it could not prevent against certain kinds of attacks. @moneromooo-monero @danrmiller @iamsmooth @fluffypony @guzzijones @Jaqueeee @kenshi84 @tewinget - in case there is someone that feels like the feature should be left in.