### PR TITLE
Better use of definite article

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2027,11 +2027,11 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   success_msg_writer() <<
     "**********************************************************************\n" <<
     tr("Your wallet has been generated!\n"
-    "To start synchronizing with the daemon, use \"refresh\" command.\n"
-    "Use \"help\" command to see the list of available commands.\n"
+    "To start synchronizing with the daemon, use the \"refresh\" command.\n"
+    "Use the \"help\" command to see the list of available commands.\n"
     "Use \"help <command>\" to see a command's documentation.\n"
-    "Always use \"exit\" command when closing monero-wallet-cli to save your\n"
-    "current session's state. Otherwise, you might need to synchronize \n"
+    "Always use the \"exit\" command when closing monero-wallet-cli to save \n"
+    "your current session's state. Otherwise, you might need to synchronize \n"
     "your wallet again (your wallet keys are NOT at risk in any case).\n")
   ;
 
@@ -2148,7 +2148,7 @@ bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
   }
   success_msg_writer() <<
     "**********************************************************************\n" <<
-    tr("Use \"help\" command to see the list of available commands.\n") <<
+    tr("Use the \"help\" command to see the list of available commands.\n") <<
     tr("Use \"help <command>\" to see a command's documentation.\n") <<
     "**********************************************************************";
   return true;

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -654,7 +654,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
-        <source>Use &quot;help&quot; command to see the list of available commands.
+        <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1624,10 +1624,10 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
         <source>Your wallet has been generated!
-To start synchronizing with the daemon, use &quot;refresh&quot; command.
-Use &quot;help&quot; command to see the list of available commands.
-Always use &quot;exit&quot; command when closing monero-wallet-cli to save your
-current session&apos;s state. Otherwise, you might need to synchronize 
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
 your wallet again (your wallet keys are NOT at risk in any case).
 </source>
         <translation type="unfinished"></translation>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -666,7 +666,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
-        <source>Use &quot;help&quot; command to see the list of available commands.
+        <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Utilisez la commande &quot;help&quot; pour voir la liste des commandes disponibles.
 </translation>
@@ -1656,10 +1656,10 @@ Attention : Certaines clés d&apos;entrées étant dépensées sont issues de <
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
         <source>Your wallet has been generated!
-To start synchronizing with the daemon, use &quot;refresh&quot; command.
-Use &quot;help&quot; command to see the list of available commands.
-Always use &quot;exit&quot; command when closing monero-wallet-cli to save your
-current session&apos;s state. Otherwise, you might need to synchronize 
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
 your wallet again (your wallet keys are NOT at risk in any case).
 </source>
         <translation>Votre portefeuille a été généré !

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -654,7 +654,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
-        <source>Use &quot;help&quot; command to see the list of available commands.
+        <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Usa il comando &quot;help&quot; per visualizzare la lista dei comandi disponibili.</translation>
     </message>
@@ -1620,10 +1620,10 @@ Avviso: alcune chiavi di input spese vengono da </translation>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
         <source>Your wallet has been generated!
-To start synchronizing with the daemon, use &quot;refresh&quot; command.
-Use &quot;help&quot; command to see the list of available commands.
-Always use &quot;exit&quot; command when closing monero-wallet-cli to save your
-current session&apos;s state. Otherwise, you might need to synchronize 
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
 your wallet again (your wallet keys are NOT at risk in any case).
 </source>
         <translation>Il tuo portafoglio è stato generato!


### PR DESCRIPTION
A bunch of CLI text should probably have the definite article "the" preceding a specific command.