### PR TITLE
cryptonote_protocol: Set send_idle_time in connection_info correctly

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -208,7 +208,7 @@ namespace cryptonote
       cnx.recv_idle_time = timestamp - cntxt.m_last_recv;
 
       cnx.send_count = cntxt.m_send_cnt;
-      cnx.send_idle_time = timestamp;
+      cnx.send_idle_time = timestamp - cntxt.m_last_send;
 
       cnx.state = get_protocol_state_string(cntxt.m_state);
 


### PR DESCRIPTION
This fixes a small bug that is visible in the daemon when using the *print_cn* ("print connections") command where for all connections the send idle time was simply displayed as current time.