### PR TITLE
Remove typeid use in the network_address

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -115,10 +115,9 @@ namespace net_utils
 		std::string host_str() const { return (*this) ? (*this)->host_str() : "<none>"; }
 		bool is_loopback() const { return (*this)->is_loopback(); }
 		bool is_local() const { return (*this)->is_local(); }
-		const std::type_info &type() const { return typeid(**this); }
 		uint8_t get_type_id() const { return (*this)->get_type_id(); }
-		template<typename Type> Type &as() { if (type() != typeid(Type)) throw std::runtime_error("Bad type"); return *(Type*)get(); }
-		template<typename Type> const Type &as() const { if (type() != typeid(Type)) throw std::runtime_error("Bad type"); return *(const Type*)get(); }
+		template<typename Type> Type &as() { if (get_type_id() != Type::ID) throw std::runtime_error("Bad type"); return *(Type*)get(); }
+		template<typename Type> const Type &as() const { if (get_type_id() != Type::ID) throw std::runtime_error("Bad type"); return *(const Type*)get(); }
 
 		BEGIN_KV_SERIALIZE_MAP()
 			uint8_t type = is_store ? this_ref.get_type_id() : 0;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -192,7 +192,7 @@ namespace cryptonote
       cnx.host = cntxt.m_remote_address.host_str();
       cnx.ip = "";
       cnx.port = "";
-      if (cntxt.m_remote_address.type() == typeid(epee::net_utils::ipv4_network_address))
+      if (cntxt.m_remote_address.get_type_id() == epee::net_utils::ipv4_network_address::ID)
       {
         cnx.ip = cnx.host;
         cnx.port = std::to_string(cntxt.m_remote_address.as<epee::net_utils::ipv4_network_address>().port());

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -939,8 +939,8 @@ namespace nodetool
         << (last_seen_stamp ? epee::misc_utils::get_time_interval_string(time(NULL) - last_seen_stamp):"never")
         << ")...");
 
-    CHECK_AND_ASSERT_MES(na.type() == typeid(epee::net_utils::ipv4_network_address), false,
-        "Only IPv4 addresses are supported here, got " << na.type().name());
+    CHECK_AND_ASSERT_MES(na.get_type_id() == epee::net_utils::ipv4_network_address::ID, false,
+        "Only IPv4 addresses are supported here");
     const epee::net_utils::ipv4_network_address &ipv4 = na.as<const epee::net_utils::ipv4_network_address>();
 
     typename net_server::t_connection_context con = AUTO_VAL_INIT(con);
@@ -1004,8 +1004,8 @@ namespace nodetool
                                   << (last_seen_stamp ? epee::misc_utils::get_time_interval_string(time(NULL) - last_seen_stamp):"never")
                                   << ")...");
 
-    CHECK_AND_ASSERT_MES(na.type() == typeid(epee::net_utils::ipv4_network_address), false,
-        "Only IPv4 addresses are supported here, got " << na.type().name());
+    CHECK_AND_ASSERT_MES(na.get_type_id() == epee::net_utils::ipv4_network_address::ID, false,
+        "Only IPv4 addresses are supported here");
     const epee::net_utils::ipv4_network_address &ipv4 = na.as<epee::net_utils::ipv4_network_address>();
 
     typename net_server::t_connection_context con = AUTO_VAL_INIT(con);
@@ -1510,8 +1510,8 @@ namespace nodetool
     if(!node_data.my_port)
       return false;
 
-    CHECK_AND_ASSERT_MES(context.m_remote_address.type() == typeid(epee::net_utils::ipv4_network_address), false,
-        "Only IPv4 addresses are supported here, got " << context.m_remote_address.type().name());
+    CHECK_AND_ASSERT_MES(context.m_remote_address.get_type_id() == epee::net_utils::ipv4_network_address::ID, false,
+        "Only IPv4 addresses are supported here");
 
     const epee::net_utils::network_address na = context.m_remote_address;
     uint32_t actual_ip = na.as<const epee::net_utils::ipv4_network_address>().ip();
@@ -1670,8 +1670,8 @@ namespace nodetool
       //try ping to be sure that we can add this peer to peer_list
       try_ping(arg.node_data, context, [peer_id_l, port_l, context, this]()
       {
-        CHECK_AND_ASSERT_MES(context.m_remote_address.type() == typeid(epee::net_utils::ipv4_network_address), void(),
-            "Only IPv4 addresses are supported here, got " << context.m_remote_address.type().name());
+        CHECK_AND_ASSERT_MES(context.m_remote_address.get_type_id() == epee::net_utils::ipv4_network_address::ID, void(),
+            "Only IPv4 addresses are supported here");
         //called only(!) if success pinged, update local peerlist
         peerlist_entry pe;
         const epee::net_utils::network_address na = context.m_remote_address;

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -36,24 +36,16 @@ namespace boost
 {
   namespace serialization
   {
-    enum { sertype_ipv4_address };
-    static inline uint8_t get_type(const epee::net_utils::network_address &na)
-    {
-      if (na.type() == typeid(epee::net_utils::ipv4_network_address))
-        return sertype_ipv4_address;
-      throw std::runtime_error("Unsupported network address type");
-      return 0;
-    }
     template <class Archive, class ver_type>
     inline void serialize(Archive &a, epee::net_utils::network_address& na, const ver_type ver)
     {
       uint8_t type;
       if (typename Archive::is_saving())
-        type = get_type(na);
+        type = na.get_type_id();
       a & type;
       switch (type)
       {
-        case sertype_ipv4_address:
+        case epee::net_utils::ipv4_network_address::ID:
           if (!typename Archive::is_saving())
             na.reset(new epee::net_utils::ipv4_network_address(0, 0));
           a & na.as<epee::net_utils::ipv4_network_address>();

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -188,7 +188,7 @@ namespace nodetool
           std::list<peerlist_entry_base<network_address_old>> local_peerlist;
           for (const auto &p: this_ref.local_peerlist_new)
           {
-            if (p.adr.type() == typeid(epee::net_utils::ipv4_network_address))
+            if (p.adr.get_type_id() == epee::net_utils::ipv4_network_address::ID)
             {
               const epee::net_utils::network_address  &na = p.adr;
               const epee::net_utils::ipv4_network_address &ipv4 = na.as<const epee::net_utils::ipv4_network_address>();
@@ -247,7 +247,7 @@ namespace nodetool
           std::list<peerlist_entry_base<network_address_old>> local_peerlist;
           for (const auto &p: this_ref.local_peerlist_new)
           {
-            if (p.adr.type() == typeid(epee::net_utils::ipv4_network_address))
+            if (p.adr.get_type_id() == epee::net_utils::ipv4_network_address::ID)
             {
               const epee::net_utils::network_address  &na = p.adr;
               const epee::net_utils::ipv4_network_address &ipv4 = na.as<const epee::net_utils::ipv4_network_address>();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -736,7 +736,7 @@ namespace cryptonote
 
     for (auto & entry : white_list)
     {
-      if (entry.adr.type() == typeid(epee::net_utils::ipv4_network_address))
+      if (entry.adr.get_type_id() == epee::net_utils::ipv4_network_address::ID)
         res.white_list.emplace_back(entry.id, entry.adr.as<epee::net_utils::ipv4_network_address>().ip(),
             entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen);
       else
@@ -745,7 +745,7 @@ namespace cryptonote
 
     for (auto & entry : gray_list)
     {
-      if (entry.adr.type() == typeid(epee::net_utils::ipv4_network_address))
+      if (entry.adr.get_type_id() == epee::net_utils::ipv4_network_address::ID)
         res.gray_list.emplace_back(entry.id, entry.adr.as<epee::net_utils::ipv4_network_address>().ip(),
             entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen);
       else


### PR DESCRIPTION
Since I had to add an ID to the derived classes anyway,
this can be used instead. This removes an apparently
pointless warning from CLANG too.