### PR TITLE
util: ignore SIGPIPE

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -146,9 +146,10 @@ namespace tools
       }
       return r;
 #else
-      /* Only blocks SIGINT and SIGTERM */
+      /* Only blocks SIGINT, SIGTERM and SIGPIPE */
       signal(SIGINT, posix_handler);
       signal(SIGTERM, posix_handler);
+      signal(SIGPIPE, SIG_IGN);
       m_handler = t;
       return true;
 #endif


### PR DESCRIPTION
In practice, this seems to cause monero-wallet-rpc to exit
when ^C quits whatever its output is piped into (such as tee),
but it saves, while it did not before.