### PR TITLE
network_throttle: remove unneeded heap allocations

### DIFF
--- a/src/p2p/network_throttle.cpp
+++ b/src/p2p/network_throttle.cpp
@@ -77,28 +77,22 @@ int network_throttle_manager::xxx;
 // ================================================================================================
 // methods:
 i_network_throttle & network_throttle_manager::get_global_throttle_in() { 
-	boost::call_once(m_once_get_global_throttle_in, [] { m_obj_get_global_throttle_in.reset(new network_throttle("in/all","<<< global-IN",10)); }	);
-	return * m_obj_get_global_throttle_in;
+	static network_throttle obj_get_global_throttle_in("in/all","<<< global-IN",10);
+	return obj_get_global_throttle_in;
 }
-boost::once_flag network_throttle_manager::m_once_get_global_throttle_in;
-std::unique_ptr<i_network_throttle> network_throttle_manager::m_obj_get_global_throttle_in;
 
 
 
 i_network_throttle & network_throttle_manager::get_global_throttle_inreq() { 
-	boost::call_once(m_once_get_global_throttle_inreq, [] { m_obj_get_global_throttle_inreq.reset(new network_throttle("inreq/all", "<== global-IN-REQ",10)); }	);
-	return * m_obj_get_global_throttle_inreq;
+	static network_throttle obj_get_global_throttle_inreq("inreq/all", "<== global-IN-REQ",10);
+	return obj_get_global_throttle_inreq;
 }
-boost::once_flag network_throttle_manager::m_once_get_global_throttle_inreq;
-std::unique_ptr<i_network_throttle> network_throttle_manager::m_obj_get_global_throttle_inreq;
 
 
 i_network_throttle & network_throttle_manager::get_global_throttle_out() { 
-	boost::call_once(m_once_get_global_throttle_out, [] { m_obj_get_global_throttle_out.reset(new network_throttle("out/all", ">>> global-OUT",10)); }	);
-	return * m_obj_get_global_throttle_out;
+	static network_throttle obj_get_global_throttle_out("out/all", ">>> global-OUT",10);
+	return obj_get_global_throttle_out;
 }
-boost::once_flag network_throttle_manager::m_once_get_global_throttle_out;
-std::unique_ptr<i_network_throttle> network_throttle_manager::m_obj_get_global_throttle_out;
 
 
 

--- a/src/p2p/network_throttle.hpp
+++ b/src/p2p/network_throttle.hpp
@@ -111,13 +111,6 @@ class network_throttle_manager {
 	
 	//protected:
 	public: // XXX
-		// [[note1]]
-		static boost::once_flag m_once_get_global_throttle_in;
-		static boost::once_flag m_once_get_global_throttle_inreq; // [[note2]]
-		static boost::once_flag m_once_get_global_throttle_out;
-		static std::unique_ptr<i_network_throttle> m_obj_get_global_throttle_in;
-		static std::unique_ptr<i_network_throttle> m_obj_get_global_throttle_inreq;
-		static std::unique_ptr<i_network_throttle> m_obj_get_global_throttle_out;
 
     static boost::mutex m_lock_get_global_throttle_in;
     static boost::mutex m_lock_get_global_throttle_inreq;


### PR DESCRIPTION
This will keep leak traces less noisy, as those were one off
allocations that were technically leaking.