### PR TITLE
fix: bind RPC to all interfaces inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ VOLUME /wallet
 EXPOSE 18080
 EXPOSE 18081
 
-ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=127.0.0.1", "--rpc-bind-port=18081", "--non-interactive"] 
+ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"] 


### PR DESCRIPTION
Binding RPC to 127.0.0.1 makes no sense. Despite the fact port 18081 is
exposed, no one will be able to connect to the daemon.

RPC should be listening at all interfaces when running inside a Docker
container.