### PR TITLE
return subaddress in get_bulk_payments

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1128,6 +1128,7 @@ namespace tools
       {
         wallet_rpc::payment_details rpc_payment;
         rpc_payment.payment_id   = epee::string_tools::pod_to_hex(payment.first);
+        rpc_payment.subaddress   = m_wallet->get_subaddress_as_str(payment.second.m_subaddr_index);
         rpc_payment.tx_hash      = epee::string_tools::pod_to_hex(payment.second.m_tx_hash);
         rpc_payment.amount       = payment.second.m_amount;
         rpc_payment.block_height = payment.second.m_block_height;


### PR DESCRIPTION
It's only suggestion.

Why i want this? Because if I save subaddress in my database and I want to check if payment was made on this address and the only way to do this through rpc is query all adresses and find this address by subindex and this is very ineffective.

Sorry, I don't c++, but it's working here.
I don't know what rpc_payment data structure, only tested like this
`
rpc_payment.payment_id   = m_wallet->get_subaddress_as_str(payment.second.m_subaddr_index);
`