### PR TITLE
tests: fix tests build

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1232,6 +1232,16 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  uint8_t core::get_ideal_hard_fork_version(uint64_t height) const
+  {
+    return get_blockchain_storage().get_ideal_hard_fork_version(height);
+  }
+  //-----------------------------------------------------------------------------------------------
+  uint8_t core::get_hard_fork_version(uint64_t height) const
+  {
+    return get_blockchain_storage().get_hard_fork_version(height);
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::check_updates()
   {
     static const char software[] = "monero";

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -621,6 +621,20 @@ namespace cryptonote
      uint64_t get_target_blockchain_height() const;
 
      /**
+      * @brief return the ideal hard fork version for a given block height
+      *
+      * @return what it says above
+      */
+     uint8_t get_ideal_hard_fork_version(uint64_t height) const;
+
+     /**
+      * @brief return the hard fork version for a given block height
+      *
+      * @return what it says above
+      */
+     uint8_t get_hard_fork_version(uint64_t height) const;
+
+     /**
       * @brief gets start_time
       *
       */

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -257,7 +257,7 @@ namespace cryptonote
       return true;
 
     // from v6, if the peer advertises a top block version, reject if it's not what it should be (will only work if no voting)
-    const uint8_t version = m_core.get_blockchain_storage().get_ideal_hard_fork_version(hshd.current_height - 1);
+    const uint8_t version = m_core.get_ideal_hard_fork_version(hshd.current_height - 1);
     if (version >= 6 && version != hshd.top_version)
     {
       LOG_DEBUG_CC(context, "Ignoring due to wrong top version (" << hshd.top_version << ", expected " << version);
@@ -305,7 +305,7 @@ namespace cryptonote
   bool t_cryptonote_protocol_handler<t_core>::get_payload_sync_data(CORE_SYNC_DATA& hshd)
   {
     m_core.get_blockchain_top(hshd.current_height, hshd.top_id);
-    hshd.top_version = m_core.get_blockchain_storage().get_hard_fork_version(hshd.current_height);
+    hshd.top_version = m_core.get_hard_fork_version(hshd.current_height);
     hshd.current_height +=1;
     return true;
   }

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -96,5 +96,7 @@ namespace tests
     bool get_blocks(uint64_t start_offset, size_t count, std::list<std::pair<cryptonote::blobdata, cryptonote::block>>& blocks, std::list<cryptonote::blobdata>& txs) const { return false; }
     bool get_transactions(const std::vector<crypto::hash>& txs_ids, std::list<cryptonote::transaction>& txs, std::list<crypto::hash>& missed_txs) const { return false; }
     bool get_block_by_hash(const crypto::hash &h, cryptonote::block &blk, bool *orphan = NULL) const { return false; }
+    uint8_t get_ideal_hard_fork_version(uint64_t height) const { return 0; }
+    uint8_t get_hard_fork_version(uint64_t height) const { return 0; }
   };
 }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -73,6 +73,8 @@ public:
   bool get_blocks(uint64_t start_offset, size_t count, std::list<std::pair<cryptonote::blobdata, cryptonote::block>>& blocks, std::list<cryptonote::blobdata>& txs) const { return false; }
   bool get_transactions(const std::vector<crypto::hash>& txs_ids, std::list<cryptonote::transaction>& txs, std::list<crypto::hash>& missed_txs) const { return false; }
   bool get_block_by_hash(const crypto::hash &h, cryptonote::block &blk, bool *orphan = NULL) const { return false; }
+  uint8_t get_ideal_hard_fork_version(uint64_t height) const { return 0; }
+  uint8_t get_hard_fork_version(uint64_t height) const { return 0; }
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;


### PR DESCRIPTION
Add get_fork_version and add_ideal_fork_version to core so
cryptonote_protocol does not have to need the Blockchain
class directly, as it's not in its dependencies, and add
those to the fake core classes in tests too.