### PR TITLE
cmake: add libversion and libcheckpoints to libwallet_merged

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -125,7 +125,16 @@ endif()
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)
-    set(libs_to_merge wallet cryptonote_core cryptonote_basic mnemonics common cncrypto ringct)
+    set(libs_to_merge
+            wallet
+            cryptonote_core
+            cryptonote_basic
+            mnemonics
+            common
+            cncrypto
+            ringct
+            checkpoints
+            version)
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt


### PR DESCRIPTION
Needed to link monero-core Qt wallet.