### PR TITLE
Fix translations header generation when cross-compilating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,11 @@ endif()
 add_definitions(-DAUTO_INITIALIZE_EASYLOGGINGPP)
 
 # Generate header for embedded translations
-add_subdirectory(translations)
+include(ExternalProject)
+ExternalProject_Add(generate_translations_header
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/translations"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/translations"
+  INSTALL_COMMAND cmake -E echo "")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/translations")
 
 add_subdirectory(external)

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -28,6 +28,8 @@
 
 cmake_minimum_required(VERSION 2.8.7)
 
+project(translations)
+
 add_executable(generate_translations_header generate_translations_header.c)
 
 find_program(LRELEASE lrelease)


### PR DESCRIPTION
Define generate_translations_header as an external project to be able
to use the compilation toolchain for the host instead of the toolchain
for the target.
