### PR TITLE
wallet2: fix temporarily missing incoming tx when being mined

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -585,7 +585,7 @@ namespace tools
     uint64_t import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, uint64_t &spent, uint64_t &unspent);
     uint64_t import_key_images(const std::string &filename, uint64_t &spent, uint64_t &unspent);
 
-    void update_pool_state();
+    void update_pool_state(bool refreshed = false);
 
     std::string encrypt(const std::string &plaintext, const crypto::secret_key &skey, bool authenticated = true) const;
     std::string encrypt_with_view_secret_key(const std::string &plaintext, bool authenticated = true) const;


### PR DESCRIPTION
When scanning the txpool without having first updated the
blockchain, the tx would be seen as neither in the txpool
nor the chain, and removed, so it'd only reappear once the
chain is refreshed, and the tx seen in a block.