### PR TITLE
daemon, wallet: add --max-log-file-size option

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -52,6 +52,7 @@
 #include "easylogging++.h"
 
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
+#define MAX_LOG_FILE_SIZE 104850000 // 100 MB - 7600 bytes
 
 #define MCFATAL(cat,x) CLOG(FATAL,cat) << x
 #define MCERROR(cat,x) CLOG(ERROR,cat) << x
@@ -123,7 +124,7 @@
 #endif
 
 std::string mlog_get_default_log_path(const char *default_filename);
-void mlog_configure(const std::string &filename_base, bool console);
+void mlog_configure(const std::string &filename_base, bool console, const std::size_t max_log_file_size = MAX_LOG_FILE_SIZE);
 void mlog_set_categories(const char *categories);
 void mlog_set_log_level(int level);
 void mlog_set_log(const char *log);

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -111,7 +111,7 @@ static const char *get_default_categories(int level)
   return categories;
 }
 
-void mlog_configure(const std::string &filename_base, bool console)
+void mlog_configure(const std::string &filename_base, bool console, const std::size_t max_log_file_size)
 {
   el::Configurations c;
   c.setGlobally(el::ConfigurationType::Filename, filename_base);
@@ -121,7 +121,7 @@ void mlog_configure(const std::string &filename_base, bool console)
     log_format = MLOG_BASE_FORMAT;
   c.setGlobally(el::ConfigurationType::Format, log_format);
   c.setGlobally(el::ConfigurationType::ToStandardOutput, console ? "true" : "false");
-  c.setGlobally(el::ConfigurationType::MaxLogFileSize, "104850000"); // 100 MB - 7600 bytes
+  c.setGlobally(el::ConfigurationType::MaxLogFileSize, std::to_string(max_log_file_size));
   el::Loggers::setDefaultConfigurations(c, true);
 
   el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -46,6 +46,11 @@ namespace daemon_args
   , "Specify log file"
   , ""
   };
+  const command_line::arg_descriptor<std::size_t> arg_max_log_file_size = {
+    "max-log-file-size"
+  , "Specify maximum log file size [B]"
+  , MAX_LOG_FILE_SIZE
+  };
   const command_line::arg_descriptor<std::string> arg_log_level = {
     "log-level"
   , ""

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char const * argv[])
       bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
       command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
+      command_line::add_arg(core_settings, daemon_args::arg_max_log_file_size);
       command_line::add_arg(core_settings, daemon_args::arg_max_concurrency);
 
       daemonizer::init_options(hidden_options, visible_options);
@@ -204,7 +205,7 @@ int main(int argc, char const * argv[])
     if (! vm["log-file"].defaulted())
       log_file_path = command_line::get_arg(vm, daemon_args::arg_log_file);
     log_file_path = bf::absolute(log_file_path, relative_path_base);
-    mlog_configure(log_file_path.string(), true);
+    mlog_configure(log_file_path.string(), true, command_line::get_arg(vm, daemon_args::arg_max_log_file_size));
 
     // Set log level
     if (!vm["log-level"].defaulted())

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -84,6 +84,7 @@ namespace wallet_args
 #endif
 
     const command_line::arg_descriptor<std::string> arg_log_level = {"log-level", "0-4 or categories", ""};
+    const command_line::arg_descriptor<std::size_t> arg_max_log_file_size = {"max-log-file-size", "Specify maximum log file size [B]", MAX_LOG_FILE_SIZE};
     const command_line::arg_descriptor<uint32_t> arg_max_concurrency = {"max-concurrency", wallet_args::tr("Max number of threads to use for a parallel job"), DEFAULT_MAX_CONCURRENCY};
     const command_line::arg_descriptor<std::string> arg_log_file = {"log-file", wallet_args::tr("Specify log file"), ""};
     const command_line::arg_descriptor<std::string> arg_config_file = {"config-file", wallet_args::tr("Config file"), "", true};
@@ -101,6 +102,7 @@ namespace wallet_args
 
     command_line::add_arg(desc_params, arg_log_file, "");
     command_line::add_arg(desc_params, arg_log_level);
+    command_line::add_arg(desc_params, arg_max_log_file_size);
     command_line::add_arg(desc_params, arg_max_concurrency);
     command_line::add_arg(desc_params, arg_config_file);
 
@@ -141,7 +143,7 @@ namespace wallet_args
       log_path = command_line::get_arg(vm, arg_log_file);
     else
       log_path = mlog_get_default_log_path(default_log_name);
-    mlog_configure(log_path, log_to_console);
+    mlog_configure(log_path, log_to_console, command_line::get_arg(vm, arg_max_log_file_size));
     if (!vm["log-level"].defaulted())
     {
       mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());


### PR DESCRIPTION
This was requested in #2321 and works with

- `monero-wallet-cli`
- `monero-wallet-rpc`
- `monerod`