### PR TITLE
wallet-dir fixes

### DIFF
--- a/src/debug_utilities/object_sizes.cpp
+++ b/src/debug_utilities/object_sizes.cpp
@@ -84,7 +84,6 @@ int main(int argc, char* argv[])
 
   SL(cryptonote::txpool_tx_meta_t);
 
-  SL(epee::net_utils::network_address_base);
   SL(epee::net_utils::ipv4_network_address);
   SL(epee::net_utils::network_address);
   SL(epee::net_utils::connection_context_base);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -154,7 +154,7 @@ namespace tools
 #else
 #define MKDIR(path, mode)    mkdir(path, mode)
 #endif
-      if (MKDIR(m_wallet_dir.c_str(), 0700) < 0)
+      if (!m_wallet_dir.empty() && MKDIR(m_wallet_dir.c_str(), 0700) < 0 && errno != EEXIST)
       {
 #ifdef _WIN32
         LOG_ERROR(tr("Failed to create directory ") + m_wallet_dir);


### PR DESCRIPTION
If `--wallet-dir` was not given in the command line, _monero-wallet-rpc_ was crashing when trying to create one with empty name.

With `--wallet-dir` specified and pointing to existing directory, _monero-wallet-rpc_ was crashing trying to re-create the dir.

This fixes both errors. Checked on Linux only.