### PR TITLE
Change all wallet language names into native names (and scripts)

### DIFF
--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -41,7 +41,7 @@ set(mnemonics_private_headers
   italian.h
   japanese.h
   language_base.h
-  old_english.h
+  english_old.h
   portuguese.h
   russian.h
   singleton.h

--- a/src/mnemonics/chinese_simplified.h
+++ b/src/mnemonics/chinese_simplified.h
@@ -72,7 +72,7 @@ namespace Language
   class Chinese_Simplified: public Base
   {
   public:
-    Chinese_Simplified(): Base("Chinese (Simplified)", std::vector<std::string>({
+    Chinese_Simplified(): Base("简体中文 (中国)", std::vector<std::string>({
       "的",
       "一",
       "是",

--- a/src/mnemonics/dutch.h
+++ b/src/mnemonics/dutch.h
@@ -49,7 +49,7 @@ namespace Language
   class Dutch: public Base
   {
   public:
-    Dutch(): Base("Dutch", std::vector<std::string>({
+    Dutch(): Base("Nederlands", std::vector<std::string>({
         "aalglad",
         "aalscholver",
         "aambeeld",

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -61,7 +61,7 @@
 #include "portuguese.h"
 #include "japanese.h"
 #include "russian.h"
-#include "old_english.h"
+#include "english_old.h"
 #include "language_base.h"
 #include "singleton.h"
 
@@ -95,7 +95,7 @@ namespace
       Language::Singleton<Language::Portuguese>::instance(),
       Language::Singleton<Language::Japanese>::instance(),
       Language::Singleton<Language::Russian>::instance(),
-      Language::Singleton<Language::OldEnglish>::instance()
+      Language::Singleton<Language::EnglishOld>::instance()
     });
     Language::Base *fallback = NULL;
 

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -318,39 +318,39 @@ namespace crypto
       {
         language = Language::Singleton<Language::English>::instance();
       }
-      else if (language_name == "Dutch")
+      else if (language_name == "Nederlands")
       {
         language = Language::Singleton<Language::Dutch>::instance();
       }
-      else if (language_name == "French")
+      else if (language_name == "Français")
       {
         language = Language::Singleton<Language::French>::instance();
       }
-      else if (language_name == "Spanish")
+      else if (language_name == "Español")
       {
         language = Language::Singleton<Language::Spanish>::instance();
       }
-      else if (language_name == "Portuguese")
+      else if (language_name == "Português")
       {
         language = Language::Singleton<Language::Portuguese>::instance();
       }
-      else if (language_name == "Japanese")
+      else if (language_name == "日本語")
       {
         language = Language::Singleton<Language::Japanese>::instance();
       }
-      else if (language_name == "Italian")
+      else if (language_name == "Italiano")
       {
         language = Language::Singleton<Language::Italian>::instance();
       }
-      else if (language_name == "German")
+      else if (language_name == "Deutsch")
       {
         language = Language::Singleton<Language::German>::instance();
       }
-      else if (language_name == "Russian")
+      else if (language_name == "русский язык")
       {
         language = Language::Singleton<Language::Russian>::instance();
       }
-      else if (language_name == "Chinese (Simplified)")
+      else if (language_name == "简体中文 (中国)")
       {
         language = Language::Singleton<Language::Chinese_Simplified>::instance();
       }
@@ -399,16 +399,16 @@ namespace crypto
     void get_language_list(std::vector<std::string> &languages)
     {
       std::vector<Language::Base*> language_instances({
-        Language::Singleton<Language::Chinese_Simplified>::instance(),
-        Language::Singleton<Language::English>::instance(),
-        Language::Singleton<Language::Dutch>::instance(),
-        Language::Singleton<Language::French>::instance(),
-        Language::Singleton<Language::Spanish>::instance(),
         Language::Singleton<Language::German>::instance(),
+        Language::Singleton<Language::English>::instance(),
+        Language::Singleton<Language::Spanish>::instance(),
+        Language::Singleton<Language::French>::instance(),
         Language::Singleton<Language::Italian>::instance(),
+        Language::Singleton<Language::Dutch>::instance(),
         Language::Singleton<Language::Portuguese>::instance(),
         Language::Singleton<Language::Russian>::instance(),
-        Language::Singleton<Language::Japanese>::instance()
+        Language::Singleton<Language::Japanese>::instance(),
+        Language::Singleton<Language::Chinese_Simplified>::instance()
       });
       for (std::vector<Language::Base*>::iterator it = language_instances.begin();
         it != language_instances.end(); it++)

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -60,7 +60,7 @@ namespace crypto
   {
 
     const int seed_length = 24;
-    const std::string old_language_name = "OldEnglish";
+    const std::string old_language_name = "EnglishOld";
     /*!
      * \brief Converts seed words to bytes (secret key).
      * \param  words           String containing the words separated by spaces.

--- a/src/mnemonics/english_old.h
+++ b/src/mnemonics/english_old.h
@@ -29,13 +29,13 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*!
- * \file old_english.h
+ * \file english_old.h
  * 
- * \brief Old English word list and map.
+ * \brief Older version of English word list and map.
  */
 
-#ifndef OLD_ENGLISH_H
-#define OLD_ENGLISH_H
+#ifndef ENGLISH_OLD_H
+#define ENGLISH_OLD_H
 
 #include <vector>
 #include <unordered_map>
@@ -48,10 +48,10 @@
  */
 namespace Language
 {
-  class OldEnglish: public Base
+  class EnglishOld: public Base
   {
   public:
-    OldEnglish(): Base("OldEnglish", std::vector<std::string>({
+    EnglishOld(): Base("EnglishOld", std::vector<std::string>({
         "like",
         "just",
         "love",

--- a/src/mnemonics/french.h
+++ b/src/mnemonics/french.h
@@ -49,7 +49,7 @@ namespace Language
   class French: public Base
   {
   public:
-    French(): Base("French", std::vector<std::string>({
+    French(): Base("Français", std::vector<std::string>({
         "abandon",
         "abattre",
         "aboi",

--- a/src/mnemonics/german.h
+++ b/src/mnemonics/german.h
@@ -51,7 +51,7 @@ namespace Language
   class German: public Base
   {
   public:
-    German(): Base("German", std::vector<std::string>({
+    German(): Base("Deutsch", std::vector<std::string>({
         "Abakus",
         "Abart",
         "abbilden",

--- a/src/mnemonics/italian.h
+++ b/src/mnemonics/italian.h
@@ -51,7 +51,7 @@ namespace Language
   class Italian: public Base
   {
   public:
-    Italian(): Base("Italian", std::vector<std::string>({
+    Italian(): Base("Italiano", std::vector<std::string>({
         "abbinare",
         "abbonato",
         "abisso",

--- a/src/mnemonics/japanese.h
+++ b/src/mnemonics/japanese.h
@@ -71,7 +71,7 @@ namespace Language
   class Japanese: public Base
   {
   public:
-    Japanese(): Base("Japanese", std::vector<std::string>({
+    Japanese(): Base("日本語", std::vector<std::string>({
         "あいこくしん",
         "あいさつ",
         "あいだ",

--- a/src/mnemonics/portuguese.h
+++ b/src/mnemonics/portuguese.h
@@ -72,7 +72,7 @@ namespace Language
   class Portuguese: public Base
   {
   public:
-    Portuguese(): Base("Portuguese", std::vector<std::string>({
+    Portuguese(): Base("Português", std::vector<std::string>({
         "abaular",
         "abdominal",
         "abeto",

--- a/src/mnemonics/russian.h
+++ b/src/mnemonics/russian.h
@@ -51,7 +51,7 @@ namespace Language
   class Russian: public Base
   {
   public:
-    Russian(): Base("Russian", std::vector<std::string>({
+    Russian(): Base("русский язык", std::vector<std::string>({
         "абажур",
         "абзац",
         "абонент",

--- a/src/mnemonics/spanish.h
+++ b/src/mnemonics/spanish.h
@@ -72,7 +72,7 @@ namespace Language
   class Spanish: public Base
   {
   public:
-    Spanish(): Base("Spanish", std::vector<std::string>({
+    Spanish(): Base("Español", std::vector<std::string>({
         "ábaco",
         "abdomen",
         "abeja",

--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -44,7 +44,7 @@
 #include "mnemonics/russian.h"
 #include "mnemonics/french.h"
 #include "mnemonics/dutch.h"
-#include "mnemonics/old_english.h"
+#include "mnemonics/english_old.h"
 #include "mnemonics/language_base.h"
 #include "mnemonics/singleton.h"
 


### PR DESCRIPTION
Also changed 'Old English' to 'English Old', because 'Old English' is actually a language in its own right, and someone may want to make a dictionary for it at some point in the future. I don't know who, but let's leave the chance open ;)