### PR TITLE
Silence stupid fallthru warning in gcc 7

### DIFF
--- a/external/boost/archive/portable_binary_oarchive.hpp
+++ b/external/boost/archive/portable_binary_oarchive.hpp
@@ -41,19 +41,24 @@ class portable_binary_oarchive_exception :
     public boost::archive::archive_exception
 {
 public:
-    typedef enum {
+    enum exception_code {
         invalid_flags 
-    } exception_code;
-    portable_binary_oarchive_exception(exception_code c = invalid_flags )
+    } m_exception_code ;
+    portable_binary_oarchive_exception(exception_code c = invalid_flags ) :
+        boost::archive::archive_exception(boost::archive::archive_exception::other_exception),
+        m_exception_code(c)
     {}
     virtual const char *what( ) const throw( )
     {
         const char *msg = "programmer error";
-        switch(code){
+        switch(m_exception_code){
         case invalid_flags:
             msg = "cannot be both big and little endian";
+            break;
         default:
-            boost::archive::archive_exception::what();
+            msg = boost::archive::archive_exception::what();
+            assert(false);
+            break;
         }
         return msg;
     }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2410,6 +2410,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
       break;
       default:
         LOG_ERROR("Unknown transfer method, using original");
+        /* FALLTHRU */
       case TransferOriginal:
         ptx_vector = m_wallet->create_transactions(dsts, fake_outs_count, 0 /* unlock_time */, priority, extra, m_trusted_daemon);
         break;


### PR DESCRIPTION
(assuming a fallthru, and not a break, was intended here)