### PR TITLE
cmake, epee: fix build with openssl v1.1 and with manually specified openssl path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,11 @@ if(NOT Boost_FOUND)
   die("Could not find Boost libraries, please make sure you have installed Boost or libboost-all-dev (1.58) or the equivalent")
 elseif(Boost_FOUND)
   message(STATUS "Found Boost Version: ${Boost_VERSION}")
+  if (Boost_VERSION VERSION_LESS 1.62 AND NOT (OPENSSL_VERSION VERSION_LESS 1.1))
+      message(FATAL_ERROR "Boost older than 1.62 is too old to link with OpenSSL 1.1 or newer. "
+                          "Update Boost or install OpenSSL 1.0 and set path to it when running cmake: "
+                          "cmake -DOPENSSL_ROOT_DIR='/usr/include/openssl-1.0;/usr/lib/openssl-1.0'")
+  endif()
 endif()
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -36,6 +36,7 @@
 #include <istream>
 #include <ostream>
 #include <string>
+#include <boost/version.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -576,7 +577,14 @@ namespace net_utils
 				m_io_service.run_one();
 			}
 			// Ignore "short read" error
-			if (ec.category() == boost::asio::error::get_ssl_category() && ec.value() != ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ))
+			if (ec.category() == boost::asio::error::get_ssl_category() &&
+			    ec.value() !=
+#if BOOST_VERSION >= 106200
+			    boost::asio::ssl::error::stream_truncated
+#else // older Boost supports only OpenSSL 1.0, so 1.0-only macros are appropriate
+			    ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
+#endif
+			    )
 				MDEBUG("Problems at ssl shutdown: " << ec.message());
 		}
 		

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -49,6 +49,5 @@ target_link_libraries(epee
     easylogging
     ${Boost_FILESYSTEM_LIBRARY}
   PRIVATE
-    ssl
-    crypto
+    ${OPENSSL_LIBRARIES}
     ${EXTRA_LIBRARIES})


### PR DESCRIPTION
Two independent patches.

 epee: use boost type for SSL error code

Fixes compile error when building with OpenSSL v1.1:
```
contrib/epee/include/net/net_helper.h: In member function ‘void epee::net_utils::blocked_mode_client::shutdown_ssl()’:
contrib/epee/include/net/net_helper.h:579:106: error: ‘SSL_R_SHORT_READ’ was not declared in this scope
    if (ec.category() == boost::asio::error::get_ssl_category() && ec.value() != ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ))
                                                                                                          ^
contrib/epee/include/net/net_helper.h:579:106: note: suggested alternative: ‘SSL_F_SSL_READ’
```
See boost/asio/ssl/error.hpp.
Boost handles differences between OpenSSL versions.


 cmake: epee: use var from FindOpenSSL.cmake

This fixes linking when path to openssl
is defined manually:
```
cmake -DOPENSSL_ROOT_DIR='/usr/include/openssl-1.0;/usr/lib/openssl-1.0' ...
```
This is useful for building with OpenSSL v1.0
when default system installation is v1.1.

The linking error is undefined SSL_load_error_strings symbol.
This is due to -L /usr/lib/openssl-1.0 not making it onto
the linkline (so -lssl pulls in the default system openssl).
