### PR TITLE
unit_tests: fix memwipe test comparison

### DIFF
--- a/tests/unit_tests/memwipe.cpp
+++ b/tests/unit_tests/memwipe.cpp
@@ -47,7 +47,7 @@ static void test(bool wipe)
   if ((intptr_t)quux == foop)
   {
     MDEBUG(std::hex << std::setw(8) << std::setfill('0') << *(uint32_t*)quux);
-    if (wipe) ASSERT_TRUE(!memcmp(quux, "\0\0\0", 3));
+    if (wipe) ASSERT_TRUE(memcmp(quux, "bar", 3));
   }
   else MWARNING("We did not get the same location, cannot check");
   free(quux);


### PR DESCRIPTION
free might overwrite the memory, so we can't expect to see
the NULs we overwrote with, but at least we shouldn't see
the original data.