### PR TITLE
simplewallet: disable donations on testnet

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4494,6 +4494,12 @@ bool simple_wallet::sweep_below(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::donate(const std::vector<std::string> &args_)
 {
+  if(m_wallet->testnet())
+  {
+    fail_msg_writer() << tr("donations are not enabled on the testnet");
+    return true;
+  }
+
   std::vector<std::string> local_args = args_;
   if(local_args.empty() || local_args.size() > 5)
   {


### PR DESCRIPTION
Fixes #2848

##### Behaviour before PR
```
[wallet 9xxxxx]: donate 5
Donating 5 to The Monero Project (donate.getmonero.org/44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A).
Wallet password: 
Error: failed to parse address
```

##### Behaviour after PR
```
[wallet 9xxxxx]: donate 1
Error: donations are not enabled on the testnet
```