### PR TITLE
core: add --db-salvage command line flag

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -213,7 +213,7 @@ const std::string lmdb_error(const std::string& error_string, int mdb_res)
 inline void lmdb_db_open(MDB_txn* txn, const char* name, int flags, MDB_dbi& dbi, const std::string& error_string)
 {
   if (auto res = mdb_dbi_open(txn, name, flags, &dbi))
-    throw0(cryptonote::DB_OPEN_FAILURE(lmdb_error(error_string + " : ", res).c_str()));
+    throw0(cryptonote::DB_OPEN_FAILURE((lmdb_error(error_string + " : ", res) + std::string(" - you may want to start with --db-salvage")).c_str()));
 }
 
 

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -107,6 +107,11 @@ namespace command_line
   , "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
   , "fast:async:1000"
   };
+  const arg_descriptor<bool> arg_db_salvage  = {
+    "db-salvage"
+  , "Try to salvage a blockchain database if it seems corrupted"
+  , false
+  };
   const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {
     "fast-block-sync"
   , "Sync up most of the way by using embedded, known block hashes."

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -214,6 +214,7 @@ namespace command_line
   extern const arg_descriptor<bool> arg_dns_checkpoints;
   extern const arg_descriptor<std::string> arg_db_type;
   extern const arg_descriptor<std::string> arg_db_sync_mode;
+  extern const arg_descriptor<bool, false> arg_db_salvage;
   extern const arg_descriptor<uint64_t> arg_fast_block_sync;
   extern const arg_descriptor<uint64_t> arg_prep_blocks_threads;
   extern const arg_descriptor<uint64_t> arg_show_time_stats;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -164,6 +164,7 @@ namespace cryptonote
     command_line::add_arg(desc, command_line::arg_prep_blocks_threads);
     command_line::add_arg(desc, command_line::arg_fast_block_sync);
     command_line::add_arg(desc, command_line::arg_db_sync_mode);
+    command_line::add_arg(desc, command_line::arg_db_salvage);
     command_line::add_arg(desc, command_line::arg_show_time_stats);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
     command_line::add_arg(desc, command_line::arg_check_updates);
@@ -278,6 +279,7 @@ namespace cryptonote
 
     std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
     std::string db_sync_mode = command_line::get_arg(vm, command_line::arg_db_sync_mode);
+    bool db_salvage = command_line::get_arg(vm, command_line::arg_db_salvage) != 0;
     bool fast_sync = command_line::get_arg(vm, command_line::arg_fast_block_sync) != 0;
     uint64_t blocks_threads = command_line::get_arg(vm, command_line::arg_prep_blocks_threads);
     std::string check_updates_string = command_line::get_arg(vm, command_line::arg_check_updates);
@@ -310,12 +312,14 @@ namespace cryptonote
     uint64_t DBS_FAST_MODE = 0;
     uint64_t DBS_FASTEST_MODE = 0;
     uint64_t DBS_SAFE_MODE = 0;
+    uint64_t DBS_SALVAGE = 0;
     if (db_type == "lmdb")
     {
       db = new BlockchainLMDB();
       DBS_SAFE_MODE = MDB_NORDAHEAD;
       DBS_FAST_MODE = MDB_NORDAHEAD | MDB_NOSYNC;
       DBS_FASTEST_MODE = MDB_NORDAHEAD | MDB_NOSYNC | MDB_WRITEMAP | MDB_MAPASYNC;
+      DBS_SALVAGE = MDB_PREVSNAPSHOT;
     }
     else
     {
@@ -386,6 +390,9 @@ namespace cryptonote
         if (*endptr == '\0')
           blocks_per_sync = bps;
       }
+
+      if (db_salvage)
+        db_flags |= DBS_SALVAGE;
 
       db->open(filename, db_flags);
       if(!db->m_open)


### PR DESCRIPTION
Use to load the database when the primary meta page is corrupted

Needs hyc's lmdb PR first.
