### PR TITLE
Minor text edits for wallet creation

### DIFF
--- a/src/common/password.cpp
+++ b/src/common/password.cpp
@@ -178,7 +178,7 @@ namespace
         return false;
       if (verify)
       {
-        std::cout << "Confirm Password: ";
+        std::cout << "Confirm password: ";
         if (!read_from_tty(pass2))
           return false;
         if(pass1!=pass2)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1135,8 +1135,8 @@ bool simple_wallet::ask_wallet_create_if_needed()
  */
 void simple_wallet::print_seed(std::string seed)
 {
-  success_msg_writer(true) << "\n" << tr("PLEASE NOTE: the following 25 words can be used to recover access to your wallet. "
-    "Please write them down and store them somewhere safe and secure. Please do not store them in "
+  success_msg_writer(true) << "\n" << tr("NOTE: the following 25 words can be used to recover access to your wallet. "
+    "Write them down and store them somewhere safe and secure. Please do not store them in "
     "your email or on file storage services outside of your immediate control.\n");
   boost::replace_nth(seed, " ", 15, "\n");
   boost::replace_nth(seed, " ", 7, "\n");

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -568,7 +568,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
-        <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+        <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -576,7 +576,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
-        <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+        <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>VEUILLEZ NOTER : les 25 mots suivants peuvent être utilisés pour restaurer votre portefeuille. Veuillez les écrire sur papier et les garder dans un endroit sûr. Ne les gardez pas dans un courriel ou dans un service de stockage de fichiers hors de votre contrôle.
 </translation>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -578,7 +578,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
-        <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+        <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>ATTENZIONE: le seguenti 25 parole possono essere usate per ripristinare il tuo portafoglio. Scrivile e conservale da qualche parte al sicuro.</translation>
     </message>


### PR DESCRIPTION
1. Password capitalization normalization

2. Fewer pleases: Almost every sentence in the Note to write the seed down began with Please. The final commit removes all but one please. Note is now less awkward and more succinct.

![password](https://user-images.githubusercontent.com/21302237/33332803-3c57fab2-d433-11e7-92fe-aeda2d09b4ec.png)

![pleases](https://user-images.githubusercontent.com/21302237/33332809-3fce53b2-d433-11e7-9206-c7dcb3c1c610.png)
