### PR TITLE
net_utils_base: added missing template keyword

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -128,7 +128,7 @@ namespace net_utils
 				case ipv4_network_address::ID:
 					if (!is_store)
 						const_cast<network_address&>(this_ref).reset(new ipv4_network_address(0, 0));
-					KV_SERIALIZE(as<ipv4_network_address>());
+					KV_SERIALIZE(template as<ipv4_network_address>());
 					break;
 				default: MERROR("Unsupported network address type: " << type); return false;
 			}


### PR DESCRIPTION
I observed this compile error with my macOS Sierra after the merging of PR #2052 :

```
monero/contrib/epee/include/net/net_utils_base.h:131:19: error: use 'template' keyword
      to treat 'as' as a dependent template name
                                        KV_SERIALIZE(as<ipv4_network_address>());
                                                     ^
                                                     template 
```

Adding the `template` keyword solves the problem.
https://stackoverflow.com/a/3786481