### PR TITLE
Fix failed linking in wallet_api tests while building without GUI

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -98,6 +98,7 @@ set_property(TARGET wallet_rpc_server
     OUTPUT_NAME "monero-wallet-rpc")
 install(TARGETS wallet_rpc_server DESTINATION bin)
 
+add_subdirectory(api)
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)
@@ -125,5 +126,4 @@ if (BUILD_GUI_DEPS)
     install(TARGETS wallet_merged
         ARCHIVE DESTINATION ${lib_folder})
 
-    add_subdirectory(api)
 endif()


### PR DESCRIPTION
Building from current master used to give me the following error (Ubuntu 16.04 LTS):

```
...
make[3]: Leaving directory '[project path]/build/release'
[ 97%] Built target daemon_rpc_server
make[3]: Entering directory '[project path]/build/release'
make[3]: Leaving directory '[project path]/build/release'
[100%] Built target daemon
/usr/bin/ld: cannot find -lwallet_api
collect2: error: ld returned 1 exit status
tests/libwallet_api_tests/CMakeFiles/libwallet_api_tests.dir/build.make:129: recipe for target 'tests/libwallet_api_tests/libwallet_api_tests' failed
make[3]: *** [tests/libwallet_api_tests/libwallet_api_tests] Error 1
make[3]: Leaving directory '[project path]/build/release'
CMakeFiles/Makefile2:3650: recipe for target 'tests/libwallet_api_tests/CMakeFiles/libwallet_api_tests.dir/all' failed
make[2]: *** [tests/libwallet_api_tests/CMakeFiles/libwallet_api_tests.dir/all] Error 2
make[2]: Leaving directory '[project path]/build/release'
Makefile:138: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '[project path]/build/release'
Makefile:62: recipe for target 'release-all' failed
make: *** [release-all] Error 2
```
Looking into this issue I noticed that since some recent changes (most likely since the commit 51895fd7df69ddb5d6bfe5c2caf2f6649cc43132 refactor) the `src/wallet/api` subfolder only seems to be included for linking when building the GUI as well. Hitherto I took out the include of this subfolder from the if clause, which caused the failed linking to work.

Feedback highly appreciated.