### PR TITLE
easylogging: show the 'no stack trace' warning only once

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -14,6 +14,7 @@
 //  http://muflihun.com
 //
 
+#define EASYLOGGING_CC
 #include "easylogging++.h"
 
 #if defined(AUTO_INITIALIZE_EASYLOGGINGPP)

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -203,16 +203,17 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #  if (ELPP_COMPILER_GCC && !ELPP_MINGW && !ELPP_OS_OPENBSD)
 #    define ELPP_STACKTRACE 1
 #  else
-#      define ELPP_STACKTRACE 0
-#      if ELPP_COMPILER_MSVC
-#         pragma message("Stack trace not available for this compiler")
-#      else
-#         warning "Stack trace not available for this compiler";
-#      endif  // ELPP_COMPILER_MSVC
 #    define ELPP_STACKTRACE 0
+#    ifdef EASYLOGGING_CC
+#      if ELPP_COMPILER_MSVC
+#        pragma message("Stack trace not available for this compiler")
+#      else
+#        warning "Stack trace not available for this compiler";
+#      endif  // ELPP_COMPILER_MSVC
+#    endif
 #  endif  // ELPP_COMPILER_GCC
 #else
-#    define ELPP_STACKTRACE 0
+#  define ELPP_STACKTRACE 0
 #endif  // (defined(ELPP_FEATURE_ALL)) || (defined(ELPP_FEATURE_CRASH_LOG))
 // Miscellaneous macros
 #define ELPP_UNUSED(x) (void)x


### PR DESCRIPTION
If execinfo.h is not available, output the stack trace warning only once, so we don't spam the build logs with it.