### PR TITLE
move get_proof_of_trust_hash from util.h to p2p_protocol_defs.h

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -40,7 +40,6 @@
 #include <string>
 
 #include "crypto/hash.h"
-#include "p2p/p2p_protocol_defs.h"
 
 /*! \brief Various Tools
  *
@@ -107,14 +106,6 @@ namespace tools
   std::error_code replace_file(const std::string& replacement_name, const std::string& replaced_name);
 
   bool sanitize_locale();
-
-  inline crypto::hash get_proof_of_trust_hash(const nodetool::proof_of_trust& pot)
-  {
-    std::string s;
-    s.append(reinterpret_cast<const char*>(&pot.peer_id), sizeof(pot.peer_id));
-    s.append(reinterpret_cast<const char*>(&pot.time), sizeof(pot.time));
-    return crypto::cn_fast_hash(s.data(), s.size());
-  }
 
   /*! \brief Defines a signal handler for win32 and *nix
    */

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1382,7 +1382,7 @@ namespace nodetool
     }
     crypto::public_key pk = AUTO_VAL_INIT(pk);
     epee::string_tools::hex_to_pod(::config::P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY, pk);
-    crypto::hash h = tools::get_proof_of_trust_hash(tr);
+    crypto::hash h = get_proof_of_trust_hash(tr);
     if(!crypto::check_signature(h, pk, tr.sign))
     {
       LOG_ERROR("check_trust failed: sign check failed");

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -440,6 +440,14 @@ namespace nodetool
 #endif
 
 
+  inline crypto::hash get_proof_of_trust_hash(const nodetool::proof_of_trust& pot)
+  {
+    std::string s;
+    s.append(reinterpret_cast<const char*>(&pot.peer_id), sizeof(pot.peer_id));
+    s.append(reinterpret_cast<const char*>(&pot.time), sizeof(pot.time));
+    return crypto::cn_fast_hash(s.data(), s.size());
+  }
+
 }
 
 


### PR DESCRIPTION
This avoids having to include p2p_protocol_defs.h in util.h,
as util.h is used a lot, and p2p_protocol_defs.h includes
a lot of other things that most users don't need.