### PR TITLE
befor -> before

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -39,12 +39,12 @@ namespace cryptonote
 
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
-    cryptonote_connection_context(): m_state(state_befor_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
+    cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
         m_last_known_hash(cryptonote::null_hash) {}
 
     enum state
     {
-      state_befor_handshake = 0, //default state
+      state_before_handshake = 0, //default state
       state_synchronizing,
       state_idle,
       state_normal
@@ -65,8 +65,8 @@ namespace cryptonote
   {
     switch (s)
     {
-    case cryptonote_connection_context::state_befor_handshake:
-      return "state_befor_handshake";
+    case cryptonote_connection_context::state_before_handshake:
+      return "state_before_handshake";
     case cryptonote_connection_context::state_synchronizing:
       return "state_synchronizing";
     case cryptonote_connection_context::state_idle:

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -252,7 +252,7 @@ namespace cryptonote
   template<class t_core>
   bool t_cryptonote_protocol_handler<t_core>::process_payload_sync_data(const CORE_SYNC_DATA& hshd, cryptonote_connection_context& context, bool is_inital)
   {
-    if(context.m_state == cryptonote_connection_context::state_befor_handshake && !is_inital)
+    if(context.m_state == cryptonote_connection_context::state_before_handshake && !is_inital)
       return true;
 
     if(context.m_state == cryptonote_connection_context::state_synchronizing)


### PR DESCRIPTION
Really unique yet consistent spelling mistake