### PR TITLE
unit_tests: data dir is now overridden with --data-dir

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -100,4 +100,4 @@ endif ()
 
 add_test(
   NAME    unit_tests
-  COMMAND unit_tests "${TEST_DATA_DIR}")
+  COMMAND unit_tests --data-dir "${TEST_DATA_DIR}")


### PR DESCRIPTION
rather than a raw string without option