### PR TITLE
electrum-words: fix seed mistakenly thought to be old style

### DIFF
--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -422,10 +422,11 @@ namespace crypto
      * \param  seed The seed to check (a space delimited concatenated word list)
      * \return      true if the seed passed is a old style seed false if not.
      */
-    bool get_is_old_style_seed(const std::string &seed)
+    bool get_is_old_style_seed(std::string seed)
     {
       std::vector<std::string> word_list;
-      boost::split(word_list, seed, boost::is_any_of(" "));
+      boost::algorithm::trim(seed);
+      boost::split(word_list, seed, boost::is_any_of(" "), boost::token_compress_on);
       return word_list.size() != (seed_length + 1);
     }
 

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -92,7 +92,7 @@ namespace crypto
      * \param  seed The seed to check (a space delimited concatenated word list)
      * \return      true if the seed passed is a old style seed false if not.
      */
-    bool get_is_old_style_seed(const std::string &seed);
+    bool get_is_old_style_seed(std::string seed);
   }
 }
 


### PR DESCRIPTION
It'd see "empty" words due to extraneous spaces