### PR TITLE
Don't lie about scrubbed<T> being a POD type.

### DIFF
--- a/src/common/memwipe.h
+++ b/src/common/memwipe.h
@@ -57,6 +57,9 @@ namespace tools {
       scrub();
     }
 
+    T& inner() { return *this; }
+    const T& inner() const { return *this; }
+
     /// Destroy the contents of the contained type.
     void scrub() {
       static_assert(std::is_pod<T>::value,
@@ -70,15 +73,5 @@ namespace tools {
   template <class T, size_t N>
   using scrubbed_arr = scrubbed<std::array<T, N>>;
 } // namespace tools
-
-// Partial specialization for std::is_pod<tools::scrubbed<T>> so that it can
-// pretend to be the containted type in those contexts.
-namespace std
-{
-  template<class t_scrubbee>
-  struct is_pod<tools::scrubbed<t_scrubbee>> {
-    static const bool value = is_pod<t_scrubbee>::value;
-  };
-}
 
 #endif // __cplusplus

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -267,7 +267,7 @@ namespace crypto {
     epee::to_hex::formatted(o, epee::as_byte_span(v)); return o;
   }
   inline std::ostream &operator <<(std::ostream &o, const crypto::secret_key &v) {
-    epee::to_hex::formatted(o, epee::as_byte_span(v)); return o;
+    epee::to_hex::formatted(o, epee::as_byte_span(v.inner())); return o;
   }
   inline std::ostream &operator <<(std::ostream &o, const crypto::key_derivation &v) {
     epee::to_hex::formatted(o, epee::as_byte_span(v)); return o;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -492,7 +492,7 @@ bool simple_wallet::viewkey(const std::vector<std::string> &args/* = std::vector
 {
   if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   // don't log
-  std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key) << std::endl;
+  std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key.inner()) << std::endl;
   std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_view_public_key) << std::endl;
 
   return true;
@@ -507,7 +507,7 @@ bool simple_wallet::spendkey(const std::vector<std::string> &args/* = std::vecto
   }
   if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   // don't log
-  std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_spend_secret_key) << std::endl;
+  std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_spend_secret_key.inner()) << std::endl;
   std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_spend_public_key) << std::endl;
 
   return true;
@@ -2099,7 +2099,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         fail_msg_writer() << tr("No data supplied, cancelled");
         return false;
       }
-      if (!epee::string_tools::hex_to_pod(spendkey_string, m_recovery_key))
+      if (!epee::string_tools::hex_to_pod(spendkey_string, m_recovery_key.inner()))
       {
         fail_msg_writer() << tr("failed to parse spend key secret key");
         return false;
@@ -2614,7 +2614,7 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     recovery_val = m_wallet->generate(m_wallet_file, std::move(rc.second).password(), recovery_key, recover, two_random);
     message_writer(console_color_white, true) << tr("Generated new wallet: ")
       << m_wallet->get_account().get_public_address_str(m_wallet->testnet());
-    std::cout << tr("View key: ") << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key) << ENDL;
+    std::cout << tr("View key: ") << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key.inner()) << ENDL;
   }
   catch (const std::exception& e)
   {
@@ -4774,9 +4774,9 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
   if (m_wallet->get_tx_key(txid, tx_key, additional_tx_keys))
   {
     ostringstream oss;
-    oss << epee::string_tools::pod_to_hex(tx_key);
+    oss << epee::string_tools::pod_to_hex(tx_key.inner());
     for (size_t i = 0; i < additional_tx_keys.size(); ++i)
-      oss << epee::string_tools::pod_to_hex(additional_tx_keys[i]);
+      oss << epee::string_tools::pod_to_hex(additional_tx_keys[i].inner());
     success_msg_writer() << tr("Tx key: ") << oss.str();
     return true;
   }
@@ -4853,7 +4853,7 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
 
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_keys;
-  if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), tx_key))
+  if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), tx_key.inner()))
   {
     fail_msg_writer() << tr("failed to parse tx key");
     return true;
@@ -4862,7 +4862,7 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
   while (!local_args[1].empty())
   {
     additional_tx_keys.resize(additional_tx_keys.size() + 1);
-    if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), additional_tx_keys.back()))
+    if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), additional_tx_keys.back().inner()))
     {
       fail_msg_writer() << tr("failed to parse tx key");
       return true;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4074,7 +4074,7 @@ void wallet2::commit_tx(pending_tx& ptx)
     cryptonote::COMMAND_RPC_SUBMIT_RAW_TX::request oreq;
     cryptonote::COMMAND_RPC_SUBMIT_RAW_TX::response ores;
     oreq.address = get_account().get_public_address_str(m_testnet);
-    oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+    oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
     oreq.tx = epee::string_tools::buff_to_hex_nodelimer(tx_to_blob(ptx.tx));
     m_daemon_rpc_mutex.lock();
     bool r = epee::net_utils::invoke_http_json("/submit_raw_tx", oreq, ores, m_http_client, rpc_timeout, "POST");
@@ -5817,7 +5817,7 @@ bool wallet2::light_wallet_login(bool &new_address)
   cryptonote::COMMAND_RPC_LOGIN::request request;
   cryptonote::COMMAND_RPC_LOGIN::response response;
   request.address = get_account().get_public_address_str(m_testnet);
-  request.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+  request.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
   // Always create account if it doesnt exist.
   request.create_account = true;
   m_daemon_rpc_mutex.lock();
@@ -5844,7 +5844,7 @@ bool wallet2::light_wallet_import_wallet_request(cryptonote::COMMAND_RPC_IMPORT_
   MDEBUG("Light wallet import wallet request");
   cryptonote::COMMAND_RPC_IMPORT_WALLET_REQUEST::request oreq;
   oreq.address = get_account().get_public_address_str(m_testnet);
-  oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+  oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
   m_daemon_rpc_mutex.lock();
   bool r = epee::net_utils::invoke_http_json("/import_wallet_request", oreq, response, m_http_client, rpc_timeout, "POST");
   m_daemon_rpc_mutex.unlock();
@@ -5863,7 +5863,7 @@ void wallet2::light_wallet_get_unspent_outs()
   
   oreq.amount = "0";
   oreq.address = get_account().get_public_address_str(m_testnet);
-  oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+  oreq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
   // openMonero specific
   oreq.dust_threshold = boost::lexical_cast<std::string>(::config::DEFAULT_DUST_THRESHOLD);
   // below are required by openMonero api - but are not used.
@@ -6012,7 +6012,7 @@ bool wallet2::light_wallet_get_address_info(cryptonote::COMMAND_RPC_GET_ADDRESS_
   cryptonote::COMMAND_RPC_GET_ADDRESS_INFO::request request;
   
   request.address = get_account().get_public_address_str(m_testnet);
-  request.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+  request.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
   m_daemon_rpc_mutex.lock();
   bool r = epee::net_utils::invoke_http_json("/get_address_info", request, response, m_http_client, rpc_timeout, "POST");
   m_daemon_rpc_mutex.unlock();
@@ -6029,7 +6029,7 @@ void wallet2::light_wallet_get_address_txs()
   cryptonote::COMMAND_RPC_GET_ADDRESS_TXS::response ires;
   
   ireq.address = get_account().get_public_address_str(m_testnet);
-  ireq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key);
+  ireq.view_key = string_tools::pod_to_hex(get_account().get_keys().m_view_secret_key.inner());
   m_daemon_rpc_mutex.lock();
   bool r = epee::net_utils::invoke_http_json("/get_address_txs", ireq, ires, m_http_client, rpc_timeout, "POST");
   m_daemon_rpc_mutex.unlock();

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -612,9 +612,9 @@ namespace tools
 
       if (req.get_tx_key)
       {
-        res.tx_key = epee::string_tools::pod_to_hex(ptx_vector.back().tx_key);
+        res.tx_key = epee::string_tools::pod_to_hex(ptx_vector.back().tx_key.inner());
         for (const crypto::secret_key& additional_tx_key : ptx_vector.back().additional_tx_keys)
-          res.tx_key += epee::string_tools::pod_to_hex(additional_tx_key);
+          res.tx_key += epee::string_tools::pod_to_hex(additional_tx_key.inner());
       }
       res.fee = ptx_vector.back().fee;
 
@@ -702,9 +702,9 @@ namespace tools
       {
         if (req.get_tx_keys)
         {
-          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key));
+          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key.inner()));
           for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys)
-            res.tx_key_list.back() += epee::string_tools::pod_to_hex(additional_tx_key);
+            res.tx_key_list.back() += epee::string_tools::pod_to_hex(additional_tx_key.inner());
         }
         // Compute amount leaving wallet in tx. By convention dests does not include change outputs
         ptx_amount = 0;
@@ -794,7 +794,7 @@ namespace tools
       {
         if (req.get_tx_keys)
         {
-          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key));
+          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key.inner()));
         }
         res.fee_list.push_back(ptx.fee);
       }
@@ -894,7 +894,7 @@ namespace tools
       {
         if (req.get_tx_keys)
         {
-          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key));
+          res.tx_key_list.push_back(epee::string_tools::pod_to_hex(ptx.tx_key.inner()));
         }
       }
 
@@ -1019,7 +1019,7 @@ namespace tools
 
       if (req.get_tx_key)
       {
-        res.tx_key = epee::string_tools::pod_to_hex(ptx.tx_key);
+        res.tx_key = epee::string_tools::pod_to_hex(ptx.tx_key.inner());
       }
 
       if (m_wallet->multisig())
@@ -1410,7 +1410,7 @@ namespace tools
       }
       else if(req.key_type.compare("view_key") == 0)
       {
-          res.key = string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key);
+          res.key = string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key.inner());
       }
       else
       {
@@ -1637,9 +1637,9 @@ namespace tools
     }
 
     std::ostringstream oss;
-    oss << epee::string_tools::pod_to_hex(tx_key);
+    oss << epee::string_tools::pod_to_hex(tx_key.inner());
     for (size_t i = 0; i < additional_tx_keys.size(); ++i)
-      oss << epee::string_tools::pod_to_hex(additional_tx_keys[i]);
+      oss << epee::string_tools::pod_to_hex(additional_tx_keys[i].inner());
     res.tx_key = oss.str();
     return true;
   }
@@ -1658,7 +1658,7 @@ namespace tools
 
     std::string tx_key_str = req.tx_key;
     crypto::secret_key tx_key;
-    if (!epee::string_tools::hex_to_pod(tx_key_str.substr(0, 64), tx_key))
+    if (!epee::string_tools::hex_to_pod(tx_key_str.substr(0, 64), tx_key.inner()))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY;
       er.message = "Tx key has invalid format";
@@ -1669,7 +1669,7 @@ namespace tools
     while (!tx_key_str.empty())
     {
       additional_tx_keys.resize(additional_tx_keys.size() + 1);
-      if (!epee::string_tools::hex_to_pod(tx_key_str.substr(0, 64), additional_tx_keys.back()))
+      if (!epee::string_tools::hex_to_pod(tx_key_str.substr(0, 64), additional_tx_keys.back().inner()))
       {
         er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY;
         er.message = "Tx key has invalid format";

--- a/tests/fuzz/cold-outputs.cpp
+++ b/tests/fuzz/cold-outputs.cpp
@@ -49,7 +49,7 @@ int ColdOutputsFuzzer::init()
 {
   static const char * const spendkey_hex = "0b4f47697ec99c3de6579304e5f25c68b07afbe55b71d99620bf6cbf4e45a80f";
   crypto::secret_key spendkey;
-  epee::string_tools::hex_to_pod(spendkey_hex, spendkey);
+  epee::string_tools::hex_to_pod(spendkey_hex, spendkey.inner());
 
   try
   {

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -50,7 +50,7 @@ int ColdTransactionFuzzer::init()
 {
   static const char * const spendkey_hex = "0b4f47697ec99c3de6579304e5f25c68b07afbe55b71d99620bf6cbf4e45a80f";
   crypto::secret_key spendkey;
-  epee::string_tools::hex_to_pod(spendkey_hex, spendkey);
+  epee::string_tools::hex_to_pod(spendkey_hex, spendkey.inner());
 
   try
   {

--- a/tests/fuzz/signature.cpp
+++ b/tests/fuzz/signature.cpp
@@ -50,7 +50,7 @@ int SignatureFuzzer::init()
 {
   static const char * const spendkey_hex = "0b4f47697ec99c3de6579304e5f25c68b07afbe55b71d99620bf6cbf4e45a80f";
   crypto::secret_key spendkey;
-  epee::string_tools::hex_to_pod(spendkey_hex, spendkey);
+  epee::string_tools::hex_to_pod(spendkey_hex, spendkey.inner());
 
   try
   {

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -57,7 +57,7 @@ static void make_wallet(unsigned int idx, tools::wallet2 &wallet)
   ASSERT_TRUE(idx < sizeof(test_addresses) / sizeof(test_addresses[0]));
 
   crypto::secret_key spendkey;
-  epee::string_tools::hex_to_pod(test_addresses[idx].spendkey, spendkey);
+  epee::string_tools::hex_to_pod(test_addresses[idx].spendkey, spendkey.inner());
 
   try
   {

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -751,8 +751,8 @@ TEST(Serialization, portability_wallet)
       swap(tx_key0, tx_key1);
     ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key0->first) == "b9aac8c020ab33859e0c0b6331f46a8780d349e7ac17b067116e2d87bf48daad");
     ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key1->first) == "6e7013684d35820f66c6679197ded9329bfe0e495effa47e7b25258799858dba");
-    ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key0->second) == "bf3614c6de1d06c09add5d92a5265d8c76af706f7bc6ac830d6b0d109aa87701");
-    ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key1->second) == "e556884246df5a787def6732c6ea38f1e092fa13e5ea98f732b99c07a6332003");
+    ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key0->second.inner()) == "bf3614c6de1d06c09add5d92a5265d8c76af706f7bc6ac830d6b0d109aa87701");
+    ASSERT_TRUE(epee::string_tools::pod_to_hex(tx_key1->second.inner()) == "e556884246df5a787def6732c6ea38f1e092fa13e5ea98f732b99c07a6332003");
   }
   // confirmed txs
   ASSERT_TRUE(w.m_confirmed_txs.size() == 1);
@@ -824,7 +824,7 @@ TEST(Serialization, portability_outputs)
     return std::move(plaintext);
   };
   crypto::secret_key view_secret_key;
-  epee::string_tools::hex_to_pod("339673bb1187e2f73ba7841ab6841c5553f96e9f13f8fe6612e69318db4e9d0a", view_secret_key);
+  epee::string_tools::hex_to_pod("339673bb1187e2f73ba7841ab6841c5553f96e9f13f8fe6612e69318db4e9d0a", view_secret_key.inner());
   bool authenticated = true;
   data = decrypt(std::string(data, magiclen), view_secret_key, authenticated);
   ASSERT_FALSE(data.empty());
@@ -1108,7 +1108,7 @@ TEST(Serialization, portability_signed_tx)
   ASSERT_TRUE(ptx.selected_transfers.front() == 2);
   // ptx.{key_images, tx_key}
   ASSERT_TRUE(ptx.key_images == "<6c3cd6af97c4070a7aef9b1344e7463e29c7cd245076fdb65da447a34da3ca76> ");
-  ASSERT_TRUE(epee::string_tools::pod_to_hex(ptx.tx_key) == "0100000000000000000000000000000000000000000000000000000000000000");
+  ASSERT_TRUE(epee::string_tools::pod_to_hex(ptx.tx_key.inner()) == "0100000000000000000000000000000000000000000000000000000000000000");
   // ptx.dests
   ASSERT_TRUE(ptx.dests.size() == 1);
   ASSERT_TRUE(ptx.dests[0].amount == 1400000000000);


### PR DESCRIPTION
@vtnerd I couldn't find a nice way to specialize the epee / string utils for this, so adding back `inner()` seems reasonable... unless you have an idea for a better trick.