### PR TITLE
checkpoints: add a testnet checkpoint at 1000000

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -140,8 +140,8 @@ namespace cryptonote
   {
     if (testnet)
     {
-      // just use the genesis block on testnet
       ADD_CHECKPOINT(0,     "48ca7cd3c8de5b6a4d53d2861fbdaedca141553559f9be9520068053cda8430b");
+      ADD_CHECKPOINT(1000000, "46b690b710a07ea051bc4a6b6842ac37be691089c0f7758cfeec4d5fc0b4a258");
       return true;
     }
     ADD_CHECKPOINT(1,     "771fbcd656ec1464d3a02ead5e18644030007a0fc664c0a964d30922821a8148");


### PR DESCRIPTION
Makes working on testnet a lot easier (much less I/O when loading
and saving wallets, and exercises the hashchain code before any
changes are merged)