### PR TITLE
fix for tx proof: use exception instead of error_str when signature gen failed

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3964,20 +3964,12 @@ bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)
 
   try
   {
-    std::string error_str;
-    std::string sig_str = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, args.size() == 3 ? args[2] : "", error_str);
-    if (sig_str.empty())
-    {
-      fail_msg_writer() << error_str;
-    }
+    std::string sig_str = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, args.size() == 3 ? args[2] : "");
+    const std::string filename = "monero_tx_proof";
+    if (epee::file_io_utils::save_string_to_file(filename, sig_str))
+      success_msg_writer() << tr("signature file saved to: ") << filename;
     else
-    {
-      const std::string filename = "monero_tx_proof";
-      if (epee::file_io_utils::save_string_to_file(filename, sig_str))
-        success_msg_writer() << tr("signature file saved to:") << filename;
-      else
-        fail_msg_writer() << tr("failed to save signature file");
-    }
+      fail_msg_writer() << tr("failed to save signature file");
   }
   catch (const std::exception &e)
   {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1467,7 +1467,7 @@ bool WalletImpl::checkTxKey(const std::string &txid_str, std::string tx_key_str,
     }
 }
 
-std::string WalletImpl::getTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message, std::string &error_str) const
+std::string WalletImpl::getTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message) const
 {
     crypto::hash txid;
     if (!epee::string_tools::hex_to_pod(txid_str, txid))
@@ -1488,7 +1488,7 @@ std::string WalletImpl::getTxProof(const std::string &txid_str, const std::strin
     try
     {
         m_status = Status_Ok;
-        return m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, message, error_str);
+        return m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, message);
     }
     catch (const std::exception &e)
     {

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -138,7 +138,7 @@ public:
     virtual std::string getUserNote(const std::string &txid) const;
     virtual std::string getTxKey(const std::string &txid) const;
     virtual bool checkTxKey(const std::string &txid, std::string tx_key, const std::string &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
-    virtual std::string getTxProof(const std::string &txid, const std::string &address, const std::string &message, std::string &error_str) const;
+    virtual std::string getTxProof(const std::string &txid, const std::string &address, const std::string &message) const;
     virtual bool checkTxProof(const std::string &txid, const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     virtual std::string signMessage(const std::string &message);
     virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6306,9 +6306,8 @@ void wallet2::check_tx_key_helper(const crypto::hash &txid, const crypto::key_de
   }
 }
 
-std::string wallet2::get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message, std::string &error_str)
+std::string wallet2::get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message)
 {
-  error_str = "";
   // determine if the address is found in the subaddress hash table (i.e. whether the proof is outbound or inbound)
   const bool is_out = m_subaddresses.count(address.m_spend_public_key) == 0;
 
@@ -6324,11 +6323,7 @@ std::string wallet2::get_tx_proof(const crypto::hash &txid, const cryptonote::ac
   {
     crypto::secret_key tx_key;
     std::vector<crypto::secret_key> additional_tx_keys;
-    if (!get_tx_key(txid, tx_key, additional_tx_keys))
-    {
-      error_str = tr("Tx secret key wasn't found in the wallet file.");
-      return {};
-    }
+    THROW_WALLET_EXCEPTION_IF(!get_tx_key(txid, tx_key, additional_tx_keys), error::wallet_internal_error, "Tx secret key wasn't found in the wallet file.");
 
     const size_t num_sigs = 1 + additional_tx_keys.size();
     shared_secret.resize(num_sigs);
@@ -6431,11 +6426,7 @@ std::string wallet2::get_tx_proof(const crypto::hash &txid, const cryptonote::ac
   bool in_pool;
   uint64_t confirmations;
   check_tx_key_helper(txid, derivation, additional_derivations, address, received, in_pool, confirmations);
-  if (!received)
-  {
-    error_str = tr("No funds received in this tx.");
-    return {};
-  }
+  THROW_WALLET_EXCEPTION_IF(!received, error::wallet_internal_error, tr("No funds received in this tx."));
 
   // concatenate all signature strings
   for (size_t i = 0; i < num_sigs; ++i)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -686,7 +686,7 @@ namespace tools
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const;
     void check_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     void check_tx_key_helper(const crypto::hash &txid, const crypto::key_derivation &derivation, const std::vector<crypto::key_derivation> &additional_derivations, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
-    std::string get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message, std::string &error_str);
+    std::string get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message);
     bool check_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message, const std::string &sig_str, uint64_t &received, bool &in_pool, uint64_t &confirmations);
 
    /*!

--- a/src/wallet/wallet2_api.h
+++ b/src/wallet/wallet2_api.h
@@ -701,7 +701,7 @@ struct Wallet
     virtual std::string getUserNote(const std::string &txid) const = 0;
     virtual std::string getTxKey(const std::string &txid) const = 0;
     virtual bool checkTxKey(const std::string &txid, std::string tx_key, const std::string &address, uint64_t &received, bool &in_pool, uint64_t &confirmations) = 0;
-    virtual std::string getTxProof(const std::string &txid, const std::string &address, const std::string &message, std::string &error_str) const = 0;
+    virtual std::string getTxProof(const std::string &txid, const std::string &address, const std::string &message) const = 0;
     virtual bool checkTxProof(const std::string &txid, const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &received, bool &in_pool, uint64_t &confirmations) = 0;
 
     /*

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1507,12 +1507,7 @@ namespace tools
 
     try
     {
-      res.signature = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, req.message, er.message);
-      if (res.signature.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        return false;
-      }
+      res.signature = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, req.message);
     }
     catch (const std::exception &e)
     {


### PR DESCRIPTION
Sorry for my carelessness, but I realized now that it's rather confusing to have two different ways of telling the caller about the halt of the process (C++ exception vs additional error string).