### PR TITLE
crypto to cncrypto 

### DIFF
--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -62,7 +62,7 @@ monero_add_library(blockchain_db
 target_link_libraries(blockchain_db
   PUBLIC
     common
-    crypto
+    cncrypto
     ringct
     ${LMDB_LIBRARY}
     ${BDB_LIBRARY}

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -79,7 +79,7 @@ monero_add_library(common
 target_link_libraries(common
   PUBLIC
     epee
-    crypto
+    cncrypto
     ${UNBOUND_LIBRARY}
     ${LIBUNWIND_LIBRARIES}
     ${Boost_DATE_TIME_LIBRARY}

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -68,13 +68,13 @@ set(crypto_private_headers
   skein.h
   skein_port.h)
 
-monero_private_headers(crypto
+monero_private_headers(cncrypto
   ${crypto_private_headers})
-monero_add_library(crypto
+monero_add_library(cncrypto
   ${crypto_sources}
   ${crypto_headers}
   ${crypto_private_headers})
-target_link_libraries(crypto
+target_link_libraries(cncrypto
   PUBLIC
     ${Boost_SYSTEM_LIBRARY}
   PRIVATE

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -62,7 +62,7 @@ monero_add_library(cryptonote_basic
 target_link_libraries(cryptonote_basic
   PUBLIC
     common
-    crypto
+    cncrypto
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -56,7 +56,7 @@ monero_add_library(cryptonote_core
 target_link_libraries(cryptonote_core
   PUBLIC
     common
-    crypto
+    cncrypto
     blockchain_db
     ringct
     ${Boost_DATE_TIME_LIBRARY}

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -87,7 +87,7 @@ target_link_libraries(daemon
     rpc
     blockchain_db
     cryptonote_core
-    crypto
+    cncrypto
     common
     p2p
     cryptonote_protocol

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -48,7 +48,7 @@ monero_add_library(ringct
 target_link_libraries(ringct
   PUBLIC
     common
-    crypto
+    cncrypto
     cryptonote_basic
   PRIVATE
     ${EXTRA_LIBRARIES})

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(simplewallet
     wallet
     rpc
     cryptonote_core
-    crypto
+    cncrypto
     common
     mnemonics
     p2p

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -108,7 +108,7 @@ if (NOT BUILD_GUI_DEPS)
       epee
       rpc
       cryptonote_core
-      crypto
+      cncrypto
       common
       ${Boost_CHRONO_LIBRARY}
       ${Boost_PROGRAM_OPTIONS_LIBRARY}
@@ -126,7 +126,7 @@ endif()
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)
-    set(libs_to_merge wallet cryptonote_core cryptonote_basic mnemonics common crypto ringct)
+    set(libs_to_merge wallet cryptonote_core cryptonote_basic mnemonics common cncrypto ringct)
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -37,17 +37,17 @@ set(crypto_sources
 set(crypto_headers
   crypto-tests.h)
 
-add_executable(crypto-tests
+add_executable(cncrypto-tests
   ${crypto_sources}
   ${crypto_headers})
-target_link_libraries(crypto-tests
+target_link_libraries(cncrypto-tests
   PRIVATE
     ${Boost_SYSTEM_LIBRARY}
     ${EXTRA_LIBRARIES})
-set_property(TARGET crypto-tests
+set_property(TARGET cncrypto-tests
   PROPERTY
     FOLDER "tests")
 
 add_test(
-  NAME    crypto
-  COMMAND crypto-tests "${CMAKE_CURRENT_SOURCE_DIR}/tests.txt")
+  NAME    cncrypto
+  COMMAND cncrypto-tests "${CMAKE_CURRENT_SOURCE_DIR}/tests.txt")

--- a/tests/daemon_tests/CMakeLists.txt
+++ b/tests/daemon_tests/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(transfers
     useragent
     rpc
     cryptonote_core
-    crypto
+    cncrypto
     common
     epee
     ${GTEST_LIBRARIES})

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(functional_tests
     cryptonote_core
     wallet
     common
-    crypto
+    cncrypto
     epee
     ${Boost_REGEX_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}

--- a/tests/hash/CMakeLists.txt
+++ b/tests/hash/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(hash-tests
   ${hash_headers})
 target_link_libraries(hash-tests
   PRIVATE
-    crypto
+    cncrypto
     ${EXTRA_LIBRARIES})
 set_property(TARGET hash-tests
   PROPERTY

--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(performance_tests
   PRIVATE
     cryptonote_core
     common
-    crypto
+    cncrypto
     epee
     ${Boost_CHRONO_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
The openssl crypto lib that is the same name as the monero crypto lib can't be packed with an android app since they pack all of the native libraries into the same folder  only distinguished by the architecture so I changed it to cncrypto.