### PR TITLE
daemon & simplewallet: don't set max-concurrency when unspecified

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -278,7 +278,7 @@ int main(int argc, char const * argv[])
     tools::set_stack_trace_log(log_file_path.filename().string());
 #endif // STACK_TRACE
 
-    if (command_line::has_arg(vm, daemon_args::arg_max_concurrency))
+    if (!command_line::is_arg_defaulted(vm, daemon_args::arg_max_concurrency))
       tools::set_max_concurrency(command_line::get_arg(vm, daemon_args::arg_max_concurrency));
 
     // logging is now set up

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -178,7 +178,7 @@ namespace wallet_args
       mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());
     }
 
-    if(command_line::has_arg(vm, arg_max_concurrency))
+    if (!command_line::is_arg_defaulted(vm, arg_max_concurrency))
       tools::set_max_concurrency(command_line::get_arg(vm, arg_max_concurrency));
 
     Print(print) << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")";


### PR DESCRIPTION
When the argument `--max-concurrency` is unspecified, previously the daemon received the default value of `0` which effectively set `max_concurrency` to `boost::thread::hardware_concurrency()`, while the wallet CLI received the default value of `1` which set `max_concurrency` to just `1`. This prevented the use of more than 2 threads for `start_mining` in the wallet CLI.

I have no idea why the defaulted values are different. Observed on OSX 10.12.6.