### PR TITLE
core: randomly shuffle outputs

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -265,7 +265,7 @@ namespace cryptonote
 
     // "Shuffle" outs
     std::vector<tx_destination_entry> shuffled_dsts(destinations);
-    std::sort(shuffled_dsts.begin(), shuffled_dsts.end(), [](const tx_destination_entry& de1, const tx_destination_entry& de2) { return de1.amount < de2.amount; } );
+    std::random_shuffle(shuffled_dsts.begin(), shuffled_dsts.end(), [](int i) { return crypto::rand<int>() % i; });
 
     uint64_t summary_outs_money = 0;
     //fill outputs


### PR DESCRIPTION
They used to be sorted by amount, which was fine before rct,
but is now suboptimal, since amounts are not known anymore.
In particular, it would give a recipient knowledge of whether
change was higher or lower than the amount received.