### PR TITLE
p2p: init hashes after deserializing a network address

### DIFF
--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -59,6 +59,8 @@ namespace boost
     {
       a & na.m_ip;
       a & na.m_port;
+      if (!typename Archive::is_saving())
+        na.init_ids();
     }
 
 


### PR DESCRIPTION
Fixes multiple connections to the same address