### PR TITLE
connection_context: initialize state

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -39,6 +39,7 @@ namespace cryptonote
 
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
+    cryptonote_connection_context(): m_state(state_befor_handshake), m_remote_blockchain_height(0), m_last_response_height(0) {}
 
     enum state
     {


### PR DESCRIPTION
Why this was initialized properly before I have no idea, but
it is not anymore. Fix it, which fixes syncing in release mode.