### PR TITLE
Makefile: Add debug-static-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ debug-test:
 
 debug-all:
 	mkdir -p build/debug
-	cd build/debug && cmake -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug ../.. && $(MAKE)
+	cd build/debug && cmake -D BUILD_TESTS=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Debug ../.. && $(MAKE)
+
+debug-static-all:
+	mkdir -p build/debug
+	cd build/debug && cmake -D BUILD_TESTS=ON -D STATIC=ON -D CMAKE_BUILD_TYPE=Debug ../.. && $(MAKE)
 
 cmake-release:
 	mkdir -p build/release


### PR DESCRIPTION
Most of the time, I find this is actually the target I want to build.