### PR TITLE
Fix #1530 Distinguish "not enough money" and "not enough unlocked money" in RPC msgs

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2821,12 +2821,19 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
   {
     fail_msg_writer() << tr("failed to get random outputs to mix: ") << e.what();
   }
-  catch (const tools::error::not_enough_money& e)
+  catch (const tools::error::not_enough_unlocked_money& e)
   {
     LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
       print_money(e.available()) %
       print_money(e.tx_amount()));
     fail_msg_writer() << tr("Not enough money in unlocked balance");
+  }
+  catch (const tools::error::not_enough_money& e)
+  {
+    LOG_PRINT_L0(boost::format("not enough money to transfer, overall balance only %s, sent amount %s") %
+      print_money(e.available()) %
+      print_money(e.tx_amount()));
+    fail_msg_writer() << tr("Not enough money in overall balance");
   }
   catch (const tools::error::tx_not_possible& e)
   {
@@ -2993,12 +3000,19 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
   {
     fail_msg_writer() << tr("failed to get random outputs to mix: ") << e.what();
   }
-  catch (const tools::error::not_enough_money& e)
+  catch (const tools::error::not_enough_unlocked_money& e)
   {
     LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
       print_money(e.available()) %
       print_money(e.tx_amount()));
     fail_msg_writer() << tr("Not enough money in unlocked balance");
+  }
+  catch (const tools::error::not_enough_money& e)
+  {
+    LOG_PRINT_L0(boost::format("not enough money to transfer, overall balance only %s, sent amount %s") %
+      print_money(e.available()) %
+      print_money(e.tx_amount()));
+    fail_msg_writer() << tr("Not enough money in overall balance");
   }
   catch (const tools::error::tx_not_possible& e)
   {
@@ -3273,12 +3287,19 @@ bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &a
   {
     fail_msg_writer() << tr("failed to get random outputs to mix: ") << e.what();
   }
-  catch (const tools::error::not_enough_money& e)
+  catch (const tools::error::not_enough_unlocked_money& e)
   {
     LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
       print_money(e.available()) %
       print_money(e.tx_amount()));
     fail_msg_writer() << tr("Not enough money in unlocked balance");
+  }
+  catch (const tools::error::not_enough_money& e)
+  {
+    LOG_PRINT_L0(boost::format("not enough money to transfer, overall balance only %s, sent amount %s") %
+      print_money(e.available()) %
+      print_money(e.tx_amount()));
+    fail_msg_writer() << tr("Not enough money in overall balance");
   }
   catch (const tools::error::tx_not_possible& e)
   {
@@ -3623,12 +3644,19 @@ bool simple_wallet::submit_transfer(const std::vector<std::string> &args_)
   {
     fail_msg_writer() << tr("failed to get random outputs to mix: ") << e.what();
   }
-  catch (const tools::error::not_enough_money& e)
+  catch (const tools::error::not_enough_unlocked_money& e)
   {
     LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
       print_money(e.available()) %
       print_money(e.tx_amount()));
     fail_msg_writer() << tr("Not enough money in unlocked balance");
+  }
+  catch (const tools::error::not_enough_money& e)
+  {
+    LOG_PRINT_L0(boost::format("not enough money to transfer, overall balance only %s, sent amount %s") %
+      print_money(e.available()) %
+      print_money(e.tx_amount()));
+    fail_msg_writer() << tr("Not enough money in overall balance");
   }
   catch (const tools::error::tx_not_possible& e)
   {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1147,11 +1147,20 @@ PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const 
             m_errorString = (boost::format(tr("failed to get random outputs to mix: %s")) % e.what()).str();
             m_status = Status_Error;
 
-        } catch (const tools::error::not_enough_money& e) {
+        } catch (const tools::error::not_enough_unlocked_money& e) {
             m_status = Status_Error;
             std::ostringstream writer;
 
             writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            m_errorString = writer.str();
+
+        } catch (const tools::error::not_enough_money& e) {
+            m_status = Status_Error;
+            std::ostringstream writer;
+
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
             m_errorString = writer.str();
@@ -1241,11 +1250,20 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             m_errorString = tr("failed to get random outputs to mix");
             m_status = Status_Error;
 
-        } catch (const tools::error::not_enough_money& e) {
+        } catch (const tools::error::not_enough_unlocked_money& e) {
             m_status = Status_Error;
             std::ostringstream writer;
 
             writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+                      print_money(e.available()) %
+                      print_money(e.tx_amount());
+            m_errorString = writer.str();
+
+        } catch (const tools::error::not_enough_money& e) {
+            m_status = Status_Error;
+            std::ostringstream writer;
+
+            writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
             m_errorString = writer.str();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1249,10 +1249,10 @@ namespace tools
     }
 
     // randomly select inputs for transaction
-    // throw if requested send amount is greater than amount available to send
+    // throw if requested send amount is greater than (unlocked) amount available to send
     std::list<size_t> selected_transfers;
     uint64_t found_money = select_transfers(needed_money, unused_transfers_indices, selected_transfers, trusted_daemon);
-    THROW_WALLET_EXCEPTION_IF(found_money < needed_money, error::not_enough_money, found_money, needed_money - fee, fee);
+    THROW_WALLET_EXCEPTION_IF(found_money < needed_money, error::not_enough_unlocked_money, found_money, needed_money - fee, fee);
 
     uint32_t subaddr_account = m_transfers[*selected_transfers.begin()].m_subaddr_index.major;
     for (auto i = ++selected_transfers.begin(); i != selected_transfers.end(); ++i)

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -68,6 +68,7 @@ namespace tools
     //         get_tx_pool_error
     //       transfer_error *
     //         get_random_outs_general_error
+    //         not_enough_unlocked_money
     //         not_enough_money
     //         tx_not_possible
     //         not_enough_outs_to_mix
@@ -356,11 +357,37 @@ namespace tools
     //----------------------------------------------------------------------------------------------------
     typedef failed_rpc_request<transfer_error, get_random_outs_error_message_index> get_random_outs_error;
     //----------------------------------------------------------------------------------------------------
+    struct not_enough_unlocked_money : public transfer_error
+    {
+      explicit not_enough_unlocked_money(std::string&& loc, uint64_t available, uint64_t tx_amount, uint64_t fee)
+        : transfer_error(std::move(loc), "not enough unlocked money")
+        , m_available(available)
+        , m_tx_amount(tx_amount)
+      {
+      }
+
+      uint64_t available() const { return m_available; }
+      uint64_t tx_amount() const { return m_tx_amount; }
+
+      std::string to_string() const
+      {
+        std::ostringstream ss;
+        ss << transfer_error::to_string() <<
+          ", available = " << cryptonote::print_money(m_available) <<
+          ", tx_amount = " << cryptonote::print_money(m_tx_amount);
+        return ss.str();
+      }
+
+    private:
+      uint64_t m_available;
+      uint64_t m_tx_amount;
+    };
+    //----------------------------------------------------------------------------------------------------
     struct not_enough_money : public transfer_error
     {
-      explicit not_enough_money(std::string&& loc, uint64_t availbable, uint64_t tx_amount, uint64_t fee)
+      explicit not_enough_money(std::string&& loc, uint64_t available, uint64_t tx_amount, uint64_t fee)
         : transfer_error(std::move(loc), "not enough money")
-        , m_available(availbable)
+        , m_available(available)
         , m_tx_amount(tx_amount)
       {
       }
@@ -384,9 +411,9 @@ namespace tools
     //----------------------------------------------------------------------------------------------------
     struct tx_not_possible : public transfer_error
     {
-      explicit tx_not_possible(std::string&& loc, uint64_t availbable, uint64_t tx_amount, uint64_t fee)
+      explicit tx_not_possible(std::string&& loc, uint64_t available, uint64_t tx_amount, uint64_t fee)
         : transfer_error(std::move(loc), "tx not possible")
-        , m_available(availbable)
+        , m_available(available)
         , m_tx_amount(tx_amount)
         , m_fee(fee)
       {


### PR DESCRIPTION
Distinguish "not enough money" and "not enough unlocked money" in error msgs.

And minor typo fix in a variable name.