### PR TITLE
Add in missing PER_BLOCK_CHECKPOINT check

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3253,6 +3253,7 @@ leave:
     }
   }
 
+#if defined(PER_BLOCK_CHECKPOINT)
   // If we're at a checkpoint, ensure that our hardcoded checkpoint hash
   // is correct.
   if(m_checkpoints.is_in_checkpoint_zone(get_current_blockchain_height()))
@@ -3264,6 +3265,7 @@ leave:
       goto leave;
     }
   }
+#endif
 
   TIME_MEASURE_FINISH(longhash_calculating_time);
   if (precomputed)


### PR DESCRIPTION
When creating a private blockchain to test things on, this code (lines 3528-3266) will always result in newly mined blocks failing checkpoint hashing. It should not be trying to verify checkpoints if `PER_BLOCK_CHECKPOINT` is not defined. I have added in a check around the code. With this change, mining new blocks works properly.