### PR TITLE
p2p: stop net server before closing starting connections

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -686,6 +686,10 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::send_stop_signal()
   {
+    MDEBUG("[node] sending stop signal");
+    m_net_server.send_stop_signal();
+    MDEBUG("[node] Stop signal sent");
+
     std::list<boost::uuids::uuid> connection_ids;
     m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt) {
       connection_ids.push_back(cntxt.m_connection_id);
@@ -695,8 +699,7 @@ namespace nodetool
       m_net_server.get_config_object().close(connection_id);
 
     m_payload_handler.stop();
-    m_net_server.send_stop_signal();
-    MDEBUG("[node] Stop signal sent");
+
     return true;
   }
   //-----------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a hang on exit due to race where a connection adds
itself to the server after the starting connections are closed,
but before the net server marks itself as stopped.