### PR TITLE
daemon: Add ability to write a PID file

### DIFF
--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -43,6 +43,10 @@ namespace daemonizer
       "detach"
     , "Run as daemon"
     };
+    const command_line::arg_descriptor<std::string> arg_pidfile = {
+      "pidfile"
+    , "File path to write the daemon's PID to (optional, requires --detach)"
+    };
     const command_line::arg_descriptor<bool> arg_non_interactive = {
       "non-interactive"
     , "Run non-interactive"
@@ -55,6 +59,7 @@ namespace daemonizer
     )
   {
     command_line::add_arg(normal_options, arg_detach);
+    command_line::add_arg(normal_options, arg_pidfile);
     command_line::add_arg(normal_options, arg_non_interactive);
   }
 
@@ -80,7 +85,12 @@ namespace daemonizer
     if (command_line::has_arg(vm, arg_detach))
     {
       tools::success_msg_writer() << "Forking to background...";
-      posix::fork();
+      std::string pidfile;
+      if (command_line::has_arg(vm, arg_pidfile))
+      {
+        pidfile = command_line::get_arg(vm, arg_pidfile);
+      }
+      posix::fork(pidfile);
       auto daemon = executor.create_daemon(vm);
       return daemon.run();
     }

--- a/src/daemonizer/posix_fork.h
+++ b/src/daemonizer/posix_fork.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2017, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -27,12 +27,13 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
+#include <string>
 
 #ifndef WIN32
 
 namespace posix {
 
-void fork();
+void fork(const std::string & pidfile);
 
 }
 

--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -8,15 +8,10 @@ Group=monero
 WorkingDirectory=~
 
 Type=forking
-ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf --detach
+PIDFile=/var/run/monerod.pid
 
-# This is necessary because monerod does not yet support
-# writing a PID file, which means systemd tries to guess the PID
-# by default, but it guesses wrong (sometimes, depending on
-# random timing of events), because the daemon forks twice.
-# The ultimate fix is for the daemon to write a PID file, and
-# a workaround is to disable the guessing feature in systemd.
-GuessMainPID=no
+ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf \
+    --detach --pidfile /var/run/monerod.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The PID file will only be written if the daemon is called with the
`--detach` command line argument and a `--pidfile /some/file/path`
argument.