### PR TITLE
wallet_rpc_server: fix spurious attempt to create wallet directory

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -146,7 +146,7 @@ namespace tools
         m_trusted_daemon = true;
       }
     }
-    if (command_line::has_arg(*m_vm, arg_wallet_dir))
+    if (!(*m_vm)[arg_wallet_dir.name].defaulted())
     {
       m_wallet_dir = command_line::get_arg(*m_vm, arg_wallet_dir);
 #ifdef _WIN32


### PR DESCRIPTION
which would fail, as the directory is an empty string