### PR TITLE
epee: give virtual dtor to network_address_base

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -71,6 +71,9 @@ namespace net_utils
 		}
 		uint64_t m_host_id;
 		uint64_t m_full_id;
+
+	protected:
+		virtual ~network_address_base() {}
 	};
 	struct ipv4_network_address: public network_address_base
 	{


### PR DESCRIPTION
It has virtual functions and is used as a base class