### PR TITLE
Updated mnemonics test to include updated language after #2002

### DIFF
--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -192,9 +192,9 @@ TEST(mnemonics, language_detection_with_bad_checksum)
 
     res = crypto::ElectrumWords::words_to_bytes(base_seed, key, language_name);
     ASSERT_EQ(true, res);
-    ASSERT_STREQ(language_name.c_str(), "Portuguese");
+    ASSERT_STREQ(language_name.c_str(), "Português");
 
     res = crypto::ElectrumWords::words_to_bytes(base_seed + " " + real_checksum, key, language_name);
     ASSERT_EQ(true, res);
-    ASSERT_STREQ(language_name.c_str(), "Portuguese");
+    ASSERT_STREQ(language_name.c_str(), "Português");
 }


### PR DESCRIPTION
When setting up the project for the first time i saw this unit test error:
```
3: [ RUN      ] mnemonics.language_detection_with_bad_checksum
3: D:/projects/coins/monero/monero/tests/unit_tests/mnemonics.cpp:195: Failure
3:       Expected: language_name.c_str()
3:       Which is: "Portugu\xC3\xAAs"
3: To be equal to: "Portuguese"
3: [  FAILED  ] mnemonics.language_detection_with_bad_checksum (176 ms)
```

This commit will fix the error by updating the language to the localized version.

Tested it on Windows 10 (32 bit mode) and Ubuntu 16.04

Please let me know if there is anything else i can check or do before this can be merged.

Have a great day!