### PR TITLE
Wallet: Add prompt-for-password flag

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -202,6 +202,8 @@ boost::optional<tools::password_container> get_password(const boost::program_opt
     return {tools::password_container{std::move(password)}};
   }
 
+  THROW_WALLET_EXCEPTION_IF(!password_prompter, tools::error::wallet_internal_error, tools::wallet2::tr("no password specified; use --prompt-for-password to prompt for a password"));
+
   return password_prompter(verify ? tr("Enter new wallet password") : tr("Wallet password"), verify);
 }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -58,6 +58,7 @@ namespace
   const command_line::arg_descriptor<bool> arg_disable_rpc_login = {"disable-rpc-login", "Disable HTTP authentication for RPC connections served by this process"};
   const command_line::arg_descriptor<bool> arg_trusted_daemon = {"trusted-daemon", "Enable commands which rely on a trusted daemon", false};
   const command_line::arg_descriptor<std::string> arg_wallet_dir = {"wallet-dir", "Directory for newly created wallets"};
+  const command_line::arg_descriptor<bool> arg_prompt_for_password = {"prompt-for-password", "Prompts for password when not provided", false};
 
   constexpr const char default_rpc_username[] = "monero";
 
@@ -1904,7 +1905,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, password_prompter).first;
+    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, nullptr).first;
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -1978,7 +1979,7 @@ namespace tools
     }
     std::unique_ptr<tools::wallet2> wal = nullptr;
     try {
-      wal = tools::wallet2::make_from_file(vm2, wallet_file, password_prompter).first;
+      wal = tools::wallet2::make_from_file(vm2, wallet_file, nullptr).first;
     }
     catch (const std::exception& e)
     {
@@ -2070,7 +2071,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_wallet_file);
   command_line::add_arg(desc_params, arg_from_json);
   command_line::add_arg(desc_params, arg_wallet_dir);
-
+  command_line::add_arg(desc_params, arg_prompt_for_password);
 
   const auto vm = wallet_args::main(
     argc, argv,
@@ -2092,6 +2093,8 @@ int main(int argc, char** argv) {
     const auto wallet_file = command_line::get_arg(*vm, arg_wallet_file);
     const auto from_json = command_line::get_arg(*vm, arg_from_json);
     const auto wallet_dir = command_line::get_arg(*vm, arg_wallet_dir);
+    const auto prompt_for_password = command_line::get_arg(*vm, arg_prompt_for_password);
+    const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
 
     if(!wallet_file.empty() && !from_json.empty())
     {
@@ -2114,13 +2117,13 @@ int main(int argc, char** argv) {
     LOG_PRINT_L0(tools::wallet_rpc_server::tr("Loading wallet..."));
     if(!wallet_file.empty())
     {
-      wal = tools::wallet2::make_from_file(*vm, wallet_file, password_prompter).first;
+      wal = tools::wallet2::make_from_file(*vm, wallet_file, password_prompt).first;
     }
     else
     {
       try
       {
-        wal = tools::wallet2::make_from_json(*vm, from_json, password_prompter);
+        wal = tools::wallet2::make_from_json(*vm, from_json, password_prompt);
       }
       catch (const std::exception &e)
       {


### PR DESCRIPTION
Adds a new command to the wallet rpc called `--prompt-for-password`.

Current behavior prior to the change is documented here:

> - --wallet-file specified with no password
>   - Asks for password and if valid logins in; failure invalid password message

Now it returns an error, "no password specified; use --prompt-for-password to prompt for a password" in this case.

- --wallet-file specified with no password
  - `--prompt-for-password` not provided? Error message "no password specified; use --prompt-for-password to prompt for a password"
  - `--prompt-for-password` provided, asks for password and if valid logins in; failure invalid password message

Ref: #2179