### PR TITLE
rpc: add new RPCs to get and set limits

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -334,9 +334,9 @@ bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
   if(args.size()==0) {
     return m_executor.get_limit();
   }
-  int limit;
+  int64_t limit;
   try {
-      limit = std::stoi(args[0]);
+      limit = std::stoll(args[0]);
   }
   catch(std::invalid_argument& ex) {
       return false;
@@ -344,7 +344,7 @@ bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
   if (limit==-1)  limit=128;
   limit *= 1024;
 
-  return m_executor.set_limit(limit);
+  return m_executor.set_limit(limit, limit);
 }
 
 bool t_command_parser_executor::set_limit_up(const std::vector<std::string>& args)
@@ -353,9 +353,9 @@ bool t_command_parser_executor::set_limit_up(const std::vector<std::string>& arg
   if(args.size()==0) {
     return m_executor.get_limit_up();
   }
-  int limit;
+  int64_t limit;
   try {
-      limit = std::stoi(args[0]);
+      limit = std::stoll(args[0]);
   }
   catch(std::invalid_argument& ex) {
       return false;
@@ -372,9 +372,9 @@ bool t_command_parser_executor::set_limit_down(const std::vector<std::string>& a
   if(args.size()==0) {
     return m_executor.get_limit_down();
   }
-  int limit;
+  int64_t limit;
   try {
-      limit = std::stoi(args[0]);
+      limit = std::stoll(args[0]);
   }
   catch(std::invalid_argument& ex) {
       return false;

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -330,59 +330,22 @@ bool t_command_parser_executor::print_status(const std::vector<std::string>& arg
 
 bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
 {
-  if(args.size()>1) return false;
-  if(args.size()==0) {
+  if (args.size() == 0) {
     return m_executor.get_limit();
   }
-  int64_t limit;
+  if (args.size() != 2) return false;
+
+  int64_t limit_down;
+  int64_t limit_up;
   try {
-      limit = std::stoll(args[0]);
+      limit_down = std::stoll(args[0]);
+      limit_up = std::stoll(args[1]);
   }
   catch(std::invalid_argument& ex) {
       return false;
   }
-  if (limit==-1)  limit=128;
-  limit *= 1024;
 
-  return m_executor.set_limit(limit, limit);
-}
-
-bool t_command_parser_executor::set_limit_up(const std::vector<std::string>& args)
-{
-  if(args.size()>1) return false;
-  if(args.size()==0) {
-    return m_executor.get_limit_up();
-  }
-  int64_t limit;
-  try {
-      limit = std::stoll(args[0]);
-  }
-  catch(std::invalid_argument& ex) {
-      return false;
-  }
-  if (limit==-1)  limit=128;
-  limit *= 1024;
-
-  return m_executor.set_limit_up(limit);
-}
-
-bool t_command_parser_executor::set_limit_down(const std::vector<std::string>& args)
-{
-  if(args.size()>1) return false;
-  if(args.size()==0) {
-    return m_executor.get_limit_down();
-  }
-  int64_t limit;
-  try {
-      limit = std::stoll(args[0]);
-  }
-  catch(std::invalid_argument& ex) {
-      return false;
-  }
-  if (limit==-1)  limit=128;
-  limit *= 1024;
-
-  return m_executor.set_limit_down(limit);
+  return m_executor.set_limit(limit_down, limit_up);
 }
 
 bool t_command_parser_executor::out_peers(const std::vector<std::string>& args)

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -171,17 +171,7 @@ t_command_server::t_command_server(
   m_command_lookup.set_handler(
       "limit"
     , std::bind(&t_command_parser_executor::set_limit, &m_parser, p::_1)
-    , "limit <kB/s> - Set download and upload limit"
-    );
-  m_command_lookup.set_handler(
-      "limit_up"
-    , std::bind(&t_command_parser_executor::set_limit_up, &m_parser, p::_1)
-    , "limit <kB/s> - Set upload limit"
-    );
-  m_command_lookup.set_handler(
-      "limit_down"
-    , std::bind(&t_command_parser_executor::set_limit_down, &m_parser, p::_1)
-    , "limit <kB/s> - Set download limit"
+    , "limit <download in kB/s> <upload in kB/s> - Set download and upload limit"
     );
     m_command_lookup.set_handler(
       "out_peers"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1149,8 +1149,8 @@ bool t_rpc_command_executor::get_limit()
     }
   }
 
-  tools::msg_writer() << "limit-down is " << res.limit_down/1024 << " kB/s";
-  tools::msg_writer() << "limit-up is " << res.limit_up/1024 << " kB/s";
+  tools::msg_writer() << "limit-down is " << res.limit_down << " kB/s";
+  tools::msg_writer() << "limit-up is " << res.limit_up << " kB/s";
 
   return true;
 }
@@ -1181,39 +1181,9 @@ bool t_rpc_command_executor::set_limit(int64_t limit_down, int64_t limit_up)
     }
   }
 
-  if (limit_down != -1)
-    tools::msg_writer() << "Set limit-down to " << limit_down/1024 << " kB/s";
-  if (limit_up != -1)
-    tools::msg_writer() << "Set limit-up to " << limit_up/1024 << " kB/s";
+  tools::msg_writer() << "Set limit-down to " << res.limit_down << " kB/s";
+  tools::msg_writer() << "Set limit-up to " << res.limit_up << " kB/s";
 
-  return true;
-}
-
-bool t_rpc_command_executor::get_limit_up()
-{
-  int limit_up = epee::net_utils::connection_basic::get_rate_up_limit();
-  tools::msg_writer() << "limit-up is " << limit_up/1024 << " kB/s";
-  return true;
-}
-
-bool t_rpc_command_executor::set_limit_up(uint64_t limit)
-{
-  epee::net_utils::connection_basic::set_rate_up_limit(limit);
-  tools::msg_writer() << "Set limit-up to " << limit/1024 << " kB/s";
-  return true;
-}
-
-bool t_rpc_command_executor::get_limit_down()
-{
-  int limit_down = epee::net_utils::connection_basic::get_rate_down_limit();
-  tools::msg_writer() << "limit-down is " << limit_down/1024 << " kB/s";
-  return true;
-}
-
-bool t_rpc_command_executor::set_limit_down(uint64_t limit)
-{
-  epee::net_utils::connection_basic::set_rate_down_limit(limit);
-  tools::msg_writer() << "Set limit-down to " << limit/1024 << " kB/s";
   return true;
 }
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1128,48 +1128,93 @@ bool t_rpc_command_executor::print_status()
 
 bool t_rpc_command_executor::get_limit()
 {
-    int limit_down = epee::net_utils::connection_basic::get_rate_down_limit( );
-    int limit_up = epee::net_utils::connection_basic::get_rate_up_limit( );
-    std::cout << "limit-down is " << limit_down/1024 << " kB/s" << std::endl;
-    std::cout << "limit-up is " << limit_up/1024 << " kB/s" << std::endl;
-    return true;
+  cryptonote::COMMAND_RPC_GET_LIMIT::request req;
+  cryptonote::COMMAND_RPC_GET_LIMIT::response res;
+
+  std::string failure_message = "Couldn't get limit";
+
+  if (m_is_rpc)
+  {
+    if (!m_rpc_client->rpc_request(req, res, "/get_limit", failure_message.c_str()))
+    {
+      return true;
+    }
+  }
+  else
+  {
+    if (!m_rpc_server->on_get_limit(req, res) || res.status != CORE_RPC_STATUS_OK)
+    {
+      tools::fail_msg_writer() << make_error(failure_message, res.status);
+      return true;
+    }
+  }
+
+  tools::msg_writer() << "limit-down is " << res.limit_down/1024 << " kB/s";
+  tools::msg_writer() << "limit-up is " << res.limit_up/1024 << " kB/s";
+
+  return true;
 }
 
-bool t_rpc_command_executor::set_limit(int limit)
+bool t_rpc_command_executor::set_limit(int64_t limit_down, int64_t limit_up)
 {
-    epee::net_utils::connection_basic::set_rate_down_limit( limit );
-    epee::net_utils::connection_basic::set_rate_up_limit( limit );
-    std::cout << "Set limit-down to " << limit/1024 << " kB/s" << std::endl;
-    std::cout << "Set limit-up to " << limit/1024 << " kB/s" << std::endl;
-    return true;
+  cryptonote::COMMAND_RPC_SET_LIMIT::request req;
+  cryptonote::COMMAND_RPC_SET_LIMIT::response res;
+
+  req.limit_down = limit_down;
+  req.limit_up = limit_up;
+
+  std::string failure_message = "Couldn't set limit";
+
+  if (m_is_rpc)
+  {
+    if (!m_rpc_client->rpc_request(req, res, "/set_limit", failure_message.c_str()))
+    {
+      return true;
+    }
+  }
+  else
+  {
+    if (!m_rpc_server->on_set_limit(req, res) || res.status != CORE_RPC_STATUS_OK)
+    {
+      tools::fail_msg_writer() << make_error(failure_message, res.status);
+      return true;
+    }
+  }
+
+  if (limit_down != -1)
+    tools::msg_writer() << "Set limit-down to " << limit_down/1024 << " kB/s";
+  if (limit_up != -1)
+    tools::msg_writer() << "Set limit-up to " << limit_up/1024 << " kB/s";
+
+  return true;
 }
 
 bool t_rpc_command_executor::get_limit_up()
 {
-    int limit_up = epee::net_utils::connection_basic::get_rate_up_limit( );
-    std::cout << "limit-up is " << limit_up/1024 << " kB/s" << std::endl;
-    return true;
+  int limit_up = epee::net_utils::connection_basic::get_rate_up_limit();
+  tools::msg_writer() << "limit-up is " << limit_up/1024 << " kB/s";
+  return true;
 }
 
-bool t_rpc_command_executor::set_limit_up(int limit)
+bool t_rpc_command_executor::set_limit_up(uint64_t limit)
 {
-    epee::net_utils::connection_basic::set_rate_up_limit( limit );
-    std::cout << "Set limit-up to " << limit/1024 << " kB/s" << std::endl;
-    return true;
+  epee::net_utils::connection_basic::set_rate_up_limit(limit);
+  tools::msg_writer() << "Set limit-up to " << limit/1024 << " kB/s";
+  return true;
 }
 
 bool t_rpc_command_executor::get_limit_down()
 {
-    int limit_down = epee::net_utils::connection_basic::get_rate_down_limit( );
-    std::cout << "limit-down is " << limit_down/1024 << " kB/s" << std::endl;
-    return true;
+  int limit_down = epee::net_utils::connection_basic::get_rate_down_limit();
+  tools::msg_writer() << "limit-down is " << limit_down/1024 << " kB/s";
+  return true;
 }
 
-bool t_rpc_command_executor::set_limit_down(int limit)
+bool t_rpc_command_executor::set_limit_down(uint64_t limit)
 {
-    epee::net_utils::connection_basic::set_rate_down_limit( limit );
-    std::cout << "Set limit-down to " << limit/1024 << " kB/s" << std::endl;
-    return true;
+  epee::net_utils::connection_basic::set_rate_down_limit(limit);
+  tools::msg_writer() << "Set limit-down to " << limit/1024 << " kB/s";
+  return true;
 }
 
 bool t_rpc_command_executor::out_peers(uint64_t limit)

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -119,11 +119,11 @@ public:
 
   bool get_limit_down();
 
-  bool set_limit(int limit);
+  bool set_limit(int64_t limit_down, int64_t limit_up);
 
-  bool set_limit_up(int limit);
+  bool set_limit_up(uint64_t limit);
 
-  bool set_limit_down(int limit);
+  bool set_limit_down(uint64_t limit);
 
   bool out_peers(uint64_t limit);
   

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1522,6 +1522,24 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_limit(const COMMAND_RPC_GET_LIMIT::request& req, COMMAND_RPC_GET_LIMIT::response& res)
+  {
+    res.limit_down = epee::net_utils::connection_basic::get_rate_down_limit();
+    res.limit_up = epee::net_utils::connection_basic::get_rate_up_limit();
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_set_limit(const COMMAND_RPC_SET_LIMIT::request& req, COMMAND_RPC_SET_LIMIT::response& res)
+  {
+    if (req.limit_down != -1)
+      epee::net_utils::connection_basic::set_rate_down_limit(req.limit_down);
+    if (req.limit_up != -1)
+      epee::net_utils::connection_basic::set_rate_up_limit(req.limit_up);
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_out_peers(const COMMAND_RPC_OUT_PEERS::request& req, COMMAND_RPC_OUT_PEERS::response& res)
   {
 	  // TODO

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -97,6 +97,8 @@ namespace cryptonote
       MAP_URI_AUTO_JON2("/get_transaction_pool_stats", on_get_transaction_pool_stats, COMMAND_RPC_GET_TRANSACTION_POOL_STATS)
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
+      MAP_URI_AUTO_JON2("/get_limit", on_get_limit, COMMAND_RPC_GET_LIMIT)
+      MAP_URI_AUTO_JON2_IF("/set_limit", on_set_limit, COMMAND_RPC_SET_LIMIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/start_save_graph", on_start_save_graph, COMMAND_RPC_START_SAVE_GRAPH, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/stop_save_graph", on_stop_save_graph, COMMAND_RPC_STOP_SAVE_GRAPH, !m_restricted)
@@ -155,6 +157,8 @@ namespace cryptonote
     bool on_get_transaction_pool_hashes(const COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::response& res);
     bool on_get_transaction_pool_stats(const COMMAND_RPC_GET_TRANSACTION_POOL_STATS::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_STATS::response& res);
     bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
+    bool on_get_limit(const COMMAND_RPC_GET_LIMIT::request& req, COMMAND_RPC_GET_LIMIT::response& res);
+    bool on_set_limit(const COMMAND_RPC_SET_LIMIT::request& req, COMMAND_RPC_SET_LIMIT::response& res);
     bool on_out_peers(const COMMAND_RPC_OUT_PEERS::request& req, COMMAND_RPC_OUT_PEERS::response& res);
     bool on_start_save_graph(const COMMAND_RPC_START_SAVE_GRAPH::request& req, COMMAND_RPC_START_SAVE_GRAPH::response& res);
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1280,9 +1280,13 @@ namespace cryptonote
     struct response
     {
       std::string status;
+      uint64_t limit_up;
+      uint64_t limit_down;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
+        KV_SERIALIZE(limit_up)
+        KV_SERIALIZE(limit_down)
       END_KV_SERIALIZE_MAP()
     };
   };

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -49,7 +49,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 13
+#define CORE_RPC_VERSION_MINOR 14
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1236,6 +1236,51 @@ namespace cryptonote
     {
 	  std::string status;
 	  
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+  
+  struct COMMAND_RPC_GET_LIMIT
+  {
+    struct request
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+    
+    struct response
+    {
+      std::string status;
+      uint64_t limit_up;
+      uint64_t limit_down;
+      
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(limit_up)
+        KV_SERIALIZE(limit_down)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+  
+  struct COMMAND_RPC_SET_LIMIT
+  {
+    struct request
+    {
+      int64_t limit_down;
+      int64_t limit_up;
+      
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(limit_down)
+        KV_SERIALIZE(limit_up)
+      END_KV_SERIALIZE_MAP()
+    };
+    
+    struct response
+    {
+      std::string status;
+      
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
This PR adds the following new RPCs:
- `set_limit <download kB/s> <upload kB/s>` set download and upload limit (restricted)
- ~~`limit_down <kB/s>` set download limit (restricted)~~
- ~~`limit_up <kB/s>` set upload limit (restricted)~~
- `get_limit` get download and upload limit
- ~~`limit_down` get download limit~~
- ~~`limit_up` get upload limit~~

Fixes https://github.com/monero-project/monero-core/issues/805