### PR TITLE
Updated OpenBSD build instructions and fixed libressl linking issue

### DIFF
--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -60,6 +60,15 @@ if (CMAKE_USE_WIN32_THREADS_INIT)
 else ()
   set(HAVE_WINDOWS_THREADS 0)
 endif ()
+
+# determine if we have libressl
+check_symbol_exists(LIBRESSL_VERSION_TEXT "openssl/opensslv.h" HAVE_LIBRESSL)
+# check if we have found HAVE_DECL_REALLOCARRAY already, so we can safely undefine and redefine it with value 1
+if (HAVE_LIBRESSL AND HAVE_DECL_REALLOCARRAY)
+  unset(HAVE_DECL_REALLOCARRAY CACHE)
+  add_definitions(-DHAVE_DECL_REALLOCARRAY=1)
+endif ()
+
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/config.h")


### PR DESCRIPTION
Issue: #2575

Build instructions for OpenBSD 6.2:
* boost (built with clang)
* cppzmq

Fixed a issue, where cmake was not able to find and link against libressl in unbound.