### PR TITLE
epee: don't disable -Wtautological-constant-out-of-range-compare on GCC

### DIFF
--- a/contrib/epee/include/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/storages/portable_storage_to_bin.h
@@ -47,7 +47,9 @@ namespace epee
 
     PRAGMA_WARNING_PUSH
       PRAGMA_GCC("GCC diagnostic ignored \"-Wstrict-aliasing\"")
+#ifdef __clang__
       PRAGMA_GCC("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"")
+#endif
       template<class t_stream>
     size_t pack_varint(t_stream& strm, size_t val)
     {   //the first two bits always reserved for size information


### PR DESCRIPTION
It's a CLANG only option, and causes GCC to error out