### PR TITLE
levin_protocol_handler_async: erase from back of vector instead of front

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -752,7 +752,7 @@ void async_protocol_handler_config<t_connection_context>::del_out_connections(si
 	{
 		try
 		{
-			auto i = out_connections.begin();
+			auto i = out_connections.end() - 1;
 			async_protocol_handler<t_connection_context> *conn = m_connects.at(*i);
 			del_connection(conn);
 			close(*i);


### PR DESCRIPTION
Addressing comments by @xyzzy42:
https://github.com/monero-project/monero/pull/2936#pullrequestreview-86339046

> The complexity of vector::erase is proportional to the number of elements after the erased element. They are all copied down. Thus, deleting a vector one by one is much faster, O(n) vs O(n^2), if you start from the end, using out_connections.end(), rather than from the beginning.

Not sure about the actual impact on performance, though (I'm not so familiar with this part of the codebase).