### PR TITLE
RPC: allow binding of restricted port in addition to core port

### DIFF
--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -47,35 +47,41 @@ public:
   }
 private:
   cryptonote::core_rpc_server m_server;
+  const std::string m_description;
 public:
   t_rpc(
       boost::program_options::variables_map const & vm
     , t_core & core
     , t_p2p & p2p
+    , const bool restricted
+    , const bool testnet
+    , const std::string & port
+    , const std::string & description
     )
-    : m_server{core.get(), p2p.get()}
+    : m_server{core.get(), p2p.get()}, m_description{description}
   {
-    MGINFO("Initializing core rpc server...");
-    if (!m_server.init(vm))
+    MGINFO("Initializing " << m_description << " rpc server...");
+
+    if (!m_server.init(vm, restricted, testnet, port))
     {
-      throw std::runtime_error("Failed to initialize core rpc server.");
+      throw std::runtime_error("Failed to initialize " + m_description + " rpc server.");
     }
-    MGINFO("Core rpc server initialized OK on port: " << m_server.get_binded_port());
+    MGINFO(m_description << " rpc server initialized OK on port: " << m_server.get_binded_port());
   }
 
   void run()
   {
-    MGINFO("Starting core rpc server...");
+    MGINFO("Starting " << m_description << " rpc server...");
     if (!m_server.run(2, false))
     {
-      throw std::runtime_error("Failed to start core rpc server.");
+      throw std::runtime_error("Failed to start " + m_description + " rpc server.");
     }
-    MGINFO("Core rpc server started ok");
+    MGINFO(m_description << " rpc server started ok");
   }
 
   void stop()
   {
-    MGINFO("Stopping core rpc server...");
+    MGINFO("Stopping " << m_description << " rpc server...");
     m_server.send_stop_signal();
     m_server.timed_wait_server_stop(5000);
   }
@@ -87,11 +93,11 @@ public:
 
   ~t_rpc()
   {
-    MGINFO("Deinitializing rpc server...");
+    MGINFO("Deinitializing " << m_description << " rpc server...");
     try {
       m_server.deinit();
     } catch (...) {
-      MERROR("Failed to deinitialize rpc server...");
+      MERROR("Failed to deinitialize " << m_description << " rpc server...");
     }
   }
 };

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -68,7 +68,9 @@ namespace cryptonote
   void core_rpc_server::init_options(boost::program_options::options_description& desc)
   {
     command_line::add_arg(desc, arg_rpc_bind_port);
+    command_line::add_arg(desc, arg_rpc_restricted_bind_port);
     command_line::add_arg(desc, arg_testnet_rpc_bind_port);
+    command_line::add_arg(desc, arg_testnet_rpc_restricted_bind_port);
     command_line::add_arg(desc, arg_restricted_rpc);
     cryptonote::rpc_args::init_options(desc);
   }
@@ -83,21 +85,21 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::init(
       const boost::program_options::variables_map& vm
+      , const bool restricted
+      , const bool testnet
+      , const std::string& port
     )
   {
-    m_testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
+    m_restricted = restricted;
+    m_testnet = testnet;
     m_net_server.set_threads_prefix("RPC");
-
-    auto p2p_bind_arg = m_testnet ? arg_testnet_rpc_bind_port : arg_rpc_bind_port;
 
     auto rpc_config = cryptonote::rpc_args::process(vm);
     if (!rpc_config)
       return false;
 
-    m_restricted = command_line::get_arg(vm, arg_restricted_rpc);
-
     boost::optional<epee::net_utils::http::login> http_login{};
-    std::string port = command_line::get_arg(vm, p2p_bind_arg);
+
     if (rpc_config->login)
       http_login.emplace(std::move(rpc_config->login->username), std::move(rpc_config->login->password).password());
 
@@ -1780,10 +1782,22 @@ namespace cryptonote
     , std::to_string(config::RPC_DEFAULT_PORT)
     };
 
+  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_restricted_bind_port = {
+      "rpc-restricted-bind-port"
+    , "Port for restricted RPC server"
+    , ""
+    };
+
   const command_line::arg_descriptor<std::string> core_rpc_server::arg_testnet_rpc_bind_port = {
       "testnet-rpc-bind-port"
     , "Port for testnet RPC server"
     , std::to_string(config::testnet::RPC_DEFAULT_PORT)
+    };
+
+  const command_line::arg_descriptor<std::string> core_rpc_server::arg_testnet_rpc_restricted_bind_port = {
+      "testnet-rpc-restricted-bind-port"
+    , "Port for testnet restricted RPC server"
+    , ""
     };
 
   const command_line::arg_descriptor<bool> core_rpc_server::arg_restricted_rpc = {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -53,7 +53,9 @@ namespace cryptonote
   public:
 
     static const command_line::arg_descriptor<std::string> arg_rpc_bind_port;
+    static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<std::string> arg_testnet_rpc_bind_port;
+    static const command_line::arg_descriptor<std::string> arg_testnet_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
 
     typedef epee::net_utils::connection_context_base connection_context;
@@ -65,7 +67,10 @@ namespace cryptonote
 
     static void init_options(boost::program_options::options_description& desc);
     bool init(
-        const boost::program_options::variables_map& vm
+        const boost::program_options::variables_map& vm,
+        const bool restricted,
+        const bool testnet,
+        const std::string& port
       );
     bool is_testnet() const { return m_testnet; }
 


### PR DESCRIPTION
This branch adds two new configuration options `--rpc-restricted-bind-port` and `--testnet-rpc-restricted-bind-port` which allow for a second port to be opened to handle RPC requests.

Let me know if this direction is unwise. I spent some time looking over the code and this was the approach that seemed most sensible to me but I'm still learning C++ so completely understand if I've done something asinine. Currently the login is the same across both but if there's value that could be split into a separate set of configuration arguments as well.

I was able to test this by using the `/getinfo` call across both and confirmed that `/get_peer_list` only works for the unrestricted. 

It's currently possible for someone to both set the core RPC port as restricted via `--restricted-rpc` and enable the restricted RPC port -- if it's worth it I can add something quickly to prevent that though.

ref: #835