### PR TITLE
net_node: fix m_in_timedsync initialization

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -61,7 +61,7 @@ namespace nodetool
   template<class base_type>
   struct p2p_connection_context_t: base_type //t_payload_net_handler::connection_context //public net_utils::connection_context_base
   {
-    p2p_connection_context_t(): support_flags(0), m_in_timedsync(false) {}
+    p2p_connection_context_t(): peer_id(0), support_flags(0), m_in_timedsync(false) {}
 
     peerid_type peer_id;
     uint32_t support_flags;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1678,6 +1678,7 @@ namespace nodetool
 
     //associate peer_id with this connection
     context.peer_id = arg.node_data.peer_id;
+    context.m_in_timedsync = false;
 
     if(arg.node_data.peer_id != m_config.m_peer_id && arg.node_data.my_port)
     {


### PR DESCRIPTION
This fixes nodes not being able to connect to nodes which use
recent code. While there, init peer_id too.