### PR TITLE
blockchain_utilities: Add monero-blockchain-{ex,im}port binaries to default install targets

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 set_property(TARGET blockchain_import
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-import")
+install(TARGETS blockchain_import DESTINATION bin)
 
 monero_add_executable(blockchain_export
   ${blockchain_export_sources}
@@ -114,4 +115,5 @@ target_link_libraries(blockchain_export
 set_property(TARGET blockchain_export
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-export")
+install(TARGETS blockchain_export DESTINATION bin)
 


### PR DESCRIPTION
Binaries available to download on https://getmonero.org/downloads/ as
embedding monerod, monero-wallet-{cli,rpc} and
monero-blockchain-{ex,im}port.

This change synchronise download results with a manual build from
source