### PR TITLE
Improve command naming and documentation

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -456,7 +456,7 @@ eof:
   class command_handler {
   public:
     typedef boost::function<bool (const std::vector<std::string> &)> callback;
-    typedef std::map<std::string, std::pair<callback, std::string> > lookup;
+    typedef std::map<std::string, std::pair<callback, std::pair<std::string, std::string>> > lookup;
 
     std::string get_usage()
     {
@@ -469,16 +469,35 @@ eof:
       for(auto& x:m_command_handlers)
       {
         ss.width(max_command_len + 3);
-        ss << std::left <<  x.first << x.second.second << ENDL;
+        ss << std::left <<  x.first << x.second.second.first << ENDL;
       }
       return ss.str();
     }
 
-    void set_handler(const std::string& cmd, const callback& hndlr, const std::string& usage = "")
+    std::string get_cmd_description(const std::string& cmd)
+    {
+      std::stringstream ss;
+      std::map<std::string, std::pair<callback, std::pair<std::string, std::string>>>::iterator it = m_command_handlers.find(cmd);
+      if(it != m_command_handlers.end())
+        ss << it->second.second.second << ENDL;
+      return ss.str();
+    }
+
+    std::string get_cmd_usage(const std::string& cmd)
+    {
+      std::stringstream ss;
+      std::map<std::string, std::pair<callback, std::pair<std::string, std::string>>>::iterator it = m_command_handlers.find(cmd);
+      if(it != m_command_handlers.end())
+        ss << it->second.second.first << ENDL;
+      return ss.str();
+    }
+
+    void set_handler(const std::string& cmd, const callback& hndlr, const std::string& usage = "", const std::string& description = "")
     {
       lookup::mapped_type & vt = m_command_handlers[cmd];
       vt.first = hndlr;
-      vt.second = usage;
+      vt.second.first = description.empty() ? cmd : usage;
+      vt.second.second = description.empty() ? usage : description;
 #ifdef HAVE_READLINE
       rdln::readline_buffer::add_completion(cmd);
 #endif

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -134,8 +134,7 @@ bool BootstrapFile::initialize_file()
   bbi.block_last_pos = 0;
 
   buffer_type buffer2;
-  boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>>* output_stream_header;
-  output_stream_header = new boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>>(buffer2);
+  boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>> output_stream_header(buffer2);
 
   uint32_t bd_size = 0;
 
@@ -147,8 +146,8 @@ bool BootstrapFile::initialize_file()
   {
     throw std::runtime_error("Error in serialization of bootstrap::file_info size");
   }
-  *output_stream_header << blob;
-  *output_stream_header << bd;
+  output_stream_header << blob;
+  output_stream_header << bd;
 
   bd = t_serializable_object_to_blob(bbi);
   MDEBUG("bootstrap::blocks_info size: " << bd.size());
@@ -158,12 +157,12 @@ bool BootstrapFile::initialize_file()
   {
     throw std::runtime_error("Error in serialization of bootstrap::blocks_info size");
   }
-  *output_stream_header << blob;
-  *output_stream_header << bd;
+  output_stream_header << blob;
+  output_stream_header << bd;
 
-  output_stream_header->flush();
-  *output_stream_header << std::string(header_size-buffer2.size(), 0); // fill in rest with null bytes
-  output_stream_header->flush();
+  output_stream_header.flush();
+  output_stream_header << std::string(header_size-buffer2.size(), 0); // fill in rest with null bytes
+  output_stream_header.flush();
   std::copy(buffer2.begin(), buffer2.end(), std::ostreambuf_iterator<char>(*m_raw_data_file));
 
   return true;

--- a/src/crypto/keccak.c
+++ b/src/crypto/keccak.c
@@ -2,6 +2,8 @@
 // 19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
 // A baseline Keccak (3rd round) implementation.
 
+#include <stdio.h>
+#include <stdlib.h>
 #include "hash-ops.h"
 #include "keccak.h"
 
@@ -73,11 +75,17 @@ void keccakf(uint64_t st[25], int rounds)
 // compute a keccak hash (md) of given byte length from "in"
 typedef uint64_t state_t[25];
 
-int keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
+void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
 {
     state_t st;
     uint8_t temp[144];
     size_t i, rsiz, rsizw;
+
+    if (mdlen <= 0 || mdlen > 200 || sizeof(st) != 200)
+    {
+      fprintf(stderr, "Bad keccak use");
+      abort();
+    }
 
     rsiz = sizeof(state_t) == mdlen ? HASH_DATA_AREA : 200 - 2 * mdlen;
     rsizw = rsiz / 8;
@@ -91,6 +99,12 @@ int keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
     }
     
     // last block and padding
+    if (inlen >= sizeof(temp) || inlen > rsiz || rsiz - inlen + inlen + 1 >= sizeof(temp) || rsiz == 0 || rsiz - 1 >= sizeof(temp) || rsizw * 8 > sizeof(temp))
+    {
+      fprintf(stderr, "Bad keccak use");
+      abort();
+    }
+
     memcpy(temp, in, inlen);
     temp[inlen++] = 1;
     memset(temp + inlen, 0, rsiz - inlen);
@@ -102,8 +116,6 @@ int keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
     keccakf(st, KECCAK_ROUNDS);
 
     memcpy(md, st, mdlen);
-
-    return 0;
 }
 
 void keccak1600(const uint8_t *in, size_t inlen, uint8_t *md)

--- a/src/crypto/keccak.h
+++ b/src/crypto/keccak.h
@@ -16,7 +16,7 @@
 #endif
 
 // compute a keccak hash (md) of given byte length from "in"
-int keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen);
+void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen);
 
 // update the state
 void keccakf(uint64_t st[25], int norounds);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1329,6 +1329,7 @@ namespace cryptonote
         << "where <level> is between 0 (no details) and 4 (very verbose), or custom category based levels (eg, *:WARNING)" << ENDL
         << ENDL
         << "Use the \"help\" command to see the list of available commands." << ENDL
+        << "Use the \"help <command>\" command to see the command's documentation." << ENDL
         << "**********************************************************************" << ENDL);
       m_starter_message_showed = true;
     }

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -65,18 +65,10 @@ bool t_command_parser_executor::save_blockchain(const std::vector<std::string>& 
   return m_executor.save_blockchain();
 }
 
-bool t_command_parser_executor::show_hash_rate(const std::vector<std::string>& args)
+bool t_command_parser_executor::set_hash_rate_visibility(const std::vector<std::string>& args)
 {
-  if (!args.empty()) return false;
-
-  return m_executor.show_hash_rate();
-}
-
-bool t_command_parser_executor::hide_hash_rate(const std::vector<std::string>& args)
-{
-  if (!args.empty()) return false;
-
-  return m_executor.hide_hash_rate();
+ if (args.empty() || (args[0] != "show" && args[0] != "hide")) return false;
+ return args[0] != "show" ? m_executor.show_hash_rate() : m_executor.hide_hash_rate();
 }
 
 bool t_command_parser_executor::show_difficulty(const std::vector<std::string>& args)
@@ -152,7 +144,7 @@ bool t_command_parser_executor::set_log_level(const std::vector<std::string>& ar
   }
 }
 
-bool t_command_parser_executor::print_height(const std::vector<std::string>& args) 
+bool t_command_parser_executor::print_height(const std::vector<std::string>& args)
 {
   if (!args.empty()) return false;
 
@@ -238,25 +230,11 @@ bool t_command_parser_executor::is_key_image_spent(const std::vector<std::string
   return true;
 }
 
-bool t_command_parser_executor::print_transaction_pool_long(const std::vector<std::string>& args)
+bool t_command_parser_executor::print_transaction_pool(const std::vector<std::string>& args)
 {
-  if (!args.empty()) return false;
+  if (!args.empty() && args[0] != "long" && args[0] != "stats") return false;
 
-  return m_executor.print_transaction_pool_long();
-}
-
-bool t_command_parser_executor::print_transaction_pool_short(const std::vector<std::string>& args)
-{
-  if (!args.empty()) return false;
-
-  return m_executor.print_transaction_pool_short();
-}
-
-bool t_command_parser_executor::print_transaction_pool_stats(const std::vector<std::string>& args)
-{
-  if (!args.empty()) return false;
-
-  return m_executor.print_transaction_pool_stats();
+  return args.empty() ? m_executor.print_transaction_pool_short() : args[0] == "long" ? m_executor.print_transaction_pool_long() : m_executor.print_transaction_pool_stats();
 }
 
 bool t_command_parser_executor::start_mining(const std::vector<std::string>& args)
@@ -302,23 +280,23 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
   if(testnet)
     std::cout << "Mining to a testnet address, make sure this is intentional!" << std::endl;
   uint64_t threads_count = 1;
-  bool do_background_mining = false;  
-  bool ignore_battery = false;  
+  bool do_background_mining = false;
+  bool ignore_battery = false;
   if(args.size() > 4)
   {
     return false;
   }
-  
+
   if(args.size() == 4)
   {
     ignore_battery = args[3] == "true";
-  }  
-  
+  }
+
   if(args.size() >= 3)
   {
     do_background_mining = args[2] == "true";
   }
-  
+
   if(args.size() >= 2)
   {
     bool ok = epee::string_tools::get_xtype_from_string(threads_count, args[1]);
@@ -353,13 +331,13 @@ bool t_command_parser_executor::print_status(const std::vector<std::string>& arg
 
 bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
 {
-  if(args.size()>1) return false;
-  if(args.size()==0) {
+  if(args.size()>2 || (args.size() == 2 && args[0] != "up" && args[0] != "down")) return false;
+  if(args.empty()) {
     return m_executor.get_limit();
   }
   int64_t limit;
   try {
-      limit = std::stoll(args[0]);
+      limit = std::stoll(args[args.size()-1]);
   }
   catch(const std::exception& ex) {
       std::cout << "failed to parse argument" << std::endl;
@@ -368,76 +346,30 @@ bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
   if (limit > 0)
     limit *= 1024;
 
-  return m_executor.set_limit(limit, limit);
-}
-
-bool t_command_parser_executor::set_limit_up(const std::vector<std::string>& args)
-{
-  if(args.size()>1) return false;
-  if(args.size()==0) {
-    return m_executor.get_limit_up();
-  }
-  int64_t limit;
-  try {
-      limit = std::stoll(args[0]);
-  }
-  catch(const std::exception& ex) {
-      std::cout << "failed to parse argument" << std::endl;
-      return false;
-  }
-  if (limit > 0)
-    limit *= 1024;
-
-  return m_executor.set_limit(0, limit);
-}
-
-bool t_command_parser_executor::set_limit_down(const std::vector<std::string>& args)
-{
-  if(args.size()>1) return false;
-  if(args.size()==0) {
-    return m_executor.get_limit_down();
-  }
-  int64_t limit;
-  try {
-      limit = std::stoll(args[0]);
-  }
-  catch(const std::exception& ex) {
-      std::cout << "failed to parse argument" << std::endl;
-      return false;
-  }
-  if (limit > 0)
-    limit *= 1024;
-
-  return m_executor.set_limit(limit, 0);
+  return args.size() == 1 ? m_executor.set_limit(limit, limit) : args[0] == "up" ? m_executor.set_limit(0, limit) : m_executor.set_limit(limit, 0);
 }
 
 bool t_command_parser_executor::out_peers(const std::vector<std::string>& args)
 {
 	if (args.empty()) return false;
-	
+
 	unsigned int limit;
 	try {
 		limit = std::stoi(args[0]);
 	}
-	  
+
 	catch(std::exception& ex) {
 		_erro("stoi exception");
 		return false;
 	}
-	
+
 	return m_executor.out_peers(limit);
 }
 
-bool t_command_parser_executor::start_save_graph(const std::vector<std::string>& args)
+bool t_command_parser_executor::save_graph(const std::vector<std::string>& args)
 {
-	if (!args.empty()) return false;
-	return m_executor.start_save_graph();
-}
-
-bool t_command_parser_executor::stop_save_graph(const std::vector<std::string>& args)
-{
-	if (!args.empty()) return false;
-	return m_executor.stop_save_graph();
+ if (args.empty() || (args[0] != "start" && args[0] != "stop")) return false;
+ return args[0] == "start" ? m_executor.start_save_graph() : m_executor.stop_save_graph();
 }
 
 bool t_command_parser_executor::hard_fork_info(const std::vector<std::string>& args)
@@ -602,9 +534,9 @@ bool t_command_parser_executor::print_blockchain_dynamic_stats(const std::vector
 
 bool t_command_parser_executor::update(const std::vector<std::string>& args)
 {
-  if(args.size() != 1)
+  if(args.size() > 1)
   {
-    std::cout << "Exactly one parameter is needed: check, download, or update" << std::endl;
+    std::cout << "Maximum one parameter is allowed: download." << std::endl;
     return false;
   }
 

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -63,9 +63,7 @@ public:
 
   bool save_blockchain(const std::vector<std::string>& args);
 
-  bool show_hash_rate(const std::vector<std::string>& args);
-
-  bool hide_hash_rate(const std::vector<std::string>& args);
+  bool set_hash_rate_visibility(const std::vector<std::string>& args);
 
   bool show_difficulty(const std::vector<std::string>& args);
 
@@ -87,11 +85,7 @@ public:
 
   bool is_key_image_spent(const std::vector<std::string>& args);
 
-  bool print_transaction_pool_long(const std::vector<std::string>& args);
-
-  bool print_transaction_pool_short(const std::vector<std::string>& args);
-
-  bool print_transaction_pool_stats(const std::vector<std::string>& args);
+  bool print_transaction_pool(const std::vector<std::string>& args);
 
   bool start_mining(const std::vector<std::string>& args);
 
@@ -103,15 +97,9 @@ public:
 
   bool set_limit(const std::vector<std::string>& args);
 
-  bool set_limit_up(const std::vector<std::string>& args);
-
-  bool set_limit_down(const std::vector<std::string>& args);
-
   bool out_peers(const std::vector<std::string>& args);
-  
-  bool start_save_graph(const std::vector<std::string>& args);
-  
-  bool stop_save_graph(const std::vector<std::string>& args);
+
+  bool save_graph(const std::vector<std::string>& args);
   
   bool hard_fork_info(const std::vector<std::string>& args);
 

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -49,215 +49,193 @@ t_command_server::t_command_server(
   , m_is_rpc(is_rpc)
 {
   m_command_lookup.set_handler(
-      "q"
-    , [] (const std::vector<std::string>& args) {return true;}
-    , "ignored"
-    );
+      "help",
+      std::bind(&t_command_server::help, this, p::_1),
+      "help [<command>]",
+      "Shows the generic help section or a <command> specific documentation."
+  );
   m_command_lookup.set_handler(
-      "help"
-    , std::bind(&t_command_server::help, this, p::_1)
-    , "Show this help"
-    );
+      "print_cn",
+      std::bind(&t_command_parser_executor::print_connections, &m_parser, p::_1),
+      "Prints the current connections."
+  );
   m_command_lookup.set_handler(
-      "print_height"
-    , std::bind(&t_command_parser_executor::print_height, &m_parser, p::_1)
-    , "Print local blockchain height"
-    );
+      "print_block",
+      std::bind(&t_command_parser_executor::print_block, &m_parser, p::_1),
+      "print_block (<block_hash> | <block_height>)",
+      "Prints the block having the specified <block_hash> or <block_height>."
+  );
   m_command_lookup.set_handler(
-      "print_pl"
-    , std::bind(&t_command_parser_executor::print_peer_list, &m_parser, p::_1)
-    , "Print peer list"
-    );
+      "is_key_image_spent",
+      std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1),
+      "is_key_image_spent <key_image>",
+      "Prints whether a given key image is in the spent key images set."
+  );
   m_command_lookup.set_handler(
-      "print_pl_stats"
-    , std::bind(&t_command_parser_executor::print_peer_list_stats, &m_parser, p::_1)
-    , "Print peer list stats"
-    );
+      "start_mining",
+      std::bind(&t_command_parser_executor::start_mining, &m_parser, p::_1),
+      "start_mining <addr> [<threads>] [do_background_mining] [ignore_battery]",
+      "Starts mining for a specified address with for default 1 thread and no background mining."
+  );
   m_command_lookup.set_handler(
-      "print_cn"
-    , std::bind(&t_command_parser_executor::print_connections, &m_parser, p::_1)
-    , "Print connections"
-    );
+      "stop_mining",
+      std::bind(&t_command_parser_executor::stop_mining, &m_parser, p::_1),
+      "Stop mining."
+  );
   m_command_lookup.set_handler(
-      "print_bc"
-    , std::bind(&t_command_parser_executor::print_blockchain_info, &m_parser, p::_1)
-    , "Print blockchain info in a given blocks range, print_bc <begin_height> [<end_height>]"
-    );
+      "print_pool",
+      std::bind(&t_command_parser_executor::print_transaction_pool, &m_parser, p::_1),
+      "print_pool [long|stats]",
+      "Prints the transaction pool, optionally in a long format."
+  );
   m_command_lookup.set_handler(
-      "print_block"
-    , std::bind(&t_command_parser_executor::print_block, &m_parser, p::_1)
-    , "Print block, print_block <block_hash> | <block_height>"
-    );
+      "hashrate",
+      std::bind(&t_command_parser_executor::set_hash_rate_visibility, &m_parser, p::_1),
+      "hashrate (show|hide)",
+      "Start showing or hiding the hash rate."
+  );
   m_command_lookup.set_handler(
-      "print_tx"
-    , std::bind(&t_command_parser_executor::print_transaction, &m_parser, p::_1)
-    , "Print transaction, print_tx <transaction_hash> [+hex] [+json]"
-    );
+      "save",
+      std::bind(&t_command_parser_executor::save_blockchain, &m_parser, p::_1),
+      "Save blockchain."
+  );
   m_command_lookup.set_handler(
-      "is_key_image_spent"
-    , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
-    , "Prints whether a given key image is in the spent key images set, is_key_image_spent <key_image>"
-    );
+      "set_log",
+      std::bind(&t_command_parser_executor::set_log_level, &m_parser, p::_1),
+      "set_log (<level>|<{+,-,}categories>)",
+      "Change current log level/categories, <level> is a number 0-4."
+  );
   m_command_lookup.set_handler(
-      "start_mining"
-    , std::bind(&t_command_parser_executor::start_mining, &m_parser, p::_1)
-    , "Start mining for specified address, start_mining <addr> [<threads>] [do_background_mining] [ignore_battery], default 1 thread, no background mining"
-    );
+      "diff",
+      std::bind(&t_command_parser_executor::show_difficulty, &m_parser, p::_1),
+      "Show difficulty."
+  );
   m_command_lookup.set_handler(
-      "stop_mining"
-    , std::bind(&t_command_parser_executor::stop_mining, &m_parser, p::_1)
-    , "Stop mining"
-    );
+      "status",
+      std::bind(&t_command_parser_executor::show_status, &m_parser, p::_1),
+      "Show status"
+  );
   m_command_lookup.set_handler(
-      "print_pool"
-    , std::bind(&t_command_parser_executor::print_transaction_pool_long, &m_parser, p::_1)
-    , "Print transaction pool (long format)"
-    );
+      "exit",
+      std::bind(&t_command_parser_executor::stop_daemon, &m_parser, p::_1),
+      "Stops the daemon"
+  );
   m_command_lookup.set_handler(
-      "print_pool_sh"
-    , std::bind(&t_command_parser_executor::print_transaction_pool_short, &m_parser, p::_1)
-    , "Print transaction pool (short format)"
-    );
+      "print_status",
+      std::bind(&t_command_parser_executor::print_status, &m_parser, p::_1),
+      "Prints daemon status."
+  );
   m_command_lookup.set_handler(
-      "print_pool_stats"
-    , std::bind(&t_command_parser_executor::print_transaction_pool_stats, &m_parser, p::_1)
-    , "Print transaction pool statistics"
-    );
+      "limit",
+      std::bind(&t_command_parser_executor::set_limit, &m_parser, p::_1),
+      "limit [[up|down] <Kb/s>]",
+      "Gets the down- and upload limit. Optionally sets the download and/or upload limit to <Kb/s>."
+  );
   m_command_lookup.set_handler(
-      "show_hr"
-    , std::bind(&t_command_parser_executor::show_hash_rate, &m_parser, p::_1)
-    , "Start showing hash rate"
-    );
+      "out_peers",
+      std::bind(&t_command_parser_executor::out_peers, &m_parser, p::_1),
+      "out_peers <amount>",
+      "Set max number of out peers to <amount>."
+  );
   m_command_lookup.set_handler(
-      "hide_hr"
-    , std::bind(&t_command_parser_executor::hide_hash_rate, &m_parser, p::_1)
-    , "Stop showing hash rate"
-    );
+      "print_pl",
+      std::bind(&t_command_parser_executor::print_peer_list, &m_parser, p::_1),
+      "Prints the current peer list."
+  );
   m_command_lookup.set_handler(
-      "save"
-    , std::bind(&t_command_parser_executor::save_blockchain, &m_parser, p::_1)
-    , "Save blockchain"
-    );
+      "print_pl_stats",
+      std::bind(&t_command_parser_executor::print_peer_list_stats, &m_parser, p::_1),
+      "Prints the current peer list stats."
+  );
   m_command_lookup.set_handler(
-      "set_log"
-    , std::bind(&t_command_parser_executor::set_log_level, &m_parser, p::_1)
-    , "set_log <level>|<{+,-,}categories> - Change current log level/categories, <level> is a number 0-4"
-    );
+      "save_graph",
+      std::bind(&t_command_parser_executor::save_graph, &m_parser, p::_1),
+      "save_graph (start|stop)",
+      "Starts or stops to save data for dr monero."
+  );
   m_command_lookup.set_handler(
-      "diff"
-    , std::bind(&t_command_parser_executor::show_difficulty, &m_parser, p::_1)
-    , "Show difficulty"
-    );
+      "hard_fork_info",
+      std::bind(&t_command_parser_executor::hard_fork_info, &m_parser, p::_1),
+      "Prints the hard fork voting information"
+  );
   m_command_lookup.set_handler(
-      "status"
-    , std::bind(&t_command_parser_executor::show_status, &m_parser, p::_1)
-    , "Show status"
-    );
+      "bans",
+      std::bind(&t_command_parser_executor::show_bans, &m_parser, p::_1),
+      "Shows the currently banned IPs"
+  );
   m_command_lookup.set_handler(
-      "stop_daemon"
-    , std::bind(&t_command_parser_executor::stop_daemon, &m_parser, p::_1)
-    , "Stop the daemon"
-    );
+      "ban",
+      std::bind(&t_command_parser_executor::ban, &m_parser, p::_1),
+      "ban <ip> [<seconds>]",
+      "Bans a given IP. Optionnally for a given amount of seconds."
+  );
   m_command_lookup.set_handler(
-      "exit"
-    , std::bind(&t_command_parser_executor::stop_daemon, &m_parser, p::_1)
-    , "Stop the daemon"
-    );
+      "unban",
+      std::bind(&t_command_parser_executor::unban, &m_parser, p::_1),
+      "unban <ip>",
+      "Unbans a given IP"
+  );
   m_command_lookup.set_handler(
-      "print_status"
-    , std::bind(&t_command_parser_executor::print_status, &m_parser, p::_1)
-    , "Prints daemon status"
-    );
+      "flush_txpool",
+      std::bind(&t_command_parser_executor::flush_txpool, &m_parser, p::_1),
+      "flush_txpool [<txid>]",
+      "Flushes a transaction from the tx pool by its <txid>, or the whole tx pool."
+  );
   m_command_lookup.set_handler(
-      "limit"
-    , std::bind(&t_command_parser_executor::set_limit, &m_parser, p::_1)
-    , "limit <kB/s> - Set download and upload limit"
-    );
+      "output_histogram",
+      std::bind(&t_command_parser_executor::output_histogram, &m_parser, p::_1),
+      "Prints the output histogram (amount, instances)."
+  );
   m_command_lookup.set_handler(
-      "limit_up"
-    , std::bind(&t_command_parser_executor::set_limit_up, &m_parser, p::_1)
-    , "limit <kB/s> - Set upload limit"
-    );
+      "print_coinbase_tx_sum",
+      std::bind(&t_command_parser_executor::print_coinbase_tx_sum, &m_parser, p::_1),
+      "print_coinbase_tx_sum <start_height> [block_count]",
+      "Prints the sum of coinbase transactions from the <start_height> for a <block_count> amount."
+  );
   m_command_lookup.set_handler(
-      "limit_down"
-    , std::bind(&t_command_parser_executor::set_limit_down, &m_parser, p::_1)
-    , "limit <kB/s> - Set download limit"
-    );
-    m_command_lookup.set_handler(
-      "out_peers"
-    , std::bind(&t_command_parser_executor::out_peers, &m_parser, p::_1)
-    , "Set max number of out peers"
-    );
-    m_command_lookup.set_handler(
-      "start_save_graph"
-    , std::bind(&t_command_parser_executor::start_save_graph, &m_parser, p::_1)
-    , "Start save data for dr monero"
-    );
-    m_command_lookup.set_handler(
-      "stop_save_graph"
-    , std::bind(&t_command_parser_executor::stop_save_graph, &m_parser, p::_1)
-    , "Stop save data for dr monero"
-    );
-    m_command_lookup.set_handler(
-      "hard_fork_info"
-    , std::bind(&t_command_parser_executor::hard_fork_info, &m_parser, p::_1)
-    , "Print hard fork voting information"
-    );
-    m_command_lookup.set_handler(
-      "bans"
-    , std::bind(&t_command_parser_executor::show_bans, &m_parser, p::_1)
-    , "Show the currently banned IPs"
-    );
-    m_command_lookup.set_handler(
-      "ban"
-    , std::bind(&t_command_parser_executor::ban, &m_parser, p::_1)
-    , "Ban a given IP for a time"
-    );
-    m_command_lookup.set_handler(
-      "unban"
-    , std::bind(&t_command_parser_executor::unban, &m_parser, p::_1)
-    , "Unban a given IP"
-    );
-    m_command_lookup.set_handler(
-      "flush_txpool"
-    , std::bind(&t_command_parser_executor::flush_txpool, &m_parser, p::_1)
-    , "Flush a transaction from the tx pool by its txid, or the whole tx pool"
-    );
-    m_command_lookup.set_handler(
-      "output_histogram"
-    , std::bind(&t_command_parser_executor::output_histogram, &m_parser, p::_1)
-    , "Print output histogram (amount, instances)"
-    );
-    m_command_lookup.set_handler(
-      "print_coinbase_tx_sum"
-    , std::bind(&t_command_parser_executor::print_coinbase_tx_sum, &m_parser, p::_1)
-    , "Print sum of coinbase transactions <start height> [block count]"
-    );
-    m_command_lookup.set_handler(
-      "alt_chain_info"
-    , std::bind(&t_command_parser_executor::alt_chain_info, &m_parser, p::_1)
-    , "Print information about alternative chains"
-    );
-    m_command_lookup.set_handler(
-      "bc_dyn_stats"
-    , std::bind(&t_command_parser_executor::print_blockchain_dynamic_stats, &m_parser, p::_1)
-    , "Print information about current blockchain dynamic state, bc_dyn_stats <last n blocks>"
-    );
-    m_command_lookup.set_handler(
-      "update"
-    , std::bind(&t_command_parser_executor::update, &m_parser, p::_1)
-    , "subcommands: check (check if an update is available), download (download it if there is), update (not implemented)"
-    );
-    m_command_lookup.set_handler(
-      "relay_tx"
-    , std::bind(&t_command_parser_executor::relay_tx, &m_parser, p::_1)
-    , "Relay a given transaction by its txid"
-    );
-    m_command_lookup.set_handler(
-      "sync_info"
-    , std::bind(&t_command_parser_executor::sync_info, &m_parser, p::_1)
-    , "Print information about blockchain sync state"
-    );
+      "alt_chain_info",
+      std::bind(&t_command_parser_executor::alt_chain_info, &m_parser, p::_1),
+      "Prints the information about alternative chains."
+  );
+  m_command_lookup.set_handler(
+      "update [download]",
+      std::bind(&t_command_parser_executor::update, &m_parser, p::_1),
+      "Checks if an update is available, optionally downloads it if there is."
+  );
+  m_command_lookup.set_handler(
+      "relay_tx",
+      std::bind(&t_command_parser_executor::relay_tx, &m_parser, p::_1),
+      "relay_tx <txid>"
+      "Relays a given transaction by its <txid>."
+  );
+  m_command_lookup.set_handler(
+      "print_tx",
+      std::bind(&t_command_parser_executor::print_transaction, &m_parser, p::_1),
+      "print_tx <transaction_hash> [+hex] [+json]",
+      "Prints the transaction."
+  );
+  m_command_lookup.set_handler(
+      "sync_info",
+      std::bind(&t_command_parser_executor::sync_info, &m_parser, p::_1),
+      "Prints the information about blockchain sync state."
+  );
+  m_command_lookup.set_handler(
+      "bc_dyn_stats",
+      std::bind(&t_command_parser_executor::print_blockchain_dynamic_stats, &m_parser, p::_1),
+      "bc_dyn_stats <last_n_blocks>",
+      "Prints the information about current blockchain dynamic state."
+  );
+  m_command_lookup.set_handler(
+      "print_height",
+      std::bind(&t_command_parser_executor::print_height, &m_parser, p::_1),
+      "Prints the local blockchain height."
+  );
+  m_command_lookup.set_handler(
+      "print_bc",
+      std::bind(&t_command_parser_executor::print_blockchain_info, &m_parser, p::_1),
+      "print_bc <begin_height> [<end_height>]",
+      "Prints the blockchain's info in a given blocks range."
+  );
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)
@@ -291,22 +269,41 @@ void t_command_server::stop_handling()
   m_command_lookup.stop_handling();
 }
 
-bool t_command_server::help(const std::vector<std::string>& args)
+bool t_command_server::help(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  std::cout << get_commands_str() << std::endl;
-  return true;
+ if (args.size() != 1)
+   std::cout << get_commands_str();
+ else
+   std::cout << get_commands_desc(args[0]);
+ return true;
 }
 
-std::string t_command_server::get_commands_str()
+std::string t_command_server::get_commands_desc(const std::string &name)
 {
-  std::stringstream ss;
-  ss << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << std::endl;
-  ss << "Commands: " << std::endl;
-  std::string usage = m_command_lookup.get_usage();
-  boost::replace_all(usage, "\n", "\n  ");
-  usage.insert(0, "  ");
-  ss << usage << std::endl;
-  return ss.str();
+ std::string desc = m_command_lookup.get_cmd_description(name);
+ std::stringstream ss;
+ if (desc.empty()) {
+   ss << "Unknown command: " << name << ENDL;
+ } else {
+   std::string usage = m_command_lookup.get_cmd_usage(name);
+   boost::replace_all(desc, "\n", "\n  ");
+   desc.insert(0, "  ");
+   boost::replace_all(usage, "\n", "\n  ");
+   usage.insert(0, "  ");
+   ss << "Desription: " << ENDL << desc << ENDL << "Usage: " << ENDL << usage;
+ }
+ return ss.str();
+}
+
+std::string t_command_server::get_commands_str() {
+ std::stringstream ss;
+ ss << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << std::endl;
+ ss << "Commands: " << std::endl;
+ std::string usage = m_command_lookup.get_usage();
+ boost::replace_all(usage, "\n", "\n  ");
+ usage.insert(0, "  ");
+ ss << usage << std::endl;
+ return ss.str();
 }
 
 } // namespace daemonize

--- a/src/daemon/command_server.h
+++ b/src/daemon/command_server.h
@@ -71,7 +71,7 @@ public:
 
 private:
   bool help(const std::vector<std::string>& args);
-
+  std::string get_commands_desc(const std::string &name);
   std::string get_commands_str();
 };
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1757,7 +1757,7 @@ bool t_rpc_command_executor::update(const std::string &command)
   }
 
   tools::msg_writer() << "Update available: v" << res.version << ": " << res.user_uri << ", hash " << res.hash;
-  if (command == "check")
+  if (command.empty())
     return true;
 
   if (!res.path.empty())

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -77,6 +77,7 @@ namespace cryptonote
     //wallet *create_wallet();
     bool process_command(const std::vector<std::string> &args);
     std::string get_commands_str();
+    std::string get_commands_desc(const std::string& name);
   private:
     bool handle_command_line(const boost::program_options::variables_map& vm);
 
@@ -141,6 +142,7 @@ namespace cryptonote
     bool sweep_main(uint64_t below, const std::vector<std::string> &args);
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);
+    bool sweep_single(const std::vector<std::string> &args);
     bool sweep_unmixable(const std::vector<std::string> &args);
     bool donate(const std::vector<std::string> &args);
     bool sign_transfer(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -524,6 +524,7 @@ namespace tools
     std::vector<pending_tx> create_transactions(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, bool trusted_daemon);
     std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, bool trusted_daemon);     // pass subaddr_indices by value on purpose
     std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, bool trusted_daemon);
+    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, bool trusted_daemon);
     std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const uint64_t unlock_time, uint32_t priority, const std::vector<uint8_t>& extra, bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
     bool check_connection(uint32_t *version = NULL, uint32_t timeout = 200000);
@@ -610,14 +611,13 @@ namespace tools
       a & m_address_book;
       if(ver < 17)
         return;
-      if (ver < 21)
+      if (ver < 22)
       {
         // we're loading an old version, where m_unconfirmed_payments payload was payment_details
-        std::unordered_map<crypto::hash, payment_details> m;
+        std::unordered_multimap<crypto::hash, payment_details> m;
         a & m;
         for (const auto &i: m)
           m_unconfirmed_payments.insert(std::make_pair(i.first, pool_payment_details{i.second, false}));
-        return;
       }
       if(ver < 18)
         return;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -38,7 +38,6 @@ using namespace epee;
 #include "wallet/wallet_args.h"
 #include "common/command_line.h"
 #include "common/i18n.h"
-#include "common/scoped_message_writer.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/account.h"
 #include "wallet_rpc_server_commands_defs.h"
@@ -813,6 +812,101 @@ namespace tools
     }
     return true;
   }
+//------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_sweep_single(const wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::response& res, epee::json_rpc::error& er)
+  {
+    std::vector<cryptonote::tx_destination_entry> dsts;
+    std::vector<uint8_t> extra;
+
+    if (!m_wallet) return not_open(er);
+    if (m_wallet->restricted())
+    {
+      er.code = WALLET_RPC_ERROR_CODE_DENIED;
+      er.message = "Command unavailable in restricted mode.";
+      return false;
+    }
+
+    // validate the transfer requested and populate dsts & extra
+    std::list<wallet_rpc::transfer_destination> destination;
+    destination.push_back(wallet_rpc::transfer_destination());
+    destination.back().amount = 0;
+    destination.back().address = req.address;
+    if (!validate_transfer(destination, req.payment_id, dsts, extra, er))
+    {
+      return false;
+    }
+
+    crypto::key_image ki;
+    if (!epee::string_tools::hex_to_pod(req.key_image, ki))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
+      er.message = "failed to parse key image";
+      return false;
+    }
+
+    try
+    {
+      uint64_t mixin = m_wallet->adjust_mixin(req.mixin);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, mixin, req.unlock_time, req.priority, extra, m_trusted_daemon);
+
+      if (ptx_vector.empty())
+      {
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "No outputs found";
+        return false;
+      }
+      if (ptx_vector.size() > 1)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "Multiple transactions are created, which is not supposed to happen";
+        return false;
+      }
+      if (ptx_vector[0].selected_transfers.size() > 1)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "The transaction uses multiple inputs, which is not supposed to happen";
+        return false;
+      }
+
+      if (!req.do_not_relay)
+        m_wallet->commit_tx(ptx_vector);
+
+      // populate response with tx hashes
+      const wallet2::pending_tx &ptx = ptx_vector[0];
+      res.tx_hash = epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx));
+      if (req.get_tx_key)
+      {
+        res.tx_key = epee::string_tools::pod_to_hex(ptx.tx_key);
+      }
+      if (req.get_tx_hex)
+      {
+        cryptonote::blobdata blob;
+        tx_to_blob(ptx.tx, blob);
+        res.tx_blob = epee::string_tools::buff_to_hex_nodelimer(blob);
+      }
+
+      return true;
+    }
+    catch (const tools::error::daemon_busy& e)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_DAEMON_IS_BUSY;
+      er.message = e.what();
+      return false;
+    }
+    catch (const std::exception& e)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+      er.message = e.what();
+      return false;
+    }
+    catch (...)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR";
+      return false;
+    }
+    return true;
+  }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_make_integrated_address(const wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er)
   {
@@ -1069,6 +1163,7 @@ namespace tools
         rpc_transfers.tx_hash      = epee::string_tools::pod_to_hex(td.m_txid);
         rpc_transfers.tx_size      = txBlob.size();
         rpc_transfers.subaddr_index = td.m_subaddr_index.minor;
+        rpc_transfers.key_image    = req.verbose && td.m_key_image_known ? epee::string_tools::pod_to_hex(td.m_key_image) : "";
         res.transfers.push_back(rpc_transfers);
       }
     }
@@ -1982,7 +2077,7 @@ int main(int argc, char** argv) {
     "monero-wallet-rpc [--wallet-file=<file>|--generate-from-json=<file>|--wallet-dir=<directory>] [--rpc-bind-port=<port>]",
     desc_params,
     po::positional_options_description(),
-    [](const std::string &s, bool emphasis){ tools::scoped_message_writer(emphasis ? epee::console_color_white : epee::console_color_default, true) << s; },
+    [](const std::string &s, bool emphasis){ epee::set_console_color(emphasis ? epee::console_color_white : epee::console_color_default, true); std::cout << s << std::endl; if (emphasis) epee::reset_console_color(); },
     "monero-wallet-rpc.log",
     true
   );

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -79,6 +79,7 @@ namespace tools
         MAP_JON_RPC_WE("transfer_split",     on_transfer_split,     wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT)
         MAP_JON_RPC_WE("sweep_dust",         on_sweep_dust,         wallet_rpc::COMMAND_RPC_SWEEP_DUST)
         MAP_JON_RPC_WE("sweep_all",          on_sweep_all,          wallet_rpc::COMMAND_RPC_SWEEP_ALL)
+        MAP_JON_RPC_WE("sweep_single",       on_sweep_single,       wallet_rpc::COMMAND_RPC_SWEEP_SINGLE)
         MAP_JON_RPC_WE("store",              on_store,              wallet_rpc::COMMAND_RPC_STORE)
         MAP_JON_RPC_WE("get_payments",       on_get_payments,       wallet_rpc::COMMAND_RPC_GET_PAYMENTS)
         MAP_JON_RPC_WE("get_bulk_payments",  on_get_bulk_payments,  wallet_rpc::COMMAND_RPC_GET_BULK_PAYMENTS)
@@ -126,6 +127,7 @@ namespace tools
       bool on_transfer_split(const wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::request& req, wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::response& res, epee::json_rpc::error& er);
       bool on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er);
       bool on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er);
+      bool on_sweep_single(const wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::response& res, epee::json_rpc::error& er);
       bool on_make_integrated_address(const wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_split_integrated_address(const wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_store(const wallet_rpc::COMMAND_RPC_STORE::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res, epee::json_rpc::error& er);
@@ -165,7 +167,6 @@ namespace tools
       void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const tools::wallet2::unconfirmed_transfer_details &pd);
       void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &payment_id, const tools::wallet2::pool_payment_details &pd);
       bool not_open(epee::json_rpc::error& er);
-      uint64_t adjust_mixin(uint64_t mixin);
       void handle_rpc_exception(const std::exception_ptr& e, epee::json_rpc::error& er, int default_error_code);
 
       wallet2 *m_wallet;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -476,6 +476,49 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_SWEEP_SINGLE
+  {
+    struct request
+    {
+      std::string address;
+      uint32_t priority;
+      uint64_t mixin;
+      uint64_t unlock_time;
+      std::string payment_id;
+      bool get_tx_key;
+      std::string key_image;
+      bool do_not_relay;
+      bool get_tx_hex;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(address)
+        KV_SERIALIZE(priority)
+        KV_SERIALIZE(mixin)
+        KV_SERIALIZE(unlock_time)
+        KV_SERIALIZE(payment_id)
+        KV_SERIALIZE(get_tx_key)
+        KV_SERIALIZE(key_image)
+        KV_SERIALIZE_OPT(do_not_relay, false)
+        KV_SERIALIZE_OPT(get_tx_hex, false)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string tx_hash;
+      std::string tx_key;
+      uint64_t fee;
+      std::string tx_blob;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash)
+        KV_SERIALIZE(tx_key)
+        KV_SERIALIZE(fee)
+        KV_SERIALIZE(tx_blob)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_STORE
   {
     struct request
@@ -562,6 +605,7 @@ namespace wallet_rpc
     std::string tx_hash;
     uint64_t tx_size;
     uint32_t subaddr_index;
+    std::string key_image;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(amount)
@@ -570,6 +614,7 @@ namespace wallet_rpc
       KV_SERIALIZE(tx_hash)
       KV_SERIALIZE(tx_size)
       KV_SERIALIZE(subaddr_index)
+      KV_SERIALIZE(key_image)
     END_KV_SERIALIZE_MAP()
   };
 
@@ -580,11 +625,13 @@ namespace wallet_rpc
       std::string transfer_type;
       uint32_t account_index;
       std::set<uint32_t> subaddr_indices;
+      bool verbose;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(transfer_type)
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(subaddr_indices)
+        KV_SERIALIZE(verbose)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -74,13 +74,9 @@ namespace
   {
     size_t inlen = sizeof(source);
     int mdlen = (int)sizeof(md);
-    int ret = keccak(source, inlen, md, mdlen);
+    keccak(source, inlen, md, mdlen);
 
     if (md[0] != 0x00)
-    {
-        return true;
-    }
-    else if (!ret)
     {
         return true;
     }


### PR DESCRIPTION
Improved command naming of some commands:

- `start_save_graph`and `stop_save_graph` are now `save_graph (start|stop)`
- `limit [<Kb/s>]`, `limit_up <Kb/s>` and `limit_down <Kb/s> are now `limit [[up|down] <Kb/s>]`
- ...

Added a documentation section for commands reachable with `help [<command>]`.