### PR TITLE
simplewallet: translate ring size 0 to mixin 0 (default values)

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -632,7 +632,7 @@ bool simple_wallet::set_default_ring_size(const std::vector<std::string> &args/*
     const auto pwd_container = get_and_verify_password();
     if (pwd_container)
     {
-      m_wallet->default_mixin(ring_size - 1);
+      m_wallet->default_mixin(ring_size > 0 ? ring_size - 1 : 0);
       m_wallet->rewrite(m_wallet_file, pwd_container->password());
     }
     return true;


### PR DESCRIPTION
Avoids turning it to a huge number