### PR TITLE
cryptonote_protocol_handler: log versions as unsigned ints

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -260,7 +260,7 @@ namespace cryptonote
     const uint8_t version = m_core.get_blockchain_storage().get_ideal_hard_fork_version(hshd.current_height - 1);
     if (version >= 6 && version != hshd.top_version)
     {
-      LOG_DEBUG_CC(context, "Ignoring due to wrong top version (" << hshd.top_version << ", expected " << version);
+      LOG_DEBUG_CC(context, "Ignoring due to wrong top version " << (unsigned)hshd.top_version << ", expected " << (unsigned)version);
       return false;
     }
 


### PR DESCRIPTION
They're interpreted as characters otherwise