### PR TITLE
Fix #2164 histogram output

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -966,7 +966,7 @@ bool t_rpc_command_executor::print_transaction_pool_stats() {
       denom = n-1;
       for (i=0; i<denom; i++)
         times[i] = i * numer / denom;
-      times[i] = res.pool_stats.oldest;
+      times[i] = now - res.pool_stats.oldest;
     } else
     {
       numer = now - res.pool_stats.oldest;


### PR DESCRIPTION
When there are more than 50txs, the timestamp for the last
bin was printed incorrectly. Subtracting "now" was omitted by mistake
in 3fc22e7b78ab1dd409de4f3e8f5bff27be19735b