### PR TITLE
Add readline improvements

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -315,7 +315,11 @@ namespace epee
       if (!m_prompt.empty())
       {
 #ifdef HAVE_READLINE
-        m_stdin_reader.get_readline_buffer().set_prompt(m_prompt);
+        std::string color_prompt = "\001\033[1;33m\002" + m_prompt;
+        if (' ' != m_prompt.back())
+          color_prompt += " ";
+        color_prompt += "\001\033[0m\002";
+        m_stdin_reader.get_readline_buffer().set_prompt(color_prompt);
 #else
         epee::set_console_color(epee::console_color_yellow, true);
         std::cout << m_prompt;

--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -168,8 +168,11 @@ static int handle_enter(int x, int y)
   }
   free(line);
   
-  rl_set_prompt(last_prompt.c_str());
-  rl_redisplay();
+  if(last_line != "exit")
+  {
+    rl_set_prompt(last_prompt.c_str());
+    rl_redisplay();
+  }
   
   rl_done = 1;
   return 0;


### PR DESCRIPTION
Color prompt now working and no reprompting on exit command.
Also incorporated #2094 for OSX compile fix.