### PR TITLE
refactoring: replace std::stringstream with std::{i|o}stringstream when allowed

### DIFF
--- a/contrib/epee/include/ado_db_helper.h
+++ b/contrib/epee/include/ado_db_helper.h
@@ -93,7 +93,7 @@ namespace ado_db_helper
 		bool flush_log(const std::string& path)
 		{
 			CRITICAL_REGION_BEGIN(m_sqls_lock);
-			std::stringstream strm;
+			std::ostringstream strm;
 			strm << "SQL PROFILE:\r\nStatements: " << m_sqls.size() << "\r\n";
 			std::list<sqls_map::iterator> m_sorted_by_time_sqls;
 			for(std::map<std::string, profile_entry>::iterator it = m_sqls.begin();it!=m_sqls.end();it++)
@@ -572,7 +572,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5, typename TParam6, typename TParam7>
 	std::string print_parameters_multi(const adapter_sevento<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, TParam7>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3 << ", " << params.tparam4 << ", " << params.tparam5 << ", " << params.tparam6 << ", " << params.tparam7;
 		return strm.str();
 	}
@@ -580,7 +580,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5, typename TParam6, typename TParam7, typename TParam8, typename TParam9>
 	std::string print_parameters_multi(const adapter_nine<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, TParam7, TParam8, TParam9>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3 << ", " << params.tparam4 << ", " << params.tparam5 << ", " << params.tparam6 << ", " << params.tparam7 << ", " << params.tparam8 << ", " << params.tparam9;
 		return strm.str();
 	}
@@ -588,7 +588,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5, typename TParam6>
 	std::string print_parameters_multi(const adapter_sixto<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3 << ", " << params.tparam4 << ", " << params.tparam5 << ", " << params.tparam6;
 		return strm.str();
 	}
@@ -596,7 +596,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5>
 	std::string print_parameters_multi(const adapter_quanto<TParam1, TParam2, TParam3, TParam4, TParam5>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3 << ", " << params.tparam4 << ", " << params.tparam5;
 		return strm.str();
 	}
@@ -605,7 +605,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3, typename TParam4>
 	std::string print_parameters_multi(const adapter_quad<TParam1, TParam2, TParam3, TParam4>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3 << ", " << params.tparam4;
 		return strm.str();
 	}
@@ -613,7 +613,7 @@ inline
 	template<typename TParam1, typename TParam2, typename TParam3>
 	std::string print_parameters_multi(const adapter_triple<TParam1, TParam2, TParam3>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << params.tparam1 << ", " << params.tparam2 << ", " << params.tparam3;
 		return strm.str();
 	}
@@ -621,7 +621,7 @@ inline
 	template<typename TParam>
 	std::string get_str_param(const TParam& prm)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << prm;
 		return strm.str();
 	}
@@ -629,7 +629,7 @@ inline
 	template<typename TParam>
 	std::string get_str_param(const std::list<TParam>& prm_lst)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		for(std::list<TParam>::const_iterator it = prm_lst.begin();it!=prm_lst.end();it++)
 			strm  << get_str_param(*it) << ", ";
 		return strm.str();
@@ -639,7 +639,7 @@ inline
 	template<typename TParam1, typename TParam2>
 	std::string print_parameters_multi(const adapter_double<TParam1, TParam2>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << get_str_param(params.tparam1) << ", " << get_str_param(params.tparam2);
 		return strm.str();
 	}
@@ -647,7 +647,7 @@ inline
 	template<typename TParam1>
 	std::string print_parameters_multi(const adapter_single<TParam1>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << get_str_param(params.tparam1);
 		return strm.str();
 	}
@@ -655,7 +655,7 @@ inline
 	template<typename TParam1>
 	std::string print_parameters_multi(const adapter_zero<TParam1>& params)
 	{
-		std::stringstream strm;
+		std::ostringstream strm;
 		strm << "(no parametrs)";
 		return strm.str();
 	}

--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -460,7 +460,7 @@ eof:
 
     std::string get_usage()
     {
-      std::stringstream ss;
+      std::ostringstream ss;
       size_t max_command_len = 0;
       for(auto& x:m_command_handlers)
         if(x.first.size() > max_command_len)

--- a/contrib/epee/include/global_stream_operators.h
+++ b/contrib/epee/include/global_stream_operators.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-std::stringstream& operator<<(std::stringstream& out, const std::wstring& ws)
+std::ostringstream& operator<<(std::ostringstream& out, const std::wstring& ws)
 {
 	std::string as = string_encoding::convert_to_ansii(ws);
 	out << as;

--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -168,7 +168,7 @@ namespace debug
 #define CATCH_ENTRY_L4(lacation, return_val) CATCH_ENTRY(lacation, return_val)
 
 
-#define ASSERT_MES_AND_THROW(message) {LOG_ERROR(message); std::stringstream ss; ss << message; throw std::runtime_error(ss.str());}
+#define ASSERT_MES_AND_THROW(message) {LOG_ERROR(message); std::ostringstream ss; ss << message; throw std::runtime_error(ss.str());}
 #define CHECK_AND_ASSERT_THROW_MES(expr, message) {if(!(expr)) ASSERT_MES_AND_THROW(message);}
 
 

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -234,7 +234,7 @@ namespace net_utils
   inline 
     std::string print_connection_context(const connection_context_base& ctx)
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << ctx.m_remote_address->str() << " " << epee::string_tools::get_str_from_guid_a(ctx.m_connection_id) << (ctx.m_is_income ? " INC":" OUT");
     return ss.str();
   }
@@ -242,7 +242,7 @@ namespace net_utils
   inline 
     std::string print_connection_context_short(const connection_context_base& ctx)
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << ctx.m_remote_address->str() << (ctx.m_is_income ? " INC":" OUT");
     return ss.str();
   }

--- a/contrib/epee/include/net/smtp.h
+++ b/contrib/epee/include/net/smtp.h
@@ -77,7 +77,7 @@ namespace net_utils
 		private:
 			std::string encodeBase64(std::string pData)
 			{
-				std::stringstream os;
+				std::ostringstream os;
 				size_t sz=pData.size();
 				std::copy(base64_text(pData.c_str()),base64_text(pData.c_str()+sz),std::ostream_iterator<char>(os));
 				return os.str();

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -109,7 +109,7 @@ namespace epee
     bool portable_storage::dump_as_json(std::string& buff, size_t indent, bool insert_newlines)
     {
       TRY_ENTRY();
-      std::stringstream ss;
+      std::ostringstream ss;
       epee::serialization::dump_as_json(ss, m_root, indent, insert_newlines);
       buff = ss.str();
       return true;
@@ -133,7 +133,7 @@ namespace epee
     bool portable_storage::store_to_binary(binarybuffer& target)
     {
       TRY_ENTRY();
-      std::stringstream ss;
+      std::ostringstream ss;
       storage_block_header sbh = AUTO_VAL_INIT(sbh);
       sbh.m_signature_a = PORTABLE_STORAGE_SIGNATUREA;
       sbh.m_signature_b = PORTABLE_STORAGE_SIGNATUREB;

--- a/contrib/epee/include/time_helper.h
+++ b/contrib/epee/include/time_helper.h
@@ -68,7 +68,7 @@ PRAGMA_WARNING_POP
 			strftime( tmpbuf, 199, "%d.%m.%Y %H:%M:%S", pt );
 		else
 		{
-			std::stringstream strs;
+			std::ostringstream strs;
 			strs << "[wrong_time: " << std::hex << time_ << "]";
 			return strs.str();
 		}
@@ -90,7 +90,7 @@ PRAGMA_WARNING_POP
 			strftime( tmpbuf, 199, "%Y_%m_%d %H_%M_%S", pt );
 		else
 		{
-			std::stringstream strs;
+			std::ostringstream strs;
 			strs << "[wrong_time: " << std::hex << time_ << "]";
 			return strs.str();
 		}

--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -369,7 +369,7 @@ bool Configurations::Parser::parseFromText(const std::string& configurationsStri
     Configurations* base) {
   sender->setFromBase(base);
   bool parsedSuccessfully = false;
-  std::stringstream ss(configurationsString);
+  std::istringstream ss(configurationsString);
   std::string line = std::string();
   Level currLevel = Level::Unknown;
   std::string currConfigStr = std::string();
@@ -991,7 +991,7 @@ std::string OS::getProperty(const char* prop) {
 }
 
 std::string OS::getDeviceName(void) {
-  std::stringstream ss;
+  std::ostringstream ss;
   std::string manufacturer = getProperty("ro.product.manufacturer");
   std::string model = getProperty("ro.product.model");
   if (manufacturer.empty() || model.empty()) {
@@ -1475,7 +1475,7 @@ void LogFormat::updateDateFormat(std::size_t index, base::type::string_t& currFo
     // User has provided format for date/time
     ++ptr;
     int count = 1;  // Start by 1 in order to remove starting brace
-    std::stringstream ss;
+    std::ostringstream ss;
     for (; *ptr; ++ptr, ++count) {
       if (*ptr == '}') {
         ++count;  // In order to remove ending brace
@@ -1687,7 +1687,7 @@ std::string TypedConfigurations::resolveFilename(const std::string& filename) {
         // User has provided format for date/time
         ++ptr;
         int count = 1;  // Start by 1 in order to remove starting brace
-        std::stringstream ss;
+        std::ostringstream ss;
         for (; *ptr; ++ptr, ++count) {
           if (*ptr == '}') {
             ++count;  // In order to remove ending brace
@@ -1885,7 +1885,7 @@ void VRegistry::setLevel(base::type::VerboseLevel level) {
 
 void VRegistry::setModules(const char* modules) {
   base::threading::ScopedLock scopedLock(lock());
-  auto addSuffix = [](std::stringstream& ss, const char* sfx, const char* prev) {
+  auto addSuffix = [](std::ostringstream& ss, const char* sfx, const char* prev) {
     if (prev != nullptr && base::utils::Str::endsWith(ss.str(), std::string(prev))) {
       std::string chr(ss.str().substr(0, ss.str().size() - strlen(prev)));
       ss.str(std::string(""));
@@ -1898,7 +1898,7 @@ void VRegistry::setModules(const char* modules) {
     }
     ss << sfx;
   };
-  auto insert = [&](std::stringstream& ss, base::type::VerboseLevel level) {
+  auto insert = [&](std::ostringstream& ss, base::type::VerboseLevel level) {
     if (!base::utils::hasFlag(LoggingFlag::DisableVModulesExtensions, *m_pFlags)) {
       addSuffix(ss, ".h", nullptr);
       m_modules.insert(std::make_pair(ss.str(), level));
@@ -1922,7 +1922,7 @@ void VRegistry::setModules(const char* modules) {
   };
   bool isMod = true;
   bool isLevel = false;
-  std::stringstream ss;
+  std::ostringstream ss;
   int level = -1;
   for (; *modules; ++modules) {
     switch (*modules) {
@@ -1957,7 +1957,7 @@ void VRegistry::setModules(const char* modules) {
 
 void VRegistry::setCategories(const char* categories, bool clear) {
   base::threading::ScopedLock scopedLock(lock());
-  auto insert = [&](std::stringstream& ss, Level level) {
+  auto insert = [&](std::ostringstream& ss, Level level) {
     m_categories.push_back(std::make_pair(ss.str(), level));
   };
 
@@ -1973,7 +1973,7 @@ void VRegistry::setCategories(const char* categories, bool clear) {
 
   bool isCat = true;
   bool isLevel = false;
-  std::stringstream ss;
+  std::ostringstream ss;
   Level level = Level::Unknown;
   for (; *categories; ++categories) {
     switch (*categories) {
@@ -2619,7 +2619,7 @@ void Writer::triggerDispatch(void) {
       && !ELPP->hasFlag(LoggingFlag::DisableApplicationAbortOnFatalLog)) {
     base::Writer(Level::Warning, m_file, m_line, m_func).construct(1, base::consts::kDefaultLoggerId)
         << "Aborting application. Reason: Fatal log at [" << m_file << ":" << m_line << "]";
-    std::stringstream reasonStream;
+    std::ostringstream reasonStream;
     reasonStream << "Fatal log at [" << m_file << ":" << m_line << "]"
                  << " If you wish to disable 'abort on fatal log' please use "
                  << "el::Helpers::addFlag(el::LoggingFlag::DisableApplicationAbortOnFatalLog)";
@@ -2721,7 +2721,7 @@ void PerformanceTracker::checkpoint(const std::string& id, const char* file, bas
 
 const base::type::string_t PerformanceTracker::getFormattedTimeTaken(struct timeval startTime) const {
   if (ELPP->hasFlag(LoggingFlag::FixedTimeFormat)) {
-    base::type::stringstream_t ss;
+    base::type::ostringstream_t ss;
     ss << base::utils::DateTime::getTimeDifference(m_endTime,
         startTime, m_timestampUnit) << " " << base::consts::kTimeFormats[static_cast<base::type::EnumType>
             (m_timestampUnit)].unit;
@@ -2820,7 +2820,7 @@ void StackTrace::generateNew(void) {
 // Static helper functions
 
 static std::string crashReason(int sig) {
-  std::stringstream ss;
+  std::ostringstream ss;
   bool foundReason = false;
   for (int i = 0; i < base::consts::kCrashSignalsCount; ++i) {
     if (base::consts::kCrashSignals[i].numb == sig) {
@@ -2840,7 +2840,7 @@ static std::string crashReason(int sig) {
 }
 /// @brief Logs reason of crash from sig
 static void logCrashReason(int sig, bool stackTraceIfAvailable, Level level, const char* logger) {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << "CRASH HANDLED; ";
   ss << crashReason(sig);
 #if ELPP_STACKTRACE
@@ -2896,7 +2896,7 @@ void CrashHandler::setHandler(const Handler& cHandler) {
 #if defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_CRASH_LOG)
 
 void Helpers::crashAbort(int sig, const char* sourceFile, unsigned int long line) {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << base::debug::crashReason(sig).c_str();
   ss << " - [Called el::Helpers::crashAbort(" << sig << ")]";
   if (sourceFile != nullptr && strlen(sourceFile) > 0) {
@@ -3009,7 +3009,7 @@ void Loggers::configureFromGlobal(const char* globalConfigurationFilePath) {
   ELPP_ASSERT(gcfStream.is_open(), "Unable to open global configuration file [" << globalConfigurationFilePath
               << "] for parsing.");
   std::string line = std::string();
-  std::stringstream ss;
+  std::ostringstream ss;
   Logger* logger = nullptr;
   auto configure = [&](void) {
     ELPP_INTERNAL_INFO(8, "Configuring logger: '" << logger->id() << "' with configurations \n" << ss.str()

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -143,14 +143,14 @@
 #if !defined(ELPP_DISABLE_ASSERT)
 #  if (defined(ELPP_DEBUG_ASSERT_FAILURE))
 #    define ELPP_ASSERT(expr, msg) if (!(expr)) { \
-std::stringstream internalInfoStream; internalInfoStream << msg; \
+std::ostringstream internalInfoStream; internalInfoStream << msg; \
 ELPP_INTERNAL_DEBUGGING_OUT_ERROR \
 << "EASYLOGGING++ ASSERTION FAILED (LINE: " << __LINE__ << ") [" #expr << "] WITH MESSAGE \"" \
 << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStream.str()) << "\"" << ELPP_INTERNAL_DEBUGGING_ENDL; base::utils::abort(1, \
 "ELPP Assertion failure, please define ELPP_DEBUG_ASSERT_FAILURE"); }
 #  else
 #    define ELPP_ASSERT(expr, msg) if (!(expr)) { \
-std::stringstream internalInfoStream; internalInfoStream << msg; \
+std::ostringstream internalInfoStream; internalInfoStream << msg; \
 ELPP_INTERNAL_DEBUGGING_OUT_ERROR\
 << "ASSERTION FAILURE FROM EASYLOGGING++ (LINE: " \
 << __LINE__ << ") [" #expr << "] WITH MESSAGE \"" << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStream.str()) << "\"" \
@@ -170,7 +170,7 @@ ELPP_INTERNAL_DEBUGGING_OUT_ERROR << ": " << strerror(errno) << " [" << errno <<
 #if defined(ELPP_DEBUG_ERRORS)
 #  if !defined(ELPP_INTERNAL_ERROR)
 #    define ELPP_INTERNAL_ERROR(msg, pe) { \
-std::stringstream internalInfoStream; internalInfoStream << "<ERROR> " << msg; \
+std::ostringstream internalInfoStream; internalInfoStream << "<ERROR> " << msg; \
 ELPP_INTERNAL_DEBUGGING_OUT_ERROR \
 << "ERROR FROM EASYLOGGING++ (LINE: " << __LINE__ << ") " \
 << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStream.str()) << ELPP_INTERNAL_DEBUGGING_ENDL; \
@@ -186,7 +186,7 @@ if (pe) { ELPP_INTERNAL_DEBUGGING_OUT_ERROR << "    "; ELPP_INTERNAL_DEBUGGING_W
 #  endif  // !(defined(ELPP_INTERNAL_INFO_LEVEL))
 #  if !defined(ELPP_INTERNAL_INFO)
 #    define ELPP_INTERNAL_INFO(lvl, msg) { if (lvl <= ELPP_INTERNAL_INFO_LEVEL) { \
-std::stringstream internalInfoStream; internalInfoStream << "<INFO> " << msg; \
+std::ostringstream internalInfoStream; internalInfoStream << "<INFO> " << msg; \
 ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStream.str()) \
 << ELPP_INTERNAL_DEBUGGING_ENDL; }}
 #  endif
@@ -498,7 +498,7 @@ namespace type {
 #  endif  // defined ELPP_CUSTOM_COUT
 typedef wchar_t char_t;
 typedef std::wstring string_t;
-typedef std::wstringstream stringstream_t;
+typedef std::wostringstream stringstream_t;
 typedef std::wfstream fstream_t;
 typedef std::wostream ostream_t;
 #else
@@ -511,7 +511,7 @@ typedef std::wostream ostream_t;
 #  endif  // defined ELPP_CUSTOM_COUT
 typedef char char_t;
 typedef std::string string_t;
-typedef std::stringstream stringstream_t;
+typedef std::ostringstream stringstream_t;
 typedef std::fstream fstream_t;
 typedef std::ostream ostream_t;
 #endif  // defined(ELPP_UNICODE)
@@ -1066,7 +1066,7 @@ class ThreadSafe {
 #  if !ELPP_USE_STD_THREADING
 /// @brief Gets ID of currently running threading in windows systems. On unix, nothing is returned.
 static std::string getCurrentThreadId(void) {
-  std::stringstream ss;
+  std::ostringstream ss;
 #      if (ELPP_OS_WINDOWS)
   ss << GetCurrentThreadId();
 #      endif  // (ELPP_OS_WINDOWS)
@@ -1075,7 +1075,7 @@ static std::string getCurrentThreadId(void) {
 #  else
 /// @brief Gets ID of currently running threading using std::this_thread::get_id()
 static std::string getCurrentThreadId(void) {
-  std::stringstream ss;
+  std::ostringstream ss;
   char prev_fill = ss.fill(' ');
   auto prev_flags = ss.flags(std::ios::hex);
   //ss.setf(std::ios::hex);

--- a/src/blockchain_db/berkeleydb/db_bdb.cpp
+++ b/src/blockchain_db/berkeleydb/db_bdb.cpp
@@ -726,8 +726,7 @@ blobdata BlockchainBDB::output_to_blob(const tx_out& output) const
 tx_out BlockchainBDB::output_from_blob(const blobdata& blob) const
 {
     LOG_PRINT_L3("BlockchainBDB::" << __func__);
-    std::stringstream ss;
-    ss << blob;
+    std::istringstream ss(blob);
     binary_archive<false> ba(ss);
     tx_out o;
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1042,8 +1042,7 @@ blobdata BlockchainLMDB::output_to_blob(const tx_out& output) const
 tx_out BlockchainLMDB::output_from_blob(const blobdata& blob) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  std::stringstream ss;
-  ss << blob;
+  std::istringstream ss(blob);
   binary_archive<false> ba(ss);
   tx_out o;
 

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -243,7 +243,7 @@ namespace cryptonote
 
         // parse the first part as uint64_t,
         // if this fails move on to the next record
-        std::stringstream ss(record.substr(0, pos));
+        std::istringstream ss(record.substr(0, pos));
         if (!(ss >> height))
         {
     continue;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -106,7 +106,7 @@ std::string ipv4_to_string(const char* src, size_t len)
 {
   assert(len >= 4);
 
-  std::stringstream ss;
+  std::ostringstream ss;
   unsigned int bytes[4];
   for (int i = 0; i < 4; i++)
   {
@@ -126,7 +126,7 @@ std::string ipv6_to_string(const char* src, size_t len)
 {
   assert(len >= 8);
 
-  std::stringstream ss;
+  std::ostringstream ss;
   unsigned int bytes[8];
   for (int i = 0; i < 8; i++)
   {

--- a/src/common/scoped_message_writer.h
+++ b/src/common/scoped_message_writer.h
@@ -49,7 +49,7 @@ class scoped_message_writer
 {
 private:
   bool m_flush;
-  std::stringstream m_oss;
+  std::ostringstream m_oss;
   epee::console_colors m_color;
   bool m_bright;
   el::Level m_log_level;

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -150,7 +150,7 @@ void log_stack_trace(const char *msg)
     free(dsym);
   }
 #else
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << el::base::debug::StackTrace();
   std::vector<std::string> lines;
   std::string s = ss.str();

--- a/src/common/varint.h
+++ b/src/common/varint.h
@@ -83,7 +83,7 @@ namespace tools {
   template<typename T>
     std::string get_varint_data(const T& v)
     {
-      std::stringstream ss;
+      std::ostringstream ss;
       write_varint(std::ostreambuf_iterator<char>(ss), v);
       return ss.str();
     }

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -95,8 +95,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool parse_and_validate_tx_from_blob(const blobdata& tx_blob, transaction& tx)
   {
-    std::stringstream ss;
-    ss << tx_blob;
+    std::istringstream ss(tx_blob);
     binary_archive<false> ba(ss);
     bool r = ::serialization::serialize(ba, tx);
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse transaction from blob");
@@ -106,8 +105,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool parse_and_validate_tx_base_from_blob(const blobdata& tx_blob, transaction& tx)
   {
-    std::stringstream ss;
-    ss << tx_blob;
+    std::istringstream ss(tx_blob);
     binary_archive<false> ba(ss);
     bool r = tx.serialize_base(ba);
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse transaction from blob");
@@ -116,8 +114,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool parse_and_validate_tx_from_blob(const blobdata& tx_blob, transaction& tx, crypto::hash& tx_hash, crypto::hash& tx_prefix_hash)
   {
-    std::stringstream ss;
-    ss << tx_blob;
+    std::istringstream ss(tx_blob);
     binary_archive<false> ba(ss);
     bool r = ::serialization::serialize(ba, tx);
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse transaction from blob");
@@ -620,7 +617,7 @@ namespace cryptonote
 
     // base rct
     {
-      std::stringstream ss;
+      std::ostringstream ss;
       binary_archive<true> ba(ss);
       const size_t inputs = t.vin.size();
       const size_t outputs = t.vout.size();
@@ -636,7 +633,7 @@ namespace cryptonote
     }
     else
     {
-      std::stringstream ss;
+      std::ostringstream ss;
       binary_archive<true> ba(ss);
       const size_t inputs = t.vin.size();
       const size_t outputs = t.vout.size();
@@ -801,8 +798,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool parse_and_validate_block_from_blob(const blobdata& b_blob, block& b)
   {
-    std::stringstream ss;
-    ss << b_blob;
+    std::istringstream ss(b_blob);
     binary_archive<false> ba(ss);
     bool r = ::serialization::serialize(ba, b);
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse block from blob");

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -112,7 +112,7 @@ namespace cryptonote
   template<class t_object>
   bool t_serializable_object_to_blob(const t_object& to, blobdata& b_blob)
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     binary_archive<true> ba(ss);
     bool r = ::serialization::serialize(ba, const_cast<t_object&>(to));
     b_blob = ss.str();
@@ -153,7 +153,7 @@ namespace cryptonote
   template <typename T>
   std::string obj_to_json_str(T& obj)
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     json_archive<true> ar(ss, true);
     bool r = ::serialization::serialize(ar, obj);
     CHECK_AND_ASSERT_MES(r, "", "obj_to_json_str failed: serialization::serialize returned false");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2021,7 +2021,7 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
 void Blockchain::print_blockchain(uint64_t start_index, uint64_t end_index) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  std::stringstream ss;
+  std::ostringstream ss;
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   auto h = m_db->height();
   if(start_index > h)
@@ -2040,7 +2040,7 @@ void Blockchain::print_blockchain(uint64_t start_index, uint64_t end_index) cons
 void Blockchain::print_blockchain_index() const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  std::stringstream ss;
+  std::ostringstream ss;
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   auto height = m_db->height();
   if (height != 0)

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -348,7 +348,7 @@ namespace cryptonote
       crypto::hash tx_prefix_hash;
       get_transaction_prefix_hash(tx, tx_prefix_hash);
 
-      std::stringstream ss_ring_s;
+      std::ostringstream ss_ring_s;
       size_t i = 0;
       for(const tx_source_entry& src_entr:  sources)
       {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -873,7 +873,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   std::string tx_memory_pool::print_pool(bool short_format) const
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
     m_blockchain.for_all_txpool_txes([&ss, short_format](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *txblob) {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -124,7 +124,7 @@ namespace cryptonote
   template<class t_core>
   void t_cryptonote_protocol_handler<t_core>::log_connections()
   {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss.precision(1);
 
     double down_sum = 0.0;

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -299,7 +299,7 @@ bool t_command_server::help(const std::vector<std::string>& args)
 
 std::string t_command_server::get_commands_str()
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << std::endl;
   ss << "Commands: " << std::endl;
   std::string usage = m_command_lookup.get_usage();

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1731,7 +1731,7 @@ namespace nodetool
   std::string node_server<t_payload_net_handler>::print_connections_container()
   {
 
-    std::stringstream ss;
+    std::ostringstream ss;
     m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
     {
       ss << cntxt.m_remote_address.str()

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -116,7 +116,7 @@ namespace nodetool
   {
     time_t now_time = 0;
     time(&now_time);
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << std::setfill ('0') << std::setw (8) << std::hex << std::noshowbase;
     for(const peerlist_entry& pe: pl)
     {

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -325,7 +325,7 @@ namespace rct {
       hashes.push_back(rv.message);
       crypto::hash h;
 
-      std::stringstream ss;
+      std::ostringstream ss;
       binary_archive<true> ba(ss);
       const size_t inputs = rv.pseudoOuts.size();
       const size_t outputs = rv.ecdhInfo.size();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -170,7 +170,7 @@ namespace cryptonote
       return blobdata;
     }
 
-    std::stringstream ss;
+    std::ostringstream ss;
     binary_archive<true> ba(ss);
     bool r = tx.serialize_base(ba);
     CHECK_AND_ASSERT_MES(r, blobdata, "Failed to serialize rct signatures base");
@@ -328,7 +328,7 @@ namespace cryptonote
     }
 
     res.status = CORE_RPC_STATUS_OK;
-    std::stringstream ss;
+    std::ostringstream ss;
     typedef COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::outs_for_amount outs_for_amount;
     typedef COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::out_entry out_entry;
     std::for_each(res.outs.begin(), res.outs.end(), [&](outs_for_amount& ofa)
@@ -418,7 +418,7 @@ namespace cryptonote
     }
 
     res.status = CORE_RPC_STATUS_OK;
-    std::stringstream ss;
+    std::ostringstream ss;
     typedef COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS::out_entry out_entry;
     CHECK_AND_ASSERT_MES(res.outs.size(), true, "internal error: res.outs.size() is empty");
     std::for_each(res.outs.begin(), res.outs.end(), [&](out_entry& oe)

--- a/src/serialization/binary_utils.h
+++ b/src/serialization/binary_utils.h
@@ -49,7 +49,7 @@ namespace serialization {
   template<class T>
     bool dump_binary(T& v, std::string& blob)
     {
-      std::stringstream ostr;
+      std::ostringstream ostr;
       binary_archive<true> oar(ostr);
       bool success = ::serialization::serialize(oar, v);
       blob = ostr.str();

--- a/src/serialization/json_utils.h
+++ b/src/serialization/json_utils.h
@@ -38,7 +38,7 @@ namespace serialization {
 template<class T>
 std::string dump_json(T &v)
 {
-  std::stringstream ostr;
+  std::ostringstream ostr;
   json_archive<true> oar(ostr);
   assert(serialization::serialize(oar, v));
   return ostr.str();

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -231,7 +231,7 @@ namespace
     {
       dnssec_str = tr("WARNING: DNSSEC validation was unsuccessful, this address may not be correct!");
     }
-    std::stringstream prompt;
+    std::ostringstream prompt;
     prompt << tr("For URL: ") << url
            << ", " << dnssec_str << std::endl
            << tr(" Monero Address = ") << addresses[0]
@@ -256,7 +256,7 @@ namespace
 
 std::string simple_wallet::get_commands_str()
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << tr("Commands: ") << ENDL;
   std::string usage = m_cmd_binder.get_usage();
   boost::replace_all(usage, "\n", "\n  ");
@@ -2544,7 +2544,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     // if we need to check for backlog, check the worst case tx
     if (m_wallet->confirm_backlog())
     {
-      std::stringstream prompt;
+      std::ostringstream prompt;
       double worst_fee_per_byte = std::numeric_limits<double>::max();
       uint64_t size = 0, fee = 0;
       for (size_t n = 0; n < ptx_vector.size(); ++n)
@@ -2611,7 +2611,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
             dust_not_in_fee += ptx_vector[n].dust;
         }
 
-        std::stringstream prompt;
+        std::ostringstream prompt;
         prompt << boost::format(tr("Sending %s.  ")) % print_money(total_sent);
         if (ptx_vector.size() > 1)
         {
@@ -4711,7 +4711,7 @@ bool simple_wallet::export_outputs(const std::vector<std::string> &args)
   {
     std::vector<tools::wallet2::transfer_details> outs = m_wallet->export_outputs();
 
-    std::stringstream oss;
+    std::ostringstream oss;
     boost::archive::portable_binary_oarchive ar(oss);
     ar << outs;
 
@@ -4790,8 +4790,7 @@ bool simple_wallet::import_outputs(const std::vector<std::string> &args)
   try
   {
     std::string body(data, headerlen);
-    std::stringstream iss;
-    iss << body;
+    std::istringstream iss(body);
     std::vector<tools::wallet2::transfer_details> outputs;
     try
     {
@@ -4800,8 +4799,7 @@ bool simple_wallet::import_outputs(const std::vector<std::string> &args)
     }
     catch (...)
     {
-      iss.str("");
-      iss << body;
+      iss.str(body);
       boost::archive::binary_iarchive ar(iss);
       ar >> outputs;
     }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -173,7 +173,7 @@ uint64_t Wallet::amountFromString(const string &amount)
 
 uint64_t Wallet::amountFromDouble(double amount)
 {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << std::fixed << std::setprecision(CRYPTONOTE_DISPLAY_DECIMAL_POINT) << amount;
     return amountFromString(ss.str());
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -433,7 +433,7 @@ static void throw_on_rpc_response_error(const boost::optional<std::string> &stat
 
 std::string strjoin(const std::vector<size_t> &V, const char *sep)
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   bool first = true;
   for (const auto &v: V)
   {
@@ -2504,8 +2504,7 @@ void wallet2::load(const std::string& wallet_, const std::string& password)
       cache_data.resize(cache_file_data.cache_data.size());
       crypto::chacha8(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cache_data[0]);
 
-      std::stringstream iss;
-      iss << cache_data;
+      std::istringstream iss(cache_data);
       try {
         boost::archive::portable_binary_iarchive ar(iss);
         ar >> *this;
@@ -2514,8 +2513,7 @@ void wallet2::load(const std::string& wallet_, const std::string& password)
       {
         LOG_PRINT_L0("Failed to open portable binary, trying unportable");
         boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
-        iss.str("");
-        iss << cache_data;
+        iss.str(cache_data);
         boost::archive::binary_iarchive ar(iss);
         ar >> *this;
       }
@@ -2523,8 +2521,7 @@ void wallet2::load(const std::string& wallet_, const std::string& password)
     catch (...)
     {
       LOG_PRINT_L1("Failed to load encrypted cache, trying unencrypted");
-      std::stringstream iss;
-      iss << buf;
+      std::istringstream iss(buf);
       try {
         boost::archive::portable_binary_iarchive ar(iss);
         ar >> *this;
@@ -2533,8 +2530,7 @@ void wallet2::load(const std::string& wallet_, const std::string& password)
       {
         LOG_PRINT_L0("Failed to open portable binary, trying unportable");
         boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
-        iss.str("");
-        iss << buf;
+        iss.str(buf);
         boost::archive::binary_iarchive ar(iss);
         ar >> *this;
       }
@@ -2648,7 +2644,7 @@ void wallet2::store_to(const std::string &path, const std::string &password)
     }
   }
   // preparing wallet data
-  std::stringstream oss;
+  std::ostringstream oss;
   boost::archive::portable_binary_oarchive ar(oss);
   ar << *this;
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -277,7 +277,7 @@ struct output_index {
         : out(other.out), amount(other.amount), blk_height(other.blk_height), tx_no(other.tx_no), out_no(other.out_no), idx(other.idx), spent(other.spent), p_blk(other.p_blk), p_tx(other.p_tx) {  }
 
     const std::string toString() const {
-        std::stringstream ss;
+        std::ostringstream ss;
 
         ss << "output_index{blk_height=" << blk_height
            << " tx_no=" << tx_no

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -370,8 +370,7 @@ public:
     m_c.handle_incoming_block(sr_block.data, bvc);
 
     cryptonote::block blk;
-    std::stringstream ss;
-    ss << sr_block.data;
+    std::istringstream ss(sr_block.data);
     binary_archive<false> ba(ss);
     ::serialization::serialize(ba, blk);
     if (!ss.good())
@@ -393,8 +392,7 @@ public:
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
 
     cryptonote::transaction tx;
-    std::stringstream ss;
-    ss << sr_tx.data;
+    std::istringstream ss(sr_tx.data);
     binary_archive<false> ba(ss);
     ::serialization::serialize(ba, tx);
     if (!ss.good())

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -45,7 +45,7 @@ namespace
 
 std::string generate_random_wallet_name()
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << boost::uuids::random_generator()();
   return ss.str();
 }

--- a/tests/fuzz/cold-outputs.cpp
+++ b/tests/fuzz/cold-outputs.cpp
@@ -85,8 +85,7 @@ int ColdOutputsFuzzer::run(const std::string &filename)
   try
   {
     std::vector<tools::wallet2::transfer_details> outputs;
-    std::stringstream iss;
-    iss << s;
+    std::istringstream iss(s);
     boost::archive::portable_binary_iarchive ar(iss);
     ar >> outputs;
     size_t n_outputs = wallet.import_outputs(outputs);

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -87,8 +87,7 @@ int ColdTransactionFuzzer::run(const std::string &filename)
   try
   {
     tools::wallet2::unsigned_tx_set exported_txs;
-    std::stringstream iss;
-    iss << s;
+    std::istringstream iss(s);
     boost::archive::portable_binary_iarchive ar(iss);
     ar >> exported_txs;
     std::vector<tools::wallet2::pending_tx> ptx;

--- a/tests/gtest/include/gtest/gtest-message.h
+++ b/tests/gtest/include/gtest/gtest-message.h
@@ -93,12 +93,12 @@ class GTEST_API_ Message {
   Message();
 
   // Copy constructor.
-  Message(const Message& msg) : ss_(new ::std::stringstream) {  // NOLINT
+  Message(const Message& msg) : ss_(new ::std::ostringstream) {  // NOLINT
     *ss_ << msg.GetString();
   }
 
   // Constructs a Message from a C-string.
-  explicit Message(const char* str) : ss_(new ::std::stringstream) {
+  explicit Message(const char* str) : ss_(new ::std::ostringstream) {
     *ss_ << str;
   }
 
@@ -221,7 +221,7 @@ class GTEST_API_ Message {
 #endif  // GTEST_OS_SYMBIAN
 
   // We'll hold the text streamed to this object here.
-  const internal::scoped_ptr< ::std::stringstream> ss_;
+  const internal::scoped_ptr< ::std::ostringstream> ss_;
 
   // We declare (but don't implement) this to prevent the compiler
   // from implementing the assignment operator.

--- a/tests/gtest/include/gtest/gtest-printers.h
+++ b/tests/gtest/include/gtest/gtest-printers.h
@@ -937,7 +937,7 @@ struct TuplePrefixPrinter {
   template <typename Tuple>
   static void TersePrintPrefixToStrings(const Tuple& t, Strings* strings) {
     TuplePrefixPrinter<N - 1>::TersePrintPrefixToStrings(t, strings);
-    ::std::stringstream ss;
+    ::std::ostringstream ss;
     UniversalTersePrint(TuplePolicy<Tuple>::template get<N - 1>(t), &ss);
     strings->push_back(ss.str());
   }
@@ -978,7 +978,7 @@ Strings UniversalTersePrintTupleFieldsToStrings(const Tuple& value) {
 
 template <typename T>
 ::std::string PrintToString(const T& value) {
-  ::std::stringstream ss;
+  ::std::ostringstream ss;
   internal::UniversalTersePrinter<T>::Print(value, &ss);
   return ss.str();
 }

--- a/tests/gtest/include/gtest/gtest.h
+++ b/tests/gtest/include/gtest/gtest.h
@@ -1642,11 +1642,11 @@ AssertionResult CmpHelperFloatingPointEQ(const char* expected_expression,
     return AssertionSuccess();
   }
 
-  ::std::stringstream expected_ss;
+  ::std::ostringstream expected_ss;
   expected_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
               << expected;
 
-  ::std::stringstream actual_ss;
+  ::std::ostringstream actual_ss;
   actual_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
             << actual;
 

--- a/tests/gtest/include/gtest/internal/gtest-string.h
+++ b/tests/gtest/include/gtest/internal/gtest-string.h
@@ -159,7 +159,7 @@ class GTEST_API_ String {
 
 // Gets the content of the stringstream's buffer as an std::string.  Each '\0'
 // character in the buffer is replaced with "\\0".
-GTEST_API_ std::string StringStreamToString(::std::stringstream* stream);
+GTEST_API_ std::string StringStreamToString(::std::ostringstream* stream);
 
 }  // namespace internal
 }  // namespace testing

--- a/tests/gtest/src/gtest.cc
+++ b/tests/gtest/src/gtest.cc
@@ -943,7 +943,7 @@ void SplitString(const ::std::string& str, char delimiter,
 // ASSERT/EXPECT in a procedure adds over 200 bytes to the procedure's
 // stack frame leading to huge stack frames in some cases; gcc does not reuse
 // the stack space.
-Message::Message() : ss_(new ::std::stringstream) {
+Message::Message() : ss_(new ::std::ostringstream) {
   // By default, we want there to be enough precision when printing
   // a double to a Message.
   *ss_ << std::setprecision(std::numeric_limits<double>::digits10 + 2);
@@ -1206,7 +1206,7 @@ std::string CreateUnifiedDiff(const std::vector<std::string>& left,
   const std::vector<EditType> edits = CalculateOptimalEdits(left, right);
 
   size_t l_i = 0, r_i = 0, edit_i = 0;
-  std::stringstream ss;
+  std::ostringstream ss;
   while (edit_i < edits.size()) {
     // Find first edit.
     while (edit_i < edits.size() && edits[edit_i] == kMatch) {
@@ -1400,11 +1400,11 @@ AssertionResult FloatingPointLE(const char* expr1,
   // val2 is NaN, as the IEEE floating-point standard requires that
   // any predicate involving a NaN must return false.
 
-  ::std::stringstream val1_ss;
+  ::std::ostringstream val1_ss;
   val1_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
           << val1;
 
-  ::std::stringstream val2_ss;
+  ::std::ostringstream val2_ss;
   val2_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
           << val2;
 
@@ -1824,7 +1824,7 @@ std::string WideStringToUtf8(const wchar_t* str, int num_chars) {
   if (num_chars == -1)
     num_chars = static_cast<int>(wcslen(str));
 
-  ::std::stringstream stream;
+  ::std::ostringstream stream;
   for (int i = 0; i < num_chars; ++i) {
     UInt32 unicode_code_point;
 
@@ -1957,21 +1957,21 @@ bool String::EndsWithCaseInsensitive(
 
 // Formats an int value as "%02d".
 std::string String::FormatIntWidth2(int value) {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << std::setfill('0') << std::setw(2) << value;
   return ss.str();
 }
 
 // Formats an int value as "%X".
 std::string String::FormatHexInt(int value) {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << std::hex << std::uppercase << value;
   return ss.str();
 }
 
 // Formats a byte as "%02X".
 std::string String::FormatByte(unsigned char value) {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << std::setfill('0') << std::setw(2) << std::hex << std::uppercase
      << static_cast<unsigned int>(value);
   return ss.str();
@@ -1979,7 +1979,7 @@ std::string String::FormatByte(unsigned char value) {
 
 // Converts the buffer in a stringstream to an std::string, converting NUL
 // bytes to "\\0" along the way.
-std::string StringStreamToString(::std::stringstream* ss) {
+std::string StringStreamToString(::std::ostringstream* ss) {
   const ::std::string& str = ss->str();
   const char* const start = str.c_str();
   const char* const end = start + str.length();
@@ -3453,7 +3453,7 @@ void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
     fflush(stderr);
     exit(EXIT_FAILURE);
   }
-  std::stringstream stream;
+  std::ostringstream stream;
   PrintXmlUnitTest(&stream, unit_test);
   fprintf(xmlout, "%s", StringStreamToString(&stream).c_str());
   fclose(xmlout);
@@ -3546,7 +3546,7 @@ std::string XmlUnitTestResultPrinter::RemoveInvalidXmlCharacters(
 
 // Formats the given time in milliseconds as seconds.
 std::string FormatTimeInMillisAsSeconds(TimeInMillis ms) {
-  ::std::stringstream ss;
+  ::std::ostringstream ss;
   ss << (static_cast<double>(ms) * 1e-3);
   return ss.str();
 }

--- a/tests/net_load_tests/net_load_tests.h
+++ b/tests/net_load_tests/net_load_tests.h
@@ -278,7 +278,7 @@ namespace net_load_tests
 
       std::string to_string() const
       {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "opened_connections_count = " << opened_connections_count <<
           ", new_connection_counter = " << new_connection_counter <<
           ", close_connection_counter = " << close_connection_counter;

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -57,7 +57,7 @@ namespace
     static_assert(sizeof(T) * 2 <= sizeof(expected), "T is too large for destination");
     std::memcpy(std::addressof(value), source, sizeof(T));
 
-    std::stringstream out;
+    std::ostringstream out;
     out << "BEGIN" << value << "END";  
     return out.str() == "BEGIN<" + std::string{expected, sizeof(T) * 2} + ">END";
   }

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -84,7 +84,7 @@ namespace
 
   std::string std_to_hex(const std::vector<unsigned char>& source)
   {
-    std::stringstream out;
+    std::ostringstream out;
     out << std::hex;
     for (const unsigned char byte : source)
     {
@@ -304,7 +304,7 @@ TEST(ToHex, Array)
 
 TEST(ToHex, Ostream)
 {
-  std::stringstream out;
+  std::ostringstream out;
   epee::to_hex::buffer(out, nullptr);
   EXPECT_TRUE(out.str().empty());
 
@@ -325,7 +325,7 @@ TEST(ToHex, Ostream)
 
 TEST(ToHex, Formatted)
 {
-  std::stringstream out;
+  std::ostringstream out;
   std::string expected{"<>"};
 
   epee::to_hex::formatted(out, nullptr);

--- a/tests/unit_tests/ringct.cpp
+++ b/tests/unit_tests/ringct.cpp
@@ -1052,7 +1052,7 @@ TEST(ringct, reject_gen_non_simple_ver_simple)
 
 TEST(ringct, key_ostream)
 {
-  std::stringstream out;
+  std::ostringstream out;
   out << "BEGIN" << rct::H << "END";
   EXPECT_EQ(
     std::string{"BEGIN<8b655970153799af2aeadc9ff1add0ea6c7251d54154cfa92c173a0dd39c1f94>END"},


### PR DESCRIPTION
Purely for the sake of readability. Perhaps gratuitous?