### PR TITLE
Change cryptonote::COMMAND_RPC_SET_LIMIT::response to use int64_t

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1653,8 +1653,8 @@ namespace cryptonote
     struct response
     {
       std::string status;
-      uint64_t limit_up;
-      uint64_t limit_down;
+      int64_t limit_up;
+      int64_t limit_down;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)


### PR DESCRIPTION
This changes response to use int64_t like the rest of the source, fixing #3051 .