### PR TITLE
Fix 'sweep_all' command when called with no args

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3068,6 +3068,12 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
 bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &args_)
 {
   // sweep_all [index=<N1>[,<N2>,...]] [<ring_size>] <address> [<payment_id>]
+  if (args_.size() == 0)
+  {
+    fail_msg_writer() << tr("No address given");
+    return true;
+  }
+
   if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   if (!try_connect_to_daemon())
     return true;
@@ -3133,12 +3139,6 @@ bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &a
     }
     if (payment_id_seen)
       local_args.pop_back();
-  }
-
-  if (local_args.size() == 0)
-  {
-    fail_msg_writer() << tr("No address given");
-    return true;
   }
 
   cryptonote::address_parse_info info;


### PR DESCRIPTION
Executing 'sweep_all' with no arguments segfaulted before.