### PR TITLE
p2p: disable gray list housekeeping when an exclusive node is given

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1951,6 +1951,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::gray_peerlist_housekeeping()
   {
+    if (!m_exclusive_peers.empty()) return true;
+
     peerlist_entry pe = AUTO_VAL_INIT(pe);
 
     if (!m_peerlist.get_random_gray_peer(pe)) {


### PR DESCRIPTION
Exclusive nodes may be used for privacy reasons, and thus we don't
want to connect to other nodes, even for checking connectivity.

See https://github.com/monero-project/monero/issues/2346