### PR TITLE
always use core_tests for consistency, not coretest

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ invokes cmake commands as needed.
 
         make release-test
 
-    *NOTE*: `coretests` test may take a few hours to complete.
+    *NOTE*: `core_tests` test may take a few hours to complete.
 
 * **Optional**: to build binaries suitable for debugging:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,7 +111,7 @@ add_test(
   COMMAND hash-target-tests)
 
 set(enabled_tests
-    coretests
+    core_tests
     difficulty
     hash
     performance_tests

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -58,10 +58,10 @@ set(core_tests_headers
   v2_tests.h
   rct.h)
 
-add_executable(coretests
+add_executable(core_tests
   ${core_tests_sources}
   ${core_tests_headers})
-target_link_libraries(coretests
+target_link_libraries(core_tests
   PRIVATE
     cryptonote_core
     p2p
@@ -69,10 +69,10 @@ target_link_libraries(coretests
     epee
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
-set_property(TARGET coretests
+set_property(TARGET core_tests
   PROPERTY
     FOLDER "tests")
 
 add_test(
-  NAME    coretests
-  COMMAND coretests --generate_and_play_test_data)
+  NAME    core_tests
+  COMMAND core_tests --generate_and_play_test_data)


### PR DESCRIPTION
Other tests use unit_tests, performance_tests, etc.
This fixes getting it wrong half the time when typing.