### PR TITLE
daemon: fix static building with libzmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ if(STATIC)
   else()
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
   endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZMQ_STATIC")
 endif()
 
 # Set default blockchain storage location:
@@ -691,12 +692,16 @@ include(version.cmake)
 
 find_path(ZMQ_INCLUDE_PATH zmq.hpp)
 find_library(ZMQ_LIB zmq)
+find_library(SODIUM_LIBRARY sodium)
 
 if(NOT ZMQ_INCLUDE_PATH)
   message(FATAL_ERROR "Could not find required header zmq.hpp")
 endif()
 if(NOT ZMQ_LIB)
-  message(FATAL_ERROR "Could not find require libzmq")
+  message(FATAL_ERROR "Could not find required libzmq")
+endif()
+if(SODIUM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${SODIUM_LIBRARY}")
 endif()
 
 function (treat_warnings_as_errors dirs)


### PR DESCRIPTION
This fixes static builds for me on Ubuntu 16.04 with libzmq3-dev and libsodium-dev dependencies installed, and MSYS2 with mingw-w64-x86_64-zeromq and mingw-w64-x86_64-libsodium dependencies installed. 

Tested only on x86_64. Needs testing on other platforms.