### PR TITLE
wallet2: fix subaddress fields serialization

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1042,7 +1042,10 @@ namespace boost
           x.m_amount_out += x.m_change;
       }
       if (ver < 7)
+      {
+        x.m_subaddr_account = 0;
         return;
+      }
       a & x.m_subaddr_account;
       a & x.m_subaddr_indices;
     }
@@ -1083,7 +1086,10 @@ namespace boost
       }
       a & x.m_unlock_time;
       if (ver < 5)
+      {
+        x.m_subaddr_account = 0;
         return;
+      }
       a & x.m_subaddr_account;
       a & x.m_subaddr_indices;
     }
@@ -1099,7 +1105,10 @@ namespace boost
         return;
       a & x.m_timestamp;
       if (ver < 2)
+      {
+        x.m_subaddr_index = {};
         return;
+      }
       a & x.m_subaddr_index;
     }
     
@@ -1110,7 +1119,10 @@ namespace boost
       a & x.m_payment_id;
       a & x.m_description;
       if (ver < 17)
+      {
+        x.m_is_subaddress = false;
         return;
+      }
       a & x.m_is_subaddress;
     }
 
@@ -1140,7 +1152,10 @@ namespace boost
       a & x.use_rct;
       a & x.dests;
       if (ver < 1)
+      {
+        x.subaddr_account = 0;
         return;
+      }
       a & x.subaddr_account;
       a & x.subaddr_indices;
     }


### PR DESCRIPTION
When loading an older wallet cache, they wouldn't be initialized,
leading them to have random(ish) values, and so assigned to some
random subaddress.