### PR TITLE
use heap for anrdoid and ios

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -90,7 +90,7 @@ if (ARM)
   endif()
 endif()
 
-# Because of the way Qt works on android with JNI, the code does not live in the main android thread
+# Because of the way GUI threads work on android with JNI, the code does not live in the main android thread
 # So this code runs with a 1 MB default stack size. 
 # This will force the use of the heap for the allocation of the scratchpad
 if (ANDROID OR IOS)


### PR DESCRIPTION
on android, if the heap is not used for the long_state array (2MB), the stack is blown and results in a segfault in slow-hash.c as the stack size is small (see code comment) on threads which are not the main UI thread. so using heap for this array is neccessary not matter if QT build or not.dently.