### PR TITLE
daemon+simplewallet: given an unknown command, show it

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -269,7 +269,7 @@ int main(int argc, char const * argv[])
         }
         else
         {
-          std::cerr << "Unknown command" << std::endl;
+          std::cerr << "Unknown command: " << command.front() << std::endl;
           return 1;
         }
       }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6586,7 +6586,8 @@ int main(int argc, char* argv[])
   std::vector<std::string> command = command_line::get_arg(*vm, arg_command);
   if (!command.empty())
   {
-    w.process_command(command);
+    if (!w.process_command(command))
+      fail_msg_writer() << tr("Unknown command: ") << command.front();
     w.stop();
     w.deinit();
   }


### PR DESCRIPTION
Currently, the simplewallet doesn't report anything when the given command is unrecognizable. For example, with this command:

    ./monero-wallet-cli --daemon-address node.moneroworld.com 18089 --wallet-file mywallet

(note the missing `:` between the host name and the port number) the wallet will just silently quit because `18089` is an unknown command. This patch makes the wallet and the daemon report such unknown command so that the user can know what was wrong.

Thanks to bug report by @BigslimVdub in https://github.com/aeonix/aeon/issues/131.
