### PR TITLE
Zmq client

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -38,12 +38,19 @@ set(daemon_rpc_server_sources
   daemon_handler.cpp
   zmq_server.cpp)
 
+set(daemon_rpc_client_sources
+  daemon_rpc_client.cpp
+  daemon_rpc_client_zmq.cpp
+  zmq_client.cpp
+  daemon_rpc_client_old.cpp)
 
 set(rpc_headers
   rpc_args.h)
 
 set(daemon_rpc_server_headers)
 
+set(daemon_rpc_client_headers
+  daemon_rpc_client.h)
 
 set(rpc_daemon_private_headers
   core_rpc_server.h
@@ -61,12 +68,20 @@ set(daemon_rpc_server_private_headers
   rpc_handler.h
   zmq_server.h)
 
+set(daemon_rpc_client_private_headers
+  daemon_rpc_client_zmq.h
+  zmq_client.h
+  daemon_rpc_client_old.h)
+
 
 monero_private_headers(rpc
   ${rpc_private_headers})
 
 monero_private_headers(daemon_rpc_server
   ${daemon_rpc_server_private_headers})
+
+monero_private_headers(daemon_rpc_client
+  ${daemon_rpc_client_private_headers})
 
 
 monero_add_library(rpc
@@ -84,6 +99,10 @@ monero_add_library(daemon_rpc_server
   ${daemon_rpc_server_headers}
   ${daemon_rpc_server_private_headers})
 
+monero_add_library(daemon_rpc_client
+  ${daemon_rpc_client_sources}
+  ${daemon_rpc_client_headers}
+  ${daemon_rpc_client_private_headers})
 
 target_link_libraries(rpc
   PUBLIC
@@ -117,3 +136,26 @@ target_link_libraries(daemon_rpc_server
     ${EXTRA_LIBRARIES})
 target_include_directories(daemon_rpc_server PUBLIC ${ZMQ_INCLUDE_PATH})
 target_include_directories(obj_daemon_rpc_server PUBLIC ${ZMQ_INCLUDE_PATH})
+
+target_link_libraries(daemon_rpc_client
+  LINK_PRIVATE
+    cryptonote_protocol
+    daemon_messages
+    serialization
+    ${Boost_CHRONO_LIBRARY}
+    ${Boost_REGEX_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${ZMQ_LIB}
+    ${EXTRA_LIBRARIES})
+target_include_directories(daemon_rpc_client PRIVATE ${ZMQ_INCLUDE_PATH})
+target_include_directories(obj_daemon_rpc_client PRIVATE ${ZMQ_INCLUDE_PATH})
+
+add_dependencies(rpc
+  version)
+
+add_dependencies(daemon_rpc_server
+  version)
+
+add_dependencies(daemon_rpc_client
+  version)

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -192,6 +192,7 @@ namespace rpc
     };
 
     std::vector<uint64_t> heights(num_found);
+    std::vector<uint64_t> timestamps(num_found);
     std::vector<bool> in_pool(num_found, false);
     std::vector<crypto::hash> found_hashes(num_found);
 
@@ -199,6 +200,7 @@ namespace rpc
     {
       found_hashes[i] = get_transaction_hash(found_txs_vec[i]);
       heights[i] = m_core.get_blockchain_storage().get_db().get_tx_block_height(found_hashes[i]);
+      timestamps[i] = m_core.get_blockchain_storage().get_db().get_block_timestamp(heights[i]);
     }
 
     // if any missing from blockchain, check in tx pool
@@ -219,6 +221,7 @@ namespace rpc
           found_hashes.push_back(h);
           found_txs_vec.push_back(tx);
           heights.push_back(std::numeric_limits<uint64_t>::max());
+          timestamps.push_back(std::numeric_limits<uint64_t>::max());
           in_pool.push_back(true);
           missed_vec.erase(itr);
         }
@@ -228,7 +231,8 @@ namespace rpc
     for (size_t i=0; i < found_hashes.size(); i++)
     {
       cryptonote::rpc::transaction_info info;
-      info.height = heights[i];
+      info.block_height = heights[i];
+      info.block_timestamp = timestamps[i];
       info.in_pool = in_pool[i];
       info.transaction = std::move(found_txs_vec[i]);
 

--- a/src/rpc/daemon_rpc_client.cpp
+++ b/src/rpc/daemon_rpc_client.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include <stdexcept>
+
+#include "rpc/daemon_rpc_client.h"
+#include "rpc/daemon_rpc_client_old.h"
+#include "rpc/daemon_rpc_client_zmq.h"
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+DaemonRPCClient* DaemonRPCClient::makeDaemonRPCClient(const CLIENT_TYPE type, const std::string& address, boost::optional<epee::net_utils::http::login> loginInfo)
+{
+  DaemonRPCClient* new_client = nullptr;
+  if (type == DaemonRPCClient::TYPE_OLD)
+  {
+    new_client = new DaemonRPCClientOld(address, loginInfo);
+  }
+  else if (type == DaemonRPCClient::TYPE_ZMQ)
+  {
+    new_client = new DaemonRPCClientZMQ(address);
+  }
+  else
+  {
+    throw std::runtime_error("Unsupported or unimplemented daemon rpc client type requested!");
+  }
+
+  return new_client;
+}
+
+} // namespace rpc
+} // namespace cryptonote

--- a/src/rpc/daemon_rpc_client.h
+++ b/src/rpc/daemon_rpc_client.h
@@ -1,0 +1,182 @@
+// Copyright (c) 2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include <boost/optional/optional.hpp>
+
+#include "rpc/message_data_structs.h"
+#include "net/http_auth.h"
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+
+/**
+ * @brief Daemon RPC Client interface
+ *
+ * This class serves to bridge the old RPC with the new ZMQ RPC such that
+ * one can command a wallet to use either to communicate with a daemon.
+ */
+class DaemonRPCClient
+{
+  public:
+
+    enum CLIENT_TYPE
+    {
+      TYPE_OLD,
+      TYPE_ZMQ
+    };
+
+    DaemonRPCClient() { }
+    virtual ~DaemonRPCClient() { }
+
+    /**
+     * @brief Check the connection to the daemon's RPC server
+     *
+     * @param timeout [in] timeout in ms to wait for a reply
+     * @param version [out] the daemon's RPC version
+     * @param error_details [out] details of any RPC error
+     *
+     * @return true if version info obtained, otherwise false
+     */
+    virtual boost::optional<std::string> checkConnection(
+        uint32_t timeout,
+        uint32_t& version) = 0;
+
+    virtual boost::optional<std::string> getHeight(
+        uint64_t& height) = 0;
+
+    virtual boost::optional<std::string> getTargetHeight(
+        uint64_t& target_height) = 0;
+
+    virtual boost::optional<std::string> getNetworkDifficulty(
+        uint64_t& difficulty) = 0;
+
+    virtual boost::optional<std::string> getDifficultyTarget(
+        uint64_t& target) = 0;
+
+    virtual boost::optional<std::string> getBlocksFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        const bool prune,
+        std::vector<cryptonote::rpc::block_with_transactions>& blocks,
+        uint64_t& start_height_out,
+        uint64_t& current_height,
+        std::vector<cryptonote::rpc::block_output_indices>& output_indices) = 0;
+
+    virtual boost::optional<std::string> getHashesFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        std::list<crypto::hash>& hashes,
+        uint64_t& start_height_out,
+        uint64_t& current_height) = 0;
+
+    virtual boost::optional<std::string> getTransactions(
+        const std::vector<crypto::hash>& tx_hashes,
+        std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info>& txs,
+        std::vector<crypto::hash>& missed_hashes) = 0;
+
+    virtual boost::optional<std::string> getBlockHeadersByHeight(
+        const std::vector<uint64_t>& heights,
+        std::vector<cryptonote::rpc::BlockHeaderResponse>& headers) = 0;
+
+    virtual boost::optional<std::string> keyImagesSpent(
+        const std::vector<crypto::key_image>& images,
+        std::vector<bool>& spent,
+        std::vector<bool>& spent_in_chain,
+        std::vector<bool>& spent_in_pool) = 0;
+
+    virtual boost::optional<std::string> getTransactionPool(
+        std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool>& transactions,
+        std::unordered_map<crypto::key_image, std::vector<crypto::hash> >& key_images) = 0;
+
+    virtual boost::optional<std::string> getRandomOutputsForAmounts(
+        const std::vector<uint64_t>& amounts,
+        const uint64_t count,
+        std::vector<amount_with_random_outputs>& amounts_with_outputs) = 0;
+
+    virtual boost::optional<std::string> sendRawTx(
+        const cryptonote::transaction& tx,
+        bool& relayed,
+        bool relay = true) = 0;
+
+    virtual boost::optional<std::string> hardForkInfo(
+        const uint8_t version,
+        hard_fork_info& info) = 0;
+
+    virtual boost::optional<std::string> getHardForkEarliestHeight(
+        const uint8_t version,
+        uint64_t& earliest_height) = 0;
+
+    virtual boost::optional<std::string> getOutputHistogram(
+        const std::vector<uint64_t>& amounts,
+        uint64_t min_count,
+        uint64_t max_count,
+        bool unlocked,
+        uint64_t recent_cutoff,
+        std::vector<output_amount_count>& histogram) = 0;
+
+    virtual boost::optional<std::string> getOutputKeys(
+        const std::vector<output_amount_and_index>& outputs,
+        std::vector<output_key_mask_unlocked>& keys) = 0;
+
+    virtual boost::optional<std::string> getRPCVersion(
+        uint32_t& version) = 0;
+
+    virtual boost::optional<std::string> getPerKBFeeEstimate(
+        const uint64_t num_grace_blocks,
+        uint64_t& estimated_per_kb_fee) = 0;
+
+    virtual boost::optional<std::string> getMiningHashRate(
+        uint64_t& speed) = 0;
+
+    virtual boost::optional<std::string> isMining(
+        bool& status) = 0;
+
+    virtual boost::optional<std::string> startMining(
+        const std::string& miner_address,
+        const uint64_t threads_count,
+        const bool do_background_mining,
+        const bool ignore_battery) = 0;
+
+    virtual boost::optional<std::string> stopMining() = 0;
+
+    virtual uint32_t getOurRPCVersion() = 0;
+
+    static DaemonRPCClient* makeDaemonRPCClient(const CLIENT_TYPE type, const std::string& address, boost::optional<epee::net_utils::http::login> loginInfo);
+};
+
+
+} // namespace rpc
+} // namespace cryptonote

--- a/src/rpc/daemon_rpc_client_old.cpp
+++ b/src/rpc/daemon_rpc_client_old.cpp
@@ -1,0 +1,1038 @@
+// Copyright (c) 2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include <chrono>
+
+#include "rpc/daemon_rpc_client_old.h"
+
+#include "rpc/core_rpc_server_commands_defs.h"
+#include "storages/http_abstract_invoke.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+
+namespace {
+
+  static const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
+
+  //TODO: threaded?
+  bool parseBlocksWithTransactions(const std::list<cryptonote::block_complete_entry>& blocks_in, std::vector<cryptonote::rpc::block_with_transactions>& blocks_out)
+  {
+    blocks_out.clear();
+    blocks_out.resize(blocks_in.size());
+
+    size_t i = 0;
+    for (const cryptonote::block_complete_entry& entry : blocks_in)
+    {
+      if (!parse_and_validate_block_from_blob(entry.block, blocks_out[i].block))
+      {
+        return false;
+      }
+
+      for (const cryptonote::blobdata& tx_blob : entry.txs)
+      {
+        cryptonote::transaction tx;
+        crypto::hash tx_hash;
+        crypto::hash tx_prefix_hash;
+
+        if (!cryptonote::parse_and_validate_tx_from_blob(tx_blob, tx, tx_hash, tx_prefix_hash))
+        {
+          return false;
+        }
+        blocks_out[i].transactions[tx_hash] = tx;
+      }
+      i++;
+    }
+
+    return true;
+  }
+
+}  // anonymous namespace
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+DaemonRPCClientOld::DaemonRPCClientOld(const std::string& address, boost::optional<epee::net_utils::http::login> loginInfo) :
+    daemonAddress(address),
+    loginInfo(loginInfo)
+{
+  resetCachedValues();
+  httpClient.set_server(address, loginInfo);
+  connect();
+}
+
+boost::optional<std::string> DaemonRPCClientOld::checkConnection(
+    uint32_t timeout,
+    uint32_t& version)
+{
+  boost::lock_guard<boost::mutex> lock(inUseMutex);
+
+  if (!connect(timeout))
+  {
+    return boost::optional<std::string>("Failed to connect to daemon");
+  }
+
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req_t = AUTO_VAL_INIT(req_t);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
+  req_t.jsonrpc = "2.0";
+  req_t.id = epee::serialization::storage_entry(0);
+  req_t.method = "get_version";
+
+  bool r = epee::net_utils::invoke_http_json("/json_rpc", req_t, resp_t, httpClient);
+  if(!r) {
+    version = 0;
+    return boost::optional<std::string>("No response from daemon");
+  }
+
+  if (resp_t.result.status != CORE_RPC_STATUS_OK)
+    version = 0;
+  else
+    version = resp_t.result.version;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getHeight(
+    uint64_t& height)
+{
+  const time_t now = time(NULL);
+
+  if (cachedHeight == 0 || now >= lastHeightCheckTime + 30) // re-cache every 30 seconds
+  {
+
+    cryptonote::COMMAND_RPC_GET_HEIGHT::request req = AUTO_VAL_INIT(req);
+    cryptonote::COMMAND_RPC_GET_HEIGHT::response res = AUTO_VAL_INIT(res);
+
+    bool r;
+    {
+      boost::lock_guard<boost::mutex> lock(inUseMutex);
+      r = epee::net_utils::invoke_http_json("/getheight", req, res, httpClient, rpc_timeout);
+    }
+
+    CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
+    CHECK_AND_ASSERT_MES(res.status != CORE_RPC_STATUS_BUSY, res.status, "Failed to connect to daemon");
+    CHECK_AND_ASSERT_MES(res.status == CORE_RPC_STATUS_OK, res.status, "Failed to get current blockchain height");
+
+    cachedHeight = res.height;
+    lastHeightCheckTime = now;
+  }
+
+  height = cachedHeight;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getTargetHeight(
+    uint64_t& target_height)
+{
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_INFO::request> req = AUTO_VAL_INIT(req);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_INFO::response, std::string> res = AUTO_VAL_INIT(res);
+
+  req.jsonrpc = "2.0";
+  req.id = epee::serialization::storage_entry(0);
+  req.method = "get_info";
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.result.status != CORE_RPC_STATUS_OK)
+  {
+    return res.result.status;
+  }
+
+  target_height = res.result.target_height;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getNetworkDifficulty(
+    uint64_t& difficulty)
+{
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_INFO::request> req = AUTO_VAL_INIT(req);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_INFO::response, std::string> res = AUTO_VAL_INIT(res);
+
+  req.jsonrpc = "2.0";
+  req.id = epee::serialization::storage_entry(0);
+  req.method = "get_info";
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.result.status != CORE_RPC_STATUS_OK)
+  {
+    return res.result.status;
+  }
+
+  difficulty = res.result.difficulty;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getDifficultyTarget(
+    uint64_t& target)
+{
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_INFO::request> req = AUTO_VAL_INIT(req);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_INFO::response, std::string> res = AUTO_VAL_INIT(res);
+
+  req.jsonrpc = "2.0";
+  req.id = epee::serialization::storage_entry(0);
+  req.method = "get_info";
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.result.status != CORE_RPC_STATUS_OK)
+  {
+    return res.result.status;
+  }
+
+  target = res.result.target;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getBlocksFast(
+    const std::list<crypto::hash>& short_chain_history,
+    const uint64_t start_height_in,
+    const bool prune,
+    std::vector<cryptonote::rpc::block_with_transactions>& blocks,
+    uint64_t& start_height_out,
+    uint64_t& current_height,
+    std::vector<cryptonote::rpc::block_output_indices>& output_indices)
+{
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
+
+  uint32_t rpc_version;
+  boost::optional<std::string> result = getRPCVersion(rpc_version);
+  if (result)
+  {
+    return result;
+  }
+
+  if (rpc_version >= MAKE_CORE_RPC_VERSION(1, 7))
+  {
+    MDEBUG("Daemon is recent enough, asking for pruned blocks");
+    req.prune = true;
+  }
+  else
+  {
+    MDEBUG("Daemon is too old, not asking for pruned blocks");
+    req.prune = false;
+  }
+
+  req.block_ids = short_chain_history;
+  req.start_height = start_height_in;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/getblocks.bin", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  CHECK_AND_ASSERT_MES(res.blocks.size() == res.output_indices.size(),
+      std::string("RPC response did not match request"),
+      std::string("mismatched blocks (") +
+          boost::lexical_cast<std::string>(res.blocks.size()) +
+          ") and output_indices (" +
+          boost::lexical_cast<std::string>(res.output_indices.size()) +
+          ") sizes from daemon");
+
+  start_height_out = res.start_height;
+  current_height = res.current_height;
+
+  if (!parseBlocksWithTransactions(res.blocks, blocks))
+  {
+    return std::string("Parsing of blocks or transactions failed");
+  }
+
+  output_indices.resize(res.output_indices.size());
+  for (size_t i = 0; i < res.output_indices.size(); i++)
+  {
+    output_indices[i].resize(res.output_indices[i].indices.size());
+    for (size_t j = 0; j < res.output_indices[i].indices.size(); j++)
+    {
+      output_indices[i][j] = std::move(res.output_indices[i].indices[j].indices);
+    }
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getHashesFast(
+    const std::list<crypto::hash>& short_chain_history,
+    const uint64_t start_height_in,
+    std::list<crypto::hash>& hashes,
+    uint64_t& start_height_out,
+    uint64_t& current_height)
+{
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req = AUTO_VAL_INIT(req);
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::response res = AUTO_VAL_INIT(res);
+
+  req.block_ids = short_chain_history;
+  req.start_height = start_height_in;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/gethashes.bin", req, res, httpClient, rpc_timeout);
+  }
+
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  start_height_out = res.start_height;
+  hashes = res.m_block_ids;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getTransactions(
+    const std::vector<crypto::hash>& tx_hashes,
+    std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info>& txs,
+    std::vector<crypto::hash>& missed_hashes)
+{
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::response res;
+
+  for (const auto& hash : tx_hashes)
+  {
+    req.txs_hashes.push_back(epee::string_tools::pod_to_hex(hash));
+  }
+
+  req.decode_as_json = false;
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/gettransactions", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  for (const auto& tx_data : res.txs)
+  {
+    cryptonote::transaction tx;
+    cryptonote::blobdata bd;
+    crypto::hash tx_hash, tx_prefix_hash;
+    if (!epee::string_tools::parse_hexstr_to_binbuff(tx_data.as_hex, bd))
+    {
+      return std::string("Failed to parse tx from RPC response");
+    }
+    if (!cryptonote::parse_and_validate_tx_from_blob(bd, tx, tx_hash, tx_prefix_hash))
+    {
+      return std::string("Failed to parse tx from RPC response");
+    }
+
+    cryptonote::rpc::transaction_info tx_info;
+
+    tx_info.transaction = tx;
+    tx_info.in_pool = tx_data.in_pool;
+    tx_info.block_height = tx_data.block_height;
+    tx_info.block_timestamp = tx_data.block_timestamp;
+    txs[tx_hash] = tx_info;
+  }
+
+  for (const std::string& tx_hash : res.missed_tx)
+  {
+    crypto::hash h;
+    if (!epee::string_tools::hex_to_pod(tx_hash, h))
+    {
+      return std::string("Failed to parse tx hash from RPC response");
+    }
+    missed_hashes.push_back(h);
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getBlockHeadersByHeight(
+    const std::vector<uint64_t>& heights,
+    std::vector<cryptonote::rpc::BlockHeaderResponse>& headers)
+{
+
+  COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request req;
+  COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response res;
+
+  req.heights = heights;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/getblocks_by_height.bin", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+  if (res.blocks.size() != heights.size())
+  {
+    return std::string("Mismatched RPC response size");
+  }
+
+  headers.clear();
+  headers.resize(heights.size());
+
+  for (size_t i=0; i < heights.size(); i++)
+  {
+    cryptonote::block bl;
+    if (!parse_and_validate_block_from_blob(res.blocks[i].block, bl))
+    {
+      return std::string("Failed to parse response from RPC");
+    }
+
+    //TODO: add other header members if needed
+    headers[i].timestamp = bl.timestamp;
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::keyImagesSpent(
+    const std::vector<crypto::key_image>& images,
+    std::vector<bool>& spent,
+    std::vector<bool>& spent_in_chain,
+    std::vector<bool>& spent_in_pool)
+{
+
+  COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_IS_KEY_IMAGE_SPENT::response res = AUTO_VAL_INIT(res);
+
+  for (const auto& key_image : images)
+  {
+    req.key_images.push_back(epee::string_tools::pod_to_hex(key_image));
+  }
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/is_key_image_spent", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+  if (res.spent_status.size() != images.size())
+  {
+    return std::string("Mismatched RPC response size");
+  }
+
+  spent.clear();
+  spent_in_chain.clear();
+  spent_in_pool.clear();
+
+  spent.resize(images.size());
+  spent_in_chain.resize(images.size());
+  spent_in_pool.resize(images.size());
+
+  for (size_t i = 0; i < images.size(); i++)
+  {
+    spent[i] = (res.spent_status[i] != COMMAND_RPC_IS_KEY_IMAGE_SPENT::UNSPENT);
+    spent_in_chain[i] = (res.spent_status[i] == COMMAND_RPC_IS_KEY_IMAGE_SPENT::SPENT_IN_BLOCKCHAIN);
+    spent_in_pool[i] = (res.spent_status[i] == COMMAND_RPC_IS_KEY_IMAGE_SPENT::SPENT_IN_POOL);
+  }
+
+  return boost::none;
+}
+
+// TODO: if key_images is needed by anything using this hopefully
+// soon to be deprecated port of the old RPC, implement it.
+boost::optional<std::string> DaemonRPCClientOld::getTransactionPool(
+    std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool>& transactions,
+    std::unordered_map<crypto::key_image, std::vector<crypto::hash> >& key_images)
+{
+
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::request hashes_req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::response hashes_res;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/get_transaction_pool_hashes.bin", hashes_req, hashes_res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (hashes_res.status != CORE_RPC_STATUS_OK)
+  {
+    return hashes_res.status;
+  }
+
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::request txs_req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::response txs_res;
+
+  for (const auto &txid : hashes_res.tx_hashes)
+  {
+    txs_req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
+  }
+
+  txs_req.decode_as_json = false;
+
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/gettransactions", txs_req, txs_res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (txs_res.status != CORE_RPC_STATUS_OK)
+  {
+    return txs_res.status;
+  }
+
+  for (const auto& tx_data : txs_res.txs)
+  {
+    if (tx_data.in_pool)
+    {
+      cryptonote::transaction tx;
+      cryptonote::blobdata bd;
+      crypto::hash tx_hash, tx_prefix_hash;
+      if (!epee::string_tools::parse_hexstr_to_binbuff(tx_data.as_hex, bd))
+      {
+        return std::string("Failed to parse tx from RPC response");
+      }
+      if (!cryptonote::parse_and_validate_tx_from_blob(bd, tx, tx_hash, tx_prefix_hash))
+      {
+        return std::string("Failed to parse tx from RPC response");
+      }
+
+      cryptonote::rpc::tx_in_pool in_pool;
+
+      in_pool.tx = tx;
+      in_pool.tx_hash = tx_hash;
+      transactions[tx_hash] = in_pool;
+    }
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getRandomOutputsForAmounts(
+    const std::vector<uint64_t>& amounts,
+    const uint64_t count,
+    std::vector<amount_with_random_outputs>& amounts_with_outputs)
+{
+
+  COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response res = AUTO_VAL_INIT(res);
+
+  req.amounts = amounts;
+  req.outs_count = count;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/getrandom_outs.bin", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+  if (res.outs.size() != amounts.size())
+  {
+    return std::string("Mismatched RPC response size");
+  }
+
+  amounts_with_outputs.clear();
+  amounts_with_outputs.resize(amounts.size());
+
+  for (size_t i=0; i < amounts.size(); i++)
+  {
+    amounts_with_outputs[i].amount = res.outs[i].amount;
+    amounts_with_outputs[i].outputs.resize(res.outs[i].outs.size());
+    size_t j = 0;
+    for (const auto& out : res.outs[i].outs)
+    {
+      amounts_with_outputs[i].outputs[j].amount_index = out.global_amount_index;
+      amounts_with_outputs[i].outputs[j].key = out.out_key;
+      j++;
+    }
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::sendRawTx(
+    const cryptonote::transaction& tx,
+    bool& relayed,
+    bool relay)
+{
+
+  crypto::hash txid;
+
+  COMMAND_RPC_SEND_RAW_TX::request req;
+  COMMAND_RPC_SEND_RAW_TX::response res;
+  req.tx_as_hex = epee::string_tools::buff_to_hex_nodelimer(tx_to_blob(tx));
+  req.do_not_relay = false;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/sendrawtransaction", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (!res.reason.empty())
+  {
+    return std::string("Daemon rejected tx, reason: ") + res.reason;
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  relayed = !res.not_relayed;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::hardForkInfo(
+    const uint8_t version,
+    hard_fork_info& info)
+{
+  boost::lock_guard<boost::mutex> lock(inUseMutex);
+
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_HARD_FORK_INFO::request> req = AUTO_VAL_INIT(req);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_HARD_FORK_INFO::response, std::string> res = AUTO_VAL_INIT(res);
+
+  req.jsonrpc = "2.0";
+  req.id = epee::serialization::storage_entry(0);
+  req.method = "hard_fork_info";
+  req.params.version = version;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.result.status != CORE_RPC_STATUS_OK)
+  {
+    return res.result.status;
+  }
+
+  info.version = res.result.version;
+  info.enabled = res.result.enabled;
+  info.window = res.result.window;
+  info.votes = res.result.votes;
+  info.threshold = res.result.threshold;
+  info.voting = res.result.voting;
+  info.state = res.result.state;
+  info.earliest_height = res.result.earliest_height;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getHardForkEarliestHeight(
+    const uint8_t version,
+    uint64_t& earliest_height)
+{
+  if (cachedHardForkEarliestHeights[version] == 0)
+  {
+    hard_fork_info info;
+
+    boost::optional<std::string> r = hardForkInfo(version, info);
+
+    if (r) return r;
+
+    cachedHardForkEarliestHeights[version] = info.enabled ? info.earliest_height : std::numeric_limits<uint64_t>::max();
+  }
+
+  earliest_height = cachedHardForkEarliestHeights[version];
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getOutputHistogram(
+    const std::vector<uint64_t>& amounts,
+    uint64_t min_count,
+    uint64_t max_count,
+    bool unlocked,
+    uint64_t recent_cutoff,
+    std::vector<output_amount_count>& histogram)
+{
+  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request> req = AUTO_VAL_INIT(req);
+  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response, std::string> res = AUTO_VAL_INIT(res);
+
+  req.jsonrpc = "2.0";
+  req.id = epee::serialization::storage_entry(0);
+  req.method = "get_output_histogram";
+
+  req.params.amounts = amounts;
+
+  req.params.unlocked = unlocked;
+  req.params.min_count = min_count;
+  req.params.max_count = max_count;
+  req.params.recent_cutoff = recent_cutoff;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.result.status != CORE_RPC_STATUS_OK)
+  {
+    return res.result.status;
+  }
+
+  histogram.clear();
+  histogram.resize(res.result.histogram.size());
+
+  for (size_t i=0; i < histogram.size(); i++)
+  {
+    histogram[i].amount = res.result.histogram[i].amount;
+    histogram[i].total_count = res.result.histogram[i].total_instances;
+    histogram[i].unlocked_count = res.result.histogram[i].unlocked_instances;
+    histogram[i].recent_count = res.result.histogram[i].recent_instances;
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getOutputKeys(
+    const std::vector<output_amount_and_index>& outputs,
+    std::vector<output_key_mask_unlocked>& keys)
+{
+
+  COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_OUTPUTS_BIN::response res = AUTO_VAL_INIT(res);
+
+  req.outputs.resize(outputs.size());
+  for (size_t i=0; i < outputs.size(); i++)
+  {
+    req.outputs[i].amount = outputs[i].amount;
+    req.outputs[i].index = outputs[i].index;
+  }
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_bin("/get_outs.bin", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+  if (res.outs.size() != outputs.size())
+  {
+    return std::string("Mismatched RPC response size");
+  }
+
+  keys.clear();
+  keys.resize(outputs.size());
+
+  for (size_t i=0; i < keys.size(); i++)
+  {
+    keys[i].key = res.outs[i].key;
+    keys[i].mask = res.outs[i].mask;
+    keys[i].unlocked = res.outs[i].unlocked;
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getRPCVersion(
+    uint32_t& version)
+{
+
+  if (cachedRPCVersion == 0)
+  {
+    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req = AUTO_VAL_INIT(req);
+    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> res = AUTO_VAL_INIT(res);
+    req.jsonrpc = "2.0";
+    req.id = epee::serialization::storage_entry(0);
+    req.method = "get_version";
+
+    bool r;
+    {
+      boost::lock_guard<boost::mutex> lock(inUseMutex);
+      r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient, rpc_timeout);
+    }
+    if (!r)
+    {
+      return std::string("Failed to connect to daemon");
+    }
+    if (res.result.status != CORE_RPC_STATUS_OK)
+    {
+      return res.result.status;
+    }
+
+    cachedRPCVersion = res.result.version;
+  }
+
+  version = cachedRPCVersion;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getPerKBFeeEstimate(
+    const uint64_t num_grace_blocks,
+    uint64_t& estimated_per_kb_fee)
+{
+
+  uint64_t height;
+
+  boost::optional<std::string> result = getHeight(height);
+  if (result)
+    return result;
+
+  if (cachedPerKBFeeEstimateHeight != height || cachedPerKBFeeEstimateGraceBlocks != num_grace_blocks)
+  {
+    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_PER_KB_FEE_ESTIMATE::request> req = AUTO_VAL_INIT(req);
+    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_PER_KB_FEE_ESTIMATE::response, std::string> res = AUTO_VAL_INIT(res);
+
+    req.jsonrpc = "2.0";
+    req.id = epee::serialization::storage_entry(0);
+    req.method = "get_fee_estimate";
+    req.params.grace_blocks = num_grace_blocks;
+
+    bool r;
+    {
+      boost::lock_guard<boost::mutex> lock(inUseMutex);
+      r = epee::net_utils::invoke_http_json("/json_rpc", req, res, httpClient, rpc_timeout);
+    }
+    if (!r)
+    {
+      return std::string("Failed to connect to daemon");
+    }
+    if (res.result.status != CORE_RPC_STATUS_OK)
+    {
+      return res.result.status;
+    }
+
+    cachedPerKBFeeEstimate = res.result.fee;
+    cachedPerKBFeeEstimateHeight = height;
+    cachedPerKBFeeEstimateGraceBlocks = num_grace_blocks;
+  }
+
+  estimated_per_kb_fee = cachedPerKBFeeEstimate;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::getMiningHashRate(
+    uint64_t& speed)
+{
+  cryptonote::COMMAND_RPC_MINING_STATUS::request req;
+  cryptonote::COMMAND_RPC_MINING_STATUS::response res;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/mining_status", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  speed = res.active ? res.speed : 0;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::isMining(
+    bool& status)
+{
+  cryptonote::COMMAND_RPC_MINING_STATUS::request req;
+  cryptonote::COMMAND_RPC_MINING_STATUS::response res;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/mining_status", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  status = res.active;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::startMining(
+    const std::string& miner_address,
+    const uint64_t threads_count,
+    const bool do_background_mining,
+    const bool ignore_battery)
+{
+  cryptonote::COMMAND_RPC_START_MINING::request req;
+  cryptonote::COMMAND_RPC_START_MINING::response res;
+
+  req.miner_address = miner_address;
+  req.threads_count = threads_count;
+  req.do_background_mining = do_background_mining;
+  req.ignore_battery = ignore_battery;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/start_mining", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientOld::stopMining()
+{
+  cryptonote::COMMAND_RPC_STOP_MINING::request req;
+  cryptonote::COMMAND_RPC_STOP_MINING::response res;
+
+  bool r;
+  {
+    boost::lock_guard<boost::mutex> lock(inUseMutex);
+    r = epee::net_utils::invoke_http_json("/stop_mining", req, res, httpClient, rpc_timeout);
+  }
+  if (!r)
+  {
+    return std::string("Failed to connect to daemon");
+  }
+  if (res.status != CORE_RPC_STATUS_OK)
+  {
+    return res.status;
+  }
+
+  return boost::none;
+}
+
+uint32_t DaemonRPCClientOld::getOurRPCVersion()
+{
+  return CORE_RPC_VERSION;
+}
+
+bool DaemonRPCClientOld::connect(uint32_t timeout)
+{
+  if(!httpClient.is_connected())
+  {
+    resetCachedValues();
+    if (!httpClient.connect(std::chrono::milliseconds(timeout)))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+void DaemonRPCClientOld::resetCachedValues()
+{
+  cachedHeight = 0;
+  cachedRPCVersion = 0;
+  lastHeightCheckTime = 0;
+
+  for (size_t n = 0; n < 256; ++n)
+    cachedHardForkEarliestHeights[n] = 0;
+}
+
+
+} // namespace rpc
+} // namespace cryptonote

--- a/src/rpc/daemon_rpc_client_old.h
+++ b/src/rpc/daemon_rpc_client_old.h
@@ -1,0 +1,198 @@
+// Copyright (c) 2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include <atomic>
+
+#include <boost/optional/optional.hpp>
+#include <boost/thread/locks.hpp>
+
+#include "rpc/daemon_rpc_client.h"
+
+#include "rpc/message_data_structs.h"
+#include "net/http_client.h"
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+
+/**
+ * @brief Daemon RPC Client interface
+ *
+ * This class serves to bridge the old RPC with the new ZMQ RPC such that
+ * one can command a wallet to use either to communicate with a daemon.
+ */
+class DaemonRPCClientOld : public DaemonRPCClient
+{
+  public:
+
+    DaemonRPCClientOld() = delete;
+    ~DaemonRPCClientOld() { }
+
+    DaemonRPCClientOld(const std::string& address, boost::optional<epee::net_utils::http::login> loginInfo);
+
+    boost::optional<std::string> checkConnection(
+        uint32_t timeout,
+        uint32_t& version);
+
+    boost::optional<std::string> getHeight(
+        uint64_t& height);
+
+    boost::optional<std::string> getTargetHeight(
+        uint64_t& target_height);
+
+    boost::optional<std::string> getNetworkDifficulty(
+        uint64_t& difficulty);
+
+    boost::optional<std::string> getDifficultyTarget(
+        uint64_t& target);
+
+    boost::optional<std::string> getBlocksFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        const bool prune,
+        std::vector<cryptonote::rpc::block_with_transactions>& blocks,
+        uint64_t& start_height_out,
+        uint64_t& current_height,
+        std::vector<cryptonote::rpc::block_output_indices>& output_indices);
+
+    boost::optional<std::string> getHashesFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        std::list<crypto::hash>& hashes,
+        uint64_t& start_height_out,
+        uint64_t& current_height);
+
+    boost::optional<std::string> getTransactions(
+        const std::vector<crypto::hash>& tx_hashes,
+        std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info>& txs,
+        std::vector<crypto::hash>& missed_hashes);
+
+    boost::optional<std::string> getBlockHeadersByHeight(
+        const std::vector<uint64_t>& heights,
+        std::vector<cryptonote::rpc::BlockHeaderResponse>& headers);
+
+    boost::optional<std::string> keyImagesSpent(
+        const std::vector<crypto::key_image>& images,
+        std::vector<bool>& spent,
+        std::vector<bool>& spent_in_chain,
+        std::vector<bool>& spent_in_pool);
+
+    boost::optional<std::string> getTransactionPool(
+        std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool>& transactions,
+        std::unordered_map<crypto::key_image, std::vector<crypto::hash> >& key_images);
+
+    boost::optional<std::string> getRandomOutputsForAmounts(
+        const std::vector<uint64_t>& amounts,
+        const uint64_t count,
+        std::vector<amount_with_random_outputs>& amounts_with_outputs);
+
+    boost::optional<std::string> sendRawTx(
+        const cryptonote::transaction& tx,
+        bool& relayed,
+        bool relay = true);
+
+    boost::optional<std::string> hardForkInfo(
+        const uint8_t version,
+        hard_fork_info& info);
+
+    boost::optional<std::string> getHardForkEarliestHeight(
+        const uint8_t version,
+        uint64_t& earliest_height);
+
+    boost::optional<std::string> getOutputHistogram(
+        const std::vector<uint64_t>& amounts,
+        uint64_t min_count,
+        uint64_t max_count,
+        bool unlocked,
+        uint64_t recent_cutoff,
+        std::vector<output_amount_count>& histogram);
+
+    boost::optional<std::string> getOutputKeys(
+        const std::vector<output_amount_and_index>& outputs,
+        std::vector<output_key_mask_unlocked>& keys);
+
+    boost::optional<std::string> getRPCVersion(
+        uint32_t& version);
+
+    boost::optional<std::string> getPerKBFeeEstimate(
+        const uint64_t num_grace_blocks,
+        uint64_t& estimated_per_kb_fee);
+
+    boost::optional<std::string> getMiningHashRate(
+        uint64_t& speed);
+
+    boost::optional<std::string> isMining(
+        bool& status);
+
+    boost::optional<std::string> startMining(
+        const std::string& miner_address,
+        const uint64_t threads_count,
+        const bool do_background_mining,
+        const bool ignore_battery);
+
+    boost::optional<std::string> stopMining();
+
+    uint32_t getOurRPCVersion();
+
+  private:
+
+    bool connect(uint32_t timeout = 1000 /* ms */);
+    bool disconnect();
+
+    std::string daemonAddress;
+    boost::optional<epee::net_utils::http::login> loginInfo;
+
+    void resetCachedValues();
+
+    epee::net_utils::http::http_simple_client httpClient;
+    
+    boost::mutex inUseMutex;
+
+    time_t lastHeightCheckTime;
+    uint64_t cachedHeight;
+
+    uint32_t cachedRPCVersion;
+
+    uint64_t cachedHardForkEarliestHeights[256];
+
+    uint64_t cachedPerKBFeeEstimate;
+    uint64_t cachedPerKBFeeEstimateHeight;
+    uint64_t cachedPerKBFeeEstimateGraceBlocks;
+};
+
+
+} // namespace rpc
+} // namespace cryptonote
+

--- a/src/rpc/daemon_rpc_client_zmq.cpp
+++ b/src/rpc/daemon_rpc_client_zmq.cpp
@@ -1,0 +1,1009 @@
+// Copyright (c) 2016, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <memory>
+
+#include "rpc/daemon_rpc_client_zmq.h"
+#include "serialization/json_object.h"
+#include "include_base_utils.h"
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+DaemonRPCClientZMQ::DaemonRPCClientZMQ(const std::string& address)
+{
+  connect(address);
+}
+
+DaemonRPCClientZMQ::~DaemonRPCClientZMQ()
+{
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::checkConnection(
+    uint32_t timeout,
+    uint32_t& version)
+{
+  return getRPCVersion(version);
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getHeight(
+    uint64_t& height)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetHeight::Request request;
+
+  error_details = doRequest<GetHeight>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetHeight::Response response = parseResponse<GetHeight>(response_json);
+
+    height = response.height;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getDaemonInfo(
+    cryptonote::rpc::DaemonInfo& info)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetInfo::Request request;
+
+  error_details = doRequest<GetInfo>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetInfo::Response response = parseResponse<GetInfo>(response_json);
+
+    info = response.info;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getTargetHeight(
+    uint64_t& target_height)
+{
+  cryptonote::rpc::DaemonInfo info;
+  boost::optional<std::string> r = getDaemonInfo(info);
+  if (r) return *r;
+
+  target_height = info.target_height;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getNetworkDifficulty(
+    uint64_t& difficulty)
+{
+  cryptonote::rpc::DaemonInfo info;
+  boost::optional<std::string> r = getDaemonInfo(info);
+  if (r) return *r;
+
+  difficulty = info.difficulty;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getDifficultyTarget(
+    uint64_t& target)
+{
+  cryptonote::rpc::DaemonInfo info;
+  boost::optional<std::string> r = getDaemonInfo(info);
+  if (r) return *r;
+
+  target = info.target;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getBlocksFast(
+    const std::list<crypto::hash>& short_chain_history,
+    const uint64_t start_height_in,
+    const bool prune,
+    std::vector<cryptonote::rpc::block_with_transactions>& blocks,
+    uint64_t& start_height_out,
+    uint64_t& current_height,
+    std::vector<cryptonote::rpc::block_output_indices>& output_indices)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetBlocksFast::Request request;
+
+  request.block_ids = short_chain_history;
+  request.start_height = start_height_in;
+
+  error_details = doRequest<GetBlocksFast>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetBlocksFast::Response response = parseResponse<GetBlocksFast>(response_json);
+
+    blocks = response.blocks;
+    start_height_out = response.start_height;
+    current_height = response.current_height;
+    output_indices = response.output_indices;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getHashesFast(
+    const std::list<crypto::hash>& short_chain_history,
+    const uint64_t start_height_in,
+    std::list<crypto::hash>& hashes,
+    uint64_t& start_height_out,
+    uint64_t& current_height)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetHashesFast::Request request;
+
+  request.known_hashes = hashes;
+  request.start_height = start_height_in;
+
+  error_details = doRequest<GetHashesFast>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetHashesFast::Response response = parseResponse<GetHashesFast>(response_json);
+
+    hashes = response.hashes;
+    start_height_out = response.start_height;
+    current_height = response.current_height;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getTransactions(
+    const std::vector<crypto::hash>& tx_hashes,
+    std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info>& txs,
+    std::vector<crypto::hash>& missed_hashes)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetTransactions::Request request;
+
+  request.tx_hashes = tx_hashes;
+
+  error_details = doRequest<GetTransactions>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetTransactions::Response response = parseResponse<GetTransactions>(response_json);
+
+    txs = response.txs;
+    missed_hashes = response.missed_hashes;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getBlockHeadersByHeight(
+    const std::vector<uint64_t>& heights,
+    std::vector<cryptonote::rpc::BlockHeaderResponse>& headers)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetBlockHeadersByHeight::Request request;
+
+  request.heights = heights;
+
+  error_details = doRequest<GetBlockHeadersByHeight>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetBlockHeadersByHeight::Response response = parseResponse<GetBlockHeadersByHeight>(response_json);
+
+    headers = response.headers;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::keyImagesSpent(
+    const std::vector<crypto::key_image>& images,
+    std::vector<bool>& spent,
+    std::vector<bool>& spent_in_chain,
+    std::vector<bool>& spent_in_pool)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  KeyImagesSpent::Request request;
+
+  request.key_images = images;
+
+  error_details = doRequest<KeyImagesSpent>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    KeyImagesSpent::Response response = parseResponse<KeyImagesSpent>(response_json);
+
+    spent.resize(images.size());
+    spent_in_chain.resize(images.size());
+    spent_in_pool.resize(images.size());
+
+    for (size_t i=0; i < response.spent_status.size(); i++)
+    {
+      spent[i] = (response.spent_status[i] != KeyImagesSpent::UNSPENT);
+      spent_in_chain[i] = (response.spent_status[i] == KeyImagesSpent::SPENT_IN_BLOCKCHAIN);
+      spent_in_pool[i] = (response.spent_status[i] == KeyImagesSpent::SPENT_IN_POOL);
+    }
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getTransactionPool(
+    std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool>& transactions,
+    std::unordered_map<crypto::key_image, std::vector<crypto::hash> >& key_images)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetTransactionPool::Request request;
+
+  error_details = doRequest<GetTransactionPool>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetTransactionPool::Response response = parseResponse<GetTransactionPool>(response_json);
+
+    if (response.status != Message::STATUS_OK)
+    {
+      return error_details;
+    }
+
+    for (const auto& poolTx : response.transactions)
+    {
+      transactions[poolTx.tx_hash] = poolTx;
+    }
+    key_images = response.key_images;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getRandomOutputsForAmounts(
+    const std::vector<uint64_t>& amounts,
+    const uint64_t count,
+    std::vector<amount_with_random_outputs>& amounts_with_outputs)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetRandomOutputsForAmounts::Request request;
+
+  request.amounts = amounts;
+  request.count = count;
+
+  error_details = doRequest<GetRandomOutputsForAmounts>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetRandomOutputsForAmounts::Response response = parseResponse<GetRandomOutputsForAmounts>(response_json);
+
+    amounts_with_outputs = response.amounts_with_outputs;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::sendRawTx(
+    const cryptonote::transaction& tx,
+    bool& relayed,
+    bool relay)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  SendRawTx::Request request;
+
+  request.tx = tx;
+  request.relay = relay;
+
+  error_details = doRequest<SendRawTx>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    SendRawTx::Response response = parseResponse<SendRawTx>(response_json);
+
+    relayed = response.relayed;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::hardForkInfo(
+    const uint8_t version,
+    hard_fork_info& info)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  HardForkInfo::Request request;
+
+  request.version = version;
+
+  error_details = doRequest<HardForkInfo>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    HardForkInfo::Response response = parseResponse<HardForkInfo>(response_json);
+
+    info = response.info;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getHardForkEarliestHeight(
+    const uint8_t version,
+    uint64_t& earliest_height)
+{
+  cryptonote::rpc::hard_fork_info info;
+  boost::optional<std::string> r = hardForkInfo(version, info);
+  if (r) return *r;
+
+  earliest_height = info.earliest_height;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getOutputHistogram(
+    const std::vector<uint64_t>& amounts,
+    uint64_t min_count,
+    uint64_t max_count,
+    bool unlocked,
+    uint64_t recent_cutoff,
+    std::vector<output_amount_count>& histogram)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetOutputHistogram::Request request;
+
+  request.amounts = amounts;
+  request.min_count = min_count;
+  request.max_count = max_count;
+  request.unlocked = unlocked;
+  request.recent_cutoff = recent_cutoff;
+
+  error_details = doRequest<GetOutputHistogram>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetOutputHistogram::Response response = parseResponse<GetOutputHistogram>(response_json);
+
+    histogram = response.histogram;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getOutputKeys(
+    const std::vector<output_amount_and_index>& outputs,
+    std::vector<output_key_mask_unlocked>& keys)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetOutputKeys::Request request;
+
+  request.outputs = outputs;
+
+  error_details = doRequest<GetOutputKeys>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetOutputKeys::Response response = parseResponse<GetOutputKeys>(response_json);
+
+    keys = response.keys;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getRPCVersion(
+    uint32_t& version)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetRPCVersion::Request request;
+
+  error_details = doRequest<GetRPCVersion>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetRPCVersion::Response response = parseResponse<GetRPCVersion>(response_json);
+
+    version = response.version;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getPerKBFeeEstimate(
+    const uint64_t num_grace_blocks,
+    uint64_t& estimated_per_kb_fee)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  GetPerKBFeeEstimate::Request request;
+
+  request.num_grace_blocks = num_grace_blocks;
+
+  error_details = doRequest<GetPerKBFeeEstimate>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    GetPerKBFeeEstimate::Response response = parseResponse<GetPerKBFeeEstimate>(response_json);
+
+    estimated_per_kb_fee = response.estimated_fee_per_kb;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getMiningStatus(
+    bool& active,
+    uint64_t& speed,
+    uint64_t& threads_count,
+    std::string& address,
+    bool& is_background_mining_enabled)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  MiningStatus::Request request;
+
+  error_details = doRequest<MiningStatus>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    MiningStatus::Response response = parseResponse<MiningStatus>(response_json);
+
+    active = response.active;
+    speed = response.speed;
+    threads_count = response.threads_count;
+    address = response.address;
+    is_background_mining_enabled = response.is_background_mining_enabled;
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::getMiningHashRate(
+    uint64_t& speed)
+{
+  bool activeVal;
+  uint64_t speedVal;
+  uint64_t threads_countVal;
+  std::string addressVal;
+  bool is_background_mining_enabledVal;
+
+  boost::optional<std::string> r = getMiningStatus(
+      activeVal,
+      speedVal,
+      threads_countVal,
+      addressVal,
+      is_background_mining_enabledVal);
+
+  if (r) return *r;
+
+  speed = speedVal;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::isMining(
+    bool& status)
+{
+  bool activeVal;
+  uint64_t speedVal;
+  uint64_t threads_countVal;
+  std::string addressVal;
+  bool is_background_mining_enabledVal;
+
+  boost::optional<std::string> r = getMiningStatus(
+      activeVal,
+      speedVal,
+      threads_countVal,
+      addressVal,
+      is_background_mining_enabledVal);
+
+  if (r) return *r;
+
+  status = activeVal;
+
+  return boost::none;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::startMining(
+    const std::string& miner_address,
+    const uint64_t threads_count,
+    const bool do_background_mining,
+    const bool ignore_battery)
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  StartMining::Request request;
+
+  request.miner_address = miner_address;
+  request.threads_count = threads_count;
+  request.do_background_mining = do_background_mining;
+  request.ignore_battery = ignore_battery;
+
+  error_details = doRequest<StartMining>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    StartMining::Response response = parseResponse<StartMining>(response_json);
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+boost::optional<std::string> DaemonRPCClientZMQ::stopMining()
+{
+  boost::optional<std::string> error_details;
+  std::shared_ptr<FullMessage> full_message_ptr;
+  rapidjson::Value response_json;
+
+  StopMining::Request request;
+
+  error_details = doRequest<StopMining>(full_message_ptr, request);
+
+  if (error_details) return error_details;
+
+  response_json = full_message_ptr->getMessageCopy();
+
+  try
+  {
+    StopMining::Response response = parseResponse<StopMining>(response_json);
+
+    return boost::none;
+  }
+  catch (...)
+  {
+    try
+    {
+      cryptonote::rpc::error err = parseError(response_json);
+
+      error_details = err.error_str;
+    }
+    catch (...)
+    {
+      error_details = "Daemon returned improper JSON-RPC response.";
+    }
+  }
+
+  return error_details;
+}
+
+uint32_t DaemonRPCClientZMQ::getOurRPCVersion()
+{
+  return cryptonote::rpc::DAEMON_RPC_VERSION_ZMQ;
+}
+
+template <typename ReqType>
+boost::optional<std::string> DaemonRPCClientZMQ::doRequest(std::shared_ptr<FullMessage>& full_message_ptr, typename ReqType::Request& request)
+{
+  // rapidjson doesn't take a copy, and ephemeral conversion behaves poorly
+  std::string request_method = ReqType::name;
+
+  auto full_request = FullMessage::requestMessage(request_method, &request);
+
+  std::string response;
+  boost::optional<std::string> error = zmq_client.doRequest(full_request.getJson(), response);
+
+  if (error)
+  {
+    return error;
+  }
+
+  try
+  {
+    full_message_ptr.reset(new FullMessage(response));
+  }
+  catch (const std::exception& e)
+  {
+    return std::string(e.what());
+  }
+
+  return boost::none;
+}
+
+template <typename ReqType>
+typename ReqType::Response DaemonRPCClientZMQ::parseResponse(rapidjson::Value& resp)
+{
+  typename ReqType::Response response;
+
+  response.fromJson(resp);
+
+  return response;
+}
+
+cryptonote::rpc::error DaemonRPCClientZMQ::parseError(rapidjson::Value& err)
+{
+  cryptonote::rpc::error error;
+  cryptonote::json::fromJsonValue(err, error);
+  LOG_ERROR("ZMQ RPC client received error: " << error.error_str);
+  return error;
+}
+
+void DaemonRPCClientZMQ::connect(const std::string& address_with_port)
+{
+  zmq_client.connect(address_with_port);
+}
+
+void DaemonRPCClientZMQ::connect(const std::string& addr, const std::string& port)
+{
+  zmq_client.connect(addr, port);
+}
+
+}  // namespace rpc
+
+}  // namespace cryptonote

--- a/src/rpc/daemon_rpc_client_zmq.h
+++ b/src/rpc/daemon_rpc_client_zmq.h
@@ -1,0 +1,185 @@
+// Copyright (c) 2016, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/optional.hpp>
+
+#include "zmq_client.h"
+
+#include "rpc/daemon_messages.h"
+#include "rpc/daemon_rpc_client.h"
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+class DaemonRPCClientZMQ : public DaemonRPCClient
+{
+  public:
+
+    DaemonRPCClientZMQ() = delete;
+    ~DaemonRPCClientZMQ();
+
+    DaemonRPCClientZMQ(const std::string& address);
+
+    boost::optional<std::string> checkConnection(
+        uint32_t timeout,
+        uint32_t& version);
+
+    boost::optional<std::string> getHeight(
+        uint64_t& height);
+
+    boost::optional<std::string> getDaemonInfo(
+        cryptonote::rpc::DaemonInfo& info);
+
+    boost::optional<std::string> getTargetHeight(
+        uint64_t& target_height);
+
+    boost::optional<std::string> getNetworkDifficulty(
+        uint64_t& difficulty);
+
+    boost::optional<std::string> getDifficultyTarget(
+        uint64_t& target);
+
+    boost::optional<std::string> getBlocksFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        const bool prune,
+        std::vector<cryptonote::rpc::block_with_transactions>& blocks,
+        uint64_t& start_height_out,
+        uint64_t& current_height,
+        std::vector<cryptonote::rpc::block_output_indices>& output_indices);
+
+    boost::optional<std::string> getHashesFast(
+        const std::list<crypto::hash>& short_chain_history,
+        const uint64_t start_height_in,
+        std::list<crypto::hash>& hashes,
+        uint64_t& start_height_out,
+        uint64_t& current_height);
+
+    boost::optional<std::string> getTransactions(
+        const std::vector<crypto::hash>& tx_hashes,
+        std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info>& txs,
+        std::vector<crypto::hash>& missed_hashes);
+
+    boost::optional<std::string> getBlockHeadersByHeight(
+        const std::vector<uint64_t>& heights,
+        std::vector<cryptonote::rpc::BlockHeaderResponse>& headers);
+
+    boost::optional<std::string> keyImagesSpent(
+        const std::vector<crypto::key_image>& images,
+        std::vector<bool>& spent,
+        std::vector<bool>& spent_in_chain,
+        std::vector<bool>& spent_in_pool);
+
+    boost::optional<std::string> getTransactionPool(
+        std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool>& transactions,
+        std::unordered_map<crypto::key_image, std::vector<crypto::hash> >& key_images);
+
+    boost::optional<std::string> getRandomOutputsForAmounts(
+        const std::vector<uint64_t>& amounts,
+        const uint64_t count,
+        std::vector<amount_with_random_outputs>& amounts_with_outputs);
+
+    boost::optional<std::string> sendRawTx(
+        const cryptonote::transaction& tx,
+        bool& relayed,
+        bool relay = true);
+
+    boost::optional<std::string> hardForkInfo(
+        const uint8_t version,
+        hard_fork_info& info);
+
+    boost::optional<std::string> getHardForkEarliestHeight(
+        const uint8_t version,
+        uint64_t& earliest_height);
+
+    boost::optional<std::string> getOutputHistogram(
+        const std::vector<uint64_t>& amounts,
+        uint64_t min_count,
+        uint64_t max_count,
+        bool unlocked,
+        uint64_t recent_cutoff,
+        std::vector<output_amount_count>& histogram);
+
+    boost::optional<std::string> getOutputKeys(
+        const std::vector<output_amount_and_index>& outputs,
+        std::vector<output_key_mask_unlocked>& keys);
+
+    boost::optional<std::string> getRPCVersion(
+        uint32_t& version);
+
+    boost::optional<std::string> getPerKBFeeEstimate(
+        const uint64_t num_grace_blocks,
+        uint64_t& estimated_per_kb_fee);
+
+    boost::optional<std::string> getMiningStatus(
+        bool& active,
+        uint64_t& speed,
+        uint64_t& threads_count,
+        std::string& address,
+        bool& is_background_mining_enabled);
+
+    boost::optional<std::string> getMiningHashRate(
+        uint64_t& speed);
+
+    boost::optional<std::string> isMining(
+        bool& status);
+
+    boost::optional<std::string> startMining(
+        const std::string& miner_address,
+        const uint64_t threads_count,
+        const bool do_background_mining,
+        const bool ignore_battery);
+
+    boost::optional<std::string> stopMining();
+
+    uint32_t getOurRPCVersion();
+
+  private:
+
+    void connect(const std::string& addr, const std::string& port);
+    void connect(const std::string& address_with_port);
+
+    template <typename ReqType>
+    boost::optional<std::string> doRequest(std::shared_ptr<FullMessage>& full_message_ptr, typename ReqType::Request& request);
+
+    template <typename ReqType>
+    typename ReqType::Response parseResponse(rapidjson::Value& resp);
+
+    cryptonote::rpc::error parseError(rapidjson::Value& resp);
+
+    ZmqClient zmq_client;
+};
+
+}  // namespace rpc
+
+}  // namespace cryptonote

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -55,7 +55,8 @@ namespace rpc
   {
     cryptonote::transaction transaction;
     bool in_pool;
-    uint64_t height;
+    uint64_t block_height;
+    uint64_t block_timestamp;
   };
 
   struct output_key_and_amount_index

--- a/src/rpc/zmq_client.cpp
+++ b/src/rpc/zmq_client.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2016, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "zmq_client.h"
+#include "../../contrib/epee/include/include_base_utils.h"
+#include <iostream>
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+ZmqClient::ZmqClient() : context(1 /* one zmq thread */),
+              req_socket(nullptr),
+              connect_address(""),
+              timeout(DEFAULT_RPC_RECEIVE_TIMEOUT_MS)
+{
+}
+
+ZmqClient::~ZmqClient()
+{
+}
+
+bool ZmqClient::connect(const std::string& address_with_port, int timeout_ms)
+{
+  std::string addr_prefix("tcp://");
+  connect_address = addr_prefix + address_with_port;
+  timeout = timeout_ms;
+
+  return createSocket();
+}
+
+bool ZmqClient::connect(const std::string& address, const std::string& port, int timeout_ms)
+{
+  std::string address_with_port = address + std::string(":") + port;
+  return connect(address_with_port, timeout_ms);
+}
+
+boost::optional<std::string> ZmqClient::doRequest(const std::string& request, std::string& response)
+{
+  if (!req_socket)
+  {
+    resetSocket();
+    if (!req_socket)
+    {
+      LOG_PRINT_L0("RPC request received, but unable to connect to daemon");
+      return std::string("No connection to daemon");
+    }
+  }
+
+  zmq::message_t request_message(request.size());
+  memcpy((void *) request_message.data(), request.c_str(), request.size());
+
+  LOG_PRINT_L2(std::string("Sending ZMQ RPC request: \"") + request + "\"");
+  req_socket->send(request_message);
+
+  zmq::message_t response_message;
+
+  if (req_socket->recv(&response_message) > 0)
+  {
+    response = std::string(reinterpret_cast<const char *>(response_message.data()), response_message.size());
+
+    LOG_PRINT_L2(std::string("Recieved ZMQ RPC response: \"") + response + "\"");
+  }
+  else
+  {
+    // in case the fault for the failed receive was on our end,
+    // reset/recreate the socket.
+    resetSocket();
+    return std::string("No response from daemon, retry later.");
+  }
+
+  return boost::none;
+}
+
+bool ZmqClient::createSocket()
+{
+  static int linger_time = 0;
+  try
+  {
+    LOG_PRINT_L2("Creating ZMQ Socket at: " << connect_address);
+    req_socket.reset(new zmq::socket_t(context, ZMQ_REQ));
+    req_socket->setsockopt(ZMQ_RCVTIMEO, &timeout, sizeof(timeout));
+    req_socket->setsockopt(ZMQ_LINGER, &linger_time, sizeof(linger_time));
+    req_socket->connect(connect_address.c_str());
+
+    LOG_PRINT_L0(std::string("Created ZMQ socket at: ") + connect_address);
+  }
+  catch (std::exception& e)
+  {
+    LOG_PRINT_L2("Exception thrown while creating ZMQ Socket at: " << connect_address + ", e.what(): " << e.what());
+    req_socket.reset();
+    LOG_ERROR(std::string("Failed to connect to ZMQ RPC endpoint at ") + connect_address);
+    return false;
+  }
+  return true;
+}
+
+bool ZmqClient::resetSocket()
+{
+  return createSocket();
+}
+
+}  // namespace rpc
+
+}  // namespace cryptonote

--- a/src/rpc/zmq_client.h
+++ b/src/rpc/zmq_client.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <memory>
+
+#include <boost/optional.hpp>
+#include <zmq.hpp>
+
+namespace cryptonote
+{
+
+namespace rpc
+{
+
+static constexpr int DEFAULT_RPC_RECEIVE_TIMEOUT_MS = 5000;
+
+class ZmqClient
+{
+  public:
+    ZmqClient();
+    ~ZmqClient();
+
+    bool connect(const std::string& address_with_port, int timeout_ms = DEFAULT_RPC_RECEIVE_TIMEOUT_MS);
+    bool connect(const std::string& address, const std::string& port, int timeout_ms = DEFAULT_RPC_RECEIVE_TIMEOUT_MS);
+
+    boost::optional<std::string> doRequest(const std::string& request, std::string& response);
+
+  private:
+    bool createSocket();
+
+    bool resetSocket();
+
+    zmq::context_t context;
+
+    // req-rep socket
+    std::shared_ptr<zmq::socket_t> req_socket;
+
+    std::string connect_address;
+    int timeout;
+};
+
+}  // namespace rpc
+
+}  // namespace cryptonote

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -656,7 +656,8 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::transaction_in
 {
   val.SetObject();
 
-  INSERT_INTO_JSON_OBJECT(val, doc, height, tx_info.height);
+  INSERT_INTO_JSON_OBJECT(val, doc, height, tx_info.block_height);
+  INSERT_INTO_JSON_OBJECT(val, doc, timestamp, tx_info.block_timestamp);
   INSERT_INTO_JSON_OBJECT(val, doc, in_pool, tx_info.in_pool);
   INSERT_INTO_JSON_OBJECT(val, doc, transaction, tx_info.transaction);
 }
@@ -669,7 +670,8 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::transaction_inf
     throw WRONG_TYPE("json object");
   }
 
-  GET_FROM_JSON_OBJECT(val, tx_info.height, height);
+  GET_FROM_JSON_OBJECT(val, tx_info.block_height, height);
+  GET_FROM_JSON_OBJECT(val, tx_info.block_timestamp, timestamp);
   GET_FROM_JSON_OBJECT(val, tx_info.in_pool, in_pool);
   GET_FROM_JSON_OBJECT(val, tx_info.transaction, transaction);
 }

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(wallet
     cryptonote_core
     mnemonics
     p2p
+    daemon_rpc_client
     ${Boost_CHRONO_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
@@ -138,6 +139,7 @@ if (BUILD_GUI_DEPS)
             cncrypto
             ringct
             checkpoints
+            daemon_rpc_client
             version)
 
     foreach(lib ${libs_to_merge})

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -44,6 +44,8 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "rpc/daemon_rpc_client_old.h"
+
 using namespace std;
 using namespace cryptonote;
 
@@ -1552,7 +1554,9 @@ bool WalletImpl::isNewWallet() const
 
 bool WalletImpl::doInit(const string &daemon_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    if (!m_wallet->init(daemon_address, m_daemon_login, upper_transaction_size_limit, ssl))
+    cryptonote::rpc::DaemonRPCClient* daemon_rpc_client = (cryptonote::rpc::DaemonRPCClient*)(new cryptonote::rpc::DaemonRPCClientOld(daemon_address, m_daemon_login));
+    
+    if (!m_wallet->init(daemon_rpc_client, daemon_address, m_daemon_login, upper_transaction_size_limit, ssl))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
@@ -1608,7 +1612,7 @@ bool WalletImpl::rescanSpent()
 
 void WalletImpl::hardForkInfo(uint8_t &version, uint64_t &earliest_height) const
 {
-    m_wallet->get_hard_fork_info(version, earliest_height);
+    m_wallet->get_hard_fork_earliest_height(version, earliest_height);
 }
 
 bool WalletImpl::useForkRules(uint8_t version, int64_t early_blocks) const 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -29,8 +29,10 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 
+#include "rpc/daemon_rpc_client.h"
 #include "wallet/wallet2_api.h"
 #include <string>
+#include <memory>
 
 namespace Monero {
 
@@ -71,6 +73,8 @@ private:
     friend struct WalletManagerFactory;
     std::string m_daemonAddress;
     std::string m_errorString;
+
+    std::shared_ptr<cryptonote::rpc::DaemonRPCClient> m_daemon;
 };
 
 } // namespace

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -62,6 +62,8 @@ using namespace epee;
 #include "common/scoped_message_writer.h"
 #include "ringct/rctSigs.h"
 
+#include "rpc/daemon_rpc_client_old.h"
+
 extern "C"
 {
 #include "crypto/keccak.h"
@@ -106,6 +108,7 @@ struct options {
   const command_line::arg_descriptor<std::string> password_file = {"password-file", tools::wallet2::tr("Wallet password file"), "", true};
   const command_line::arg_descriptor<int> daemon_port = {"daemon-port", tools::wallet2::tr("Use daemon instance at port <arg> instead of 18081"), 0};
   const command_line::arg_descriptor<std::string> daemon_login = {"daemon-login", tools::wallet2::tr("Specify username[:password] for daemon RPC client"), "", true};
+  const command_line::arg_descriptor<bool> use_daemon_zmq_rpc = {"use-daemon-zmq-rpc", tools::wallet2::tr("Use the new ZMQ RPC to communicate with the daemon"), false};
   const command_line::arg_descriptor<bool> testnet = {"testnet", tools::wallet2::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
   const command_line::arg_descriptor<bool> restricted = {"restricted-rpc", tools::wallet2::tr("Restricts to view-only commands"), false};
 };
@@ -144,6 +147,8 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   auto daemon_host = command_line::get_arg(vm, opts.daemon_host);
   auto daemon_port = command_line::get_arg(vm, opts.daemon_port);
 
+  bool daemon_zmq = command_line::get_arg(vm, opts.use_daemon_zmq_rpc);
+
   if (!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port)
   {
     tools::fail_msg_writer() << tools::wallet2::tr("can't specify daemon host or port more than once");
@@ -167,14 +172,33 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
 
   if (!daemon_port)
   {
-    daemon_port = testnet ? config::testnet::RPC_DEFAULT_PORT : config::RPC_DEFAULT_PORT;
+    if (daemon_zmq)
+    {
+      daemon_port = testnet ? config::testnet::ZMQ_RPC_DEFAULT_PORT : config::ZMQ_RPC_DEFAULT_PORT;
+    }
+    else
+    {
+      daemon_port = testnet ? config::testnet::RPC_DEFAULT_PORT : config::RPC_DEFAULT_PORT;
+    }
   }
 
   if (daemon_address.empty())
     daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
 
+  cryptonote::rpc::DaemonRPCClient::CLIENT_TYPE client_type;
+  if (daemon_zmq)
+  {
+    client_type = cryptonote::rpc::DaemonRPCClient::TYPE_ZMQ;
+  }
+  else
+  {
+    client_type = cryptonote::rpc::DaemonRPCClient::TYPE_OLD;
+  }
+
+  cryptonote::rpc::DaemonRPCClient* daemon_rpc_client = cryptonote::rpc::DaemonRPCClient::makeDaemonRPCClient(client_type, daemon_address, login);
+
   std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(testnet, restricted));
-  wallet->init(std::move(daemon_address), std::move(login));
+  wallet->init(daemon_rpc_client, std::move(daemon_address), std::move(login));
   return wallet;
 }
 
@@ -468,6 +492,7 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.password_file);
   command_line::add_arg(desc_params, opts.daemon_port);
   command_line::add_arg(desc_params, opts.daemon_login);
+  command_line::add_arg(desc_params, opts.use_daemon_zmq_rpc);
   command_line::add_arg(desc_params, opts.testnet);
   command_line::add_arg(desc_params, opts.restricted);
 }
@@ -525,9 +550,11 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 }
 
 //----------------------------------------------------------------------------------------------------
-bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool ssl)
+bool wallet2::init(cryptonote::rpc::DaemonRPCClient* daemon_client, std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool ssl)
 {
   m_checkpoints.init_default_checkpoints(m_testnet);
+  m_daemon.reset(daemon_client);
+
   if(m_http_client.is_connected())
     m_http_client.disconnect();
   m_is_initialized = true;
@@ -1220,20 +1247,17 @@ void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::trans
         get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, entry.first->second.m_payment_id);
       }
     }
-    entry.first->second.m_subaddr_account = subaddr_account;
-    entry.first->second.m_subaddr_indices = subaddr_indices;
   }
   entry.first->second.m_block_height = height;
   entry.first->second.m_timestamp = ts;
-  entry.first->second.m_unlock_time = tx.unlock_time;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::process_new_blockchain_entry(const cryptonote::block& b, const cryptonote::block_complete_entry& bche, const crypto::hash& bl_id, uint64_t height, const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices &o_indices)
+void wallet2::process_new_blockchain_entry(const cryptonote::block& b, const cryptonote::rpc::block_with_transactions& bwt, const crypto::hash& bl_id, uint64_t height, const cryptonote::rpc::block_output_indices &o_indices)
 {
   size_t txidx = 0;
-  THROW_WALLET_EXCEPTION_IF(bche.txs.size() + 1 != o_indices.indices.size(), error::wallet_internal_error,
-      "block transactions=" + std::to_string(bche.txs.size()) +
-      " not match with daemon response size=" + std::to_string(o_indices.indices.size()));
+  THROW_WALLET_EXCEPTION_IF(bwt.transactions.size() + 1 != o_indices.size(), error::wallet_internal_error,
+      "block transactions=" + std::to_string(bwt.transactions.size()) +
+      " not match with daemon response size=" + std::to_string(o_indices.size()));
 
   //handle transactions from new block
     
@@ -1241,19 +1265,13 @@ void wallet2::process_new_blockchain_entry(const cryptonote::block& b, const cry
   if(b.timestamp + 60*60*24 > m_account.get_createtime() && height >= m_refresh_from_block_height)
   {
     TIME_MEASURE_START(miner_tx_handle_time);
-    process_new_transaction(get_transaction_hash(b.miner_tx), b.miner_tx, o_indices.indices[txidx++].indices, height, b.timestamp, true, false);
+    process_new_transaction(cryptonote::get_transaction_hash(b.miner_tx), b.miner_tx, o_indices[txidx++], height, b.timestamp, true, false);
     TIME_MEASURE_FINISH(miner_tx_handle_time);
 
     TIME_MEASURE_START(txs_handle_time);
-    THROW_WALLET_EXCEPTION_IF(bche.txs.size() != b.tx_hashes.size(), error::wallet_internal_error, "Wrong amount of transactions for block");
-    size_t idx = 0;
-    for (const auto& txblob: bche.txs)
+    for (auto& tx_pair : bwt.transactions)
     {
-      cryptonote::transaction tx;
-      bool r = parse_and_validate_tx_base_from_blob(txblob, tx);
-      THROW_WALLET_EXCEPTION_IF(!r, error::tx_parse_error, txblob);
-      process_new_transaction(b.tx_hashes[idx], tx, o_indices.indices[txidx++].indices, height, b.timestamp, false, false);
-      ++idx;
+      process_new_transaction(cryptonote::get_transaction_hash(tx_pair.second), tx_pair.second, o_indices[txidx++], height, b.timestamp, false, false);
     }
     TIME_MEASURE_FINISH(txs_handle_time);
     LOG_PRINT_L2("Processed block: " << bl_id << ", height " << height << ", " <<  miner_tx_handle_time + txs_handle_time << "(" << miner_tx_handle_time << "/" << txs_handle_time <<")ms");
@@ -1279,6 +1297,7 @@ void wallet2::get_short_chain_history(std::list<crypto::hash>& ids) const
     ids.push_back(m_blockchain.genesis());
     return;
   }
+
   size_t current_back_offset = 1;
   bool base_included = false;
   while(current_back_offset < sz)
@@ -1308,16 +1327,12 @@ void wallet2::parse_block_round(const cryptonote::blobdata &blob, cryptonote::bl
     bl_id = get_block_hash(bl);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices)
+void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::rpc::block_with_transactions>& blocks, std::vector<cryptonote::rpc::block_output_indices> &o_indices)
 {
-  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
-  req.block_ids = short_chain_history;
-
   uint32_t rpc_version;
-  boost::optional<std::string> result = m_node_rpc_proxy.get_rpc_version(rpc_version);
-  // no error
-  if (!!result)
+  boost::optional<std::string> result = m_daemon->getRPCVersion(rpc_version);
+  bool prune = false;
+  if (result)
   {
     // empty string -> not connection
     THROW_WALLET_EXCEPTION_IF(result->empty(), tools::error::no_connection_to_daemon, "getversion");
@@ -1325,7 +1340,7 @@ void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, 
     if (*result != CORE_RPC_STATUS_OK)
     {
       MDEBUG("Cannot determined daemon RPC version, not asking for pruned blocks");
-      req.prune = false; // old daemon
+      prune = false; // old daemon
     }
   }
   else
@@ -1333,50 +1348,35 @@ void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, 
     if (rpc_version >= MAKE_CORE_RPC_VERSION(1, 7))
     {
       MDEBUG("Daemon is recent enough, asking for pruned blocks");
-      req.prune = true;
+      prune = true;
     }
     else
     {
       MDEBUG("Daemon is too old, not asking for pruned blocks");
-      req.prune = false;
+      prune = false;
     }
   }
 
-  req.start_height = start_height;
-  m_daemon_rpc_mutex.lock();
-  bool r = net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getblocks.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getblocks.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_blocks_error, res.status);
-  THROW_WALLET_EXCEPTION_IF(res.blocks.size() != res.output_indices.size(), error::wallet_internal_error,
-      "mismatched blocks (" + boost::lexical_cast<std::string>(res.blocks.size()) + ") and output_indices (" +
-      boost::lexical_cast<std::string>(res.output_indices.size()) + ") sizes from daemon");
+  uint64_t current_height;
 
-  blocks_start_height = res.start_height;
-  blocks = res.blocks;
-  o_indices = res.output_indices;
+  boost::optional<std::string> r;
+  r = m_daemon->getBlocksFast(short_chain_history, start_height, prune, blocks, blocks_start_height, current_height, o_indices);
+
+  THROW_WALLET_EXCEPTION_IF(r, error::get_blocks_error, *r);
+  THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error,
+      "mismatched blocks (" + boost::lexical_cast<std::string>(blocks.size()) + ") and output_indices (" +
+      boost::lexical_cast<std::string>(o_indices.size()) + ") sizes from daemon");
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::pull_hashes(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<crypto::hash> &hashes)
 {
-  cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req = AUTO_VAL_INIT(req);
-  cryptonote::COMMAND_RPC_GET_HASHES_FAST::response res = AUTO_VAL_INIT(res);
-  req.block_ids = short_chain_history;
+  uint64_t current_height;
+  boost::optional<std::string> r = m_daemon->getHashesFast(short_chain_history, start_height, hashes, blocks_start_height, current_height);
 
-  req.start_height = start_height;
-  m_daemon_rpc_mutex.lock();
-  bool r = net_utils::invoke_http_bin("/gethashes.bin", req, res, m_http_client, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gethashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "gethashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_hashes_error, res.status);
-
-  blocks_start_height = res.start_height;
-  hashes = res.m_block_ids;
+  THROW_WALLET_EXCEPTION_IF(r, error::get_hashes_error, *r);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::block_complete_entry> &blocks, const std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t& blocks_added)
+void wallet2::process_blocks(uint64_t start_height, const std::vector<cryptonote::rpc::block_with_transactions> &blocks, const std::vector<cryptonote::rpc::block_output_indices> &o_indices, uint64_t& blocks_added)
 {
   size_t current_index = start_height;
   blocks_added = 0;
@@ -1385,71 +1385,9 @@ void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::
   THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error, "size mismatch");
   THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(current_index), error::wallet_internal_error, "Index out of bounds of hashchain");
 
-  tools::threadpool& tpool = tools::threadpool::getInstance();
-  int threads = tpool.get_max_concurrency();
-  if (threads > 1)
+  for (auto& bl_entry : blocks)
   {
-    std::vector<crypto::hash> round_block_hashes(threads);
-    std::vector<cryptonote::block> round_blocks(threads);
-    std::deque<bool> error(threads);
-    size_t blocks_size = blocks.size();
-    std::list<block_complete_entry>::const_iterator blocki = blocks.begin();
-    for (size_t b = 0; b < blocks_size; b += threads)
-    {
-      size_t round_size = std::min((size_t)threads, blocks_size - b);
-      tools::threadpool::waiter waiter;
-
-      std::list<block_complete_entry>::const_iterator tmpblocki = blocki;
-      for (size_t i = 0; i < round_size; ++i)
-      {
-        tpool.submit(&waiter, boost::bind(&wallet2::parse_block_round, this, std::cref(tmpblocki->block),
-          std::ref(round_blocks[i]), std::ref(round_block_hashes[i]), std::ref(error[i])));
-        ++tmpblocki;
-      }
-      waiter.wait();
-      tmpblocki = blocki;
-      for (size_t i = 0; i < round_size; ++i)
-      {
-        THROW_WALLET_EXCEPTION_IF(error[i], error::block_parse_error, tmpblocki->block);
-        ++tmpblocki;
-      }
-      for (size_t i = 0; i < round_size; ++i)
-      {
-        const crypto::hash &bl_id = round_block_hashes[i];
-        cryptonote::block &bl = round_blocks[i];
-
-        if(current_index >= m_blockchain.size())
-        {
-          process_new_blockchain_entry(bl, *blocki, bl_id, current_index, o_indices[b+i]);
-          ++blocks_added;
-        }
-        else if(bl_id != m_blockchain[current_index])
-        {
-          //split detected here !!!
-          THROW_WALLET_EXCEPTION_IF(current_index == start_height, error::wallet_internal_error,
-            "wrong daemon response: split starts from the first block in response " + string_tools::pod_to_hex(bl_id) +
-            " (height " + std::to_string(start_height) + "), local block id at this height: " +
-            string_tools::pod_to_hex(m_blockchain[current_index]));
-
-          detach_blockchain(current_index);
-          process_new_blockchain_entry(bl, *blocki, bl_id, current_index, o_indices[b+i]);
-        }
-        else
-        {
-          LOG_PRINT_L2("Block is already in blockchain: " << string_tools::pod_to_hex(bl_id));
-        }
-        ++current_index;
-        ++blocki;
-      }
-    }
-  }
-  else
-  {
-  for(auto& bl_entry: blocks)
-  {
-    cryptonote::block bl;
-    bool r = cryptonote::parse_and_validate_block_from_blob(bl_entry.block, bl);
-    THROW_WALLET_EXCEPTION_IF(!r, error::block_parse_error, bl_entry.block);
+    const cryptonote::block& bl = bl_entry.block;
 
     crypto::hash bl_id = get_block_hash(bl);
     if(current_index >= m_blockchain.size())
@@ -1457,6 +1395,7 @@ void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::
       process_new_blockchain_entry(bl, bl_entry, bl_id, current_index, o_indices[tx_o_indices_idx]);
       ++blocks_added;
     }
+    //FIXME: deal with blocks_added var in this branch?
     else if(bl_id != m_blockchain[current_index])
     {
       //split detected here !!!
@@ -1476,7 +1415,6 @@ void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::
     ++current_index;
     ++tx_o_indices_idx;
   }
-  }
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::refresh()
@@ -1491,7 +1429,7 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched)
   refresh(start_height, blocks_fetched, received_money);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::list<cryptonote::block_complete_entry> &prev_blocks, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, bool &error)
+void wallet2::pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::vector<cryptonote::rpc::block_with_transactions> &prev_blocks, std::vector<cryptonote::rpc::block_with_transactions> &blocks, std::vector<cryptonote::rpc::block_output_indices> &o_indices, bool &error)
 {
   error = false;
 
@@ -1499,18 +1437,18 @@ void wallet2::pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_hei
   {
     // prepend the last 3 blocks, should be enough to guard against a block or two's reorg
     cryptonote::block bl;
-    std::list<cryptonote::block_complete_entry>::const_reverse_iterator i = prev_blocks.rbegin();
+    std::vector<cryptonote::rpc::block_with_transactions>::const_reverse_iterator i = prev_blocks.rbegin();
     for (size_t n = 0; n < std::min((size_t)3, prev_blocks.size()); ++n)
     {
-      bool ok = cryptonote::parse_and_validate_block_from_blob(i->block, bl);
-      THROW_WALLET_EXCEPTION_IF(!ok, error::block_parse_error, i->block);
-      short_chain_history.push_front(cryptonote::get_block_hash(bl));
+      short_chain_history.push_front(cryptonote::get_block_hash(i->block));
       ++i;
     }
 
     // pull the new blocks
     pull_blocks(start_height, blocks_start_height, short_chain_history, blocks, o_indices);
   }
+  //TODO: we've got all these fancy wallet errors being thrown,
+  //      it'd be a pity to waste them here...
   catch(...)
   {
     error = true;
@@ -1524,17 +1462,9 @@ void wallet2::remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashe
   while (uit != m_unconfirmed_payments.end())
   {
     const crypto::hash &txid = uit->second.m_tx_hash;
-    bool found = false;
-    for (const auto &it2: tx_hashes)
-    {
-      if (it2 == txid)
-      {
-        found = true;
-        break;
-      }
-    }
+
     auto pit = uit++;
-    if (!found)
+    if (std::find(tx_hashes.begin(), tx_hashes.end(), txid) != tx_hashes.end())
     {
       MDEBUG("Removing " << txid << " from unconfirmed payments, not found in pool");
       m_unconfirmed_payments.erase(pit);
@@ -1550,30 +1480,27 @@ void wallet2::update_pool_state(bool refreshed)
   MDEBUG("update_pool_state start");
 
   // get the pool state
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::request req;
-  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::response res;
-  m_daemon_rpc_mutex.lock();
-  bool r = epee::net_utils::invoke_http_json("/get_transaction_pool_hashes.bin", req, res, m_http_client, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_transaction_pool_hashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_transaction_pool_hashes.bin");
-  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_tx_pool_error);
+
+  std::unordered_map<crypto::hash, cryptonote::rpc::tx_in_pool> transactions;
+  std::unordered_map<crypto::key_image, std::vector<crypto::hash> > key_images;
+  std::string error_details;
+
+  boost::optional<std::string> r = m_daemon->getTransactionPool(transactions, key_images);
+  THROW_WALLET_EXCEPTION_IF(r, error::get_tx_pool_error);
   MDEBUG("update_pool_state got pool");
 
   // remove any pending tx that's not in the pool
   std::unordered_map<crypto::hash, wallet2::unconfirmed_transfer_details>::iterator it = m_unconfirmed_txs.begin();
   while (it != m_unconfirmed_txs.end())
   {
-    const crypto::hash &txid = it->first;
+    const std::string& txid = epee::string_tools::pod_to_hex(it->first);
+
     bool found = false;
-    for (const auto &it2: res.tx_hashes)
+    if (transactions.find(it->first) != transactions.end())
     {
-      if (it2 == txid)
-      {
-        found = true;
-        break;
-      }
+      found = true;
     }
+
     auto pit = it++;
     if (!found)
     {
@@ -1621,14 +1548,23 @@ void wallet2::update_pool_state(bool refreshed)
   // the in transfers list instead (or nowhere if it just
   // disappeared without being mined)
   if (refreshed)
-    remove_obsolete_pool_txs(res.tx_hashes);
+  {
+    std::vector<crypto::hash> tx_hashes;
+    tx_hashes.resize(transactions.size());
+    size_t index = 0;
+    for (const auto& tx : transactions)
+    {
+      tx_hashes[index++] = tx.first;
+    }
+    remove_obsolete_pool_txs(tx_hashes);
+  }
 
   MDEBUG("update_pool_state done second loop");
 
-  // gather txids of new pool txes to us
-  std::vector<crypto::hash> txids;
-  for (const auto &txid: res.tx_hashes)
+  // add new pool txes to us
+  for (auto it: transactions)
   {
+    const crypto::hash& txid = it.first;
     if (m_scanned_pool_txs[0].find(txid) != m_scanned_pool_txs[0].end() || m_scanned_pool_txs[1].find(txid) != m_scanned_pool_txs[1].end())
     {
       LOG_PRINT_L2("Already seen " << txid << ", skipped");
@@ -1647,30 +1583,27 @@ void wallet2::update_pool_state(bool refreshed)
     {
       LOG_PRINT_L1("Found new pool tx: " << txid);
       bool found = false;
-      for (const auto &i: m_unconfirmed_txs)
+      auto utx_it = m_unconfirmed_txs.find(txid);
+      if (utx_it != m_unconfirmed_txs.end())
       {
-        if (i.first == txid)
+        found = true;
+        // if this is a payment to yourself at a different subaddress account, don't skip it
+        // so that you can see the incoming pool tx with 'show_transfers' on that receiving subaddress account
+        const unconfirmed_transfer_details& utd = utx_it->second;
+        for (const auto& dst : utd.m_dests)
         {
-          found = true;
-          // if this is a payment to yourself at a different subaddress account, don't skip it
-          // so that you can see the incoming pool tx with 'show_transfers' on that receiving subaddress account
-          const unconfirmed_transfer_details& utd = i.second;
-          for (const auto& dst : utd.m_dests)
+          auto subaddr_index = m_subaddresses.find(dst.addr.m_spend_public_key);
+          if (subaddr_index != m_subaddresses.end() && subaddr_index->second.major != utd.m_subaddr_account)
           {
-            auto subaddr_index = m_subaddresses.find(dst.addr.m_spend_public_key);
-            if (subaddr_index != m_subaddresses.end() && subaddr_index->second.major != utd.m_subaddr_account)
-            {
-              found = false;
-              break;
-            }
+            found = false;
+            break;
           }
-          break;
         }
       }
       if (!found)
       {
-        // not one of those we sent ourselves
-        txids.push_back(txid);
+	// not one of those we sent ourselves
+	process_new_transaction(txid, it.second.tx, std::vector<uint64_t>(), 0, time(NULL), false, true);
       }
       else
       {
@@ -1681,78 +1614,14 @@ void wallet2::update_pool_state(bool refreshed)
     {
       LOG_PRINT_L1("Already saw that one, it's for us");
     }
+    m_scanned_pool_txs[0].insert(txid);
+    if (m_scanned_pool_txs[0].size() > 5000)
+    {
+      std::swap(m_scanned_pool_txs[0], m_scanned_pool_txs[1]);
+      m_scanned_pool_txs[0].clear();
+    }
   }
 
-  // get those txes
-  if (!txids.empty())
-  {
-    cryptonote::COMMAND_RPC_GET_TRANSACTIONS::request req;
-    cryptonote::COMMAND_RPC_GET_TRANSACTIONS::response res;
-    for (const auto &txid: txids)
-      req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
-    MDEBUG("asking for " << txids.size() << " transactions");
-    req.decode_as_json = false;
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/gettransactions", req, res, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    MDEBUG("Got " << r << " and " << res.status);
-    if (r && res.status == CORE_RPC_STATUS_OK)
-    {
-      if (res.txs.size() == txids.size())
-      {
-        for (const auto &tx_entry: res.txs)
-        {
-          if (tx_entry.in_pool)
-          {
-            cryptonote::transaction tx;
-            cryptonote::blobdata bd;
-            crypto::hash tx_hash, tx_prefix_hash;
-            if (epee::string_tools::parse_hexstr_to_binbuff(tx_entry.as_hex, bd))
-            {
-              if (cryptonote::parse_and_validate_tx_from_blob(bd, tx, tx_hash, tx_prefix_hash))
-              {
-                const std::vector<crypto::hash>::const_iterator i = std::find(txids.begin(), txids.end(), tx_hash);
-                if (i != txids.end())
-                {
-                  process_new_transaction(tx_hash, tx, std::vector<uint64_t>(), 0, time(NULL), false, true);
-                  m_scanned_pool_txs[0].insert(tx_hash);
-                  if (m_scanned_pool_txs[0].size() > 5000)
-                  {
-                    std::swap(m_scanned_pool_txs[0], m_scanned_pool_txs[1]);
-                    m_scanned_pool_txs[0].clear();
-                  }
-                }
-                else
-                {
-                  MERROR("Got txid " << tx_hash << " which we did not ask for");
-                }
-              }
-              else
-              {
-                LOG_PRINT_L0("failed to validate transaction from daemon");
-              }
-            }
-            else
-            {
-              LOG_PRINT_L0("Failed to parse transaction from daemon");
-            }
-          }
-          else
-          {
-            LOG_PRINT_L1("Transaction from daemon was in pool, but is no more");
-          }
-        }
-      }
-      else
-      {
-        LOG_PRINT_L0("Expected " << txids.size() << " tx(es), got " << res.txs.size());
-      }
-    }
-    else
-    {
-      LOG_PRINT_L0("Error calling gettransactions daemon RPC: r " << r << ", status " << res.status);
-    }
-  }
   MDEBUG("update_pool_state end");
 }
 //----------------------------------------------------------------------------------------------------
@@ -1881,8 +1750,8 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
   tools::threadpool& tpool = tools::threadpool::getInstance();
   tools::threadpool::waiter waiter;
   uint64_t blocks_start_height;
-  std::list<cryptonote::block_complete_entry> blocks;
-  std::vector<COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> o_indices;
+  std::vector<cryptonote::rpc::block_with_transactions> blocks;
+  std::vector<cryptonote::rpc::block_output_indices> o_indices;
   bool refreshed = false;
 
   // pull the first set of blocks
@@ -1914,8 +1783,8 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
     {
       // pull the next set of blocks while we're processing the current one
       uint64_t next_blocks_start_height;
-      std::list<cryptonote::block_complete_entry> next_blocks;
-      std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> next_o_indices;
+	     std::vector<cryptonote::rpc::block_with_transactions> next_blocks;
+	     std::vector<cryptonote::rpc::block_output_indices> next_o_indices;
       bool error = false;
       tpool.submit(&waiter, [&]{pull_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, next_blocks, next_o_indices, error);});
 
@@ -1924,7 +1793,6 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
       waiter.wait();
       if(blocks_start_height == next_blocks_start_height)
       {
-        m_node_rpc_proxy.set_height(m_blockchain.size());
         refreshed = true;
         break;
       }
@@ -2637,37 +2505,23 @@ bool wallet2::check_connection(uint32_t *version, uint32_t timeout)
 {
   THROW_WALLET_EXCEPTION_IF(!m_is_initialized, error::wallet_not_initialized);
 
-  boost::lock_guard<boost::mutex> lock(m_daemon_rpc_mutex);
-
   // TODO: Add light wallet version check.
   if(m_light_wallet) {
       version = 0;
       return m_light_wallet_connected;
   }
+  uint32_t remote_version;
+  std::string error_details;
 
-  if(!m_http_client.is_connected())
+  boost::optional<std::string> r = m_daemon->checkConnection(timeout, remote_version);
+  if (r)
   {
-    m_node_rpc_proxy.invalidate();
-    if (!m_http_client.connect(std::chrono::milliseconds(timeout)))
-      return false;
+    LOG_ERROR(std::string("Error in wallet2::check_connection -- ") + *r);
+    return false;
   }
-
   if (version)
   {
-    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_VERSION::request> req_t = AUTO_VAL_INIT(req_t);
-    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_VERSION::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
-    req_t.jsonrpc = "2.0";
-    req_t.id = epee::serialization::storage_entry(0);
-    req_t.method = "get_version";
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client);
-    if(!r) {
-      *version = 0;
-      return false;
-    }
-    if (resp_t.result.status != CORE_RPC_STATUS_OK)
-      *version = 0;
-    else
-      *version = resp_t.result.version;
+    *version = remote_version;
   }
 
   return true;
@@ -3084,29 +2938,41 @@ void wallet2::get_unconfirmed_payments(std::list<std::pair<crypto::hash,wallet2:
 //----------------------------------------------------------------------------------------------------
 void wallet2::rescan_spent()
 {
+  std::vector<bool> spent;
+  std::vector<bool> spent_in_chain;
+  std::vector<bool> spent_in_pool;
+
+  // make a list of key images for all our outputs
+
   // This is RPC call that can take a long time if there are many outputs,
   // so we call it several times, in stripes, so we don't time out spuriously
-  std::vector<int> spent_status;
-  spent_status.reserve(m_transfers.size());
   const size_t chunk_size = 1000;
   for (size_t start_offset = 0; start_offset < m_transfers.size(); start_offset += chunk_size)
   {
     const size_t n_outputs = std::min<size_t>(chunk_size, m_transfers.size() - start_offset);
-    MDEBUG("Calling is_key_image_spent on " << start_offset << " - " << (start_offset + n_outputs - 1) << ", out of " << m_transfers.size());
-    COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req = AUTO_VAL_INIT(req);
-    COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
-    for (size_t n = start_offset; n < start_offset + n_outputs; ++n)
-      req.key_images.push_back(string_tools::pod_to_hex(m_transfers[n].m_key_image));
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/is_key_image_spent", req, daemon_resp, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "is_key_image_spent");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "is_key_image_spent");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status != CORE_RPC_STATUS_OK, error::is_key_image_spent_error, daemon_resp.status);
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.spent_status.size() != n_outputs, error::wallet_internal_error,
+
+    std::vector<crypto::key_image> key_images;
+    key_images.resize(n_outputs);
+    for (size_t i = start_offset; i < n_outputs; ++i)
+    {
+      const transfer_details& td = m_transfers[i];
+      key_images[i] = td.m_key_image;
+    }
+
+    std::vector<bool> spent_tmp;
+    std::vector<bool> spent_in_chain_tmp;
+    std::vector<bool> spent_in_pool_tmp;
+
+    boost::optional<std::string> r = m_daemon->keyImagesSpent(key_images, spent_tmp, spent_in_chain_tmp, spent_in_pool_tmp);
+
+    THROW_WALLET_EXCEPTION_IF(r, error::is_key_image_spent_error, *r);
+    THROW_WALLET_EXCEPTION_IF(spent_tmp.size() != n_outputs, error::wallet_internal_error,
       "daemon returned wrong response for is_key_image_spent, wrong amounts count = " +
-      std::to_string(daemon_resp.spent_status.size()) + ", expected " +  std::to_string(n_outputs));
-    std::copy(daemon_resp.spent_status.begin(), daemon_resp.spent_status.end(), std::back_inserter(spent_status));
+      std::to_string(spent_tmp.size()) + ", expected " +  std::to_string(n_outputs));
+
+    spent.insert(spent.end(), spent_tmp.begin(), spent_tmp.end());
+    spent_in_chain.insert(spent_in_chain.end(), spent_in_chain_tmp.begin(), spent_in_chain_tmp.end());
+    spent_in_pool.insert(spent_in_pool.end(), spent_in_pool_tmp.begin(), spent_in_pool_tmp.end());
   }
 
   // update spent status
@@ -3116,7 +2982,8 @@ void wallet2::rescan_spent()
     // a view wallet may not know about key images
     if (!td.m_key_image_known)
       continue;
-    if (td.m_spent != (spent_status[i] != COMMAND_RPC_IS_KEY_IMAGE_SPENT::UNSPENT))
+
+    if (td.m_spent != spent[i])
     {
       if (td.m_spent)
       {
@@ -3475,6 +3342,12 @@ crypto::hash8 wallet2::get_short_payment_id(const pending_tx &ptx) const
 void wallet2::commit_tx(pending_tx& ptx)
 {
   using namespace cryptonote;
+    // sanity checks
+    for (size_t idx: ptx.selected_transfers)
+    {
+      THROW_WALLET_EXCEPTION_IF(idx >= m_transfers.size(), error::wallet_internal_error,
+          "Bad output index in selected transfers: " + boost::lexical_cast<std::string>(idx));
+    }
   
   if(m_light_wallet) 
   {
@@ -3492,28 +3365,18 @@ void wallet2::commit_tx(pending_tx& ptx)
   }
   else
   {
-    // Normal submit
-    COMMAND_RPC_SEND_RAW_TX::request req;
-    req.tx_as_hex = epee::string_tools::buff_to_hex_nodelimer(tx_to_blob(ptx.tx));
-    req.do_not_relay = false;
-    COMMAND_RPC_SEND_RAW_TX::response daemon_send_resp;
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/sendrawtransaction", req, daemon_send_resp, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "sendrawtransaction");
-    THROW_WALLET_EXCEPTION_IF(daemon_send_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "sendrawtransaction");
-    THROW_WALLET_EXCEPTION_IF(daemon_send_resp.status != CORE_RPC_STATUS_OK, error::tx_rejected, ptx.tx, daemon_send_resp.status, daemon_send_resp.reason);
-    // sanity checks
-    for (size_t idx: ptx.selected_transfers)
-    {
-      THROW_WALLET_EXCEPTION_IF(idx >= m_transfers.size(), error::wallet_internal_error,
-          "Bad output index in selected transfers: " + boost::lexical_cast<std::string>(idx));
-    }
-  }
-  crypto::hash txid;
+    bool should_relay = true;
+    bool was_relayed;
 
-  txid = get_transaction_hash(ptx.tx);
+    boost::optional<std::string> r = m_daemon->sendRawTx(ptx.tx, was_relayed, should_relay);
+
+    THROW_WALLET_EXCEPTION_IF(r, error::tx_rejected, ptx.tx, "Failed", *r);
+  }
+
+  crypto::hash txid = get_transaction_hash(ptx.tx);
+
   crypto::hash payment_id = crypto::null_hash;
+
   std::vector<cryptonote::tx_destination_entry> dests;
   uint64_t amount_in = 0;
   if (store_tx_info())
@@ -3923,7 +3786,7 @@ uint64_t wallet2::get_fee_multiplier(uint32_t priority, int fee_algorithm)
 uint64_t wallet2::get_dynamic_per_kb_fee_estimate()
 {
   uint64_t fee;
-  boost::optional<std::string> result = m_node_rpc_proxy.get_dynamic_per_kb_fee_estimate(FEE_ESTIMATE_GRACE_BLOCKS, fee);
+  boost::optional<std::string> result = m_daemon->getPerKBFeeEstimate(FEE_ESTIMATE_GRACE_BLOCKS, fee);
   if (!result)
     return fee;
   LOG_PRINT_L1("Failed to query per kB fee, using " << print_money(FEE_PER_KB));
@@ -4190,32 +4053,35 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
   if (fake_outputs_count > 0)
   {
     // get histogram for the amounts we need
-    epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request> req_t = AUTO_VAL_INIT(req_t);
-    epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
-    m_daemon_rpc_mutex.lock();
-    req_t.jsonrpc = "2.0";
-    req_t.id = epee::serialization::storage_entry(0);
-    req_t.method = "get_output_histogram";
+
+    std::vector<uint64_t> amounts;
+    uint64_t min_count = 0;
+    uint64_t max_count = 0;  // no max
+    bool unlocked;
+    std::vector<cryptonote::rpc::output_amount_count> histogram;
+    std::string error_details;
+
     for(size_t idx: selected_transfers)
-      req_t.params.amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
-    std::sort(req_t.params.amounts.begin(), req_t.params.amounts.end());
-    auto end = std::unique(req_t.params.amounts.begin(), req_t.params.amounts.end());
-    req_t.params.amounts.resize(std::distance(req_t.params.amounts.begin(), end));
-    req_t.params.unlocked = true;
-    req_t.params.recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "transfer_selected");
-    THROW_WALLET_EXCEPTION_IF(resp_t.result.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_output_histogram");
-    THROW_WALLET_EXCEPTION_IF(resp_t.result.status != CORE_RPC_STATUS_OK, error::get_histogram_error, resp_t.result.status);
+    {
+      amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
+    }
+
+    std::sort(amounts.begin(), amounts.end());
+    auto end = std::unique(amounts.begin(), amounts.end());
+
+    amounts.resize(std::distance(amounts.begin(), end));
+    unlocked = true;
+    uint64_t recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
+    boost::optional<std::string> r = m_daemon->getOutputHistogram(amounts, min_count, max_count, unlocked, recent_cutoff, histogram);
+    THROW_WALLET_EXCEPTION_IF(r, error::get_histogram_error, *r);
 
     // we ask for more, to have spares if some outputs are still locked
     size_t base_requested_outputs_count = (size_t)((fake_outputs_count + 1) * 1.5 + 1);
     LOG_PRINT_L2("base_requested_outputs_count: " << base_requested_outputs_count);
 
     // generate output indices to request
-    COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
-    COMMAND_RPC_GET_OUTPUTS_BIN::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+    std::vector<cryptonote::rpc::output_amount_and_index> req_outputs;
+    std::vector<cryptonote::rpc::output_key_mask_unlocked> keys;
 
     size_t num_selected_transfers = 0;
     for(size_t idx: selected_transfers)
@@ -4226,19 +4092,19 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       std::unordered_set<uint64_t> seen_indices;
       // request more for rct in base recent (locked) coinbases are picked, since they're locked for longer
       size_t requested_outputs_count = base_requested_outputs_count + (td.is_rct() ? CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE : 0);
-      size_t start = req.outputs.size();
+      size_t start = req_outputs.size();
 
       // if there are just enough outputs to mix with, use all of them.
       // Eventually this should become impossible.
       uint64_t num_outs = 0, num_recent_outs = 0;
-      for (auto he: resp_t.result.histogram)
+      for (auto& he: histogram)
       {
         if (he.amount == amount)
         {
-          LOG_PRINT_L2("Found " << print_money(amount) << ": " << he.total_instances << " total, "
-              << he.unlocked_instances << " unlocked, " << he.recent_instances << " recent");
-          num_outs = he.unlocked_instances;
-          num_recent_outs = he.recent_instances;
+          LOG_PRINT_L2("Found " << print_money(amount) << ": " << he.total_count << " total, "
+              << he.unlocked_count << " unlocked, " << he.recent_count << " recent");
+          num_outs = he.unlocked_count;
+          num_recent_outs = he.recent_count;
           break;
         }
       }
@@ -4261,19 +4127,19 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       if (num_outs <= requested_outputs_count)
       {
         for (uint64_t i = 0; i < num_outs; i++)
-          req.outputs.push_back({amount, i});
+          req_outputs.push_back({amount, i});
         // duplicate to make up shortfall: this will be caught after the RPC call,
         // so we can also output the amounts for which we can't reach the required
         // mixin after checking the actual unlockedness
         for (uint64_t i = num_outs; i < requested_outputs_count; ++i)
-          req.outputs.push_back({amount, num_outs - 1});
+          req_outputs.push_back({amount, num_outs - 1});
       }
       else
       {
         // start with real one
         uint64_t num_found = 1;
         seen_indices.emplace(td.m_global_output_index);
-        req.outputs.push_back({amount, td.m_global_output_index});
+        req_outputs.push_back({amount, td.m_global_output_index});
         LOG_PRINT_L1("Selecting real output: " << td.m_global_output_index << " for " << print_money(amount));
 
         // while we still need more mixins
@@ -4315,29 +4181,27 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
             continue;
           seen_indices.emplace(i);
 
-          req.outputs.push_back({amount, i});
+          req_outputs.push_back({amount, i});
           ++num_found;
         }
       }
 
       // sort the subsection, to ensure the daemon doesn't know wich output is ours
-      std::sort(req.outputs.begin() + start, req.outputs.end(),
-          [](const get_outputs_out &a, const get_outputs_out &b) { return a.index < b.index; });
+      std::sort(req_outputs.begin() + start, req_outputs.end(),
+          [](const cryptonote::rpc::output_amount_and_index& a, const cryptonote::rpc::output_amount_and_index& b) { return a.index < b.index; });
     }
 
-    for (auto i: req.outputs)
+    for (auto i: req_outputs)
       LOG_PRINT_L1("asking for output " << i.index << " for " << print_money(i.amount));
 
+    error_details = "";
     // get the keys for those
-    m_daemon_rpc_mutex.lock();
-    r = epee::net_utils::invoke_http_bin("/get_outs.bin", req, daemon_resp, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_outs.bin");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_outs.bin");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status != CORE_RPC_STATUS_OK, error::get_random_outs_error, daemon_resp.status);
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.outs.size() != req.outputs.size(), error::wallet_internal_error,
+    r = boost::none;
+    r = m_daemon->getOutputKeys(req_outputs, keys);
+    THROW_WALLET_EXCEPTION_IF(r, error::get_random_outs_error, *r);
+    THROW_WALLET_EXCEPTION_IF(keys.size() != req_outputs.size(), error::wallet_internal_error,
       "daemon returned wrong response for get_outs.bin, wrong amounts count = " +
-      std::to_string(daemon_resp.outs.size()) + ", expected " +  std::to_string(req.outputs.size()));
+      std::to_string(keys.size()) + ", expected " +  std::to_string(req_outputs.size()));
 
     std::unordered_map<uint64_t, uint64_t> scanty_outs;
     size_t base = 0;
@@ -4359,9 +4223,9 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       for (size_t n = 0; n < requested_outputs_count; ++n)
       {
         size_t i = base + n;
-        if (req.outputs[i].index == td.m_global_output_index)
-          if (daemon_resp.outs[i].key == boost::get<txout_to_key>(td.m_tx.vout[td.m_internal_output_index].target).key)
-            if (daemon_resp.outs[i].mask == mask)
+        if (req_outputs[i].index == td.m_global_output_index)
+          if (keys[i].key == boost::get<txout_to_key>(td.m_tx.vout[td.m_internal_output_index].target).key)
+            if (keys[i].mask == mask)
               real_out_found = true;
       }
       THROW_WALLET_EXCEPTION_IF(!real_out_found, error::wallet_internal_error,
@@ -4382,8 +4246,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       for (size_t o = 0; o < requested_outputs_count && outs.back().size() < fake_outputs_count + 1; ++o)
       {
         size_t i = base + order[o];
-        LOG_PRINT_L2("Index " << i << "/" << requested_outputs_count << ": idx " << req.outputs[i].index << " (real " << td.m_global_output_index << "), unlocked " << daemon_resp.outs[i].unlocked << ", key " << daemon_resp.outs[i].key);
-        tx_add_fake_output(outs, req.outputs[i].index, daemon_resp.outs[i].key, daemon_resp.outs[i].mask, td.m_global_output_index, daemon_resp.outs[i].unlocked);
+        LOG_PRINT_L2("Index " << i << "/" << requested_outputs_count << ": idx " << req_outputs[i].index << " (real " << td.m_global_output_index << "), unlocked " << keys[i].unlocked << ", key " << keys[i].key);
+        tx_add_fake_output(outs, req_outputs[i].index, keys[i].key, keys[i].mask, td.m_global_output_index, keys[i].unlocked);
       }
       if (outs.back().size() < fake_outputs_count + 1)
       {
@@ -5964,9 +5828,9 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
   return ptx_vector;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::get_hard_fork_info(uint8_t version, uint64_t &earliest_height)
+void wallet2::get_hard_fork_earliest_height(uint8_t version, uint64_t &earliest_height)
 {
-  boost::optional<std::string> result = m_node_rpc_proxy.get_earliest_height(version, earliest_height);
+  boost::optional<std::string> result = m_daemon->getHardForkEarliestHeight(version, earliest_height);
   throw_on_rpc_response_error(result, "get_hard_fork_info");
 }
 //----------------------------------------------------------------------------------------------------
@@ -5976,10 +5840,9 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
   if(m_light_wallet)
     return true;
   uint64_t height, earliest_height;
-  boost::optional<std::string> result = m_node_rpc_proxy.get_height(height);
-  throw_on_rpc_response_error(result, "get_info");
-  result = m_node_rpc_proxy.get_earliest_height(version, earliest_height);
-  throw_on_rpc_response_error(result, "get_hard_fork_info");
+  boost::optional<std::string> result = m_daemon->getHeight(height);
+  throw_on_rpc_response_error(result, "get_height");
+  get_hard_fork_earliest_height(version, earliest_height);
 
   bool close_enough = height >=  earliest_height - early_blocks; // start using the rules that many blocks beforehand
   if (close_enough)
@@ -6032,25 +5895,24 @@ std::vector<uint64_t> wallet2::get_unspent_amounts_vector()
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet2::select_available_outputs_from_histogram(uint64_t count, bool atleast, bool unlocked, bool allow_rct, bool trusted_daemon)
 {
-  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request> req_t = AUTO_VAL_INIT(req_t);
-  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
-  m_daemon_rpc_mutex.lock();
-  req_t.jsonrpc = "2.0";
-  req_t.id = epee::serialization::storage_entry(0);
-  req_t.method = "get_output_histogram";
+  std::vector<uint64_t> amounts;
+  uint64_t min_count;
+  uint64_t max_count;
+  uint64_t recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
+  std::vector<cryptonote::rpc::output_amount_count> histogram;
+  std::string error_details;
+
   if (trusted_daemon)
-    req_t.params.amounts = get_unspent_amounts_vector();
-  req_t.params.min_count = count;
-  req_t.params.max_count = 0;
-  req_t.params.unlocked = unlocked;
-  bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "select_available_outputs_from_histogram");
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_output_histogram");
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.status != CORE_RPC_STATUS_OK, error::get_histogram_error, resp_t.result.status);
+    amounts = get_unspent_amounts_vector();
+
+  min_count = count;
+  max_count = 0;
+
+  boost::optional<std::string> r = m_daemon->getOutputHistogram(amounts, min_count, max_count, unlocked, recent_cutoff, histogram);
+  THROW_WALLET_EXCEPTION_IF(r, error::get_histogram_error, *r);
 
   std::set<uint64_t> mixable;
-  for (const auto &i: resp_t.result.histogram)
+  for (const auto &i: histogram)
   {
     mixable.insert(i.amount);
   }
@@ -6073,24 +5935,22 @@ std::vector<size_t> wallet2::select_available_outputs_from_histogram(uint64_t co
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_num_rct_outputs()
 {
-  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request> req_t = AUTO_VAL_INIT(req_t);
-  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
-  m_daemon_rpc_mutex.lock();
-  req_t.jsonrpc = "2.0";
-  req_t.id = epee::serialization::storage_entry(0);
-  req_t.method = "get_output_histogram";
-  req_t.params.amounts.push_back(0);
-  req_t.params.min_count = 0;
-  req_t.params.max_count = 0;
-  bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
-  m_daemon_rpc_mutex.unlock();
-  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_num_rct_outputs");
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_output_histogram");
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.status != CORE_RPC_STATUS_OK, error::get_histogram_error, resp_t.result.status);
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.histogram.size() != 1, error::get_histogram_error, "Expected exactly one response");
-  THROW_WALLET_EXCEPTION_IF(resp_t.result.histogram[0].amount != 0, error::get_histogram_error, "Expected 0 amount");
+  std::vector<uint64_t> amounts;
+  uint64_t min_count = 0;
+  uint64_t max_count = 0;  // no max
+  bool unlocked = true;
+  uint64_t recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
+  std::vector<cryptonote::rpc::output_amount_count> histogram;
+  std::string error_details;
 
-  return resp_t.result.histogram[0].total_instances;
+  amounts.push_back(0);
+
+  boost::optional<std::string> r = m_daemon->getOutputHistogram(amounts, min_count, max_count, unlocked, recent_cutoff, histogram);
+  THROW_WALLET_EXCEPTION_IF(r, error::get_histogram_error, *r);
+  THROW_WALLET_EXCEPTION_IF(histogram.size() != 1, error::get_histogram_error, "Expected exactly one response");
+  THROW_WALLET_EXCEPTION_IF(histogram[0].amount != 0, error::get_histogram_error, "Expected 0 amount");
+
+  return histogram[0].total_count;
 }
 //----------------------------------------------------------------------------------------------------
 const wallet2::transfer_details &wallet2::get_transfer_details(size_t idx) const
@@ -6175,7 +6035,7 @@ uint64_t wallet2::get_daemon_blockchain_height(string &err)
 {
   uint64_t height;
 
-  boost::optional<std::string> result = m_node_rpc_proxy.get_height(height);
+  boost::optional<std::string> result = m_daemon->getHeight(height);
   if (result)
   {
     err = *result;
@@ -6188,34 +6048,13 @@ uint64_t wallet2::get_daemon_blockchain_height(string &err)
 
 uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 {
-  epee::json_rpc::request<cryptonote::COMMAND_RPC_GET_INFO::request> req_t = AUTO_VAL_INIT(req_t);
-  epee::json_rpc::response<cryptonote::COMMAND_RPC_GET_INFO::response, std::string> resp_t = AUTO_VAL_INIT(resp_t);
-  m_daemon_rpc_mutex.lock();
-  req_t.jsonrpc = "2.0";
-  req_t.id = epee::serialization::storage_entry(0);
-  req_t.method = "get_info";
-  bool ok = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client);
-  m_daemon_rpc_mutex.unlock();
-  if (ok)
-  {
-    if (resp_t.result.status == CORE_RPC_STATUS_BUSY)
-    {
-      err = "daemon is busy. Please try again later.";
-    }
-    else if (resp_t.result.status != CORE_RPC_STATUS_OK)
-    {
-      err = resp_t.result.status;
-    }
-    else // success, cleaning up error message
-    {
-      err = "";
-    }
-  }
-  else
-  {
-    err = "possibly lost connection to daemon";
-  }
-  return resp_t.result.target_height;
+  uint64_t target_height = 0;
+
+  boost::optional<std::string> r = m_daemon->getTargetHeight(target_height);
+
+  if (r) err = *r;
+
+  return target_height;
 }
 
 uint64_t wallet2::get_approximate_blockchain_height() const
@@ -6475,8 +6314,7 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, uint64_t &spent, uint64_t &unspent, bool check_spent)
 {
-  COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req = AUTO_VAL_INIT(req);
-  COMMAND_RPC_IS_KEY_IMAGE_SPENT::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+  std::vector<crypto::key_image> key_images;
 
   THROW_WALLET_EXCEPTION_IF(signed_key_images.size() > m_transfers.size(), error::wallet_internal_error,
       "The blockchain is out of date compared to the signed key images");
@@ -6512,7 +6350,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
         + boost::lexical_cast<std::string>(signed_key_images.size()) + ", key image " + epee::string_tools::pod_to_hex(key_image)
         + ", signature " + epee::string_tools::pod_to_hex(signature) + ", pubkey " + epee::string_tools::pod_to_hex(*pkeys[0]));
 
-    req.key_images.push_back(epee::string_tools::pod_to_hex(key_image));
+    key_images.push_back(key_image);
   }
 
   for (size_t n = 0; n < signed_key_images.size(); ++n)
@@ -6522,26 +6360,28 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
     m_transfers[n].m_key_image_known = true;
   }
 
+  std::vector<bool> is_spent;
+  std::vector<bool> is_spent_in_chain;
+  std::vector<bool> is_spent_in_pool;
+
   if(check_spent)
   {
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/is_key_image_spent", req, daemon_resp, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "is_key_image_spent");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "is_key_image_spent");
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.status != CORE_RPC_STATUS_OK, error::is_key_image_spent_error, daemon_resp.status);
-    THROW_WALLET_EXCEPTION_IF(daemon_resp.spent_status.size() != signed_key_images.size(), error::wallet_internal_error,
+    boost::optional<std::string> r = m_daemon->keyImagesSpent(key_images, is_spent, is_spent_in_chain, is_spent_in_pool);
+    THROW_WALLET_EXCEPTION_IF(r, error::is_key_image_spent_error, *r);
+    THROW_WALLET_EXCEPTION_IF(is_spent.size() != key_images.size(), error::wallet_internal_error,
       "daemon returned wrong response for is_key_image_spent, wrong amounts count = " +
-      std::to_string(daemon_resp.spent_status.size()) + ", expected " +  std::to_string(signed_key_images.size()));
-    for (size_t n = 0; n < daemon_resp.spent_status.size(); ++n)
+      std::to_string(is_spent.size()) + ", expected " +  std::to_string(key_images.size()));
+
+    for (size_t n = 0; n < is_spent.size(); ++n)
     {
       transfer_details &td = m_transfers[n];
-      td.m_spent = daemon_resp.spent_status[n] != COMMAND_RPC_IS_KEY_IMAGE_SPENT::UNSPENT;
+      td.m_spent = is_spent[n];
     }
   }
   spent = 0;
   unspent = 0;
-  std::unordered_set<crypto::hash> spent_txids;   // For each spent key image, search for a tx in m_transfers that uses it as input.
+  std::vector<crypto::hash> spent_txids;   // For each spent key image, search for a tx in m_transfers that uses it as input.
+  std::unordered_set<crypto::hash> spent_txids_set;   // For easy uniqueness check
   std::vector<size_t> swept_transfers;            // If such a spending tx wasn't found in m_transfers, this means the spending tx 
                                                   // was created by sweep_all, so we can't know the spent height and other detailed info.
   for(size_t i = 0; i < m_transfers.size(); ++i)
@@ -6553,9 +6393,9 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
     else
       unspent += amount;
     LOG_PRINT_L2("Transfer " << i << ": " << print_money(amount) << " (" << td.m_global_output_index << "): "
-        << (td.m_spent ? "spent" : "unspent") << " (key image " << req.key_images[i] << ")");
+        << (td.m_spent ? "spent" : "unspent") << " (key image " << epee::string_tools::pod_to_hex(key_images[i]) << ")");
 
-    if (i < daemon_resp.spent_status.size() && daemon_resp.spent_status[i] == COMMAND_RPC_IS_KEY_IMAGE_SPENT::SPENT_IN_BLOCKCHAIN)
+    if (i < is_spent.size() && is_spent_in_chain[i])
     {
       bool is_spent_tx_found = false;
       for (auto it = m_transfers.rbegin(); &(*it) != &td; ++it)
@@ -6572,9 +6412,13 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
         if (is_spent_tx)
         {
           is_spent_tx_found = true;
-          spent_txids.insert(it->m_txid);
-          break;
-        }
+	  if (spent_txids_set.find(it->m_txid) == spent_txids_set.end())
+	  {
+	    spent_txids_set.insert(it->m_txid);
+	    spent_txids.push_back(it->m_txid);
+	  }
+	}
+	  break;
       }
 
       if (!is_spent_tx_found)
@@ -6585,33 +6429,23 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
 
   if (check_spent)
   {
+
     // query outgoing txes
-    COMMAND_RPC_GET_TRANSACTIONS::request gettxs_req;
-    COMMAND_RPC_GET_TRANSACTIONS::response gettxs_res;
-    gettxs_req.decode_as_json = false;
-    for (const crypto::hash& spent_txid : spent_txids)
-      gettxs_req.txs_hashes.push_back(epee::string_tools::pod_to_hex(spent_txid));
-    m_daemon_rpc_mutex.lock();
-    bool r = epee::net_utils::invoke_http_json("/gettransactions", gettxs_req, gettxs_res, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
-    THROW_WALLET_EXCEPTION_IF(gettxs_res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "gettransactions");
-    THROW_WALLET_EXCEPTION_IF(gettxs_res.txs.size() != spent_txids.size(), error::wallet_internal_error,
-      "daemon returned wrong response for gettransactions, wrong count = " + std::to_string(gettxs_res.txs.size()) + ", expected " + std::to_string(spent_txids.size()));
+    std::unordered_map<crypto::hash, cryptonote::rpc::transaction_info> transactions;
+    std::vector<crypto::hash> missed_hashes;
+
+    boost::optional<std::string> result = m_daemon->getTransactions(spent_txids, transactions, missed_hashes);
+    throw_on_rpc_response_error(result, "getTransactions");
+    THROW_WALLET_EXCEPTION_IF(transactions.size() != spent_txids.size(), error::wallet_internal_error,
+      "daemon returned wrong response for getTransactions, wrong count = " + std::to_string(transactions.size()) + ", expected " + std::to_string(spent_txids.size()));
 
     // process each outgoing tx
-    auto spent_txid = spent_txids.begin();
-    for (const COMMAND_RPC_GET_TRANSACTIONS::entry& e : gettxs_res.txs)
+    for (const auto& e : transactions)
     {
-      THROW_WALLET_EXCEPTION_IF(e.in_pool, error::wallet_internal_error, "spent tx isn't supposed to be in txpool");
+      const auto& spent_txid = e.first;
+      THROW_WALLET_EXCEPTION_IF(e.second.in_pool, error::wallet_internal_error, "spent tx isn't supposed to be in txpool");
 
-      // parse tx
-      cryptonote::blobdata bd;
-      THROW_WALLET_EXCEPTION_IF(!epee::string_tools::parse_hexstr_to_binbuff(e.as_hex, bd), error::wallet_internal_error, "parse_hexstr_to_binbuff failed");
-      cryptonote::transaction spent_tx;
-      crypto::hash spnet_txid_parsed, spent_txid_prefix;
-      THROW_WALLET_EXCEPTION_IF(!cryptonote::parse_and_validate_tx_from_blob(bd, spent_tx, spnet_txid_parsed, spent_txid_prefix), error::wallet_internal_error, "parse_and_validate_tx_from_blob failed");
-      THROW_WALLET_EXCEPTION_IF(*spent_txid != spnet_txid_parsed, error::wallet_internal_error, "parsed txid mismatch");
+      const cryptonote::transaction& spent_tx = e.second.transaction;
 
       // get received (change) amount
       uint64_t tx_money_got_in_outs = 0;
@@ -6666,10 +6500,10 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
           amount = td.amount();
           tx_money_spent_in_ins += amount;
 
-          LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << *spent_txid);
-          set_spent(it->second, e.block_height);
+          LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << spent_txid);
+          set_spent(it->second, e.second.block_height);
           if (m_callback)
-            m_callback->on_money_spent(e.block_height, *spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index);
+            m_callback->on_money_spent(e.second.block_height, spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index);
           if (subaddr_account != (uint32_t)-1 && subaddr_account != td.m_subaddr_index.major)
             LOG_PRINT_L0("WARNING: This tx spends outputs received by different subaddress accounts, which isn't supposed to happen");
           subaddr_account = td.m_subaddr_index.major;
@@ -6678,19 +6512,17 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
       }
 
       // create outgoing payment
-      process_outgoing(*spent_txid, spent_tx, e.block_height, e.block_timestamp, tx_money_spent_in_ins, tx_money_got_in_outs, subaddr_account, subaddr_indices);
+      process_outgoing(spent_txid, spent_tx, e.second.block_height, e.second.block_timestamp, tx_money_spent_in_ins, tx_money_got_in_outs, subaddr_account, subaddr_indices);
 
       // erase corresponding incoming payment
       for (auto j = m_payments.begin(); j != m_payments.end(); ++j)
       {
-        if (j->second.m_tx_hash == *spent_txid)
+        if (j->second.m_tx_hash == spent_txid)
         {
           m_payments.erase(j);
           break;
         }
       }
-
-      ++spent_txid;
     }
 
     for (size_t n : swept_transfers)
@@ -7038,38 +6870,32 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
   }
   while (true)
   {
-    COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request req;
-    COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response res;
+    std::vector<cryptonote::rpc::BlockHeaderResponse> headers;
+
     uint64_t height_mid = (height_min + height_max) / 2;
-    req.heights =
+    std::vector<uint64_t> heights =
     {
       height_min,
       height_mid,
       height_max
     };
-    bool r = net_utils::invoke_http_bin("/getblocks_by_height.bin", req, res, m_http_client, rpc_timeout);
-    if (!r || res.status != CORE_RPC_STATUS_OK)
+
+    boost::optional<std::string> r = m_daemon->getBlockHeadersByHeight(heights, headers);
+    if (r || headers.size() != heights.size())
     {
       std::ostringstream oss;
-      oss << "failed to get blocks by heights: ";
-      for (auto height : req.heights)
+      oss << "failed to get block headers by heights: ";
+      for (auto height : heights)
         oss << height << ' ';
       oss << endl << "reason: ";
-      if (!r)
-        oss << "possibly lost connection to daemon";
-      else if (res.status == CORE_RPC_STATUS_BUSY)
-        oss << "daemon is busy";
-      else
-        oss << res.status;
+      oss << *r;
       throw std::runtime_error(oss.str());
     }
-    cryptonote::block blk_min, blk_mid, blk_max;
-    if (!parse_and_validate_block_from_blob(res.blocks[0].block, blk_min)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_min));
-    if (!parse_and_validate_block_from_blob(res.blocks[1].block, blk_mid)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_mid));
-    if (!parse_and_validate_block_from_blob(res.blocks[2].block, blk_max)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_max));
-    uint64_t timestamp_min = blk_min.timestamp;
-    uint64_t timestamp_mid = blk_mid.timestamp;
-    uint64_t timestamp_max = blk_max.timestamp;
+
+    uint64_t timestamp_min = headers[0].timestamp;
+    uint64_t timestamp_mid = headers[1].timestamp;
+    uint64_t timestamp_max = headers[2].timestamp;
+
     if (!(timestamp_min <= timestamp_mid && timestamp_mid <= timestamp_max))
     {
       // the timestamps are not in the chronological order. 
@@ -7098,8 +6924,8 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
 bool wallet2::is_synced() const
 {
   uint64_t height;
-  boost::optional<std::string> result = m_node_rpc_proxy.get_target_height(height);
-  if (result && *result != CORE_RPC_STATUS_OK)
+  boost::optional<std::string> result = m_daemon->getTargetHeight(height);
+  if (result)
     return false;
   return get_blockchain_current_height() >= height;
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -55,6 +55,9 @@
 #include "ringct/rctOps.h"
 #include "checkpoints/checkpoints.h"
 
+#include "rpc/daemon_rpc_client.h"
+#include "rpc/message_data_structs.h"
+
 #include "wallet_errors.h"
 #include "common/password.h"
 #include "node_rpc_proxy.h"
@@ -147,7 +150,7 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false),m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(const wallet2& other) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_daemon(other.m_daemon) {}
 
   public:
     static const char* tr(const char* str);
@@ -173,7 +176,7 @@ namespace tools
 
     static bool verify_password(const std::string& keys_file_name, const std::string& password, bool watch_only);
 
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex), m_light_wallet(false), m_light_wallet_scanned_block_height(0), m_light_wallet_blockchain_height(0), m_light_wallet_connected(false), m_light_wallet_balance(0), m_light_wallet_unlocked_balance(0) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_light_wallet(false), m_light_wallet_scanned_block_height(0), m_light_wallet_blockchain_height(0), m_light_wallet_connected(false), m_light_wallet_balance(0), m_light_wallet_unlocked_balance(0) {}
 
     struct tx_scan_info_t
     {
@@ -424,7 +427,7 @@ namespace tools
     // into account the current median block size rather than
     // the minimum block size.
     bool deinit();
-    bool init(std::string daemon_address = "http://localhost:8080",
+    bool init(cryptonote::rpc::DaemonRPCClient* daemon_client, std::string daemon_address = "http://localhost:8080",
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
 
     void stop() { m_run.store(false, std::memory_order_relaxed); }
@@ -678,7 +681,7 @@ namespace tools
     uint64_t get_num_rct_outputs();
     const transfer_details &get_transfer_details(size_t idx) const;
 
-    void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
+    void get_hard_fork_earliest_height(uint8_t version, uint64_t &earliest_height);
     bool use_fork_rules(uint8_t version, int64_t early_blocks = 0);
     int get_fee_algorithm();
 
@@ -773,16 +776,16 @@ namespace tools
      */
     bool load_keys(const std::string& keys_file_name, const std::string& password);
     void process_new_transaction(const crypto::hash &txid, const cryptonote::transaction& tx, const std::vector<uint64_t> &o_indices, uint64_t height, uint64_t ts, bool miner_tx, bool pool);
-    void process_new_blockchain_entry(const cryptonote::block& b, const cryptonote::block_complete_entry& bche, const crypto::hash& bl_id, uint64_t height, const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices &o_indices);
+    void process_new_blockchain_entry(const cryptonote::block& b, const cryptonote::rpc::block_with_transactions& bwt, const crypto::hash& bl_id, uint64_t height, const cryptonote::rpc::block_output_indices &o_indices);
     void detach_blockchain(uint64_t height);
     void get_short_chain_history(std::list<crypto::hash>& ids) const;
     bool is_tx_spendtime_unlocked(uint64_t unlock_time, uint64_t block_height) const;
     bool clear();
-    void pull_blocks(uint64_t start_height, uint64_t& blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices);
+    void pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::rpc::block_with_transactions>& blocks, std::vector<cryptonote::rpc::block_output_indices> &o_indices);
     void pull_hashes(uint64_t start_height, uint64_t& blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<crypto::hash> &hashes);
     void fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history);
-    void pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::list<cryptonote::block_complete_entry> &prev_blocks, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, bool &error);
-    void process_blocks(uint64_t start_height, const std::list<cryptonote::block_complete_entry> &blocks, const std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t& blocks_added);
+    void pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::vector<cryptonote::rpc::block_with_transactions> &prev_blocks, std::vector<cryptonote::rpc::block_with_transactions> &blocks, std::vector<cryptonote::rpc::block_output_indices> &o_indices, bool &error);
+    void process_blocks(uint64_t start_height, const std::vector<cryptonote::rpc::block_with_transactions> &blocks, const std::vector<cryptonote::rpc::block_output_indices> &o_indices, uint64_t& blocks_added);
     uint64_t select_transfers(uint64_t needed_money, std::vector<size_t> unused_transfers_indices, std::list<size_t>& selected_transfers, bool trusted_daemon);
     bool prepare_file_names(const std::string& file_path);
     void process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height);
@@ -864,7 +867,6 @@ namespace tools
     bool m_confirm_backlog;
     uint32_t m_confirm_backlog_threshold;
     bool m_is_initialized;
-    NodeRPCProxy m_node_rpc_proxy;
     std::unordered_set<crypto::hash> m_scanned_pool_txs[2];
 
     // Light wallet
@@ -880,6 +882,7 @@ namespace tools
     std::unordered_map<crypto::hash, address_tx> m_light_wallet_address_txs;
     // store calculated key image for faster lookup
     std::unordered_map<crypto::public_key, std::map<uint64_t, crypto::key_image> > m_key_image_cache;
+    std::shared_ptr<cryptonote::rpc::DaemonRPCClient> m_daemon;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 20)
@@ -1272,40 +1275,37 @@ namespace tools
     uint32_t subaddr_account = m_transfers[*selected_transfers.begin()].m_subaddr_index.major;
     for (auto i = ++selected_transfers.begin(); i != selected_transfers.end(); ++i)
       THROW_WALLET_EXCEPTION_IF(subaddr_account != *i, error::wallet_internal_error, "the tx uses funds from multiple accounts");
-
-    typedef COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::out_entry out_entry;
     typedef cryptonote::tx_source_entry::output_entry tx_output_entry;
 
-    COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
+    std::vector<uint64_t> req_amounts;
+    uint64_t req_count;
+    std::vector<cryptonote::rpc::amount_with_random_outputs> amounts_with_outputs;
+
     if(fake_outputs_count)
     {
-      COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request req = AUTO_VAL_INIT(req);
-      req.outs_count = fake_outputs_count + 1;// add one to make possible (if need) to skip real output key
+      req_count = fake_outputs_count + 1;// add one to make possible (if need) to skip real output key
       for(size_t idx: selected_transfers)
       {
         const transfer_container::const_iterator it = m_transfers.begin() + idx;
         THROW_WALLET_EXCEPTION_IF(it->m_tx.vout.size() <= it->m_internal_output_index, error::wallet_internal_error,
           "m_internal_output_index = " + std::to_string(it->m_internal_output_index) +
           " is greater or equal to outputs count = " + std::to_string(it->m_tx.vout.size()));
-        req.amounts.push_back(it->amount());
+        req_amounts.push_back(it->amount());
       }
 
-      m_daemon_rpc_mutex.lock();
-      bool r = epee::net_utils::invoke_http_bin("/getrandom_outs.bin", req, daemon_resp, m_http_client, rpc_timeout);
-      m_daemon_rpc_mutex.unlock();
-      THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getrandom_outs.bin");
-      THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getrandom_outs.bin");
-      THROW_WALLET_EXCEPTION_IF(daemon_resp.status != CORE_RPC_STATUS_OK, error::get_random_outs_error, daemon_resp.status);
-      THROW_WALLET_EXCEPTION_IF(daemon_resp.outs.size() != selected_transfers.size(), error::wallet_internal_error,
+      std::string error_details;
+      boost::optional<std::string> r = m_daemon->getRandomOutputsForAmounts(req_amounts, req_count, amounts_with_outputs);
+      THROW_WALLET_EXCEPTION_IF(r, error::get_random_outs_error, *r);
+      THROW_WALLET_EXCEPTION_IF(amounts_with_outputs.size() != selected_transfers.size(), error::wallet_internal_error,
         "daemon returned wrong response for getrandom_outs.bin, wrong amounts count = " +
-        std::to_string(daemon_resp.outs.size()) + ", expected " +  std::to_string(selected_transfers.size()));
+        std::to_string(amounts_with_outputs.size()) + ", expected " +  std::to_string(selected_transfers.size()));
 
       std::unordered_map<uint64_t, uint64_t> scanty_outs;
-      for(COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::outs_for_amount& amount_outs: daemon_resp.outs)
+      for (auto& amount_outs : amounts_with_outputs)
       {
-        if (amount_outs.outs.size() < fake_outputs_count)
+        if (amount_outs.outputs.size() < fake_outputs_count)
         {
-          scanty_outs[amount_outs.amount] = amount_outs.outs.size();
+          scanty_outs[amount_outs.amount] = amount_outs.outputs.size();
         }
       }
       THROW_WALLET_EXCEPTION_IF(!scanty_outs.empty(), error::not_enough_outs_to_mix, scanty_outs, fake_outputs_count);
@@ -1322,16 +1322,16 @@ namespace tools
       src.amount = td.amount();
       src.rct = false;
       //paste mixin transaction
-      if(daemon_resp.outs.size())
+      if(amounts_with_outputs.size())
       {
-        daemon_resp.outs[i].outs.sort([](const out_entry& a, const out_entry& b){return a.global_amount_index < b.global_amount_index;});
-        for(out_entry& daemon_oe: daemon_resp.outs[i].outs)
+        std::sort(amounts_with_outputs[i].outputs.begin(), amounts_with_outputs[i].outputs.end(), [](const cryptonote::rpc::output_key_and_amount_index& a, const cryptonote::rpc::output_key_and_amount_index& b){return a.amount_index < b.amount_index;});
+        for (cryptonote::rpc::output_key_and_amount_index& daemon_oe : amounts_with_outputs[i].outputs)
         {
-          if(td.m_global_output_index == daemon_oe.global_amount_index)
+          if(td.m_global_output_index == daemon_oe.amount_index)
             continue;
           tx_output_entry oe;
-          oe.first = daemon_oe.global_amount_index;
-          oe.second.dest = rct::pk2rct(daemon_oe.out_key);
+          oe.first = daemon_oe.amount_index;
+          oe.second.dest = rct::pk2rct(daemon_oe.key);
           oe.second.mask = rct::identity();
           src.outputs.push_back(oe);
           if(src.outputs.size() >= fake_outputs_count)

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "rpc/daemon_rpc_client.h"
 
 #include <string>
 #include <vector>
@@ -870,6 +871,10 @@ struct WalletManager
 
     //! checks for an update and returns version, hash and url
     static std::tuple<bool, std::string, std::string, std::string, std::string> checkUpdates(const std::string &software, const std::string &subdir);
+
+    static cryptonote::rpc::DaemonRPCClient::CLIENT_TYPE rpcClientType;
+
+    static void setRPCClientType(const cryptonote::rpc::DaemonRPCClient::CLIENT_TYPE type) { rpcClientType = type; }
 };
 
 


### PR DESCRIPTION
Created a client class for the daemon RPC which can be either the old RPC or the new zmq RPC, and refactored the wallet to use this new class (so it can be told at runtime...well, at launch...which RPC to use).

Notes:
-  There are a few cases where the wallet is still using the old RPC as it was.  Those cases are where there are new RPC calls which are present in the old RPC, but not mirrored in the zmq RPC, or where the refactor merits a bit more thought.  The vast majority (90+ %) is sorted to use the new abstracted daemon client lib.

-  Needs testing.