### PR TITLE
Prevent crash if performing certain actions before wallet is initialized

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -511,6 +511,7 @@ bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::
 {
   if(m_http_client.is_connected())
     m_http_client.disconnect();
+  m_is_initialized = true;
   m_upper_transaction_size_limit = upper_transaction_size_limit;
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
@@ -1845,6 +1846,7 @@ void wallet2::detach_blockchain(uint64_t height)
 //----------------------------------------------------------------------------------------------------
 bool wallet2::deinit()
 {
+  m_is_initialized=false;
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -2361,6 +2363,8 @@ bool wallet2::prepare_file_names(const std::string& file_path)
 //----------------------------------------------------------------------------------------------------
 bool wallet2::check_connection(uint32_t *version, uint32_t timeout)
 {
+  THROW_WALLET_EXCEPTION_IF(!m_is_initialized, error::wallet_not_initialized);
+
   boost::lock_guard<boost::mutex> lock(m_daemon_rpc_mutex);
 
   if(!m_http_client.is_connected())

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -105,7 +105,7 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_is_initialized(false),m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
 
   public:
     static const char* tr(const char* str);
@@ -129,7 +129,7 @@ namespace tools
     //! Just parses variables.
     static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm);
 
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
 
     struct transfer_details
     {
@@ -695,6 +695,7 @@ namespace tools
     uint32_t m_min_output_count;
     uint64_t m_min_output_value;
     bool m_merge_destinations;
+    bool m_is_initialized;
     NodeRPCProxy m_node_rpc_proxy;
     std::unordered_set<crypto::hash> m_scanned_pool_txs[2];
   };

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -49,6 +49,7 @@ namespace tools
     //     wallet_runtime_error *
     //       wallet_internal_error
     //         unexpected_txin_type
+    //         wallet_not_initialized
     //   std::logic_error
     //     wallet_logic_error *
     //       file_exists
@@ -176,6 +177,15 @@ namespace tools
     private:
       cryptonote::transaction m_tx;
     };
+    //----------------------------------------------------------------------------------------------------
+    struct wallet_not_initialized : public wallet_internal_error
+    {
+      explicit wallet_not_initialized(std::string&& loc)
+        : wallet_internal_error(std::move(loc), "wallet is not initialized")
+      {
+      }
+    };
+
     //----------------------------------------------------------------------------------------------------
     const char* const file_error_messages[] = {
       "file already exists",


### PR DESCRIPTION
Prevents crash if using libwallet and you don't call init() on the wallet before you do certain things such as refresh.

Sample crash trace file:
https://paste.fedoraproject.org/paste/0LYsQNJA6UEPycFY7ccJSl5M1UNdIGYhyRLivL9gydE=