### PR TITLE
Fixes #759 Add sanity check on restore height

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1588,7 +1588,17 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
     }
     if (m_restoring)
+    {
+      uint64_t estimate_height = m_wallet->estimate_blockchain_height();
+      if (m_restore_height >= estimate_height)
+      {
+        success_msg_writer() << tr("Restore height ") << m_restore_height << (" is not yet reached. The current estimated height is ") << estimate_height;
+        std::string confirm = input_line(tr("Still apply restore height?  (Y/Yes/N/No): "));
+        if (std::cin.eof() || command_line::is_no(confirm))
+          m_restore_height = 0;
+      }
       m_wallet->set_refresh_from_block_height(m_restore_height);
+    }
   }
   else
   {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2413,26 +2413,7 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const std::stri
 
   // try asking the daemon first
   if(m_refresh_from_block_height == 0 && !recover){
-    std::string err;
-    uint64_t height = 0;
-
-    // we get the max of approximated height and known height
-    // approximated height is the least of daemon target height
-    // (the max of what the other daemons are claiming is their
-    // height) and the theoretical height based on the local
-    // clock. This will be wrong only if both the local clock
-    // is bad *and* a peer daemon claims a highest height than
-    // the real chain.
-    // known height is the height the local daemon is currently
-    // synced to, it will be lower than the real chain height if
-    // the daemon is currently syncing.
-    height = get_approximate_blockchain_height();
-    uint64_t target_height = get_daemon_blockchain_target_height(err);
-    if (err.empty() && target_height < height)
-      height = target_height;
-    uint64_t local_height = get_daemon_blockchain_height(err);
-    if (err.empty() && local_height > height)
-      height = local_height;
+    uint64_t height = estimate_blockchain_height();
     m_refresh_from_block_height = height >= blocks_per_month ? height - blocks_per_month : 0;
   }
 
@@ -2450,6 +2431,38 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const std::stri
   store();
   return retval;
 }
+
+ uint64_t wallet2::estimate_blockchain_height()
+ {
+   // -1 month for fluctuations in block time and machine date/time setup.
+   // avg seconds per block
+   const int seconds_per_block = DIFFICULTY_TARGET_V2;
+   // ~num blocks per month
+   const uint64_t blocks_per_month = 60*60*24*30/seconds_per_block;
+
+   // try asking the daemon first
+   std::string err;
+   uint64_t height = 0;
+
+   // we get the max of approximated height and known height
+   // approximated height is the least of daemon target height
+   // (the max of what the other daemons are claiming is their
+   // height) and the theoretical height based on the local
+   // clock. This will be wrong only if both the local clock
+   // is bad *and* a peer daemon claims a highest height than
+   // the real chain.
+   // known height is the height the local daemon is currently
+   // synced to, it will be lower than the real chain height if
+   // the daemon is currently syncing.
+   height = get_approximate_blockchain_height();
+   uint64_t target_height = get_daemon_blockchain_target_height(err);
+   if (err.empty() && target_height < height)
+     height = target_height;
+   uint64_t local_height = get_daemon_blockchain_height(err);
+   if (err.empty() && local_height > height)
+     height = local_height;
+   return height;
+ }
 
 /*!
 * \brief Creates a watch only wallet from a public address and a view secret key.

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -709,6 +709,7 @@ namespace tools
     * \brief Calculates the approximate blockchain height from current date/time.
     */
     uint64_t get_approximate_blockchain_height() const;
+    uint64_t estimate_blockchain_height();
     std::vector<size_t> select_available_outputs_from_histogram(uint64_t count, bool atleast, bool unlocked, bool allow_rct, bool trusted_daemon);
     std::vector<size_t> select_available_outputs(const std::function<bool(const transfer_details &td)> &f);
     std::vector<size_t> select_available_unmixable_outputs(bool trusted_daemon);


### PR DESCRIPTION
Refactored the block height estimation and added a sanity check on the wallet's restoration height.