### PR TITLE
Update sync time copy

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1089,7 +1089,7 @@ namespace cryptonote
     if(!m_starter_message_showed)
     {
       MGINFO_YELLOW(ENDL << "**********************************************************************" << ENDL
-        << "The daemon will start synchronizing with the network. It may take up to several hours." << ENDL
+        << "The daemon will start synchronizing with the network. This may take a long time to complete." << ENDL
         << ENDL
         << "You can set the level of process detailization* through \"set_log <level|categories>\" command*," << ENDL
         << "where <level> is between 0 (no details) and 4 (very verbose), or custom category based levels (eg, *:WARNING)" << ENDL


### PR DESCRIPTION
As Monero's blockchain has grown, most users take more than "several hours" for a fresh sync. This PR makes the daemon sync time message more accurate.

![screen shot 2017-05-10 at 2 31 33 pm](https://cloud.githubusercontent.com/assets/21302237/25914956/e4f099f8-358d-11e7-842a-764984cf4413.png)
