### PR TITLE
Don't copy blockchain for coinbase_tx_sum

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1353,10 +1353,10 @@ public:
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const = 0;
 
   /**
-   * @brief runs a function over all blocks stored
+   * @brief runs a function over a range of blocks
    *
-   * The subclass should run the passed function for each block it has
-   * stored, passing (block_height, block_hash, block) as its parameters.
+   * The subclass should run the passed function for each block in the
+   * specified range, passing (block_height, block_hash, block) as its parameters.
    *
    * If any call to the function returns false, the subclass should return
    * false.  Otherwise, the subclass returns true.
@@ -1364,11 +1364,13 @@ public:
    * The subclass should throw DB_ERROR if any of the expected values are
    * not found.  Current implementations simply return false.
    *
+   * @param h1 the start height
+   * @param h2 the end height
    * @param std::function fn the function to run
    *
    * @return false if the function returns false for any block, otherwise true
    */
-  virtual bool for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const = 0;
+  virtual bool for_blocks_range(const uint64_t& h1, const uint64_t& h2, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const = 0;
 
   /**
    * @brief runs a function over all transactions stored

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2380,7 +2380,7 @@ bool BlockchainLMDB::for_all_key_images(std::function<bool(const crypto::key_ima
   return ret;
 }
 
-bool BlockchainLMDB::for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)> f) const
+bool BlockchainLMDB::for_blocks_range(const uint64_t& h1, const uint64_t& h2, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)> f) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
@@ -2392,7 +2392,15 @@ bool BlockchainLMDB::for_all_blocks(std::function<bool(uint64_t, const crypto::h
   MDB_val v;
   bool ret = true;
 
-  MDB_cursor_op op = MDB_FIRST;
+  MDB_cursor_op op;
+  if (h1)
+  {
+    MDB_val_set(k, h1);
+	op = MDB_SET;
+  } else
+  {
+    op = MDB_FIRST;
+  }
   while (1)
   {
     int ret = mdb_cursor_get(m_cur_blocks, &k, &v, op);
@@ -2414,6 +2422,8 @@ bool BlockchainLMDB::for_all_blocks(std::function<bool(uint64_t, const crypto::h
       ret = false;
       break;
     }
+    if (height >= h2)
+      break;
   }
 
   TXN_POSTFIX_RDONLY();

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -249,7 +249,7 @@ public:
   virtual bool for_all_txpool_txes(std::function<bool(const crypto::hash&, const txpool_tx_meta_t&, const cryptonote::blobdata*)> f, bool include_blob = false) const;
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const;
-  virtual bool for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const;
+  virtual bool for_blocks_range(const uint64_t& h1, const uint64_t& h2, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const;
   virtual bool for_all_transactions(std::function<bool(const crypto::hash&, const cryptonote::transaction&)>) const;
   virtual bool for_all_outputs(std::function<bool(uint64_t amount, const crypto::hash &tx_hash, size_t tx_idx)> f) const;
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4164,9 +4164,9 @@ bool Blockchain::for_all_key_images(std::function<bool(const crypto::key_image&)
   return m_db->for_all_key_images(f);
 }
 
-bool Blockchain::for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const block&)> f) const
+bool Blockchain::for_blocks_range(const uint64_t& h1, const uint64_t& h2, std::function<bool(uint64_t, const crypto::hash&, const block&)> f) const
 {
-  return m_db->for_all_blocks(f);
+  return m_db->for_blocks_range(h1, h2, f);
 }
 
 bool Blockchain::for_all_transactions(std::function<bool(const crypto::hash&, const cryptonote::transaction&)> f) const

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -790,13 +790,15 @@ namespace cryptonote
     bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const;
 
     /**
-     * @brief perform a check on all blocks in the blockchain
+     * @brief perform a check on all blocks in the blockchain in the given range
      *
+     * @param h1 the start height
+     * @param h2 the end height
      * @param std::function the check to perform, pass/fail
      *
      * @return false if any block fails the check, otherwise true
      */
-    bool for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const block&)>) const;
+    bool for_blocks_range(const uint64_t& h1, const uint64_t& h2, std::function<bool(uint64_t, const crypto::hash&, const block&)>) const;
 
     /**
      * @brief perform a check on all transactions in the blockchain

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -713,12 +713,13 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   std::pair<uint64_t, uint64_t> core::get_coinbase_tx_sum(const uint64_t start_offset, const size_t count)
   {
-    std::list<block> blocks;
     uint64_t emission_amount = 0;
     uint64_t total_fee_amount = 0;
-    this->get_blocks(start_offset, count, blocks);
-    for(auto& b: blocks)
+    if (count)
     {
+      const uint64_t end = start_offset + count - 1;
+      m_blockchain_storage.for_blocks_range(start_offset, end,
+        [this, &emission_amount, &total_fee_amount](uint64_t, const crypto::hash& hash, const block& b){
       std::list<transaction> txs;
       std::list<crypto::hash> missed_txs;
       uint64_t coinbase_amount = get_outs_money_amount(b.miner_tx);
@@ -731,6 +732,8 @@ namespace cryptonote
       
       emission_amount += coinbase_amount - tx_fee_amount;
       total_fee_amount += tx_fee_amount;
+      return true;
+      });
     }
 
     return std::pair<uint64_t, uint64_t>(emission_amount, total_fee_amount);

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -106,7 +106,7 @@ public:
   virtual void remove_spent_key(const crypto::key_image& k_image) {}
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const { return true; }
-  virtual bool for_all_blocks(std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const { return true; }
+  virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const { return true; }
   virtual bool for_all_transactions(std::function<bool(const crypto::hash&, const cryptonote::transaction&)>) const { return true; }
   virtual bool for_all_outputs(std::function<bool(uint64_t amount, const crypto::hash &tx_hash, size_t tx_idx)> f) const { return true; }
   virtual bool is_read_only() const { return false; }


### PR DESCRIPTION
Changed Blockchain::for_all_blocks() to for_blocks_range()
Operate on blockchain in-place instead of building a copy first.

Trying to use print_coinbase_tx_sum on the entire blockchain would kill my daemon on VPS with out of memory because it would try to build an in-memory copy of the entire blockchain before processing. Now the command still takes a long time to run but it actually finishes instead of killing the server.