### PR TITLE
remove "using namespace std" from headers

### DIFF
--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -66,8 +66,6 @@ namespace epee
 namespace net_utils
 {
 
-using namespace std; 
-
 	/*struct url 
 	{
 	public:

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -208,7 +208,7 @@ uint64_t BlockchainDB::add_block( const block& blk
   time1 = epee::misc_utils::get_tick_count();
   add_transaction(blk_hash, blk.miner_tx);
   int tx_i = 0;
-  crypto::hash tx_hash = null_hash;
+  crypto::hash tx_hash = crypto::null_hash;
   for (const transaction& tx : txs)
   {
     tx_hash = blk.tx_hashes[tx_i];

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -48,6 +48,7 @@
 #endif
 
 using epee::string_tools::pod_to_hex;
+using namespace crypto;
 
 // Increase when the DB changes in a non backward compatible way, and there
 // is no automatic conversion, so that a full resync is needed.

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -256,7 +256,7 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
 
   seek_height = start_height;
   BootstrapFile bootstrap;
-  streampos pos;
+  std::streampos pos;
   // BootstrapFile bootstrap(import_file_path);
   uint64_t total_source_blocks = bootstrap.count_blocks(import_file_path, pos, seek_height);
   MINFO("bootstrap file last block number: " << total_source_blocks-1 << " (zero-based height)  total blocks: " << total_source_blocks);

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -221,7 +221,7 @@ void BootstrapFile::write_block(block& block)
   // now add all regular transactions
   for (const auto& tx_id : block.tx_hashes)
   {
-    if (tx_id == null_hash)
+    if (tx_id == crypto::null_hash)
     {
       throw std::runtime_error("Aborting: tx == null_hash");
     }
@@ -433,7 +433,7 @@ uint64_t BootstrapFile::count_bytes(std::ifstream& import_file, uint64_t blocks,
 
 uint64_t BootstrapFile::count_blocks(const std::string& import_file_path)
 {
-  streampos dummy_pos;
+  std::streampos dummy_pos;
   uint64_t dummy_height = 0;
   return count_blocks(import_file_path, dummy_pos, dummy_height);
 }
@@ -441,7 +441,7 @@ uint64_t BootstrapFile::count_blocks(const std::string& import_file_path)
 // If seek_height is non-zero on entry, return a stream position <= this height when finished.
 // And return the actual height corresponding to this position. Allows the caller to locate its
 // starting position without having to reread the entire file again.
-uint64_t BootstrapFile::count_blocks(const std::string& import_file_path, streampos &start_pos, uint64_t& seek_height)
+uint64_t BootstrapFile::count_blocks(const std::string& import_file_path, std::streampos &start_pos, uint64_t& seek_height)
 {
   boost::filesystem::path raw_file_path(import_file_path);
   boost::system::error_code ec;

--- a/src/blockchain_utilities/bootstrap_file.h
+++ b/src/blockchain_utilities/bootstrap_file.h
@@ -57,7 +57,7 @@ class BootstrapFile
 public:
 
   uint64_t count_bytes(std::ifstream& import_file, uint64_t blocks, uint64_t& h, bool& quit);
-  uint64_t count_blocks(const std::string& dir_path, streampos& start_pos, uint64_t& seek_height);
+  uint64_t count_blocks(const std::string& dir_path, std::streampos& start_pos, uint64_t& seek_height);
   uint64_t count_blocks(const std::string& dir_path);
   uint64_t seek_to_first_chunk(std::ifstream& import_file);
 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -45,6 +45,8 @@ using namespace epee;
 
 // #define ENABLE_HASH_CASH_INTEGRITY_CHECK
 
+using namespace crypto;
+
 static const uint64_t valid_decomposed_outputs[] = {
   (uint64_t)1, (uint64_t)2, (uint64_t)3, (uint64_t)4, (uint64_t)5, (uint64_t)6, (uint64_t)7, (uint64_t)8, (uint64_t)9, // 1 piconero
   (uint64_t)10, (uint64_t)20, (uint64_t)30, (uint64_t)40, (uint64_t)50, (uint64_t)60, (uint64_t)70, (uint64_t)80, (uint64_t)90,

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -61,6 +61,8 @@
 
 #define FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE (100*1024*1024) // 100 MB
 
+using namespace crypto;
+
 //#include "serialization/json_archive.h"
 
 /* TODO:

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -498,8 +498,8 @@ namespace cryptonote
       return false;
     }
 
-    tx_hash = null_hash;
-    tx_prefixt_hash = null_hash;
+    tx_hash = crypto::null_hash;
+    tx_prefixt_hash = crypto::null_hash;
 
     if(!parse_tx_from_blob(tx, tx_hash, tx_prefixt_hash, tx_blob))
     {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -40,6 +40,8 @@ using namespace epee;
 #include "crypto/hash.h"
 #include "ringct/rctSigs.h"
 
+using namespace crypto;
+
 namespace cryptonote
 {
   //---------------------------------------------------------------

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -51,6 +51,8 @@
 
 DISABLE_VS_WARNINGS(4244 4345 4503) //'boost::foreach_detail_::or_' : decorated name length exceeded, name was truncated
 
+using namespace crypto;
+
 namespace cryptonote
 {
   namespace

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -297,9 +297,9 @@ namespace cryptonote
     m_core.set_target_blockchain_height((hshd.current_height));
     int64_t diff = static_cast<int64_t>(hshd.current_height) - static_cast<int64_t>(m_core.get_current_blockchain_height());
     uint64_t abs_diff = std::abs(diff);
-    uint64_t max_block_height = max(hshd.current_height,m_core.get_current_blockchain_height());
+    uint64_t max_block_height = std::max(hshd.current_height,m_core.get_current_blockchain_height());
     uint64_t last_block_v1 = m_core.get_testnet() ? 624633 : 1009826;
-    uint64_t diff_v2 = max_block_height > last_block_v1 ? min(abs_diff, max_block_height - last_block_v1) : 0;
+    uint64_t diff_v2 = max_block_height > last_block_v1 ? std::min(abs_diff, max_block_height - last_block_v1) : 0;
     MCLOG(is_inital ? el::Level::Info : el::Level::Debug, "global", context <<  "Sync data returned a new top block candidate: " << m_core.get_current_blockchain_height() << " -> " << hshd.current_height
       << " [Your node is " << abs_diff << " blocks (" << ((abs_diff - diff_v2) / (24 * 60 * 60 / DIFFICULTY_TARGET_V1)) + (diff_v2 / (24 * 60 * 60 / DIFFICULTY_TARGET_V2)) << " days) "
       << (0 <= diff ? std::string("behind") : std::string("ahead"))

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1011,7 +1011,7 @@ bool t_rpc_command_executor::print_transaction_pool_stats() {
     tools::msg_writer() << "   Age      Txes       Bytes";
     for (i=0; i<n; i++)
     {
-      tools::msg_writer() << get_time_hms(times[i]) << setw(8) << res.pool_stats.histo[i].txs << setw(12) << res.pool_stats.histo[i].bytes;
+      tools::msg_writer() << get_time_hms(times[i]) << std::setw(8) << res.pool_stats.histo[i].txs << std::setw(12) << res.pool_stats.histo[i].bytes;
     }
   }
   tools::msg_writer();

--- a/src/p2p/connection_basic.cpp
+++ b/src/p2p/connection_basic.cpp
@@ -158,7 +158,7 @@ connection_basic::connection_basic(boost::asio::io_service& io_service, std::ato
 	++ref_sock_count; // increase the global counter
 	mI->m_peer_number = sock_number.fetch_add(1); // use, and increase the generated number
 
-	string remote_addr_str = "?";
+	std::string remote_addr_str = "?";
 	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
 
 	_note("Spawned connection p2p#"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_ref_sock_count);
@@ -166,7 +166,7 @@ connection_basic::connection_basic(boost::asio::io_service& io_service, std::ato
 }
 
 connection_basic::~connection_basic() noexcept(false) {
-	string remote_addr_str = "?";
+	std::string remote_addr_str = "?";
 	m_ref_sock_count--;
 	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
 	_note("Destructing connection p2p#"<<mI->m_peer_number << " to " << remote_addr_str);

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -35,8 +35,6 @@
 #define RCTOPS_H
 
 #include <cstddef>
-#include <mutex>
-#include <vector>
 #include <tuple>
 
 #include "crypto/generic-ops.h"
@@ -56,9 +54,6 @@ extern "C" {
 #else
 #define DP(x)
 #endif
-
-using namespace std;
-using namespace crypto;
 
 namespace rct {
 
@@ -99,13 +94,13 @@ namespace rct {
     key pkGen();
     //generates a random secret and corresponding public key
     void skpkGen(key &sk, key &pk);
-    tuple<key, key> skpkGen();
+    std::tuple<key, key> skpkGen();
     //generates a <secret , public> / Pedersen commitment to the amount
-    tuple<ctkey, ctkey> ctskpkGen(xmr_amount amount);
+    std::tuple<ctkey, ctkey> ctskpkGen(xmr_amount amount);
     //generates C =aG + bH from b, a is random
     void genC(key & C, const key & a, xmr_amount amount);
     //this one is mainly for testing, can take arbitrary amounts..
-    tuple<ctkey, ctkey> ctskpkGen(const key &bH);
+    std::tuple<ctkey, ctkey> ctskpkGen(const key &bH);
     // make a pedersen commitment with given key
     key commit(xmr_amount amount, const key &mask);
     // make a pedersen commitment with zero key

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -36,7 +36,6 @@
 #define RCTSIGS_H
 
 #include <cstddef>
-#include <mutex>
 #include <vector>
 #include <tuple>
 
@@ -60,9 +59,6 @@ extern "C" {
 #endif
 
 
-
-using namespace std;
-using namespace crypto;
 
 namespace rct {
 
@@ -110,7 +106,7 @@ namespace rct {
     //populateFromBlockchain creates a keymatrix with "mixin" columns and one of the columns is inPk
     //   the return value are the key matrix, and the index where inPk was put (random).
     void getKeyFromBlockchain(ctkey & a, size_t reference_index);
-    tuple<ctkeyM, xmr_amount> populateFromBlockchain(ctkeyV inPk, int mixin);
+    std::tuple<ctkeyM, xmr_amount> populateFromBlockchain(ctkeyV inPk, int mixin);
 
     //RingCT protocol
     //genRct:
@@ -122,10 +118,10 @@ namespace rct {
     //decodeRct: (c.f. http://eprint.iacr.org/2015/1098 section 5.1.1)
     //   uses the attached ecdh info to find the amounts represented by each output commitment
     //   must know the destination private key to find the correct amount, else will return a random number
-    rctSig genRct(const key &message, const ctkeyV & inSk, const keyV & destinations, const vector<xmr_amount> & amounts, const ctkeyM &mixRing, const keyV &amount_keys, unsigned int index, ctkeyV &outSk);
-    rctSig genRct(const key &message, const ctkeyV & inSk, const ctkeyV  & inPk, const keyV & destinations, const vector<xmr_amount> & amounts, const keyV &amount_keys, const int mixin);
-    rctSig genRctSimple(const key & message, const ctkeyV & inSk, const ctkeyV & inPk, const keyV & destinations, const vector<xmr_amount> & inamounts, const vector<xmr_amount> & outamounts, const keyV &amount_keys, xmr_amount txnFee, unsigned int mixin);
-    rctSig genRctSimple(const key & message, const ctkeyV & inSk, const keyV & destinations, const vector<xmr_amount> & inamounts, const vector<xmr_amount> & outamounts, xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<unsigned int> & index, ctkeyV &outSk);
+    rctSig genRct(const key &message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & amounts, const ctkeyM &mixRing, const keyV &amount_keys, unsigned int index, ctkeyV &outSk);
+    rctSig genRct(const key &message, const ctkeyV & inSk, const ctkeyV  & inPk, const keyV & destinations, const std::vector<xmr_amount> & amounts, const keyV &amount_keys, const int mixin);
+    rctSig genRctSimple(const key & message, const ctkeyV & inSk, const ctkeyV & inPk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts, const keyV &amount_keys, xmr_amount txnFee, unsigned int mixin);
+    rctSig genRctSimple(const key & message, const ctkeyV & inSk, const keyV & destinations, const std::vector<xmr_amount> & inamounts, const std::vector<xmr_amount> & outamounts, xmr_amount txnFee, const ctkeyM & mixRing, const keyV &amount_keys, const std::vector<unsigned int> & index, ctkeyV &outSk);
     bool verRct(const rctSig & rv, bool semantics);
     static inline bool verRct(const rctSig & rv) { return verRct(rv, true) && verRct(rv, false); }
     bool verRctSimple(const rctSig & rv, bool semantics);

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -33,9 +33,7 @@
 #define RCT_TYPES_H
 
 #include <cstddef>
-#include <mutex>
 #include <vector>
-#include <tuple>
 #include <iostream>
 #include <cinttypes>
 
@@ -67,9 +65,6 @@ extern "C" {
 
 //for printing large ints
 
-using namespace std;
-using namespace crypto;
-
 //Namespace specifically for ring ct code
 namespace rct {
     //basic ops containers
@@ -89,8 +84,8 @@ namespace rct {
         bool operator==(const key &k) const { return !memcmp(bytes, k.bytes, sizeof(bytes)); }
         unsigned char bytes[32];
     };
-    typedef vector<key> keyV; //vector of keys
-    typedef vector<keyV> keyM; //matrix of keys (indexed by column first)
+    typedef std::vector<key> keyV; //vector of keys
+    typedef std::vector<keyV> keyM; //matrix of keys (indexed by column first)
 
     //containers For CT operations
     //if it's  representing a private ctkey then "dest" contains the secret key of the address
@@ -101,8 +96,8 @@ namespace rct {
         key dest;
         key mask; //C here if public
     };
-    typedef vector<ctkey> ctkeyV;
-    typedef vector<ctkeyV> ctkeyM;
+    typedef std::vector<ctkey> ctkeyV;
+    typedef std::vector<ctkeyV> ctkeyM;
 
     //data for passing the amount to the receiver secretly
     // If the pedersen commitment to an amount is C = aG + bH,
@@ -184,7 +179,7 @@ namespace rct {
         ctkeyM mixRing; //the set of all pubkeys / copy
         //pairs that you mix with
         keyV pseudoOuts; //C - for simple rct
-        vector<ecdhTuple> ecdhInfo;
+        std::vector<ecdhTuple> ecdhInfo;
         ctkeyV outPk;
         xmr_amount txnFee; // contains b
 
@@ -245,8 +240,8 @@ namespace rct {
         }
     };
     struct rctSigPrunable {
-        vector<rangeSig> rangeSigs;
-        vector<mgSig> MGs; // simple rct has N, full has 1
+        std::vector<rangeSig> rangeSigs;
+        std::vector<mgSig> MGs; // simple rct has N, full has 1
 
         template<bool W, template <bool> class Archive>
         bool serialize_rctsig_prunable(Archive<W> &ar, uint8_t type, size_t inputs, size_t outputs, size_t mixin)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -995,7 +995,7 @@ namespace cryptonote
     }
     blobdata block_blob = t_serializable_object_to_blob(b);
     crypto::public_key tx_pub_key = cryptonote::get_tx_pub_key_from_extra(b.miner_tx);
-    if(tx_pub_key == null_pkey)
+    if(tx_pub_key == crypto::null_pkey)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: failed to create block template";

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4266,7 +4266,7 @@ bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
     return true;
   }
   crypto::public_key tx_pub_key = get_tx_pub_key_from_extra(tx);
-  if (tx_pub_key == null_pkey)
+  if (tx_pub_key == crypto::null_pkey)
   {
     fail_msg_writer() << tr("Tx pubkey was not found");
     return true;
@@ -4993,7 +4993,7 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
       fail_msg_writer() << tr("failed to parse address");
       return true;
     }
-    crypto::hash payment_id = null_hash;
+    crypto::hash payment_id = crypto::null_hash;
     size_t description_start = 2;
     if (info.has_payment_id)
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -67,6 +67,8 @@ extern "C"
 #include "crypto/keccak.h"
 #include "crypto/crypto-ops.h"
 }
+using namespace std;
+using namespace crypto;
 using namespace cryptonote;
 
 #undef MONERO_DEFAULT_LOG_CATEGORY

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -34,12 +34,8 @@
 
 #include "include_base_utils.h"
 #include "version.h"
-
-using namespace epee;
-
 #include <iostream>
 #include <sstream>
-using namespace std;
 
 #include <boost/program_options.hpp>
 
@@ -56,6 +52,8 @@ using namespace std;
 #endif
 
 namespace po = boost::program_options;
+using namespace std;
+using namespace epee;
 using namespace cryptonote;
 using namespace crypto;
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -47,6 +47,7 @@
 using namespace std;
 
 using namespace epee;
+using namespace crypto;
 using namespace cryptonote;
 
 

--- a/tests/unit_tests/ringct.cpp
+++ b/tests/unit_tests/ringct.cpp
@@ -38,6 +38,7 @@
 #include "ringct/rctSigs.h"
 #include "ringct/rctOps.h"
 
+using namespace std;
 using namespace crypto;
 using namespace rct;
 

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -49,6 +49,7 @@
 #include "gtest/gtest.h"
 #include "unit_tests_utils.h"
 using namespace std;
+using namespace crypto;
 
 struct Struct
 {


### PR DESCRIPTION
It's nasty, and actually breaks on Solaris, where if.h fails to
build due to:

  struct map *if_memmap;