### PR TITLE
fix callback signatures

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -98,8 +98,8 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
             }
         }
     }
-
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount)
+    
+    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount)
     {
 
         std::string tx_hash =  epee::string_tools::pod_to_hex(txid);
@@ -114,7 +114,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount)
+    virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount)
     {
 
         std::string tx_hash =  epee::string_tools::pod_to_hex(txid);
@@ -129,8 +129,8 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, uint64_t amount,
-                                const cryptonote::transaction& spend_tx)
+    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx,
+                                uint64_t amount, const cryptonote::transaction& spend_tx)
     {
         // TODO;
         std::string tx_hash = epee::string_tools::pod_to_hex(txid);


### PR DESCRIPTION
implemented callbacks did not match those defined in wallet2.h for i_wallet2_callback and so were never called.