### PR TITLE
Problem: Copyright notice is very confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Monero
 
-Copyright (c) 2014-2017, The Monero Project
-Portions Copyright (c) 2012-2013, The Cryptonote developers
+Copyright (c) 2014-2017 The Monero Project.   
+Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Development Resources
 


### PR DESCRIPTION
It doesn't show in plain text, but when the MD is displayed it shows the whole copyright notice on one single line and it doesn't make sense.
Solution: add line break to copyright notice and fix grammar.