### PR TITLE
p2p: move m_in_timedsync from connection_context to p2p_connection_co…

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -155,7 +155,6 @@ namespace net_utils
     const network_address m_remote_address;
     const bool     m_is_income;
     const time_t   m_started;
-    bool     m_in_timedsync;
     time_t   m_last_recv;
     time_t   m_last_send;
     uint64_t m_recv_cnt;
@@ -171,7 +170,6 @@ namespace net_utils
                                             m_remote_address(remote_address),
                                             m_is_income(is_income),
                                             m_started(time(NULL)),
-                                            m_in_timedsync(false),
                                             m_last_recv(last_recv),
                                             m_last_send(last_send),
                                             m_recv_cnt(recv_cnt),
@@ -184,7 +182,6 @@ namespace net_utils
                                m_remote_address(new ipv4_network_address(0,0)),
                                m_is_income(false),
                                m_started(time(NULL)),
-                               m_in_timedsync(false),
                                m_last_recv(0),
                                m_last_send(0),
                                m_recv_cnt(0),

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -61,8 +61,11 @@ namespace nodetool
   template<class base_type>
   struct p2p_connection_context_t: base_type //t_payload_net_handler::connection_context //public net_utils::connection_context_base
   {
+    p2p_connection_context_t(): support_flags(0), m_in_timedsync(false) {}
+
     peerid_type peer_id;
     uint32_t support_flags;
+    bool m_in_timedsync;
   };
 
   template<class t_payload_net_handler>


### PR DESCRIPTION
…ntext

It's got no place in the base class as it's P2P specific field