### PR TITLE
Add a --fluffy-blocks option to relay blocks as fluffy blocks

### DIFF
--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -137,4 +137,9 @@ namespace command_line
   , "Check for new versions of monero: [disabled|notify|download|update]"
   , "notify"
   };
+  const arg_descriptor<bool> arg_fluffy_blocks  = {
+    "fluffy-blocks"
+  , "Relay blocks as fluffy blocks where possible (automatic on testnet)"
+  , false
+  };
 }

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -220,4 +220,5 @@ namespace command_line
   extern const arg_descriptor<uint64_t> arg_show_time_stats;
   extern const arg_descriptor<size_t> arg_block_sync_size;
   extern const arg_descriptor<std::string> arg_check_updates;
+  extern const arg_descriptor<bool> arg_fluffy_blocks;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -164,6 +164,7 @@ namespace cryptonote
     command_line::add_arg(desc, command_line::arg_show_time_stats);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
     command_line::add_arg(desc, command_line::arg_check_updates);
+    command_line::add_arg(desc, command_line::arg_fluffy_blocks);
 
     // we now also need some of net_node's options (p2p bind arg, for separate data dir)
     command_line::add_arg(desc, nodetool::arg_testnet_p2p_bind_port, false);
@@ -199,6 +200,7 @@ namespace cryptonote
 
     set_enforce_dns_checkpoints(command_line::get_arg(vm, command_line::arg_dns_checkpoints));
     test_drop_download_height(command_line::get_arg(vm, command_line::arg_test_drop_download_height));
+    m_fluffy_blocks_enabled = m_testnet || get_arg(vm, command_line::arg_fluffy_blocks);
 
     if (command_line::get_arg(vm, command_line::arg_test_drop_download) == true)
       test_drop_download();

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -728,6 +728,13 @@ namespace cryptonote
       */     
      bool get_testnet() const { return m_testnet; };
 
+     /**
+      * @brief get whether fluffy blocks are enabled
+      *
+      * @return whether fluffy blocks are enabled
+      */
+     bool fluffy_blocks_enabled() const { return m_fluffy_blocks_enabled; }
+
    private:
 
      /**
@@ -945,6 +952,8 @@ namespace cryptonote
      tools::download_async_handle m_update_download;
      size_t m_last_update_length;
      boost::mutex m_update_mutex;
+
+     bool m_fluffy_blocks_enabled;
    };
 }
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1622,7 +1622,7 @@ skip:
     {
       if (peer_id && exclude_context.m_connection_id != context.m_connection_id)
       {
-        if(m_core.get_testnet() && (support_flags & P2P_SUPPORT_FLAG_FLUFFY_BLOCKS))
+        if(m_core.fluffy_blocks_enabled() && (support_flags & P2P_SUPPORT_FLAG_FLUFFY_BLOCKS))
         {
           LOG_DEBUG_CC(context, "PEER SUPPORTS FLUFFY BLOCKS - RELAYING THIN/COMPACT WHATEVER BLOCK");
           fluffyConnections.push_back(context.m_connection_id);

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -100,5 +100,6 @@ namespace tests
     uint8_t get_ideal_hard_fork_version(uint64_t height) const { return 0; }
     uint8_t get_hard_fork_version(uint64_t height) const { return 0; }
     cryptonote::difficulty_type get_block_cumulative_difficulty(uint64_t height) const { return 0; }
+    bool fluffy_blocks_enabled() const { return false; }
   };
 }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -77,6 +77,7 @@ public:
   uint8_t get_ideal_hard_fork_version(uint64_t height) const { return 0; }
   uint8_t get_hard_fork_version(uint64_t height) const { return 0; }
   cryptonote::difficulty_type get_block_cumulative_difficulty(uint64_t height) const { return 0; }
+  bool fluffy_blocks_enabled() const { return false; }
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;


### PR DESCRIPTION
Defaults to off, but fluffy blocks are forced enabled on testnet