### PR TITLE
Fix compiler warnings with Clang 6.0.0.

### DIFF
--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
   }
   r = core_storage->init(db, opt_testnet);
 
-  CHECK_AND_ASSERT_MES(r, false, "Failed to initialize source blockchain storage");
+  CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
   LOG_PRINT_L0("Source blockchain storage initialized OK");
   LOG_PRINT_L0("Exporting blockchain raw data...");
 
@@ -192,7 +192,7 @@ int main(int argc, char* argv[])
     BootstrapFile bootstrap;
     r = bootstrap.store_blockchain_raw(core_storage, NULL, output_file_path, block_stop);
   }
-  CHECK_AND_ASSERT_MES(r, false, "Failed to export blockchain raw data");
+  CHECK_AND_ASSERT_MES(r, 1, "Failed to export blockchain raw data");
   LOG_PRINT_L0("Blockchain raw data exported OK");
   return 0;
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1632,7 +1632,7 @@ skip:
 
     // sort peers between fluffy ones and others
     std::list<boost::uuids::uuid> fullConnections, fluffyConnections;
-    m_p2p->for_each_connection([this, &arg, &fluffy_arg, &exclude_context, &fullConnections, &fluffyConnections](connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)
+    m_p2p->for_each_connection([this, &exclude_context, &fullConnections, &fluffyConnections](connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)
     {
       if (peer_id && exclude_context.m_connection_id != context.m_connection_id)
       {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2033,7 +2033,7 @@ just_dir:
   if (wal) wrpc.set_wallet(wal.release());
   bool r = wrpc.init(&(vm.get()));
   CHECK_AND_ASSERT_MES(r, 1, tools::wallet_rpc_server::tr("Failed to initialize wallet rpc server"));
-  tools::signal_handler::install([&wrpc, &wal](int) {
+  tools::signal_handler::install([&wrpc](int) {
     wrpc.send_stop_signal();
   });
   LOG_PRINT_L0(tools::wallet_rpc_server::tr("Starting wallet rpc server"));


### PR DESCRIPTION
Fix compiler warnings with Clang 6.0.0.

```
monero/src/cryptonote_protocol/block_queue.cpp:208:44: error:
      suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  static const boost::uuids::uuid uuid0 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                           {                                          }

monero/src/wallet/wallet_rpc_server.cpp:1895:43: error:
      lambda capture 'wal' is not used [-Werror,-Wunused-lambda-capture]
  tools::signal_handler::install([&wrpc, &wal](int) {
                                          ^

monero/src/cryptonote_protocol/cryptonote_protocol_handler.inl:1616:40: error:
      lambda capture 'arg' is not used [-Werror,-Wunused-lambda-capture]
    m_p2p->for_each_connection([this, &arg, &fluffy_arg, &exclude_context, &fullConnections...
                                       ^

monero/src/cryptonote_protocol/cryptonote_protocol_handler.inl:1616:46: error:
      lambda capture 'fluffy_arg' is not used [-Werror,-Wunused-lambda-capture]
    m_p2p->for_each_connection([this, &arg, &fluffy_arg, &exclude_context, &fullConnections...
                                             ^

monero/src/blockchain_utilities/blockchain_export.cpp:181:3: error:
      bool literal returned from 'main' [-Werror,-Wmain]
  CHECK_AND_ASSERT_MES(r, false, "Failed to initialize source blockchain storage");
  ^                       ~~~~~
monero/contrib/epee/include/misc_log_ex.h:180:97: note:
      expanded from macro 'CHECK_AND_ASSERT_MES'
  ...fail_ret_val, message)   do{if(!(expr)) {LOG_ERROR(message); return fail_ret_val;};}while(0)
                                                                  ^      ~~~~~~~~~~~~
monero/src/blockchain_utilities/blockchain_export.cpp:195:3: error:
      bool literal returned from 'main' [-Werror,-Wmain]
  CHECK_AND_ASSERT_MES(r, false, "Failed to export blockchain raw data");
  ^                       ~~~~~
monero/contrib/epee/include/misc_log_ex.h:180:97: note:
      expanded from macro 'CHECK_AND_ASSERT_MES'
  ...fail_ret_val, message)   do{if(!(expr)) {LOG_ERROR(message); return fail_ret_val;};}while(0)
                                                                  ^      ~~~~~~~~~~~~
```