### PR TITLE
background mining: Fix AC power supply detection on Linux

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -858,19 +858,6 @@ namespace cryptonote
           const boost::filesystem::path& power_supply_path = iter->path();
           if (boost::filesystem::is_directory(power_supply_path))
           {
-            std::ifstream power_supply_present_stream((power_supply_path / "present").string());
-            if (power_supply_present_stream.fail())
-            {
-              LOG_PRINT_L0("Unable to read from " << power_supply_path << " to check if power supply present");
-              continue;
-            }
-
-            if (power_supply_present_stream.get() != '1')
-            {
-              LOG_PRINT_L4("Power supply not present at " << power_supply_path);
-              continue;
-            }
-
             boost::filesystem::path power_supply_type_path = power_supply_path / "type";
             if (boost::filesystem::is_regular_file(power_supply_type_path))
             {


### PR DESCRIPTION
The '/sys/class/power_supply/*/present' file usually does not exist for AC power supplies, so expecting it to be there prevents from detecting them.
And if a battery is not present, it will usually not appear in /sys/class/power_supply/, so checking for the 'present' file isn't useful.

Checking the 'online' file for AC power supplies and the 'status' file for batteries should suffice.
