### PR TITLE
fixed easylogging compile issue on OpenBSD

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -99,6 +99,11 @@
 #else
 #  define ELPP_OS_FREEBSD 0
 #endif
+#if (defined(__OpenBSD__))
+#  define ELPP_OS_OPENBSD 1
+#else
+#  define ELPP_OS_OPENBSD 0
+#endif
 #if (defined(__sun))
 #  define ELPP_OS_SOLARIS 1
 #else
@@ -110,7 +115,7 @@
 #   define ELPP_OS_DRAGONFLY 0
 #endif
 // Unix
-#if ((ELPP_OS_LINUX || ELPP_OS_MAC || ELPP_OS_FREEBSD || ELPP_OS_SOLARIS || ELPP_OS_DRAGONFLY) && (!ELPP_OS_WINDOWS))
+#if ((ELPP_OS_LINUX || ELPP_OS_MAC || ELPP_OS_FREEBSD || ELPP_OS_SOLARIS || ELPP_OS_DRAGONFLY || ELPP_OS_OPENBSD) && (!ELPP_OS_WINDOWS))
 #  define ELPP_OS_UNIX 1
 #else
 #  define ELPP_OS_UNIX 0
@@ -195,7 +200,7 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #  define ELPP_INTERNAL_INFO(lvl, msg)
 #endif  // (defined(ELPP_DEBUG_INFO))
 #if (defined(ELPP_FEATURE_ALL)) || (defined(ELPP_FEATURE_CRASH_LOG))
-#  if (ELPP_COMPILER_GCC && !ELPP_MINGW)
+#  if (ELPP_COMPILER_GCC && !ELPP_MINGW && !ELPP_OS_OPENBSD)
 #    define ELPP_STACKTRACE 1
 #  else
 #      define ELPP_STACKTRACE 0


### PR DESCRIPTION
Issue: #2575
Add ELPP_OS_OPENBSD macros to easylogging++.h so that it will build on
OpenBSD.