### PR TITLE
ringct: pseudoOuts moved to prunable in the simple bulletproof case

### DIFF
--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -299,7 +299,7 @@ namespace boost
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
-    if (x.type == rct::RCTTypeSimple || x.type == rct::RCTTypeSimpleBulletproof)
+    if (x.type == rct::RCTTypeSimple) // moved to prunable with bulletproofs
       a & x.pseudoOuts;
     a & x.ecdhInfo;
     serializeOutPk(a, x.outPk, ver);
@@ -313,6 +313,8 @@ namespace boost
     if (x.rangeSigs.empty())
       a & x.bulletproofs;
     a & x.MGs;
+    if (x.rangeSigs.empty())
+      a & x.pseudoOuts;
   }
 
   template <class Archive>
@@ -325,7 +327,7 @@ namespace boost
       throw boost::archive::archive_exception(boost::archive::archive_exception::other_exception, "Unsupported rct type");
     // a & x.message; message is not serialized, as it can be reconstructed from the tx data
     // a & x.mixRing; mixRing is not serialized, as it can be reconstructed from the offsets
-    if (x.type == rct::RCTTypeSimple || x.type == rct::RCTTypeSimpleBulletproof)
+    if (x.type == rct::RCTTypeSimple)
       a & x.pseudoOuts;
     a & x.ecdhInfo;
     serializeOutPk(a, x.outPk, ver);
@@ -335,6 +337,8 @@ namespace boost
     if (x.p.rangeSigs.empty())
       a & x.p.bulletproofs;
     a & x.p.MGs;
+    if (x.type == rct::RCTTypeSimpleBulletproof)
+      a & x.p.pseudoOuts;
   }
 }
 }

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -246,7 +246,7 @@ namespace rct {
           // inputs/outputs not saved, only here for serialization help
           // FIELD(message) - not serialized, it can be reconstructed
           // FIELD(mixRing) - not serialized, it can be reconstructed
-          if (type == RCTTypeSimple || type == RCTTypeSimpleBulletproof)
+          if (type == RCTTypeSimple) // moved to prunable with bulletproofs
           {
             ar.tag("pseudoOuts");
             ar.begin_array();
@@ -294,6 +294,7 @@ namespace rct {
         std::vector<rangeSig> rangeSigs;
         std::vector<Bulletproof> bulletproofs;
         std::vector<mgSig> MGs; // simple rct has N, full has 1
+        keyV pseudoOuts; //C - for simple rct
 
         template<bool W, template <bool> class Archive>
         bool serialize_rctsig_prunable(Archive<W> &ar, uint8_t type, size_t inputs, size_t outputs, size_t mixin)
@@ -381,6 +382,21 @@ namespace rct {
                ar.delimit_array();
           }
           ar.end_array();
+          if (type == RCTTypeSimpleBulletproof)
+          {
+            ar.tag("pseudoOuts");
+            ar.begin_array();
+            PREPARE_CUSTOM_VECTOR_SERIALIZATION(inputs, pseudoOuts);
+            if (pseudoOuts.size() != inputs)
+              return false;
+            for (size_t i = 0; i < inputs; ++i)
+            {
+              FIELDS(pseudoOuts[i])
+              if (inputs - i > 1)
+                ar.delimit_array();
+            }
+            ar.end_array();
+          }
           return true;
         }
 


### PR DESCRIPTION
Saves 64 bytes non prunable data per typical tx

This breaks v7 consensus, will require a testnet reorg from v6