### PR TITLE
simplewallet: mnemonic language command-line arg

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -266,6 +266,7 @@ namespace cryptonote
     std::string m_generate_from_keys;
     std::string m_generate_from_multisig_keys;
     std::string m_generate_from_json;
+    std::string m_mnemonic_language;
     std::string m_import_path;
 
     std::string m_electrum_seed;  // electrum-style seed parameter


### PR DESCRIPTION
Add `--mnemonic-language` command-line arg so it's possible to generate a wallet
without interacting with the CLI.