### PR TITLE
monero-wallet-cli: New command 'wallet_info'

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -713,6 +713,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("set_tx_note", boost::bind(&simple_wallet::set_tx_note, this, _1), tr("Set an arbitrary string note for a txid"));
   m_cmd_binder.set_handler("get_tx_note", boost::bind(&simple_wallet::get_tx_note, this, _1), tr("Get a string note for a txid"));
   m_cmd_binder.set_handler("status", boost::bind(&simple_wallet::status, this, _1), tr("Show wallet status information"));
+  m_cmd_binder.set_handler("wallet_info", boost::bind(&simple_wallet::wallet_info, this, _1), tr("Show wallet information"));
   m_cmd_binder.set_handler("sign", boost::bind(&simple_wallet::sign, this, _1), tr("Sign the contents of a file"));
   m_cmd_binder.set_handler("verify", boost::bind(&simple_wallet::verify, this, _1), tr("Verify a signature on the contents of a file"));
   m_cmd_binder.set_handler("export_key_images", boost::bind(&simple_wallet::export_key_images, this, _1), tr("Export a signed set of key images"));
@@ -4440,6 +4441,16 @@ bool simple_wallet::status(const std::vector<std::string> &args)
   {
     fail_msg_writer() << "Refreshed " << local_height << "/?, daemon connection error";
   }
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::wallet_info(const std::vector<std::string> &args)
+{
+  success_msg_writer() << "Filename: " << m_wallet->get_wallet_file();
+  success_msg_writer() << "Address: " << m_wallet->get_account().get_public_address_str(m_wallet->testnet());
+  success_msg_writer() << "Watch only: " << (m_wallet->watch_only() ? "Yes" : "No");
+  success_msg_writer() << "Restricted RPC: " << (m_wallet->restricted() ? "Yes" : "No");
+  success_msg_writer() << "Testnet: " << (m_wallet->testnet() ? "Yes" : "No");
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4446,11 +4446,10 @@ bool simple_wallet::status(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::wallet_info(const std::vector<std::string> &args)
 {
-  success_msg_writer() << "Filename: " << m_wallet->get_wallet_file();
-  success_msg_writer() << "Address: " << m_wallet->get_account().get_public_address_str(m_wallet->testnet());
-  success_msg_writer() << "Watch only: " << (m_wallet->watch_only() ? "Yes" : "No");
-  success_msg_writer() << "Restricted RPC: " << (m_wallet->restricted() ? "Yes" : "No");
-  success_msg_writer() << "Testnet: " << (m_wallet->testnet() ? "Yes" : "No");
+  message_writer() << tr("Filename: ") << m_wallet->get_wallet_file();
+  message_writer() << tr("Address: ") << m_wallet->get_account().get_public_address_str(m_wallet->testnet());
+  message_writer() << tr("Watch only: ") << (m_wallet->watch_only() ? tr("Yes") : tr("No"));
+  message_writer() << tr("Testnet: ") << (m_wallet->testnet() ? tr("Yes") : tr("No"));
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -165,6 +165,7 @@ namespace cryptonote
     bool set_tx_note(const std::vector<std::string> &args);
     bool get_tx_note(const std::vector<std::string> &args);
     bool status(const std::vector<std::string> &args);
+    bool wallet_info(const std::vector<std::string> &args);
     bool set_default_priority(const std::vector<std::string> &args);
     bool sign(const std::vector<std::string> &args);
     bool verify(const std::vector<std::string> &args);


### PR DESCRIPTION
I propose/implemented a new command *wallet_info* for the CLI wallet. It displays the filename of the current wallet, its address, whether it is watch only, whether it runs with RPC restricted, and whether it runs on testnet.

When I juggled with several wallets for tests recently I noticed that there is currently no way to display the filename of the current wallet from within  the *monero-wallet-cli* program, and no *comment* or *label* feature either in order to recognize the currently opened wallet, only the address, and who remembers addresses of quickly generated and deleted-again test wallets, right?

First I wanted to simply output the filename as a second line with the *address* command, but moneromooo opined for a separate command. When I found  other little bits of info currently not yet query-able I was conviced and implemented command *wallet_info*.

There is of course already a command to query the address, but I think *wallet_info* should show it as well because after all that's info No. 1 about a wallet.