### PR TITLE
Fixes static_assert on arm and ppc builds

### DIFF
--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -29,6 +29,7 @@
 #include "json_object.h"
 
 #include <limits>
+#include <type_traits>
 #include "string_tools.h"
 
 namespace cryptonote
@@ -52,8 +53,9 @@ namespace
   void convert_numeric(Source source, Type& i)
   {
     static_assert(
+      (std::is_same<Type, char>() && std::is_same<Source, int>()) ||
       std::numeric_limits<Source>::is_signed == std::numeric_limits<Type>::is_signed,
-      "source and destination signs do not match"
+      "comparisons below may have undefined behavior"
     );
     if (source < std::numeric_limits<Type>::min())
     {


### PR DESCRIPTION
See https://github.com/monero-project/monero/issues/2471

@NanoAkron @madscientist159 verify this fixes the build on your machines (I currently do not have an arm or ppc machine ready for testing ... yet). 