### PR TITLE
m_hardfork memory management cleanup in Blockchain

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -414,16 +414,6 @@ bool Blockchain::init(BlockchainDB* db, const bool testnet, const cryptonote::te
   return true;
 }
 //------------------------------------------------------------------
-bool Blockchain::init(BlockchainDB* db, HardFork*& hf, const bool testnet)
-{
-  if (hf != nullptr)
-    m_hardfork.reset(hf);
-  bool res = init(db, testnet, NULL);
-  if (hf == nullptr)
-    hf = m_hardfork.get();
-  return res;
-}
-//------------------------------------------------------------------
 bool Blockchain::store_blockchain()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -133,7 +133,7 @@ static const uint64_t testnet_hard_fork_version_1_till = 624633;
 
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
-  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_sz_limit(0),
+  m_db(), m_tx_pool(tx_pool), m_hardfork(nullptr), m_timestamps_and_difficulties_height(0), m_current_block_cumul_sz_limit(0),
   m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_blocks_per_sync(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_cancel(false)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
@@ -330,11 +330,11 @@ bool Blockchain::init(BlockchainDB* db, const bool testnet, const cryptonote::te
   if (m_hardfork == nullptr)
   {
     if (fakechain)
-      m_hardfork = new HardFork(*db, 1, 0);
+      m_hardfork.reset(new HardFork(*db, 1, 0));
     else if (m_testnet)
-      m_hardfork = new HardFork(*db, 1, testnet_hard_fork_version_1_till);
+      m_hardfork.reset(new HardFork(*db, 1, testnet_hard_fork_version_1_till));
     else
-      m_hardfork = new HardFork(*db, 1, mainnet_hard_fork_version_1_till);
+      m_hardfork.reset(new HardFork(*db, 1, mainnet_hard_fork_version_1_till));
   }
   if (fakechain)
   {
@@ -353,7 +353,7 @@ bool Blockchain::init(BlockchainDB* db, const bool testnet, const cryptonote::te
   }
   m_hardfork->init();
 
-  m_db->set_hard_fork(m_hardfork);
+  m_db->set_hard_fork(m_hardfork.get());
 
   // if the blockchain is new, add the genesis block
   // this feels kinda kludgy to do it this way, but can be looked at later.
@@ -417,10 +417,10 @@ bool Blockchain::init(BlockchainDB* db, const bool testnet, const cryptonote::te
 bool Blockchain::init(BlockchainDB* db, HardFork*& hf, const bool testnet)
 {
   if (hf != nullptr)
-    m_hardfork = hf;
+    m_hardfork.reset(hf);
   bool res = init(db, testnet, NULL);
   if (hf == nullptr)
-    hf = m_hardfork;
+    hf = m_hardfork.get();
   return res;
 }
 //------------------------------------------------------------------
@@ -487,7 +487,6 @@ bool Blockchain::deinit()
     LOG_ERROR("There was an issue closing/storing the blockchain, shutting down now to prevent issues!");
   }
 
-  delete m_hardfork;
   delete m_db;
   return true;
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -119,17 +119,6 @@ namespace cryptonote
     bool init(BlockchainDB* db, const bool testnet = false, const cryptonote::test_options *test_options = NULL);
 
     /**
-     * @brief Initialize the Blockchain state
-     *
-     * @param db a pointer to the backing store to use for the blockchain
-     * @param hf a structure containing hardfork information
-     * @param testnet true if on testnet, else false
-     *
-     * @return true on success, false if any initialization steps fail
-     */
-    bool init(BlockchainDB* db, HardFork*& hf, const bool testnet = false);
-
-    /**
      * @brief Uninitializes the blockchain state
      *
      * Saves to disk any state that needs to be maintained

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1024,7 +1024,7 @@ namespace cryptonote
     checkpoints m_checkpoints;
     bool m_enforce_dns_checkpoints;
 
-    HardFork *m_hardfork;
+    std::unique_ptr<HardFork> m_hardfork;
 
     bool m_testnet;
 


### PR DESCRIPTION
Two seemingly innocuous changes to learn github, learn git, and get my feet wet with the codebase.

I look forward to your feedback.

** 1st Commit **

After reviewing moneromooo-monero misc patches, I felt that it would be simpler to have explicit memory ownership of the HardFork object using a unique_ptr in the Blockchain object.

Using this pattern makes the memory ownership more obvious reading the code and utilizes RAII to remove the delete; ptr = NULL pattern.

** 2nd Commit **

I deleted an unused function that made me stumble when trekking through the code for the first time following the m_hardfork object. If there is a future plan for this interface please share it in the comments.