### PR TITLE
Change default block sync size from 200 to 20

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -89,7 +89,7 @@
 
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              200    //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              20     //by default, blocks count in blocks downloading
 #define CRYPTONOTE_PROTOCOL_HOP_RELAX_COUNT             3      //value of hop, after which we use only announce of new block
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    86400 //seconds, one day


### PR DESCRIPTION
With the new sync algorithm, the network overhead will be masked
as the thread adding blocks isn't interrupted by network calls
anymore. This should reduce memory usage a lot during sync.