### PR TITLE
miner: always update block template when starting

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -289,8 +289,7 @@ namespace cryptonote
       return false;
     }
 
-    if(!m_template_no)
-      request_block_template();//lets update block template
+    request_block_template();//lets update block template
 
     boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
     boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);


### PR DESCRIPTION
This fixes using the previous address when starting mining,
then stopping and restarting with a different address