### PR TITLE
simplewallet: lock idle scope when sweeping

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2751,6 +2751,8 @@ bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &a
      }
   }
 
+  LOCK_IDLE_SCOPE();
+
   try
   {
     // figure out what tx will be necessary


### PR DESCRIPTION
This ensures the chain and related structures can't change
while we're using them