### PR TITLE
Fix2741

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -34,6 +34,7 @@
 #include <cstring>  // memcpy
 #include <random>
 
+#include "common/util.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "crypto/crypto.h"
 #include "profile_tools.h"
@@ -1128,6 +1129,11 @@ void BlockchainLMDB::open(const std::string& filename, const int db_flags)
     throw0(DB_ERROR(lmdb_error("Failed to create lmdb environment: ", result).c_str()));
   if ((result = mdb_env_set_maxdbs(m_env, 20)))
     throw0(DB_ERROR(lmdb_error("Failed to set max number of dbs: ", result).c_str()));
+
+  int threads = tools::get_max_concurrency();
+  if (threads > 110 &&	/* maxreaders default is 126, leave some slots for other read processes */
+    (result = mdb_env_set_maxreaders(m_env, threads+16)))
+    throw0(DB_ERROR(lmdb_error("Failed to set max number of readers: ", result).c_str()));
 
   size_t mapsize = DEFAULT_MAPSIZE;
 

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -39,7 +39,7 @@ namespace tools
 threadpool::threadpool() : running(true), active(0) {
   boost::thread::attributes attrs;
   attrs.set_stack_size(THREAD_STACK_SIZE);
-  max = tools::get_max_concurrency() * 2;
+  max = tools::get_max_concurrency();
   size_t i = max;
   while(i--) {
     threads.push_back(boost::thread(attrs, boost::bind(&threadpool::run, this)));
@@ -74,7 +74,7 @@ void threadpool::submit(waiter *obj, std::function<void()> f) {
 }
 
 int threadpool::get_max_concurrency() {
-  return max / 2;
+  return max;
 }
 
 void threadpool::waiter::wait() {


### PR DESCRIPTION
Don't overallocate threads, set LMDB maxreaders if larger number of threads are in use. Fixes #2741 