### PR TITLE
Update README - Missing dependancy (zeroMQ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ library archives (`.a`).
 | Boost          | 1.58          | NO       | `libboost-all-dev` | `boost`        | NO       | C++ libraries  |
 | OpenSSL        | basically any | NO       | `libssl-dev`       | `openssl`      | NO       | sha256 sum     |
 | libunbound     | 1.4.16        | YES      | `libunbound-dev`   | `unbound`      | NO       | DNS resolver   |
+| libzmq         | ?             | YES      | `libzmq3-dev`      | `zeromq`       | NO       | Message queue  |
 | libminiupnpc   | 2.0           | YES      | `libminiupnpc-dev` | `miniupnpc`    | YES      | NAT punching   |
 | libunwind      | any           | NO       | `libunwind8-dev`   | `libunwind`    | YES      | Stack traces   |
 | liblzma        | any           | NO       | `liblzma-dev`      | `xz`           | YES      | For libunwind  |


### PR DESCRIPTION
Add missing dependency which is non-optional for building on ubuntu 16.04 LTS