### PR TITLE
blockchain: skip checking tx semantics in embedded block hash range

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4154,6 +4154,15 @@ void Blockchain::load_compiled_in_block_hashes()
 }
 #endif
 
+bool Blockchain::is_within_compiled_block_hash_area(uint64_t height) const
+{
+#if defined(PER_BLOCK_CHECKPOINT)
+  return height < m_blocks_hash_check.size();
+#else
+  return false;
+#endif
+}
+
 void Blockchain::lock()
 {
   m_blockchain_lock.lock();

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -865,6 +865,9 @@ namespace cryptonote
     cryptonote::blobdata get_txpool_tx_blob(const crypto::hash& txid) const;
     bool for_all_txpool_txes(std::function<bool(const crypto::hash&, const txpool_tx_meta_t&, const cryptonote::blobdata*)>, bool include_blob = false) const;
 
+    bool is_within_compiled_block_hash_area(uint64_t height) const;
+    bool is_within_compiled_block_hash_area() const { return is_within_compiled_block_hash_area(m_db->height()); }
+
     void lock();
     void unlock();
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -564,7 +564,11 @@ namespace cryptonote
         rv.outPk[n].dest = rct::pk2rct(boost::get<txout_to_key>(tx.vout[n].target).key);
     }
 
-    if(!check_tx_semantic(tx, keeped_by_block))
+    if (keeped_by_block && get_blockchain_storage().is_within_compiled_block_hash_area())
+    {
+      MTRACE("Skipping semantics check for tx kept by block in embedded hash area");
+    }
+    else if(!check_tx_semantic(tx, keeped_by_block))
     {
       LOG_PRINT_L1("WRONG TRANSACTION BLOB, Failed to check tx " << tx_hash << " semantic, rejected");
       tvc.m_verifivation_failed = true;


### PR DESCRIPTION
If the txes are bad, this'll be picked up by the block hash mismatch
since the tx merkle root is part of the block hash.