### PR TITLE
all recover options with password

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -458,6 +458,16 @@ bool WalletImpl::recoverFromKeys(const std::string &path,
                                 const std::string &viewkey_string,
                                 const std::string &spendkey_string)
 {
+    return recoverFromKeysWithPassword(path, "", language, address_string, viewkey_string, spendkey_string);
+}
+
+bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
+                                 const std::string &password,
+                                 const std::string &language,
+                                 const std::string &address_string,
+                                 const std::string &viewkey_string,
+                                 const std::string &spendkey_string)
+{
     cryptonote::address_parse_info info;
     if(!get_account_address_from_str(info, m_wallet->testnet(), address_string))
     {
@@ -524,12 +534,12 @@ bool WalletImpl::recoverFromKeys(const std::string &path,
     try
     {
         if (has_spendkey) {
-            m_wallet->generate(path, "", info.address, spendkey, viewkey);
+            m_wallet->generate(path, password, info.address, spendkey, viewkey);
             setSeedLanguage(language);
             LOG_PRINT_L1("Generated new wallet from keys with seed language: " + language);
         }
         else {
-            m_wallet->generate(path, "", info.address, viewkey);
+            m_wallet->generate(path, password, info.address, viewkey);
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         
@@ -570,6 +580,11 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
 
 bool WalletImpl::recover(const std::string &path, const std::string &seed)
 {
+    return recover(path, "", seed);
+}
+
+bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed)
+{
     clearStatus();
     m_errorString.clear();
     if (seed.empty()) {
@@ -590,7 +605,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
 
     try {
         m_wallet->set_seed_language(old_language);
-        m_wallet->generate(path, "", recovery_key, true, false);
+        m_wallet->generate(path, password, recovery_key, true, false);
 
     } catch (const std::exception &e) {
         m_status = Status_Critical;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -59,7 +59,18 @@ public:
     bool createWatchOnly(const std::string &path, const std::string &password,
                             const std::string &language) const;
     bool open(const std::string &path, const std::string &password);
+    bool recover(const std::string &path,const std::string &password,
+                            const std::string &seed);
+    bool recoverFromKeysWithPassword(const std::string &path,
+                            const std::string &password,
+                            const std::string &language,
+                            const std::string &address_string,
+                            const std::string &viewkey_string,
+                            const std::string &spendkey_string = "");
+    // following two methods are deprecated since they create passwordless wallets
+    // use the two equivalent methods above
     bool recover(const std::string &path, const std::string &seed);
+    // deprecated: use recoverFromKeysWithPassword() instead
     bool recoverFromKeys(const std::string &path,
                             const std::string &language,
                             const std::string &address_string, 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -749,7 +749,7 @@ struct WalletManager
      * \brief  Creates new wallet
      * \param  path           Name of wallet file
      * \param  password       Password of wallet file
-     * \param  language       Language to be used to generate electrum seed memo
+     * \param  language       Language to be used to generate electrum seed mnemonic
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
     virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false) = 0;
@@ -763,16 +763,51 @@ struct WalletManager
     virtual Wallet * openWallet(const std::string &path, const std::string &password, bool testnet = false) = 0;
 
     /*!
-     * \brief  recovers existing wallet using memo (electrum seed)
+     * \brief  recovers existing wallet using mnemonic (electrum seed)
      * \param  path           Name of wallet file to be created
-     * \param  memo           memo (25 words electrum seed)
+     * \param  password       Password of wallet file
+     * \param  mnemonic       mnemonic (25 words electrum seed)
      * \param  testnet        testnet
      * \param  restoreHeight  restore from start height
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
-    virtual Wallet * recoveryWallet(const std::string &path, const std::string &memo, bool testnet = false, uint64_t restoreHeight = 0) = 0;
+    virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
+                                    bool testnet = false, uint64_t restoreHeight = 0) = 0;
+
+    /*!
+     * \deprecated this method creates a wallet WITHOUT a passphrase, use the alternate recoverWallet() method
+     * \brief  recovers existing wallet using mnemonic (electrum seed)
+     * \param  path           Name of wallet file to be created
+     * \param  mnemonic       mnemonic (25 words electrum seed)
+     * \param  testnet        testnet
+     * \param  restoreHeight  restore from start height
+     * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+     */
+    virtual Wallet * recoveryWallet(const std::string &path, const std::string &mnemonic, bool testnet = false, uint64_t restoreHeight = 0) = 0;
+
+    /*!
+     * \brief  recovers existing wallet using keys. Creates a view only wallet if spend key is omitted
+     * \param  path           Name of wallet file to be created
+     * \param  password       Password of wallet file
+     * \param  language       language
+     * \param  testnet        testnet
+     * \param  restoreHeight  restore from start height
+     * \param  addressString  public address
+     * \param  viewKeyString  view key
+     * \param  spendKeyString spend key (optional)
+     * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+     */
+    virtual Wallet * createWalletFromKeys(const std::string &path,
+                                                    const std::string &password,
+                                                    const std::string &language,
+                                                    bool testnet,
+                                                    uint64_t restoreHeight,
+                                                    const std::string &addressString,
+                                                    const std::string &viewKeyString,
+                                                    const std::string &spendKeyString = "") = 0;
 
    /*!
+    * \deprecated this method creates a wallet WITHOUT a passphrase, use createWalletFromKeys(..., password, ...) instead
     * \brief  recovers existing wallet using keys. Creates a view only wallet if spend key is omitted
     * \param  path           Name of wallet file to be created
     * \param  language       language

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -76,17 +76,39 @@ Wallet *WalletManagerImpl::openWallet(const std::string &path, const std::string
     return wallet;
 }
 
-Wallet *WalletManagerImpl::recoveryWallet(const std::string &path, const std::string &memo, bool testnet, uint64_t restoreHeight)
+Wallet *WalletManagerImpl::recoveryWallet(const std::string &path, const std::string &mnemonic, bool testnet, uint64_t restoreHeight)
+{
+    return recoveryWallet(path, "", mnemonic, testnet, restoreHeight);
+}
+
+Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
+                                                const std::string &language,
+                                                bool testnet,
+                                                uint64_t restoreHeight,
+                                                const std::string &addressString,
+                                                const std::string &viewKeyString,
+                                                const std::string &spendKeyString)
+{
+    return createWalletFromKeys(path, "", language, testnet, restoreHeight,
+                                addressString, viewKeyString, spendKeyString);
+}
+
+Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
+                                                const std::string &password,
+                                                const std::string &mnemonic,
+                                                bool testnet,
+                                                uint64_t restoreHeight)
 {
     WalletImpl * wallet = new WalletImpl(testnet);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recover(path, memo);
+    wallet->recover(path, password, mnemonic);
     return wallet;
 }
 
-Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path, 
+Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
+                                                const std::string &password,
                                                 const std::string &language,
                                                 bool testnet, 
                                                 uint64_t restoreHeight,
@@ -98,7 +120,7 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recoverFromKeys(path, language, addressString, viewKeyString, spendKeyString);
+    wallet->recoverFromKeysWithPassword(path, password, language, addressString, viewKeyString, spendKeyString);
     return wallet;
 }
 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -40,7 +40,22 @@ public:
     Wallet * createWallet(const std::string &path, const std::string &password,
                           const std::string &language, bool testnet);
     Wallet * openWallet(const std::string &path, const std::string &password, bool testnet);
-    virtual Wallet * recoveryWallet(const std::string &path, const std::string &memo, bool testnet, uint64_t restoreHeight);
+    virtual Wallet * recoveryWallet(const std::string &path,
+                                       const std::string &password,
+                                       const std::string &mnemonic,
+                                       bool testnet,
+                                       uint64_t restoreHeight);
+    virtual Wallet * createWalletFromKeys(const std::string &path,
+                                             const std::string &password,
+                                             const std::string &language,
+                                             bool testnet,
+                                             uint64_t restoreHeight,
+                                             const std::string &addressString,
+                                             const std::string &viewKeyString,
+                                             const std::string &spendKeyString = "");
+    // next two methods are deprecated - use the above version which allow setting of a password
+    virtual Wallet * recoveryWallet(const std::string &path, const std::string &mnemonic, bool testnet, uint64_t restoreHeight);
+    // deprecated: use createWalletFromKeys(..., password, ...) instead
     virtual Wallet * createWalletFromKeys(const std::string &path, 
                                                     const std::string &language,
                                                     bool testnet, 


### PR DESCRIPTION
Recovering from keys or seed created a wallet on disk with no password. Any attacker watching the wallet directory could copy away such a file for future use. These creation methods were marked as deprecated and new methods implemented which accept a password parameter. Unfortunately, a password parameter could not simply be added to recoverFromKeys() as that would ambiguate the call (the last parm <spendkey_string> is optional) so the new method was called recoverWithKeys().

Tested with monerujo.