### PR TITLE
Ignore cmake-build-debug folder on CLion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
 install_manifest.txt
+cmake-build-debug/
 
 ### Linux ###
 *~


### PR DESCRIPTION
Developing Monero on JetBrain's CLion causes the creation of a `cmake-build-debug/` output folder.
This is an attempt to allow me to use `git add .` back without having to care about that folder which doesn't belong on this repository.