### PR TITLE
Add script to format all sources with clang-format-4.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,96 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ clean:
 	[ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting."; exit 1;)
 	rm -rf build
 
+format-sources:
+	./format-sources.sh
+
 tags:
 	ctags -R --sort=1 --c++-kinds=+p --fields=+iaS --extra=+q --language-force=C++ src contrib tests/gtest
 

--- a/format-sources.sh
+++ b/format-sources.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+# Format all sources with specific version of clang-format
+#
+# --check parameter can be used to check if the sources are
+# properly formatted without modifying them. This is useful
+# in a CI environment.
+#
+# Since clang-format can be installed either as clang-format
+# or clang-format-4.0, we need to figure out which the current
+# system has.
+
+CLANG_FORMAT=$(which clang-format-4.0)
+
+# if clang-format-4.0 was not found, use regular clang-format.
+if [ -z $CLANG_FORMAT ]; then
+  CLANG_FORMAT=$(which clang-format)
+fi
+
+if [ -z $CLANG_FORMAT ]; then
+  echo "Unable to find clang-format or clang-format-4.0!"
+  exit 1
+fi
+
+if ! [[ $($CLANG_FORMAT --version 2>&1) =~ "clang-format version 4.0" ]]; then
+  echo "clang-format version 4.0 not found!"
+  exit 1
+fi
+
+if [ "$1" == "--check" ]; then
+  ARGUMENTS="-output-replacements-xml"
+fi
+
+# Run clang-format for all .cpp and .h files found in subdirectories.
+# Excluding 3rd party files.
+#
+# If --check was passed, then clang is instructed to print all the changes it *would* do.
+# That output is grepped of replacement tags to see if there is anything to change.
+# If something was found, an error will be returned to indicate that sources are not
+# properly formatted.
+
+! find -L . -iregex '.*\.[ch]\(pp\)?' \
+       -not -iregex '.*contrib.*' \
+       -not -iregex '.*external.*' \
+       | xargs -I filename $CLANG_FORMAT $ARGUMENTS --style=file -i filename \
+       | grep "</replacement>"
+exit $?
+


### PR DESCRIPTION
To ensure all sources are consistently formatted, the formatting
should be automated. Additionally there should be a way to check
that sources are always properly formatted. Especially when
accepting 3rd party pull requests.

This patch adds a script that:
- can format all of the project's source code
- can check if all of the project's sources are properly formatted

Script uses google style formatting generated with command:
clang-format-4.0 -style=google -dump-config > .clang-format

Sources can be formatted by either running:
./format-sources.sh
or
make format-sources

Note the script has not yet been run and the sources
have not yet been formatted.