### PR TITLE
p2p: fallback on seed nodes if we can't make a connection

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -226,6 +226,7 @@ namespace nodetool
     bool is_addr_recently_failed(const epee::net_utils::network_address& addr);
     bool is_priority_node(const epee::net_utils::network_address& na);
     std::set<std::string> get_seed_nodes(bool testnet) const;
+    bool connect_to_seed();
 
     template <class Container>
     bool connect_to_peerlist(const Container& peers);


### PR DESCRIPTION
This avoids failing to connect to the network in case all
known peers are unavailable (which can happen if the peer
list is small).