### PR TITLE
Set default refresh type to default enum value and add sanity check.

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1469,8 +1469,18 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         }
       }
     }
-    if (m_restoring)
-      m_wallet->set_refresh_from_block_height(m_restore_height);
+    if (m_restoring) {
+        std::string errmsg;
+        uint64_t blockchain_target_height = m_wallet->get_daemon_blockchain_target_height(errmsg);
+        if (errmsg.empty() && m_restore_height > blockchain_target_height){
+            message_writer() << tr("The restore height ") << m_restore_height << tr(" is not yet reached. The current target height is ") << blockchain_target_height;
+            std::string confirm = command_line::input_line(tr("Proceed anyway?  (Y/Yes/N/No): "));
+            if (std::cin.eof() || !command_line::is_yes(confirm))
+                return false;
+        }
+        m_wallet->set_refresh_from_block_height(m_restore_height);
+    }
+
   }
   else
   {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -147,7 +147,7 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false),m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshDefault), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false),m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
 
   public:
     static const char* tr(const char* str);


### PR DESCRIPTION
Used the defined `RefreshDefault` as default rather than it's current `RefreshOptimizeCoinbase` value.