### PR TITLE
abstracted nework addresses

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server.h
+++ b/contrib/epee/include/net/abstract_tcp_server.h
@@ -296,7 +296,7 @@ namespace net_utils
 	}
 	//----------------------------------------------------------------------------------------
 	template<class THandler>
-	bool abstract_tcp_server<THandler>::invoke_connection(SOCKET hnew_sock, long ip_from, int post_from)
+	bool abstract_tcp_server<THandler>::invoke_connection(SOCKET hnew_sock, const network_address &remote_address)
 	{
 		m_connections_lock.lock();
 		m_connections.push_back(thread_context());
@@ -304,8 +304,7 @@ namespace net_utils
 		m_connections.back().m_socket = hnew_sock;
 		m_connections.back().powner = this;
 		m_connections.back().m_self_it = --m_connections.end();
-		m_connections.back().m_context.m_remote_ip = ip_from;
-		m_connections.back().m_context.m_remote_port = post_from;
+		m_connections.back().m_context.m_remote_address = remote_address;
 		m_connections.back().m_htread = threads_helper::create_thread(ConnectionHandlerProc, &m_connections.back());
 
 		return true;

--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -69,7 +69,7 @@ namespace net_utils
 
   struct i_connection_filter
   {
-    virtual bool is_remote_ip_allowed(uint32_t adress)=0;
+    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address)=0;
   protected:
     virtual ~i_connection_filter(){}
   };

--- a/contrib/epee/include/net/abstract_tcp_server_cp.inl
+++ b/contrib/epee/include/net/abstract_tcp_server_cp.inl
@@ -471,7 +471,7 @@ bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 }
 //-------------------------------------------------------------
 template<class TProtocol>
-bool cp_server_impl<TProtocol>::add_new_connection(SOCKET new_sock, long ip_from, int port_from)
+bool cp_server_impl<TProtocol>::add_new_connection(SOCKET new_sock, const network_address &address_from)
 {
 	PROFILE_FUNC("[add_new_connection]");
 	
@@ -487,8 +487,7 @@ bool cp_server_impl<TProtocol>::add_new_connection(SOCKET new_sock, long ip_from
 	m_connections_lock.unlock();
 	conn.init_buffers();
 	conn.m_sock = new_sock;
-	conn.context.m_remote_ip = ip_from;
-	conn.context.m_remote_port = port_from;
+	conn.context.m_remote_address = address_from;
 	conn.m_completion_port = m_completion_port;
 	{
 		PROFILE_FUNC("[add_new_connection] CreateIoCompletionPort");

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -39,7 +39,7 @@
               epee::net_utils::http::http_response_info& response, \
               context_type& m_conn_context) \
 {\
-  LOG_PRINT_L2("HTTP [" << epee::string_tools::get_ip_string_from_int32(m_conn_context.m_remote_ip ) << "] " << query_info.m_http_method_str << " " << query_info.m_URI); \
+  LOG_PRINT_L2("HTTP [" << m_conn_context.m_remote_address.host_str() << "] " << query_info.m_http_method_str << " " << query_info.m_URI); \
   response.m_response_code = 200; \
   response.m_response_comment = "Ok"; \
   if(!handle_http_request_map(query_info, response, m_conn_context)) \

--- a/contrib/epee/include/net/levin_client_async.h
+++ b/contrib/epee/include/net/levin_client_async.h
@@ -492,8 +492,7 @@ namespace levin
 		{
 
 			net_utils::connection_context_base conn_context;
-			conn_context.m_remote_ip = m_ip;
-			conn_context.m_remote_port = m_port;
+			conn_context.m_remote_address = m_address;
 			if(head.m_have_to_return_data)
 			{
 				std::string return_buff;

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -193,7 +193,7 @@ POP_WARNINGS
 	//----------------------------------------------------------------------------
 	bool get_ip_int32_from_string(uint32_t& ip, const std::string& ip_str);
   //----------------------------------------------------------------------------
-  inline bool parse_peer_from_string(uint32_t& ip, uint32_t& port, const std::string& addres)
+  inline bool parse_peer_from_string(uint32_t& ip, uint16_t& port, const std::string& addres)
   {
     //parse ip and address
     std::string::size_type p = addres.find(':');

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -49,6 +49,8 @@ namespace cryptonote
     bool localhost;
     bool local_ip;
 
+    std::string address;
+    std::string host;
     std::string ip;
     std::string port;
 
@@ -76,6 +78,8 @@ namespace cryptonote
       KV_SERIALIZE(incoming)
       KV_SERIALIZE(localhost)
       KV_SERIALIZE(local_ip)
+      KV_SERIALIZE(address)
+      KV_SERIALIZE(host)
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
       KV_SERIALIZE(peer_id)

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -123,9 +123,9 @@ namespace nodetool
     size_t get_outgoing_connections_count();
     peerlist_manager& get_peerlist_manager(){return m_peerlist;}
     void delete_connections(size_t count);
-    virtual bool block_ip(uint32_t adress, time_t seconds = P2P_IP_BLOCKTIME);
-    virtual bool unblock_ip(uint32_t address);
-    virtual std::map<uint32_t, time_t> get_blocked_ips() { CRITICAL_REGION_LOCAL(m_blocked_ips_lock); return m_blocked_ips; }
+    virtual bool block_host(const epee::net_utils::network_address &adress, time_t seconds = P2P_IP_BLOCKTIME);
+    virtual bool unblock_host(const epee::net_utils::network_address &address);
+    virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
   private:
     const std::vector<std::string> m_seed_nodes_list =
     { "seeds.moneroseeds.se"
@@ -186,11 +186,11 @@ namespace nodetool
     virtual bool drop_connection(const epee::net_utils::connection_context_base& context);
     virtual void request_callback(const epee::net_utils::connection_context_base& context);
     virtual void for_each_connection(std::function<bool(typename t_payload_net_handler::connection_context&, peerid_type, uint32_t)> f);
-    virtual bool add_ip_fail(uint32_t address);
+    virtual bool add_host_fail(const epee::net_utils::network_address &address);
     //----------------- i_connection_filter  --------------------------------------------------------
-    virtual bool is_remote_ip_allowed(uint32_t adress);
+    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address);
     //-----------------------------------------------------------------------------------------------
-    bool parse_peer_from_string(nodetool::net_address& pe, const std::string& node_addr);
+    bool parse_peer_from_string(epee::net_utils::network_address& pe, const std::string& node_addr, uint16_t default_port = 0);
     bool handle_command_line(
         const boost::program_options::variables_map& vm
       );
@@ -209,18 +209,18 @@ namespace nodetool
 
     bool make_new_connection_from_anchor_peerlist(const std::vector<anchor_peerlist_entry>& anchor_peerlist);
     bool make_new_connection_from_peerlist(bool use_white_list);
-    bool try_to_connect_and_handshake_with_new_peer(const net_address& na, bool just_take_peerlist = false, uint64_t last_seen_stamp = 0, PeerType peer_type = white, uint64_t first_seen_stamp = 0);
+    bool try_to_connect_and_handshake_with_new_peer(const epee::net_utils::network_address& na, bool just_take_peerlist = false, uint64_t last_seen_stamp = 0, PeerType peer_type = white, uint64_t first_seen_stamp = 0);
     size_t get_random_index_with_fixed_probability(size_t max_index);
     bool is_peer_used(const peerlist_entry& peer);
     bool is_peer_used(const anchor_peerlist_entry& peer);
-    bool is_addr_connected(const net_address& peer);
+    bool is_addr_connected(const epee::net_utils::network_address& peer);
     template<class t_callback>
     bool try_ping(basic_node_data& node_data, p2p_connection_context& context, t_callback cb);
     bool try_get_support_flags(const p2p_connection_context& context, std::function<void(p2p_connection_context&, const uint32_t&)> f);
     bool make_expected_connections_count(PeerType peer_type, size_t expected_connections);
-    void cache_connect_fail_info(const net_address& addr);
-    bool is_addr_recently_failed(const net_address& addr);
-    bool is_priority_node(const net_address& na);
+    void cache_connect_fail_info(const epee::net_utils::network_address& addr);
+    bool is_addr_recently_failed(const epee::net_utils::network_address& addr);
+    bool is_priority_node(const epee::net_utils::network_address& na);
     std::set<std::string> get_seed_nodes(bool testnet) const;
 
     template <class Container>
@@ -236,9 +236,9 @@ namespace nodetool
     bool set_rate_down_limit(const boost::program_options::variables_map& vm, int64_t limit);
     bool set_rate_limit(const boost::program_options::variables_map& vm, int64_t limit);
 
-    bool has_too_many_connections(const uint32_t ip);
+    bool has_too_many_connections(const epee::net_utils::network_address &address);
 
-    bool check_connection_and_handshake_with_peer(const net_address& na, uint64_t last_seen_stamp);
+    bool check_connection_and_handshake_with_peer(const epee::net_utils::network_address& na, uint64_t last_seen_stamp);
     bool gray_peerlist_housekeeping();
 
     void kill() { ///< will be called e.g. from deinit()
@@ -308,23 +308,23 @@ namespace nodetool
 #ifdef ALLOW_DEBUG_COMMANDS
     uint64_t m_last_stat_request_time;
 #endif
-    std::list<net_address>   m_priority_peers;
-    std::vector<net_address> m_exclusive_peers;
-    std::vector<net_address> m_seed_nodes;
+    std::list<epee::net_utils::network_address>   m_priority_peers;
+    std::vector<epee::net_utils::network_address> m_exclusive_peers;
+    std::vector<epee::net_utils::network_address> m_seed_nodes;
     std::list<nodetool::peerlist_entry> m_command_line_peers;
     uint64_t m_peer_livetime;
     //keep connections to initiate some interactions
     net_server m_net_server;
     boost::uuids::uuid m_network_id;
 
-    std::map<net_address, time_t> m_conn_fails_cache;
+    std::map<epee::net_utils::network_address, time_t> m_conn_fails_cache;
     epee::critical_section m_conn_fails_cache_lock;
 
-    epee::critical_section m_blocked_ips_lock;
-    std::map<uint32_t, time_t> m_blocked_ips;
+    epee::critical_section m_blocked_hosts_lock;
+    std::map<std::string, time_t> m_blocked_hosts;
 
-    epee::critical_section m_ip_fails_score_lock;
-    std::map<uint32_t, uint64_t> m_ip_fails_score;
+    epee::critical_section m_host_fails_score_lock;
+    std::map<std::string, uint64_t> m_host_fails_score;
 
     bool m_testnet;
   };

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -51,10 +51,10 @@ namespace nodetool
     virtual void request_callback(const epee::net_utils::connection_context_base& context)=0;
     virtual uint64_t get_connections_count()=0;
     virtual void for_each_connection(std::function<bool(t_connection_context&, peerid_type, uint32_t)> f)=0;
-    virtual bool block_ip(uint32_t adress, time_t seconds = 0)=0;
-    virtual bool unblock_ip(uint32_t adress)=0;
-    virtual std::map<uint32_t, time_t> get_blocked_ips()=0;
-    virtual bool add_ip_fail(uint32_t adress)=0;
+    virtual bool block_host(const epee::net_utils::network_address &address, time_t seconds = 0)=0;
+    virtual bool unblock_host(const epee::net_utils::network_address &address)=0;
+    virtual std::map<std::string, time_t> get_blocked_hosts()=0;
+    virtual bool add_host_fail(const epee::net_utils::network_address &address)=0;
   };
 
   template<class t_connection_context>
@@ -93,19 +93,19 @@ namespace nodetool
     {
       return false;
     }
-    virtual bool block_ip(uint32_t adress, time_t seconds)
+    virtual bool block_host(const epee::net_utils::network_address &address, time_t seconds)
     {
       return true;
     }
-    virtual bool unblock_ip(uint32_t adress)
+    virtual bool unblock_host(const epee::net_utils::network_address &address)
     {
       return true;
     }
-    virtual std::map<uint32_t, time_t> get_blocked_ips()
+    virtual std::map<std::string, time_t> get_blocked_hosts()
     {
-      return std::map<uint32_t, time_t>();
+      return std::map<std::string, time_t>();
     }
-    virtual bool add_ip_fail(uint32_t adress)
+    virtual bool add_host_fail(const epee::net_utils::network_address &address)
     {
       return true;
     }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 10
+#define CORE_RPC_VERSION_MINOR 11
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -861,18 +861,23 @@ namespace cryptonote
 
   struct peer {
     uint64_t id;
+    std::string host;
     uint32_t ip;
     uint16_t port;
     uint64_t last_seen;
 
     peer() = default;
 
+    peer(uint64_t id, const std::string &host, uint64_t last_seen)
+      : id(id), host(host), ip(0), port(0), last_seen(last_seen)
+    {}
     peer(uint64_t id, uint32_t ip, uint16_t port, uint64_t last_seen)
-      : id(id), ip(ip), port(port), last_seen(last_seen)
+      : id(id), host(std::to_string(ip)), ip(ip), port(port), last_seen(last_seen)
     {}
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(id)
+      KV_SERIALIZE(host)
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
       KV_SERIALIZE(last_seen)
@@ -1226,10 +1231,12 @@ namespace cryptonote
   {
     struct ban
     {
+      std::string host;
       uint32_t ip;
       uint32_t seconds;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(host)
         KV_SERIALIZE(ip)
         KV_SERIALIZE(seconds)
       END_KV_SERIALIZE_MAP()
@@ -1257,11 +1264,13 @@ namespace cryptonote
   {
     struct ban
     {
+      std::string host;
       uint32_t ip;
       bool ban;
       uint32_t seconds;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(host)
         KV_SERIALIZE(ip)
         KV_SERIALIZE(ban)
         KV_SERIALIZE(seconds)


### PR DESCRIPTION
All code which was using ip and port now uses a new IPv4 object,
subclass of a new network_address class. This will allow easy
addition of I2P addresses later (and also IPv6, etc).
Both old style and new style peer lists are now sent in the P2P
protocol, which is inefficient but allows peers using both
codebases to talk to each other. This will be removed in the
future. No other subclasses than IPv4 exist yet.