### PR TITLE
readline_buffer: fix busy wait

### DIFF
--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -122,7 +122,7 @@ static int process_input()
   struct timeval t;
   
   t.tv_sec = 0;
-  t.tv_usec = 0;
+  t.tv_usec = 1000;
   
   FD_ZERO(&fds);
   FD_SET(STDIN_FILENO, &fds);


### PR DESCRIPTION
It'd eat up a core constantly, due to spending its time jumping
back and forth between userland and kernel. We now wait for up
to a millisecond in kernel, which will be transparent to the user
and drop to idle most of the time.