### PR TITLE
Fix #2120: return per-tx amount in transfer_split RPC call.

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -509,6 +509,7 @@ namespace tools
     try
     {
       uint64_t mixin = req.mixin;
+      uint64_t ptx_amount;
       if (mixin < 2 && m_wallet->use_fork_rules(2, 10)) {
         LOG_PRINT_L1("Requested mixin " << req.mixin << " too low for hard fork 2, using 2");
         mixin = 2;
@@ -530,6 +531,12 @@ namespace tools
         {
           res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key));
         }
+        // Compute amount leaving wallet in tx. By convention dests does not include change outputs
+        ptx_amount = 0;
+        for(auto & dt: ptx.dests)
+          ptx_amount += dt.amount;
+        res.amount_list.push_back(ptx_amount);
+
         res.fee_list.push_back(ptx.fee);
       }
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -180,11 +180,13 @@ namespace wallet_rpc
     {
       std::list<std::string> tx_hash_list;
       std::list<std::string> tx_key_list;
+      std::list<uint64_t> amount_list;
       std::list<uint64_t> fee_list;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
         KV_SERIALIZE(tx_key_list)
+        KV_SERIALIZE(amount_list)
         KV_SERIALIZE(fee_list)
       END_KV_SERIALIZE_MAP()
     };


### PR DESCRIPTION
Also very minor cleaning in log msgs and tab vs. space.