### PR TITLE
RPC: CORS add Access-Control-Allow-Headers to OPTIONS preflight

### DIFF
--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -639,6 +639,9 @@ namespace net_utils
 				buf += "Access-Control-Allow-Origin: ";
 				buf += m_query_info.m_header_info.m_origin;
 				buf += "\r\n";
+				buf += "Access-Control-Expose-Headers: www-authenticate\r\n";
+				if (m_query_info.m_http_method == http::http_method_options)
+					buf += "Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With\r\n";
 				buf += "Access-Control-Allow-Methods: POST, PUT, GET, OPTIONS\r\n";
 			}
 		}


### PR DESCRIPTION
In #2723 I added CORS headers to the RPC server. I used cURL at the time to test it and based the implementation off of the spec but doing such I didn't realize in order for browsers to properly use this they'd need a few additional headers.

Upon further review though there are two required here [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) and [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers). The former is used for allowing the Authentication and X-Requested-With headers (with the latter of those often sent via ajax libraries). The latter is used to allow digest authentication via CORS as otherwise there's no way to access the contents of `www-authenticate` to build the subsequent request.

Sorry about that -- I have a local node test harness setup for it now in case we need to make further modifications. Had opted to use cURL originally as I was having issues using the digest authentication in my browser but by doing so I wasn't accurately reflecting the request headers that the browser sends in this case. Made a note to circle back and test this directly in the browser but I should have held off on the initial PR until I had done that as my testing wasn't representative of the true behavior here.