### PR TITLE
core: guard against exceptions in handle_incoming_{block,tx}

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -368,6 +368,9 @@ private:
   // migrate from DB version 0 to 1
   void migrate_0_1();
 
+  void cleanup_batch();
+
+private:
   MDB_env* m_env;
 
   MDB_dbi m_blocks;

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -208,7 +208,8 @@ int check_flush(cryptonote::core &core, std::list<block_complete_entry> &blocks,
     }
 
   } // each download block
-  core.cleanup_handle_incoming_blocks();
+  if (!core.cleanup_handle_incoming_blocks())
+    return 1;
 
   blocks.clear();
   return 0;
@@ -394,7 +395,10 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
           blocks.push_back({block, txs});
           int ret = check_flush(core, blocks, false);
           if (ret)
+          {
+            quit = 2; // make sure we don't commit partial block data
             break;
+          }
         }
         else
         {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -585,6 +585,8 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_txs(const std::list<blobdata>& tx_blobs, std::vector<tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay)
   {
+    TRY_ENTRY();
+
     struct result { bool res; cryptonote::transaction tx; crypto::hash hash; crypto::hash prefix_hash; bool in_txpool; bool in_blockchain; };
     std::vector<result> results(tx_blobs.size());
 
@@ -638,6 +640,8 @@ namespace cryptonote
         MDEBUG("tx added: " << results[i].hash);
     }
     return ok;
+
+    CATCH_ENTRY_L0("core::handle_incoming_txs()", false);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, bool keeped_by_block, bool relayed, bool do_not_relay)
@@ -1075,6 +1079,8 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_block(const blobdata& block_blob, block_verification_context& bvc, bool update_miner_blocktemplate)
   {
+    TRY_ENTRY();
+
     // load json & DNS checkpoints every 10min/hour respectively,
     // and verify them with respect to what blocks we already have
     CHECK_AND_ASSERT_MES(update_checkpoints(), false, "One or more checkpoints loaded from json or dns conflicted with existing checkpoints.");
@@ -1098,6 +1104,8 @@ namespace cryptonote
     if(update_miner_blocktemplate && bvc.m_added_to_main_chain)
        update_miner_block_template();
     return true;
+
+    CATCH_ENTRY_L0("core::handle_incoming_block()", false);
   }
   //-----------------------------------------------------------------------------------------------
   // Used by the RPC server to check the size of an incoming

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1068,12 +1068,13 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::cleanup_handle_incoming_blocks(bool force_sync)
   {
+    bool success = false;
     try {
-      m_blockchain_storage.cleanup_handle_incoming_blocks(force_sync);
+      success = m_blockchain_storage.cleanup_handle_incoming_blocks(force_sync);
     }
     catch (...) {}
     m_incoming_tx_lock.unlock();
-    return true;
+    return success;
   }
 
   //-----------------------------------------------------------------------------------------------

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -364,7 +364,12 @@ namespace cryptonote
 
     block_verification_context bvc = boost::value_initialized<block_verification_context>();
     m_core.handle_incoming_block(arg.b.block, bvc); // got block from handle_notify_new_block
-    m_core.cleanup_handle_incoming_blocks(true);
+    if (!m_core.cleanup_handle_incoming_blocks(true))
+    {
+      LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+      m_core.resume_mine();
+      return 1;
+    }
     m_core.resume_mine();
     if(bvc.m_verifivation_failed)
     {
@@ -623,7 +628,12 @@ namespace cryptonote
           
         block_verification_context bvc = boost::value_initialized<block_verification_context>();
         m_core.handle_incoming_block(arg.b.block, bvc); // got block from handle_notify_new_block
-        m_core.cleanup_handle_incoming_blocks(true);
+        if (!m_core.cleanup_handle_incoming_blocks(true))
+        {
+          LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+          m_core.resume_mine();
+          return 1;
+        }
         m_core.resume_mine();
         
         if( bvc.m_verifivation_failed )
@@ -1055,7 +1065,11 @@ skip:
                 }))
                   LOG_ERROR_CCONTEXT("span connection id not found");
 
-                m_core.cleanup_handle_incoming_blocks();
+                if (!m_core.cleanup_handle_incoming_blocks())
+                {
+                  LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+                  return 1;
+                }
                 // in case the peer had dropped beforehand, remove the span anyway so other threads can wake up and get it
                 m_block_queue.remove_spans(span_connection_id, start_height);
                 return 1;
@@ -1080,7 +1094,12 @@ skip:
               }))
                 LOG_ERROR_CCONTEXT("span connection id not found");
 
-              m_core.cleanup_handle_incoming_blocks();
+              if (!m_core.cleanup_handle_incoming_blocks())
+              {
+                LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+                return 1;
+              }
+
               // in case the peer had dropped beforehand, remove the span anyway so other threads can wake up and get it
               m_block_queue.remove_spans(span_connection_id, start_height);
               return 1;
@@ -1094,7 +1113,12 @@ skip:
               }))
                 LOG_ERROR_CCONTEXT("span connection id not found");
 
-              m_core.cleanup_handle_incoming_blocks();
+              if (!m_core.cleanup_handle_incoming_blocks())
+              {
+                LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+                return 1;
+              }
+
               // in case the peer had dropped beforehand, remove the span anyway so other threads can wake up and get it
               m_block_queue.remove_spans(span_connection_id, start_height);
               return 1;
@@ -1107,7 +1131,11 @@ skip:
 
           MCINFO("sync-info", "Block process time (" << blocks.size() << " blocks, " << num_txs << " txs): " << block_process_time_full + transactions_process_time_full << " (" << transactions_process_time_full << "/" << block_process_time_full << ") ms");
 
-          m_core.cleanup_handle_incoming_blocks();
+          if (!m_core.cleanup_handle_incoming_blocks())
+          {
+            LOG_PRINT_CCONTEXT_L0("Failure in cleanup_handle_incoming_blocks");
+            return 1;
+          }
 
           m_block_queue.remove_spans(span_connection_id, start_height);
 


### PR DESCRIPTION
When one happens, cleanup must be called or the incoming tx
lock will stay locked