### PR TITLE
fix hashchain.trim unit test

### DIFF
--- a/tests/unit_tests/hashchain.cpp
+++ b/tests/unit_tests/hashchain.cpp
@@ -118,11 +118,11 @@ TEST(hashchain, trim)
   hashchain.push_back(make_hash(3));
   ASSERT_EQ(hashchain.offset(), 0);
   hashchain.trim(2);
-  ASSERT_EQ(hashchain.offset(), 2);
+  ASSERT_EQ(hashchain.offset(), 1);
   ASSERT_EQ(hashchain.size(), 3);
   ASSERT_EQ(hashchain[2], make_hash(3));
   hashchain.trim(3);
-  ASSERT_EQ(hashchain.offset(), 3);
+  ASSERT_EQ(hashchain.offset(), 2);
   ASSERT_EQ(hashchain.size(), 3);
   ASSERT_FALSE(hashchain.empty());
   ASSERT_EQ(hashchain.genesis(), make_hash(1));


### PR DESCRIPTION
https://github.com/monero-project/monero/commit/37c12119ab2fc2119528900e1afd2097ed1a3185 broke the unit test, I'm not sure if this might be a bug @moneromooo-monero.