### PR TITLE
fixed linking against libreadline on OpenBSD

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -68,3 +68,7 @@ main()
 if(NOT Readline_LIBRARY)
   set(Readline_LIBRARY "")
 endif()
+
+if(Readline_LIBRARY AND OPENBSD)
+  list(APPEND EXTRA_LIBRARIES curses)
+endif()


### PR DESCRIPTION
To fix the linking error described here https://github.com/monero-project/monero/pull/2841#issuecomment-346129030 we also need to link libcurses.