### PR TITLE
tests: pass data dir as arg

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@
 
 # The docs say this only affects grouping in IDEs
 set(folder "tests")
+set(TEST_DATA_DIR "${CMAKE_CURRENT_LIST_DIR}/data")
 
 if (WIN32 AND STATIC)
   add_definitions(-DSTATICLIB)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -97,4 +97,4 @@ endif ()
 
 add_test(
   NAME    unit_tests
-  COMMAND unit_tests)
+  COMMAND unit_tests "${TEST_DATA_DIR}")

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -30,14 +30,32 @@
 
 #include "gtest/gtest.h"
 
+#include <boost/filesystem.hpp>
+
 #include "include_base_utils.h"
+#include "unit_tests_utils.h"
+
+boost::filesystem::path unit_test::data_dir;
 
 int main(int argc, char** argv)
 {
-  epee::string_tools::set_module_name_and_folder(argv[0]);
   mlog_configure(mlog_get_default_log_path("unit_tests.log"), true);
   epee::debug::get_set_enable_assert(true, false);
 
   ::testing::InitGoogleTest(&argc, argv);
+
+  // Process remaining arguments
+  if (argc == 2 && argv[1] != NULL) { // one arg: path to dir with test data
+    unit_test::data_dir = argv[1];
+  } else if (argc == 1) { // legacy: assume test binaries in 'build/release'
+    epee::string_tools::set_module_name_and_folder(argv[0]);
+    unit_test::data_dir = boost::filesystem::path(epee::string_tools::get_current_module_folder())
+                          .parent_path().parent_path().parent_path().parent_path()
+                          .append("tests").append("data");
+  } else {
+    std::cerr << "Usage: " << argv[0] << " [<path-to-test-data-dir>]" << std::endl;
+    return 1;
+  }
+
   return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -47,6 +47,7 @@
 #include "serialization/binary_utils.h"
 #include "wallet/wallet2.h"
 #include "gtest/gtest.h"
+#include "unit_tests_utils.h"
 using namespace std;
 
 struct Struct
@@ -671,12 +672,12 @@ TEST(Serialization, portability_wallet)
   const bool testnet = true;
   const bool restricted = false;
   tools::wallet2 w(testnet, restricted);
-  string wallet_file = epee::string_tools::get_current_module_folder() + "/../../../../tests/data/wallet_9svHk1";
+  const boost::filesystem::path wallet_file = unit_test::data_dir / "wallet_9svHk1";
   string password = "test";
   bool r = false;
   try
   {
-    w.load(wallet_file, password);
+    w.load(wallet_file.native(), password);
     r = true;
   }
   catch (const exception& e)
@@ -791,9 +792,9 @@ TEST(Serialization, portability_wallet)
 TEST(Serialization, portability_outputs)
 {
   // read file
-  const std::string filename = epee::string_tools::get_current_module_folder() + "/../../../../tests/data/outputs";
+  const boost::filesystem::path filename = unit_test::data_dir / "outputs";
   std::string data;
-  bool r = epee::file_io_utils::load_file_to_string(filename, data);
+  bool r = epee::file_io_utils::load_file_to_string(filename.native(), data);
   ASSERT_TRUE(r);
   const size_t magiclen = strlen(OUTPUT_EXPORT_FILE_MAGIC);
   ASSERT_FALSE(data.size() < magiclen || memcmp(data.data(), OUTPUT_EXPORT_FILE_MAGIC, magiclen));
@@ -906,10 +907,10 @@ TEST(Serialization, portability_outputs)
 #define UNSIGNED_TX_PREFIX "Monero unsigned tx set\003"
 TEST(Serialization, portability_unsigned_tx)
 {
-  const string filename = epee::string_tools::get_current_module_folder() + "/../../../../tests/data/unsigned_monero_tx";
+  const boost::filesystem::path filename = unit_test::data_dir / "unsigned_monero_tx";
   std::string s;
   const bool testnet = true;
-  bool r = epee::file_io_utils::load_file_to_string(filename, s);
+  bool r = epee::file_io_utils::load_file_to_string(filename.native(), s);
   ASSERT_TRUE(r);
   const size_t magiclen = strlen(UNSIGNED_TX_PREFIX);
   ASSERT_FALSE(strncmp(s.c_str(), UNSIGNED_TX_PREFIX, magiclen));
@@ -1054,10 +1055,10 @@ TEST(Serialization, portability_unsigned_tx)
 #define SIGNED_TX_PREFIX "Monero signed tx set\003"
 TEST(Serialization, portability_signed_tx)
 {
-  const string filename = epee::string_tools::get_current_module_folder() + "/../../../../tests/data/signed_monero_tx";
+  const boost::filesystem::path filename = unit_test::data_dir / "signed_monero_tx";
   const bool testnet = true;
   std::string s;
-  bool r = epee::file_io_utils::load_file_to_string(filename, s);
+  bool r = epee::file_io_utils::load_file_to_string(filename.native(), s);
   ASSERT_TRUE(r);
   const size_t magiclen = strlen(SIGNED_TX_PREFIX);
   ASSERT_FALSE(strncmp(s.c_str(), SIGNED_TX_PREFIX, magiclen));

--- a/tests/unit_tests/unit_tests_utils.h
+++ b/tests/unit_tests/unit_tests_utils.h
@@ -31,9 +31,12 @@
 #pragma once
 
 #include <atomic>
+#include <boost/filesystem.hpp>
 
 namespace unit_test
 {
+  extern boost::filesystem::path data_dir;
+
   class call_counter
   {
   public:


### PR DESCRIPTION
This fixes test failure on builds that happen
to be built in 'build/' instead of 'build/release'.