### PR TITLE
performance_tests: add main account to test is_out_to_acc_precomp

### DIFF
--- a/tests/performance_tests/is_out_to_acc.h
+++ b/tests/performance_tests/is_out_to_acc.h
@@ -64,6 +64,7 @@ public:
   {
     const cryptonote::txout_to_key& tx_out = boost::get<cryptonote::txout_to_key>(m_tx.vout[0].target);
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
+    subaddresses[m_bob.get_keys().m_account_address.m_spend_public_key] = {0,0};
     std::vector<crypto::key_derivation> additional_derivations;
     boost::optional<cryptonote::subaddress_receive_info> info = cryptonote::is_out_to_acc_precomp(subaddresses, tx_out.key, m_derivation, additional_derivations, 0);
     return (bool)info;


### PR DESCRIPTION
This keeps it using the usual case