### PR TITLE
Add "Restart=always", "PrivateTmp=true" to monerod.service file.

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -14,5 +14,8 @@ PIDFile=/run/monero/monerod.pid
 ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf \
     --detach --pidfile /run/monero/monerod.pid
 
+Restart=always
+PrivateTmp=true
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The file needs some `Restart=`, there are a few possible arguments. None restart the service as reliably as `always`. With both `on-failure` and `on-abnormal` I've seen the service stuck in a failed state.

As for `PrivateTmp=true`, why not?

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=