### PR TITLE
move db specific options to BlockchainDB

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -78,6 +78,23 @@ std::string blockchain_db_types(const std::string& sep)
   return ret;
 }
 
+std::string arg_db_type_description = "Specify database type, available: " + cryptonote::blockchain_db_types(", ");
+const command_line::arg_descriptor<std::string> arg_db_type = {
+  "db-type"
+, arg_db_type_description.c_str()
+, DEFAULT_DB_TYPE
+};
+const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
+  "db-sync-mode"
+, "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
+, "fast:async:1000"
+};
+const command_line::arg_descriptor<bool> arg_db_salvage  = {
+  "db-salvage"
+, "Try to salvage a blockchain database if it seems corrupted"
+, false
+};
+
 BlockchainDB *new_db(const std::string& db_type)
 {
   if (db_type == "lmdb")
@@ -87,6 +104,13 @@ BlockchainDB *new_db(const std::string& db_type)
     return new BlockchainBDB();
 #endif
   return NULL;
+}
+
+void BlockchainDB::init_options(boost::program_options::options_description& desc)
+{
+  command_line::add_arg(desc, arg_db_type);
+  command_line::add_arg(desc, arg_db_sync_mode);
+  command_line::add_arg(desc, arg_db_salvage);
 }
 
 void BlockchainDB::pop_block()

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -33,6 +33,8 @@
 #include <list>
 #include <string>
 #include <exception>
+#include <boost/program_options.hpp>
+#include "common/command_line.h"
 #include "crypto/hash.h"
 #include "cryptonote_protocol/blobdatatype.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -100,6 +102,10 @@ namespace cryptonote
 
 /** a pair of <transaction hash, output index>, typedef for convenience */
 typedef std::pair<crypto::hash, uint64_t> tx_out_index;
+
+extern const command_line::arg_descriptor<std::string> arg_db_type;
+extern const command_line::arg_descriptor<std::string> arg_db_sync_mode;
+extern const command_line::arg_descriptor<bool, false> arg_db_salvage;
 
 #pragma pack(push, 1)
 
@@ -534,6 +540,11 @@ public:
    * @brief An empty destructor.
    */
   virtual ~BlockchainDB() { };
+
+  /**
+   * @brief init command line options
+   */
+  static void init_options(boost::program_options::options_description& desc);
 
   /**
    * @brief reset profiling stats

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -32,7 +32,6 @@
 #include <boost/algorithm/string/compare.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <unordered_set>
-#include "blockchain_db/db_types.h"
 #include "common/i18n.h"
 #include "cryptonote_config.h"
 #include "string_tools.h"
@@ -94,22 +93,6 @@ namespace command_line
   const arg_descriptor<bool> arg_dns_checkpoints  = {
     "enforce-dns-checkpointing"
   , "checkpoints from DNS server will be enforced"
-  , false
-  };
-  std::string arg_db_type_description = "Specify database type, available: " + cryptonote::blockchain_db_types(", ");
-  const command_line::arg_descriptor<std::string> arg_db_type = {
-    "db-type"
-  , arg_db_type_description.c_str()
-  , DEFAULT_DB_TYPE
-  };
-  const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
-    "db-sync-mode"
-  , "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
-  , "fast:async:1000"
-  };
-  const arg_descriptor<bool> arg_db_salvage  = {
-    "db-salvage"
-  , "Try to salvage a blockchain database if it seems corrupted"
   , false
   };
   const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -212,9 +212,6 @@ namespace command_line
   extern const arg_descriptor<int> 		arg_test_dbg_lock_sleep;
   extern const arg_descriptor<bool, false> arg_testnet_on;
   extern const arg_descriptor<bool> arg_dns_checkpoints;
-  extern const arg_descriptor<std::string> arg_db_type;
-  extern const arg_descriptor<std::string> arg_db_sync_mode;
-  extern const arg_descriptor<bool, false> arg_db_salvage;
   extern const arg_descriptor<uint64_t> arg_fast_block_sync;
   extern const arg_descriptor<uint64_t> arg_prep_blocks_threads;
   extern const arg_descriptor<uint64_t> arg_show_time_stats;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -156,11 +156,8 @@ namespace cryptonote
 
     command_line::add_arg(desc, command_line::arg_testnet_on);
     command_line::add_arg(desc, command_line::arg_dns_checkpoints);
-    command_line::add_arg(desc, command_line::arg_db_type);
     command_line::add_arg(desc, command_line::arg_prep_blocks_threads);
     command_line::add_arg(desc, command_line::arg_fast_block_sync);
-    command_line::add_arg(desc, command_line::arg_db_sync_mode);
-    command_line::add_arg(desc, command_line::arg_db_salvage);
     command_line::add_arg(desc, command_line::arg_show_time_stats);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
     command_line::add_arg(desc, command_line::arg_check_updates);
@@ -170,6 +167,7 @@ namespace cryptonote
     command_line::add_arg(desc, nodetool::arg_p2p_bind_port, false);
 
     miner::init_options(desc);
+    BlockchainDB::init_options(desc);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_command_line(const boost::program_options::variables_map& vm)
@@ -279,9 +277,9 @@ namespace cryptonote
       m_config_folder_mempool = m_config_folder_mempool + "/" + m_port;
     }
 
-    std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
-    std::string db_sync_mode = command_line::get_arg(vm, command_line::arg_db_sync_mode);
-    bool db_salvage = command_line::get_arg(vm, command_line::arg_db_salvage) != 0;
+    std::string db_type = command_line::get_arg(vm, cryptonote::arg_db_type);
+    std::string db_sync_mode = command_line::get_arg(vm, cryptonote::arg_db_sync_mode);
+    bool db_salvage = command_line::get_arg(vm, cryptonote::arg_db_salvage) != 0;
     bool fast_sync = command_line::get_arg(vm, command_line::arg_fast_block_sync) != 0;
     uint64_t blocks_threads = command_line::get_arg(vm, command_line::arg_prep_blocks_threads);
     std::string check_updates_string = command_line::get_arg(vm, command_line::arg_check_updates);

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -142,7 +142,7 @@ int main(int argc, char const * argv[])
 
     epee::debug::g_test_dbg_lock_sleep() = command_line::get_arg(vm, command_line::arg_test_dbg_lock_sleep);
 
-    std::string db_type = command_line::get_arg(vm, command_line::arg_db_type);
+    std::string db_type = command_line::get_arg(vm, cryptonote::arg_db_type);
 
     // verify that blockchaindb type is valid
     if(!cryptonote::blockchain_valid_db_type(db_type))

--- a/src/debug_utilities/CMakeLists.txt
+++ b/src/debug_utilities/CMakeLists.txt
@@ -37,7 +37,6 @@ monero_add_executable(cn_deserialize
 target_link_libraries(cn_deserialize
   LINK_PRIVATE
     cryptonote_core
-    common
     blockchain_db
     p2p
     epee

--- a/tests/core_proxy/CMakeLists.txt
+++ b/tests/core_proxy/CMakeLists.txt
@@ -39,8 +39,6 @@ target_link_libraries(core_proxy
   PRIVATE
     cryptonote_core
     cryptonote_protocol
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -30,8 +30,6 @@ add_executable(block_fuzz_tests block.cpp fuzzer.cpp)
 target_link_libraries(block_fuzz_tests
   PRIVATE
     cryptonote_core
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}
@@ -44,8 +42,6 @@ add_executable(transaction_fuzz_tests transaction.cpp fuzzer.cpp)
 target_link_libraries(transaction_fuzz_tests
   PRIVATE
     cryptonote_core
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}
@@ -59,8 +55,6 @@ target_link_libraries(signature_fuzz_tests
   PRIVATE
     wallet
     cryptonote_core
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}
@@ -74,8 +68,6 @@ target_link_libraries(cold-outputs_fuzz_tests
   PRIVATE
     wallet
     cryptonote_core
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}
@@ -89,8 +81,6 @@ target_link_libraries(cold-transaction_fuzz_tests
   PRIVATE
     wallet
     cryptonote_core
-    common
-    blockchain_db
     p2p
     epee
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
Avoids common depending on blockchain_db, which can cause
link errors.