### PR TITLE
Dockerfile: add option to set build parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN apt-get update && \
 
 WORKDIR /src
 COPY . .
+
+ARG NPROC
 RUN rm -rf build && \
-    make -j$(nproc) release-static
+    if [ -z "$NPROC" ];then make -j$(nproc) release-static;else make -j$NPROC release-static;fi
 
 # runtime stage
 FROM ubuntu:16.04

--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ Installing a snap is very quick. Snaps are secure. They are isolated with all of
 
 * Docker
 
+        # Build using all available cores
         docker build -t monero .
+
+        # or build using a specific number of cores (reduce RAM requirement)
+        docker build --build-arg NPROC=1 -t monero .
      
         # either run in foreground
         docker run -it -v /monero/chain:/root/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero


### PR DESCRIPTION
Solution for #2865 

> docker build --build-arg NPROC=1 -t monero .