### PR TITLE
Issue1947

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -56,6 +56,7 @@ namespace net_utils
     const uint32_t m_remote_port;
     const bool     m_is_income;
     const time_t   m_started;
+    bool     m_in_timedsync;
     time_t   m_last_recv;
     time_t   m_last_send;
     uint64_t m_recv_cnt;
@@ -72,6 +73,7 @@ namespace net_utils
                                             m_remote_port(remote_port),
                                             m_is_income(is_income),
                                             m_started(time(NULL)),
+                                            m_in_timedsync(false),
                                             m_last_recv(last_recv),
                                             m_last_send(last_send),
                                             m_recv_cnt(recv_cnt),
@@ -85,6 +87,7 @@ namespace net_utils
                                m_remote_port(0),
                                m_is_income(false),
                                m_started(time(NULL)),
+                               m_in_timedsync(false),
                                m_last_recv(0),
                                m_last_send(0),
                                m_recv_cnt(0),

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 target_link_libraries(epee
   PUBLIC
-    crypto
+    cncrypto
     easylogging
     ${Boost_FILESYSTEM_LIBRARY}
   PRIVATE

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -814,6 +814,7 @@ namespace nodetool
     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_TIMED_SYNC::response>(context_.m_connection_id, COMMAND_TIMED_SYNC::ID, arg, m_net_server.get_config_object(),
       [this](int code, const typename COMMAND_TIMED_SYNC::response& rsp, p2p_connection_context& context)
     {
+      context.m_in_timedsync = false;
       if(code < 0)
       {
         LOG_ERROR_CC(context, "COMMAND_TIMED_SYNC invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
@@ -1300,10 +1301,13 @@ namespace nodetool
     MDEBUG("STARTED PEERLIST IDLE HANDSHAKE");
     typedef std::list<std::pair<epee::net_utils::connection_context_base, peerid_type> > local_connects_type;
     local_connects_type cncts;
-    m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
+    m_net_server.get_config_object().foreach_connection([&](p2p_connection_context& cntxt)
     {
-      if(cntxt.peer_id)
+      if(cntxt.peer_id && !cntxt.m_in_timedsync)
+      {
+        cntxt.m_in_timedsync = true;
         cncts.push_back(local_connects_type::value_type(cntxt, cntxt.peer_id));//do idle sync only with handshaked connections
+      }
       return true;
     });
 


### PR DESCRIPTION
Proposed fix for issue #1947 
1) Don't timeout a request that is making substantial progress, even if slow. If at least 512 bytes are received, reset the timer to allow the request as much time as needed to complete.
2) Don't issue a new timedsync request while one is already in progress. The timedsync is issued every minute while an in-progress request can take up to two minutes. If you have a request that can barely complete in two minutes, but a new request is issued on top of it, that new request's timer starts from the moment it was submitted, but it cannot receive a response until the running request finishes. Inevitably the new request will timeout and close the connection, thus nullifying any progress the running request had made.