### PR TITLE
Add histogram to poolstats

### DIFF
--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 target_link_libraries(epee
   PUBLIC
-    crypto
+    cncrypto
     easylogging
     ${Boost_FILESYSTEM_LIBRARY}
   PRIVATE

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 11
+#define CORE_RPC_VERSION_MINOR 12
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1047,6 +1047,17 @@ namespace cryptonote
     };
   };
 
+  struct txpool_histo
+  {
+    uint32_t txs;
+    uint64_t bytes;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(txs)
+      KV_SERIALIZE(bytes)
+    END_KV_SERIALIZE_MAP()
+  };
+
   struct txpool_stats
   {
     uint64_t bytes_total;
@@ -1058,6 +1069,8 @@ namespace cryptonote
     uint32_t num_failing;
     uint32_t num_10m;
     uint32_t num_not_relayed;
+    uint64_t histo_98pc;
+    std::vector<txpool_histo> histo;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(bytes_total)
@@ -1069,6 +1082,8 @@ namespace cryptonote
       KV_SERIALIZE(num_failing)
       KV_SERIALIZE(num_10m)
       KV_SERIALIZE(num_not_relayed)
+      KV_SERIALIZE(histo_98pc)
+      KV_SERIALIZE_CONTAINER_POD_AS_BLOB(histo)
     END_KV_SERIALIZE_MAP()
   };
 


### PR DESCRIPTION
If there's more than 1 tx in the pool, print a histogram of the age distribution of the txes, using up to 10 bins.

The pool's not very interesting at the moment:

```
print_pool_stats
40 tx(es), 10017447 bytes total (min 13255, max 257878, avg 250436)
fees 11.636061160000 (avg 0.290901529000 per tx, 0.000001161579 per byte )
0 not relayed, 0 failing, 39 older than 10 minutes (oldest 23 hours ago)

   Age      Txes       Bytes
00:00:00       1       13255
02:20:16       0           0
04:40:32       0           0
07:00:48       0           0
09:21:04       0           0
11:41:20       0           0
14:01:36       0           0
16:21:52       0           0
18:42:08      32     8209052
21:02:24       7     1795140
```
