### PR TITLE
network_throttle: remove unneeded heap allocations

### DIFF
--- a/src/p2p/network_throttle.cpp
+++ b/src/p2p/network_throttle.cpp
@@ -77,7 +77,8 @@ int network_throttle_manager::xxx;
 // ================================================================================================
 // methods:
 i_network_throttle & network_throttle_manager::get_global_throttle_in() { 
-	boost::call_once(m_once_get_global_throttle_in, [] { m_obj_get_global_throttle_in.reset(new network_throttle("in/all","<<< global-IN",10)); }	);
+	static network_throttle nt("in/all","<<< global-IN",10);
+	boost::call_once(m_once_get_global_throttle_in, [] { m_obj_get_global_throttle_in.reset(&nt); } );
 	return * m_obj_get_global_throttle_in;
 }
 boost::once_flag network_throttle_manager::m_once_get_global_throttle_in;
@@ -86,7 +87,8 @@ std::unique_ptr<i_network_throttle> network_throttle_manager::m_obj_get_global_t
 
 
 i_network_throttle & network_throttle_manager::get_global_throttle_inreq() { 
-	boost::call_once(m_once_get_global_throttle_inreq, [] { m_obj_get_global_throttle_inreq.reset(new network_throttle("inreq/all", "<== global-IN-REQ",10)); }	);
+	static network_throttle nt("inreq/all", "<== global-IN-REQ",10);
+	boost::call_once(m_once_get_global_throttle_inreq, [] { m_obj_get_global_throttle_inreq.reset(&nt); } );
 	return * m_obj_get_global_throttle_inreq;
 }
 boost::once_flag network_throttle_manager::m_once_get_global_throttle_inreq;
@@ -94,7 +96,8 @@ std::unique_ptr<i_network_throttle> network_throttle_manager::m_obj_get_global_t
 
 
 i_network_throttle & network_throttle_manager::get_global_throttle_out() { 
-	boost::call_once(m_once_get_global_throttle_out, [] { m_obj_get_global_throttle_out.reset(new network_throttle("out/all", ">>> global-OUT",10)); }	);
+	static network_throttle nt("out/all", ">>> global-OUT",10);
+	boost::call_once(m_once_get_global_throttle_out, [] { m_obj_get_global_throttle_out.reset(&nt); } );
 	return * m_obj_get_global_throttle_out;
 }
 boost::once_flag network_throttle_manager::m_once_get_global_throttle_out;


### PR DESCRIPTION
This will keep leak traces less noisy, as those were one off
allocations that were technically leaking.