### PR TITLE
Speedup print_pool_stats

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1046,6 +1046,12 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  bool core::get_pool_transaction_stats(struct txpool_stats& stats) const
+  {
+    m_mempool.get_transaction_stats(stats);
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::get_pool_transaction(const crypto::hash &id, cryptonote::blobdata& tx) const
   {
     return m_mempool.get_transaction(id, tx);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -411,6 +411,13 @@ namespace cryptonote
      bool get_pool_transaction_hashes(std::vector<crypto::hash>& txs) const;
 
      /**
+      * @copydoc tx_memory_pool::get_transactions
+      *
+      * @note see tx_memory_pool::get_transactions
+      */
+     bool get_pool_transaction_stats(struct txpool_stats& stats) const;
+
+     /**
       * @copydoc tx_memory_pool::get_transaction
       *
       * @note see tx_memory_pool::get_transaction

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -243,6 +243,13 @@ namespace cryptonote
     void get_transaction_hashes(std::vector<crypto::hash>& txs) const;
 
     /**
+     * @brief get a summary statistics of all transaction hashes in the pool
+     *
+     * @param stats return-by-reference the pool statistics
+     */
+    void get_transaction_stats(struct txpool_stats& stats) const;
+
+    /**
      * @brief get information about all transactions and key images in the pool
      *
      * see documentation on tx_info and spent_key_image_info for more details

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -911,57 +911,35 @@ bool t_rpc_command_executor::print_transaction_pool_short() {
 }
 
 bool t_rpc_command_executor::print_transaction_pool_stats() {
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL::request req;
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL::response res;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_STATS::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_STATS::response res;
 
-  std::string fail_message = "Problem fetching transaction pool";
+  std::string fail_message = "Problem fetching transaction pool stats";
 
   if (m_is_rpc)
   {
-    if (!m_rpc_client->rpc_request(req, res, "/get_transaction_pool", fail_message.c_str()))
+    if (!m_rpc_client->rpc_request(req, res, "/get_transaction_pool_stats", fail_message.c_str()))
     {
       return true;
     }
   }
   else
   {
-    if (!m_rpc_server->on_get_transaction_pool(req, res) || res.status != CORE_RPC_STATUS_OK)
+    memset(&res.pool_stats, 0, sizeof(res.pool_stats));
+    if (!m_rpc_server->on_get_transaction_pool_stats(req, res) || res.status != CORE_RPC_STATUS_OK)
     {
       tools::fail_msg_writer() << make_error(fail_message, res.status);
       return true;
     }
   }
 
-  size_t n_transactions = res.transactions.size();
-  size_t bytes = 0, min_bytes = 0, max_bytes = 0;
-  size_t n_not_relayed = 0;
-  uint64_t fee = 0;
-  uint64_t oldest = 0;
-  size_t n_10m = 0;
-  size_t n_failing = 0;
+  size_t n_transactions = res.pool_stats.txs_total;
   const uint64_t now = time(NULL);
-  for (const auto &tx_info: res.transactions)
-  {
-    bytes += tx_info.blob_size;
-    if (min_bytes == 0 || tx_info.blob_size < min_bytes)
-      min_bytes = tx_info.blob_size;
-    if (tx_info.blob_size > max_bytes)
-      max_bytes = tx_info.blob_size;
-    if (!tx_info.relayed)
-      n_not_relayed++;
-    fee += tx_info.fee;
-    if (oldest == 0 || tx_info.receive_time < oldest)
-      oldest = tx_info.receive_time;
-    if (tx_info.receive_time < now - 600)
-      n_10m++;
-    if (tx_info.last_failed_height)
-      ++n_failing;
-  }
-  size_t avg_bytes = n_transactions ? bytes / n_transactions : 0;
+  size_t avg_bytes = n_transactions ? res.pool_stats.bytes_total / n_transactions : 0;
 
-  tools::msg_writer() << n_transactions << " tx(es), " << bytes << " bytes total (min " << min_bytes << ", max " << max_bytes << ", avg " << avg_bytes << ")" << std::endl
-      << "fees " << cryptonote::print_money(fee) << " (avg " << cryptonote::print_money(n_transactions ? fee / n_transactions : 0) << " per tx" << ", " << cryptonote::print_money(bytes ? fee / bytes : 0) << " per byte )" << std::endl
-      << n_not_relayed << " not relayed, " << n_failing << " failing, " << n_10m << " older than 10 minutes (oldest " << (oldest == 0 ? "-" : get_human_time_ago(oldest, now)) << ")" << std::endl;
+  tools::msg_writer() << n_transactions << " tx(es), " << res.pool_stats.bytes_total << " bytes total (min " << res.pool_stats.bytes_min << ", max " << res.pool_stats.bytes_max << ", avg " << avg_bytes << ")" << std::endl
+      << "fees " << cryptonote::print_money(res.pool_stats.fee_total) << " (avg " << cryptonote::print_money(n_transactions ? res.pool_stats.fee_total / n_transactions : 0) << " per tx" << ", " << cryptonote::print_money(res.pool_stats.bytes_total ? res.pool_stats.fee_total / res.pool_stats.bytes_total : 0) << " per byte )" << std::endl
+      << res.pool_stats.num_not_relayed << " not relayed, " << res.pool_stats.num_failing << " failing, " << res.pool_stats.num_10m << " older than 10 minutes (oldest " << (res.pool_stats.oldest == 0 ? "-" : get_human_time_ago(res.pool_stats.oldest, now)) << ")" << std::endl;
 
   return true;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -797,6 +797,14 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_transaction_pool_stats(const COMMAND_RPC_GET_TRANSACTION_POOL_STATS::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_STATS::response& res)
+  {
+    CHECK_CORE_BUSY();
+    m_core.get_pool_transaction_stats(res.pool_stats);
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res)
   {
     // FIXME: replace back to original m_p2p.send_stop_signal() after

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -93,6 +93,7 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/set_log_categories", on_set_log_categories, COMMAND_RPC_SET_LOG_CATEGORIES, !m_restricted)
       MAP_URI_AUTO_JON2("/get_transaction_pool", on_get_transaction_pool, COMMAND_RPC_GET_TRANSACTION_POOL)
       MAP_URI_AUTO_JON2("/get_transaction_pool_hashes.bin", on_get_transaction_pool_hashes, COMMAND_RPC_GET_TRANSACTION_POOL_HASHES)
+      MAP_URI_AUTO_JON2("/get_transaction_pool_stats", on_get_transaction_pool_stats, COMMAND_RPC_GET_TRANSACTION_POOL_STATS)
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
@@ -148,6 +149,7 @@ namespace cryptonote
     bool on_set_log_categories(const COMMAND_RPC_SET_LOG_CATEGORIES::request& req, COMMAND_RPC_SET_LOG_CATEGORIES::response& res);
     bool on_get_transaction_pool(const COMMAND_RPC_GET_TRANSACTION_POOL::request& req, COMMAND_RPC_GET_TRANSACTION_POOL::response& res);
     bool on_get_transaction_pool_hashes(const COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::response& res);
+    bool on_get_transaction_pool_stats(const COMMAND_RPC_GET_TRANSACTION_POOL_STATS::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_STATS::response& res);
     bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
     bool on_out_peers(const COMMAND_RPC_OUT_PEERS::request& req, COMMAND_RPC_OUT_PEERS::response& res);
     bool on_start_save_graph(const COMMAND_RPC_START_SAVE_GRAPH::request& req, COMMAND_RPC_START_SAVE_GRAPH::response& res);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 10
+#define CORE_RPC_VERSION_MINOR 11
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1043,6 +1043,51 @@ namespace cryptonote
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(tx_hashes)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
+  struct txpool_stats
+  {
+    uint64_t bytes_total;
+    uint32_t bytes_min;
+    uint32_t bytes_max;
+    uint64_t fee_total;
+    uint64_t oldest;
+    uint32_t txs_total;
+    uint32_t num_failing;
+    uint32_t num_10m;
+    uint32_t num_not_relayed;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(bytes_total)
+      KV_SERIALIZE(bytes_min)
+      KV_SERIALIZE(bytes_max)
+      KV_SERIALIZE(fee_total)
+      KV_SERIALIZE(oldest)
+      KV_SERIALIZE(txs_total)
+      KV_SERIALIZE(num_failing)
+      KV_SERIALIZE(num_10m)
+      KV_SERIALIZE(num_not_relayed)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  struct COMMAND_RPC_GET_TRANSACTION_POOL_STATS
+  {
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      txpool_stats pool_stats;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(pool_stats)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
Since we're just counting txs, there's no reason to deserialize all the blobs.
Add a new get_transaction_pool_stats RPC that just returns the statistics.

Original code:
```
time ./monerod print_pool_stats
511 tx(es), 128702430 bytes total (min 13254, max 258312, avg 251863)
fees 148.600494060000 (avg 0.290803315185 per tx, 0.000001154605 per byte )
0 not relayed, 0 failing, 462 older than 10 minutes (oldest 3 hours ago)


real    0m12.368s
user    0m1.720s
sys     0m0.733s
```
New code:
```
time ./m2 print_pool_stats
513 tx(es), 128728942 bytes total (min 13254, max 258312, avg 250933)
fees 148.631392460000 (avg 0.289729809863 per tx, 0.000001154607 per byte )
0 not relayed, 0 failing, 462 older than 10 minutes (oldest 3 hours ago)


real    0m0.006s
user    0m0.003s
sys     0m0.000s
```