### PR TITLE
wallet_api: make this optional but not built by default

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -126,6 +126,6 @@ if (BUILD_GUI_DEPS)
     endif()
     install(TARGETS wallet_merged
         ARCHIVE DESTINATION ${lib_folder})
-
-    add_subdirectory(api)
 endif()
+
+add_subdirectory(api)

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -78,6 +78,8 @@ target_link_libraries(wallet_api
   PRIVATE
     ${EXTRA_LIBRARIES})
 
+set_property(TARGET wallet_api PROPERTY EXCLUDE_FROM_ALL TRUE)
+set_property(TARGET obj_wallet_api PROPERTY EXCLUDE_FROM_ALL TRUE)
 
 if(IOS)
     set(lib_folder lib-${ARCH})


### PR DESCRIPTION
It means it can still be built with make -C build/debug wallet_api
but still not DoS us while debugging