### PR TITLE
[DO NOT MERGE] Print blockchain growth stats

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -536,6 +536,11 @@ int main(int argc, char* argv[])
       , "Count blocks in bootstrap file and exit"
       , false
   };
+  const command_line::arg_descriptor<bool>     arg_block_stats = {
+    "block-stats"
+      , "Tally blocks in bootstrap file and exit"
+      , false
+  };
   const command_line::arg_descriptor<std::string> arg_database = {
     "database", available_dbs.c_str(), default_db_type
   };
@@ -556,6 +561,7 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_cmd_sett, arg_block_stop);
 
   command_line::add_arg(desc_cmd_only, arg_count_blocks);
+  command_line::add_arg(desc_cmd_only, arg_block_stats);
   command_line::add_arg(desc_cmd_only, arg_pop_blocks);
   command_line::add_arg(desc_cmd_only, arg_drop_hf);
   command_line::add_arg(desc_cmd_only, command_line::arg_help);
@@ -644,6 +650,12 @@ int main(int argc, char* argv[])
   {
     BootstrapFile bootstrap;
     bootstrap.count_blocks(import_file_path);
+    return 0;
+  }
+  if (command_line::has_arg(vm, arg_block_stats))
+  {
+    BootstrapFile bootstrap;
+    bootstrap.block_stats(import_file_path);
     return 0;
   }
 

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -482,6 +482,7 @@ uint64_t BootstrapFile::block_stats(const std::string& import_file_path)
   struct tm prevtm = {0}, currtm;
   uint64_t prevsz = 0, currsz = 0;
   uint64_t currblks = 0;
+  uint64_t prevtxs = 0, currtxs = 0;
   boost::filesystem::path raw_file_path(import_file_path);
   boost::system::error_code ec;
   if (!boost::filesystem::exists(raw_file_path, ec))
@@ -511,7 +512,7 @@ uint64_t BootstrapFile::block_stats(const std::string& import_file_path)
   std::string str1;
   char buf1[2048];
   char buffer_block[BUFFER_SIZE];
-  std::cout << "Date\tBlocks\tBlocks/Day\tBytes/Day\tTotal Bytes" << ENDL;
+  std::cout << ENDL << "Date\tBlocks/day\tBlocks\tTxs/Day\tTxs\tBytes/Day\tBytes" << ENDL;
 
   while (! quit)
   {
@@ -567,13 +568,16 @@ uint64_t BootstrapFile::block_stats(const std::string& import_file_path)
 	  goto skip;
         strftime(buffer, sizeof(buffer), "%Y-%m-%d", &prevtm);
         prevtm = currtm;
-        std::cout << buffer << "\t" << h << "\t" << currblks << "\t" << currsz << "\t" << prevsz + currsz << ENDL;
+        std::cout << buffer << "\t" << currblks << "\t" << h << "\t" << currtxs << "\t" << prevtxs + currtxs << "\t" << currsz << "\t" << prevsz + currsz << ENDL;
         prevsz += currsz;
         currsz = 0;
         currblks = 0;
+	prevtxs += currtxs;
+	currtxs = 0;
       }
 skip:
       currsz += bp.block_size;
+      currtxs += bp.txs.size();
       currblks++;
     }
     catch (const std::exception& e)

--- a/src/blockchain_utilities/bootstrap_file.h
+++ b/src/blockchain_utilities/bootstrap_file.h
@@ -57,6 +57,7 @@ class BootstrapFile
 public:
 
   uint64_t count_blocks(const std::string& dir_path);
+  uint64_t block_stats(const std::string& dir_path);
   uint64_t seek_to_first_chunk(std::ifstream& import_file);
 
   bool store_blockchain_raw(cryptonote::Blockchain* cs, cryptonote::tx_memory_pool* txp,


### PR DESCRIPTION
Add an option to blockchain-import to read the .raw file and just print running totals of bytes and blocks per day. Data is tab-separated, suitable for importing into a spreadsheet app. The attached image was generated from a run on data up to the end of August.
![growth](https://user-images.githubusercontent.com/306354/29991819-07d97032-8f86-11e7-958f-d2e65b01279c.png)
