### PR TITLE
Adding needed Ubuntu packages dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN set -x \
       git \
       libboost1.58-all-dev \
       libssl-dev \
+      libzmq3-dev \
+      libsodium-dev \
       make \
       pkg-config \
   ' \


### PR DESCRIPTION
This commit adds ubuntu packages that are needed to build the Docker container.
There is an issue related to that: https://github.com/monero-project/monero/issues/2520