### PR TITLE
Remove is_pod trait

### DIFF
--- a/contrib/epee/include/memwipe.h
+++ b/contrib/epee/include/memwipe.h
@@ -67,18 +67,14 @@ namespace tools {
     }
   };
 
+  template<typename T>
+  T& unwrap(scrubbed<T>& src) { return src; }
+
+  template<typename T>
+  const T& unwrap(scrubbed<T> const& src) { return src; }
+
   template <class T, size_t N>
   using scrubbed_arr = scrubbed<std::array<T, N>>;
 } // namespace tools
-
-// Partial specialization for std::is_pod<tools::scrubbed<T>> so that it can
-// pretend to be the containted type in those contexts.
-namespace std
-{
-  template<class t_scrubbee>
-  struct is_pod<tools::scrubbed<t_scrubbee>> {
-    static const bool value = is_pod<t_scrubbee>::value;
-  };
-}
 
 #endif // __cplusplus

--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -108,7 +108,7 @@ namespace epee
   template<typename T>
   constexpr bool has_padding() noexcept
   {
-    return !std::is_pod<T>::value || alignof(T) != 1;
+    return !std::is_standard_layout<T>() || alignof(T) != 1;
   }
 
   //! \return Cast data from `src` as `span<const std::uint8_t>`.

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -45,6 +45,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include "hex.h"
+#include "memwipe.h"
 #include "span.h"
 #include "warnings.h"
 
@@ -330,7 +331,7 @@ POP_WARNINGS
   template<class t_pod_type>
   std::string pod_to_hex(const t_pod_type& s)
   {
-    static_assert(std::is_pod<t_pod_type>::value, "expected pod type");
+    static_assert(std::is_standard_layout<t_pod_type>(), "expected standard layout type");
     return to_hex::string(as_byte_span(s));
   }
   //----------------------------------------------------------------------------
@@ -349,6 +350,12 @@ POP_WARNINGS
 
     s = *(t_pod_type*)bin_buff.data();
     return true;
+  }
+  //----------------------------------------------------------------------------
+  template<class t_pod_type>
+  bool hex_to_pod(const std::string& hex_str, tools::scrubbed<t_pod_type>& s)
+  {
+    return hex_to_pod(hex_str, unwrap(s));
   }
   //----------------------------------------------------------------------------
   bool validate_hex(uint64_t length, const std::string& str);


### PR DESCRIPTION
Specializing a trait to lie about the properties of a class is probably a bad idea. Instead, the requirements for hex conversion were relaxed to `is_standard_layout`. Microsoft has a decent [writeup of the traits](https://msdn.microsoft.com/en-us/library/mt767760.aspx). Although, the writeup never mentions that `is_standard_layout` must be contiguous (i.e. no vtables).