### PR TITLE
wallet: support for multisig seeds

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -92,6 +92,8 @@ namespace cryptonote
         bool recover, bool two_random, const std::string &old_language);
     bool new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
+    bool new_wallet(const boost::program_options::variables_map& vm,
+        const std::string &multisig_keys, const std::string &old_language);
     bool open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
 
@@ -305,6 +307,7 @@ namespace cryptonote
 
     crypto::secret_key m_recovery_key;  // recovery key (used as random for wallet gen)
     bool m_restore_deterministic_wallet;  // recover flag
+    bool m_restore_multisig_wallet;  // recover flag
     bool m_non_deterministic;  // old 2-random generation
     bool m_trusted_daemon;
     bool m_allow_mismatched_daemon_version;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -436,6 +436,15 @@ namespace tools
     typedef std::tuple<uint64_t, crypto::public_key, rct::key> get_outs_entry;
 
     /*!
+     * \brief  Generates a wallet or restores one.
+     * \param  wallet_        Name of wallet file
+     * \param  password       Password of wallet file
+     * \param  multisig_data  The multisig restore info and keys
+     */
+    void generate(const std::string& wallet_, const epee::wipeable_string& password,
+      const std::string& multisig_data);
+
+    /*!
      * \brief Generates a wallet or restores one.
      * \param  wallet_        Name of wallet file
      * \param  password       Password of wallet file
@@ -610,6 +619,7 @@ namespace tools
     bool watch_only() const { return m_watch_only; }
     bool multisig(bool *ready = NULL, uint32_t *threshold = NULL, uint32_t *total = NULL) const;
     bool has_multisig_partial_key_images() const;
+    bool get_multisig_seed(std::string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
 
     // locked & unlocked balance of given or current subaddress account
     uint64_t balance(uint32_t subaddr_index_major) const;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -60,6 +60,7 @@ namespace tools
     //       file_save_error
     //       invalid_password
     //       invalid_priority
+    //       invalid_multisig_seed
     //       refresh_error *
     //         acc_outs_lookup_error
     //         block_parse_error
@@ -260,6 +261,16 @@ namespace tools
     {
       explicit invalid_priority(std::string&& loc)
         : wallet_logic_error(std::move(loc), "invalid priority")
+      {
+      }
+
+      std::string to_string() const { return wallet_logic_error::to_string(); }
+    };
+
+    struct invalid_multisig_seed : public wallet_logic_error
+    {
+      explicit invalid_multisig_seed(std::string&& loc)
+        : wallet_logic_error(std::move(loc), "invalid multisig seed")
       {
       }
 


### PR DESCRIPTION
They are hex rather than words, because they are a lot longer
than "normal" seeds, as they have to embed a lot more information