### PR TITLE
subaddresses backwards compatibility 

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1044,8 +1044,7 @@ void WalletImpl::setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex
 //    - confirmed_transfer_details)
 
 PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const string &payment_id, optional<uint64_t> amount, uint32_t mixin_count,
-                                                  uint32_t subaddr_account, std::set<uint32_t> subaddr_indices,
-                                                  PendingTransaction::Priority priority)
+                                                  PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
     clearStatus();

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -73,7 +73,7 @@ public:
     int status() const;
     std::string errorString() const;
     bool setPassword(const std::string &password);
-    std::string address(uint32_t accountIndex, uint32_t addressIndex) const;
+    std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const;
     std::string integratedAddress(const std::string &payment_id) const;
     std::string secretViewKey() const;
     std::string publicViewKey() const;
@@ -88,8 +88,8 @@ public:
     ConnectionStatus connected() const;
     void setTrustedDaemon(bool arg);
     bool trustedDaemon() const;
-    uint64_t balance(uint32_t accountIndex) const;
-    uint64_t unlockedBalance(uint32_t accountIndex) const;
+    uint64_t balance(uint32_t accountIndex = 0) const;
+    uint64_t unlockedBalance(uint32_t accountIndex = 0) const;
     uint64_t blockChainHeight() const;
     uint64_t approximateBlockChainHeight() const;
     uint64_t daemonBlockChainHeight() const;
@@ -117,9 +117,9 @@ public:
 
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                         optional<uint64_t> amount, uint32_t mixin_count,
-                                        uint32_t subaddr_account,
-                                        std::set<uint32_t> subaddr_indices,
-                                        PendingTransaction::Priority priority = PendingTransaction::Priority_Low);
+                                        PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
+                                        uint32_t subaddr_account = 0,
+                                        std::set<uint32_t> subaddr_indices = {});
     virtual PendingTransaction * createSweepUnmixableTransaction();
     bool submitTransaction(const std::string &fileName);
     virtual UnsignedTransaction * loadUnsignedTx(const std::string &unsigned_filename);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -692,20 +692,20 @@ void wallet2::expand_subaddresses(const cryptonote::subaddress_index& index)
 //----------------------------------------------------------------------------------------------------
 std::string wallet2::get_subaddress_label(const cryptonote::subaddress_index& index) const
 {
-  if (index.major >= m_subaddress_labels.size())
-    throw std::runtime_error("index.major is out of bound");
-  if (index.minor >= m_subaddress_labels[index.major].size())
-    throw std::runtime_error("index.minor is out of bound");
+  if (index.major >= m_subaddress_labels.size() || index.minor >= m_subaddress_labels[index.major].size())
+  {
+    MERROR("Subaddress label doesn't exist");
+    return "";
+  }
   return m_subaddress_labels[index.major][index.minor];
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::set_subaddress_label(const cryptonote::subaddress_index& index, const std::string &label)
 {
-  if (index.major >= m_subaddress_labels.size())
-    throw std::runtime_error("index.major is out of bound");
-  if (index.minor >= m_subaddress_labels[index.major].size())
-    throw std::runtime_error("index.minor is out of bound");
-  m_subaddress_labels[index.major][index.minor] = label;
+  if (index.major >= m_subaddress_labels.size() || index.minor >= m_subaddress_labels[index.major].size())
+    MERROR("Subaddress index is out of bounds. Failed to set subaddress label.");
+  else
+    m_subaddress_labels[index.major][index.minor] = label;
 }
 //----------------------------------------------------------------------------------------------------
 /*!

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -467,8 +467,8 @@ namespace tools
     size_t get_num_subaddresses(uint32_t index_major) const { return index_major < m_subaddress_labels.size() ? m_subaddress_labels[index_major].size() : 0; }
     void add_subaddress(uint32_t index_major, const std::string& label); // throws when index is out of bound
     void expand_subaddresses(const cryptonote::subaddress_index& index);
-    std::string get_subaddress_label(const cryptonote::subaddress_index& index) const; // throws when index is out of bound
-    void set_subaddress_label(const cryptonote::subaddress_index &index, const std::string &label); // throws when index is out of bound
+    std::string get_subaddress_label(const cryptonote::subaddress_index& index) const;
+    void set_subaddress_label(const cryptonote::subaddress_index &index, const std::string &label);
     /*!
      * \brief Tells if the wallet file is deprecated.
      */

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -360,7 +360,7 @@ struct Wallet
     //! in case error status, returns error string
     virtual std::string errorString() const = 0;
     virtual bool setPassword(const std::string &password) = 0;
-    virtual std::string address(uint32_t accountIndex, uint32_t addressIndex) const = 0;
+    virtual std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const = 0;
     std::string mainAddress() const { return address(0, 0); }
     virtual std::string path() const = 0;
     virtual bool testnet() const = 0;
@@ -476,14 +476,14 @@ struct Wallet
     virtual ConnectionStatus connected() const = 0;
     virtual void setTrustedDaemon(bool arg) = 0;
     virtual bool trustedDaemon() const = 0;
-    virtual uint64_t balance(uint32_t accountIndex) const = 0;
+    virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
     uint64_t balanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
             result += balance(i);
         return result;
     }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex) const = 0;
+    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0) const = 0;
     uint64_t unlockedBalanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
@@ -623,9 +623,9 @@ struct Wallet
 
     virtual PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                                    optional<uint64_t> amount, uint32_t mixin_count,
-                                                   uint32_t subaddr_account,
-                                                   std::set<uint32_t> subaddr_indices,
-                                                   PendingTransaction::Priority = PendingTransaction::Priority_Low) = 0;
+                                                   PendingTransaction::Priority = PendingTransaction::Priority_Low,
+                                                   uint32_t subaddr_account = 0,
+                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
 
     /*!
      * \brief createSweepUnmixableTransaction creates transaction with unmixable outputs.

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -580,9 +580,9 @@ TEST_F(WalletTest1, WalletTransaction)
                                                                              PAYMENT_ID_EMPTY,
                                                                              AMOUNT_10XMR,
                                                                              MIXIN_COUNT,
+                                                                             Monero::PendingTransaction::Priority_Medium,
                                                                              0,
-                                                                             std::set<uint32_t>{},
-                                                                             Monero::PendingTransaction::Priority_Medium);
+                                                                             std::set<uint32_t>{});
     ASSERT_TRUE(transaction->status() == Monero::PendingTransaction::Status_Ok);
     wallet1->refresh();
 
@@ -621,7 +621,7 @@ TEST_F(WalletTest1, WalletTransactionWithMixin)
         std::cerr << "Transaction mixin count: " << mixin << std::endl;
 	
         Monero::PendingTransaction * transaction = wallet1->createTransaction(
-                    recepient_address, payment_id, AMOUNT_5XMR, mixin, 0, std::set<uint32_t>{});
+                    recepient_address, payment_id, AMOUNT_5XMR, mixin, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
 
         std::cerr << "Transaction status: " << transaction->status() << std::endl;
         std::cerr << "Transaction fee: " << Monero::Wallet::displayAmount(transaction->fee()) << std::endl;
@@ -663,7 +663,7 @@ TEST_F(WalletTest1, WalletTransactionWithPriority)
         std::cerr << "Transaction priority: " << *it << std::endl;
 	
         Monero::PendingTransaction * transaction = wallet1->createTransaction(
-                    recepient_address, payment_id, AMOUNT_5XMR, mixin, 0, std::set<uint32_t>{}, *it);
+                    recepient_address, payment_id, AMOUNT_5XMR, mixin, *it, 0, std::set<uint32_t>{});
         std::cerr << "Transaction status: " << transaction->status() << std::endl;
         std::cerr << "Transaction fee: " << Monero::Wallet::displayAmount(transaction->fee()) << std::endl;
         std::cerr << "Transaction error: " << transaction->errorString() << std::endl;
@@ -719,7 +719,7 @@ TEST_F(WalletTest1, WalletTransactionAndHistory)
 
     Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
                                                                        PAYMENT_ID_EMPTY,
-                                                                       AMOUNT_10XMR * 5, 1, 0, std::set<uint32_t>{});
+                                                                       AMOUNT_10XMR * 5, 1, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
 
     ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
@@ -761,7 +761,7 @@ TEST_F(WalletTest1, WalletTransactionWithPaymentId)
 
     Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet4_addr,
                                                                        payment_id,
-                                                                       AMOUNT_1XMR, 1, 0, std::set<uint32_t>{});
+                                                                       AMOUNT_1XMR, 1, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
 
     ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
     ASSERT_TRUE(tx->commit());
@@ -934,7 +934,7 @@ TEST_F(WalletTest2, WalletCallbackSent)
 
     Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->mainAddress(),
                                                                        PAYMENT_ID_EMPTY,
-                                                                       amount, 1, 0, std::set<uint32_t>{});
+                                                                       amount, 1, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
     std::cout << "** Committing transaction: " << Monero::Wallet::displayAmount(tx->amount())
               << " with fee: " << Monero::Wallet::displayAmount(tx->fee());
 
@@ -975,7 +975,7 @@ TEST_F(WalletTest2, WalletCallbackReceived)
     std::cout << "** Sending " << Monero::Wallet::displayAmount(amount) << " to " << wallet_dst->mainAddress();
     Monero::PendingTransaction * tx = wallet_src->createTransaction(wallet_dst->mainAddress(),
                                                                        PAYMENT_ID_EMPTY,
-                                                                       amount, 1, 0, std::set<uint32_t>{});
+                                                                       amount, 1, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
 
     std::cout << "** Committing transaction: " << Monero::Wallet::displayAmount(tx->amount())
               << " with fee: " << Monero::Wallet::displayAmount(tx->fee());


### PR DESCRIPTION
ping @kenshi84 

These small changes makes current master of GUI run. And probably also the Monerujo wallet. Will require some changes in https://github.com/monero-project/monero-core/pull/793

Also, it fixes the issue where GUI crashes when an old wallet is opened, because of subaddress index is getting out of bounds. Although, i nicer solution might be assigning old tx's to account/subindex 0 when cache is upgraded?