### PR TITLE
Add on_get_alt_blocks_hashes RPC call

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -227,6 +227,28 @@ namespace cryptonote
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }
+    bool core_rpc_server::on_get_alt_blocks_hashes(const COMMAND_RPC_GET_ALT_BLOCKS_HASHES::request& req, COMMAND_RPC_GET_ALT_BLOCKS_HASHES::response& res)
+    {
+      CHECK_CORE_BUSY();
+      std::list<block> blks;
+
+      if(!m_core.get_alternative_blocks(blks))
+      {
+          res.status = "Failed";
+          return false;
+      }
+
+      res.blks_hashes.reserve(blks.size());
+
+      for (auto const& blk: blks)
+      {
+          res.blks_hashes.push_back(epee::string_tools::pod_to_hex(get_block_hash(blk)));
+      }
+
+      MDEBUG("on_get_alt_blocks_hashes: " << blks.size() << " blocks " );
+      res.status = CORE_RPC_STATUS_OK;
+      return true;
+  }
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_blocks_by_height(const COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response& res)
   {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -81,6 +81,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/get_outs.bin", on_get_outs_bin, COMMAND_RPC_GET_OUTPUTS_BIN)
       MAP_URI_AUTO_BIN2("/getrandom_rctouts.bin", on_get_random_rct_outs, COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
+      MAP_URI_AUTO_JON2("/get_alt_blocks_hashes", on_get_alt_blocks_hashes, COMMAND_RPC_GET_ALT_BLOCKS_HASHES)
       MAP_URI_AUTO_JON2("/is_key_image_spent", on_is_key_image_spent, COMMAND_RPC_IS_KEY_IMAGE_SPENT)
       MAP_URI_AUTO_JON2("/sendrawtransaction", on_send_raw_tx, COMMAND_RPC_SEND_RAW_TX)
       MAP_URI_AUTO_JON2_IF("/start_mining", on_start_mining, COMMAND_RPC_START_MINING, !m_restricted)
@@ -128,6 +129,7 @@ namespace cryptonote
 
     bool on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAND_RPC_GET_HEIGHT::response& res);
     bool on_get_blocks(const COMMAND_RPC_GET_BLOCKS_FAST::request& req, COMMAND_RPC_GET_BLOCKS_FAST::response& res);
+    bool on_get_alt_blocks_hashes(const COMMAND_RPC_GET_ALT_BLOCKS_HASHES::request& req, COMMAND_RPC_GET_ALT_BLOCKS_HASHES::response& res);
     bool on_get_blocks_by_height(const COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response& res);
     bool on_get_hashes(const COMMAND_RPC_GET_HASHES_FAST::request& req, COMMAND_RPC_GET_HASHES_FAST::response& res);
     bool on_get_transactions(const COMMAND_RPC_GET_TRANSACTIONS::request& req, COMMAND_RPC_GET_TRANSACTIONS::response& res);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 12
+#define CORE_RPC_VERSION_MINOR 13
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -146,6 +146,25 @@ namespace cryptonote
     };
   };
 
+    struct COMMAND_RPC_GET_ALT_BLOCKS_HASHES
+    {
+        struct request
+        {
+            BEGIN_KV_SERIALIZE_MAP()
+            END_KV_SERIALIZE_MAP()
+        };
+
+        struct response
+        {
+            std::vector<std::string> blks_hashes;
+            std::string status;
+
+            BEGIN_KV_SERIALIZE_MAP()
+                KV_SERIALIZE(blks_hashes)
+                KV_SERIALIZE(status)
+            END_KV_SERIALIZE_MAP()
+        };
+    };
   struct COMMAND_RPC_GET_HASHES_FAST
   {
 


### PR DESCRIPTION
The PR is a result of this issue: https://github.com/monero-project/monero/issues/2080

Basically, it adds `get_alt_blocks_hashes` RPC call to get hashes of alternative blocks from the daemon. Currently, only number of alt blocks, through `get_info` RPC could be obtained. Getting actual information about these blocks was not available. 

The rpc call is already running on my development vps for testing. Basic support for viewing the details of the alternative blocks has already been added, thought this new call, to the onion explorer and can be seen here as an example: http://139.162.32.245:8081/altblocks

Any feedback appreciated of possible changes and improvements. 
