### PR TITLE
Add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Dates are provided in the format YYYY-MM-DD.
 
 Packages are available for
 
+* Ubuntu and [snap supported](https://snapcraft.io/docs/core/install) systems.
+
+    snap install monero --beta
+
 * Arch Linux (via [AUR](https://aur.archlinux.org/)):
   - Stable release: [`monero`](https://aur.archlinux.org/packages/monero)
   - Bleeding edge: [`bitmonero-git`](https://aur.archlinux.org/packages/bitmonero-git)

--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Dates are provided in the format YYYY-MM-DD.
 
 Packages are available for
 
-* Ubuntu and [snap supported](https://snapcraft.io/docs/core/install) systems.
+* Ubuntu and [snap supported](https://snapcraft.io/docs/core/install) systems, via a community contributed build.
 
     snap install monero --beta
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
 
 * Arch Linux (via [AUR](https://aur.archlinux.org/)):
   - Stable release: [`monero`](https://aur.archlinux.org/packages/monero)


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install Monero` simplifying the installation instructions for your users.