### PR TITLE
core: guard against a mined block not finding all txes in the pool

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1026,7 +1026,15 @@ namespace cryptonote
     block_verification_context bvc = boost::value_initialized<block_verification_context>();
     m_miner.pause();
     std::list<block_complete_entry> blocks;
-    blocks.push_back(get_block_complete_entry(b, m_mempool));
+    try
+    {
+      blocks.push_back(get_block_complete_entry(b, m_mempool));
+    }
+    catch (const std::exception &e)
+    {
+      m_miner.resume();
+      return false;
+    }
     prepare_handle_incoming_blocks(blocks);
     m_blockchain_storage.add_new_block(b, bvc);
     cleanup_handle_incoming_blocks(true);


### PR DESCRIPTION
This can happen for several reasons, but mainly if another block
was received, which took that tx off the pool.