### PR TITLE
Fix on_transfer RPC incorrect logging info

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -422,7 +422,7 @@ namespace tools
     std::vector<cryptonote::tx_destination_entry> dsts;
     std::vector<uint8_t> extra;
 
-    LOG_PRINT_L3("on_transfer_split starts");
+    LOG_PRINT_L3("on_transfer starts");
     if (!m_wallet) return not_open(er);
     if (m_wallet->restricted())
     {


### PR DESCRIPTION
"on_transfer" incorrectly logs as "on_transfer_split".