### PR TITLE
wallet2: missing underflow check on low heights

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2209,7 +2209,7 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const std::stri
     // Set blockchain height calculated from current date/time
     uint64_t approx_blockchain_height = get_approximate_blockchain_height();
     if(approx_blockchain_height > 0) {
-      m_refresh_from_block_height = approx_blockchain_height - blocks_per_month;
+      m_refresh_from_block_height = approx_blockchain_height >= blocks_per_month ? approx_blockchain_height - blocks_per_month : 0;
     }
   }
   bool r = store_keys(m_keys_file, password, false);


### PR DESCRIPTION
Lack of it results in `m_refresh_from_block_height` being < 0 (18446744...) on low heights, which blocks `process_new_blockchain_entry` and never process coins on heights less than blocks_per_month.

Follow-up to #2258