### PR TITLE
Fix #2559: more flexible print_tx daemon command

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -187,9 +187,24 @@ bool t_command_parser_executor::print_block(const std::vector<std::string>& args
 
 bool t_command_parser_executor::print_transaction(const std::vector<std::string>& args)
 {
+  bool include_hex = false;
+  bool include_json = false;
+
+  // Assumes that optional flags come after mandatory argument <transaction_hash>
+  for (unsigned int i = 1; i < args.size(); ++i) {
+    if (args[i] == "+hex")
+      include_hex = true;
+    else if (args[i] == "+json")
+      include_json = true;
+    else
+    {
+      std::cout << "unexpected argument: " << args[i] << std::endl;
+      return true;
+    }
+  }
   if (args.empty())
   {
-    std::cout << "expected: print_tx <transaction hash>" << std::endl;
+    std::cout << "expected: print_tx <transaction_hash> [+hex] [+json]" << std::endl;
     return true;
   }
 
@@ -197,7 +212,7 @@ bool t_command_parser_executor::print_transaction(const std::vector<std::string>
   crypto::hash tx_hash;
   if (parse_hash256(str_hash, tx_hash))
   {
-    m_executor.print_transaction(tx_hash);
+    m_executor.print_transaction(tx_hash, include_hex, include_json);
   }
 
   return true;

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -91,7 +91,7 @@ t_command_server::t_command_server(
   m_command_lookup.set_handler(
       "print_tx"
     , std::bind(&t_command_parser_executor::print_transaction, &m_parser, p::_1)
-    , "Print transaction, print_tx <transaction_hash>"
+    , "Print transaction, print_tx <transaction_hash> [+hex] [+json]"
     );
   m_command_lookup.set_handler(
       "is_key_image_spent"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -95,7 +95,7 @@ public:
 
   bool print_block_by_height(uint64_t height);
 
-  bool print_transaction(crypto::hash transaction_hash);
+  bool print_transaction(crypto::hash transaction_hash, bool include_hex, bool include_json);
 
   bool is_key_image_spent(const crypto::key_image &ki);
 


### PR DESCRIPTION
More flexible print_tx command in daemon.

Simply calling `print_tx <transaction hash>` now prints just a one-liner of which block contains the tx (or if it's in the pool).

More verbose output can be added with `+hex` and/or `+json`. These optional flags can be added in any order (as long as they are after the <transaction_hash> argument. It should be consistent to print a blank line at the end in every possible cases including arguments parsing failure.

After this update, you should call `print_tx <transaction hash> +hex +json` to get the very same result as the current `print_tx`command.