### PR TITLE
minor fix: correct usage of <type_traits> methods

### DIFF
--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -56,7 +56,7 @@ namespace epee
        derived-to-base conversions. This is NOT desireable because an array of
        derived types is not an array of base types. It is possible to handle
        this case, implement when/if needed. */
-    static_assert(!std::is_class<T>(), "no class types are currently allowed");
+    static_assert(!std::is_class<T>::value, "no class types are currently allowed");
   public:
     using value_type = T;
     using size_type = std::size_t;
@@ -108,7 +108,7 @@ namespace epee
   template<typename T>
   constexpr bool has_padding() noexcept
   {
-    return !std::is_pod<T>() || alignof(T) != 1;
+    return !std::is_pod<T>::value || alignof(T) != 1;
   }
 
   //! \return Cast data from `src` as `span<const std::uint8_t>`.
@@ -123,7 +123,7 @@ namespace epee
   template<typename T>
   span<const std::uint8_t> as_byte_span(const T& src) noexcept
   {
-    static_assert(!std::is_empty<T>(), "empty types will not work -> sizeof == 1");
+    static_assert(!std::is_empty<T>::value, "empty types will not work -> sizeof == 1");
     static_assert(!has_padding<T>(), "source type may have padding");
     return {reinterpret_cast<const std::uint8_t*>(std::addressof(src)), sizeof(T)};
   }

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -53,7 +53,7 @@ namespace
   void convert_numeric(Source source, Type& i)
   {
     static_assert(
-      (std::is_same<Type, char>() && std::is_same<Source, int>()) ||
+      (std::is_same<Type, char>::value && std::is_same<Source, int>::value) ||
       std::numeric_limits<Source>::is_signed == std::numeric_limits<Type>::is_signed,
       "comparisons below may have undefined behavior"
     );

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -110,7 +110,7 @@ struct PARSE_FAIL : public JSON_ERROR
 template<typename Type>
 inline constexpr bool is_to_hex()
 {
-  return std::is_pod<Type>() && !std::is_integral<Type>();
+  return std::is_pod<Type>::value && !std::is_integral<Type>::value;
 }
 
 

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -55,12 +55,12 @@ namespace
   bool can_construct()
   {
     const unsigned count =
-      unsigned(std::is_constructible<Destination, Source>()) +
-      unsigned(std::is_constructible<Destination, Source&>()) +
-      unsigned(std::is_convertible<Source, Destination>()) +
-      unsigned(std::is_convertible<Source&, Destination>()) +
-      unsigned(std::is_assignable<Destination, Source>()) +
-      unsigned(std::is_assignable<Destination, Source&>());
+      unsigned(std::is_constructible<Destination, Source>::value) +
+      unsigned(std::is_constructible<Destination, Source&>::value) +
+      unsigned(std::is_convertible<Source, Destination>::value) +
+      unsigned(std::is_convertible<Source&, Destination>::value) +
+      unsigned(std::is_assignable<Destination, Source>::value) +
+      unsigned(std::is_assignable<Destination, Source&>::value);
     EXPECT_TRUE(count == 6 || count == 0) <<
       "Mismatch on construction results - " << count << " were true";
     return count == 6; 
@@ -141,35 +141,35 @@ namespace
 
 TEST(Span, Traits)
 {
-  EXPECT_TRUE((std::is_same<std::size_t, typename epee::span<char>::size_type>()));
-  EXPECT_TRUE((std::is_same<std::ptrdiff_t, typename epee::span<char>::difference_type>()));
-  EXPECT_TRUE((std::is_same<char, typename epee::span<char>::value_type>()));
-  EXPECT_TRUE((std::is_same<char*, typename epee::span<char>::pointer>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<char>::const_pointer>()));
-  EXPECT_TRUE((std::is_same<char*, typename epee::span<char>::iterator>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<char>::const_iterator>()));
-  EXPECT_TRUE((std::is_same<char&, typename epee::span<char>::reference>()));
-  EXPECT_TRUE((std::is_same<const char&, typename epee::span<char>::const_reference>()));
+  EXPECT_TRUE((std::is_same<std::size_t, typename epee::span<char>::size_type>::value));
+  EXPECT_TRUE((std::is_same<std::ptrdiff_t, typename epee::span<char>::difference_type>::value));
+  EXPECT_TRUE((std::is_same<char, typename epee::span<char>::value_type>::value));
+  EXPECT_TRUE((std::is_same<char*, typename epee::span<char>::pointer>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<char>::const_pointer>::value));
+  EXPECT_TRUE((std::is_same<char*, typename epee::span<char>::iterator>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<char>::const_iterator>::value));
+  EXPECT_TRUE((std::is_same<char&, typename epee::span<char>::reference>::value));
+  EXPECT_TRUE((std::is_same<const char&, typename epee::span<char>::const_reference>::value));
 
-  EXPECT_TRUE((std::is_same<std::size_t, typename epee::span<const char>::size_type>()));
-  EXPECT_TRUE((std::is_same<std::ptrdiff_t, typename epee::span<const char>::difference_type>()));
-  EXPECT_TRUE((std::is_same<const char, typename epee::span<const char>::value_type>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::pointer>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::const_pointer>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::iterator>()));
-  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::const_iterator>()));
-  EXPECT_TRUE((std::is_same<const char&, typename epee::span<const char>::reference>()));
-  EXPECT_TRUE((std::is_same<const char&, typename epee::span<const char>::const_reference>()));
+  EXPECT_TRUE((std::is_same<std::size_t, typename epee::span<const char>::size_type>::value));
+  EXPECT_TRUE((std::is_same<std::ptrdiff_t, typename epee::span<const char>::difference_type>::value));
+  EXPECT_TRUE((std::is_same<const char, typename epee::span<const char>::value_type>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::pointer>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::const_pointer>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::iterator>::value));
+  EXPECT_TRUE((std::is_same<const char*, typename epee::span<const char>::const_iterator>::value));
+  EXPECT_TRUE((std::is_same<const char&, typename epee::span<const char>::reference>::value));
+  EXPECT_TRUE((std::is_same<const char&, typename epee::span<const char>::const_reference>::value));
 }
 
 TEST(Span, MutableConstruction)
 {
   struct no_conversion{};
 
-  EXPECT_TRUE(std::is_constructible<epee::span<char>>());
-  EXPECT_TRUE((std::is_constructible<epee::span<char>, char*, std::size_t>()));
-  EXPECT_FALSE((std::is_constructible<epee::span<char>, const char*, std::size_t>()));
-  EXPECT_FALSE((std::is_constructible<epee::span<char>, unsigned char*, std::size_t>()));
+  EXPECT_TRUE(std::is_constructible<epee::span<char>>::value);
+  EXPECT_TRUE((std::is_constructible<epee::span<char>, char*, std::size_t>::value));
+  EXPECT_FALSE((std::is_constructible<epee::span<char>, const char*, std::size_t>::value));
+  EXPECT_FALSE((std::is_constructible<epee::span<char>, unsigned char*, std::size_t>::value));
 
   EXPECT_TRUE((can_construct<epee::span<char>, std::nullptr_t>()));
   EXPECT_TRUE((can_construct<epee::span<char>, char(&)[1]>()));
@@ -193,10 +193,10 @@ TEST(Span, ImmutableConstruction)
 {
   struct no_conversion{};
 
-  EXPECT_TRUE(std::is_constructible<epee::span<const char>>());
-  EXPECT_TRUE((std::is_constructible<epee::span<const char>, char*, std::size_t>()));
-  EXPECT_TRUE((std::is_constructible<epee::span<const char>, const char*, std::size_t>()));
-  EXPECT_FALSE((std::is_constructible<epee::span<const char>, unsigned char*, std::size_t>()));
+  EXPECT_TRUE(std::is_constructible<epee::span<const char>>::value);
+  EXPECT_TRUE((std::is_constructible<epee::span<const char>, char*, std::size_t>::value));
+  EXPECT_TRUE((std::is_constructible<epee::span<const char>, const char*, std::size_t>::value));
+  EXPECT_FALSE((std::is_constructible<epee::span<const char>, unsigned char*, std::size_t>::value));
 
   EXPECT_FALSE((can_construct<epee::span<const char>, std::string>()));
   EXPECT_FALSE((can_construct<epee::span<const char>, std::vector<char>>()));
@@ -219,11 +219,11 @@ TEST(Span, ImmutableConstruction)
 
 TEST(Span, NoExcept)
 {
-  EXPECT_TRUE(std::is_nothrow_default_constructible<epee::span<char>>());
-  EXPECT_TRUE(std::is_nothrow_move_constructible<epee::span<char>>());
-  EXPECT_TRUE(std::is_nothrow_copy_constructible<epee::span<char>>());
-  EXPECT_TRUE(std::is_move_assignable<epee::span<char>>());
-  EXPECT_TRUE(std::is_copy_assignable<epee::span<char>>());
+  EXPECT_TRUE(std::is_nothrow_default_constructible<epee::span<char>>::value);
+  EXPECT_TRUE(std::is_nothrow_move_constructible<epee::span<char>>::value);
+  EXPECT_TRUE(std::is_nothrow_copy_constructible<epee::span<char>>::value);
+  EXPECT_TRUE(std::is_move_assignable<epee::span<char>>::value);
+  EXPECT_TRUE(std::is_copy_assignable<epee::span<char>>::value);
 
   char data[10];
   epee::span<char> lvalue(data);


### PR DESCRIPTION
AFAIK, methods in `<type_traits>` should be used as a static member data of a class template like
```c++
std::is_pod<T>::value
```
instead of as a function template like
```c++
std::is_pod<T>()
```
(I'm unsure if this is even conforming to the standard.)