### PR TITLE
cryptonote_protocol: fix size_t used in wire format

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -271,7 +271,7 @@ namespace cryptonote
     {
       crypto::hash block_hash;
       uint64_t current_blockchain_height;      
-      std::vector<size_t> missing_tx_indices;
+      std::vector<uint64_t> missing_tx_indices;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_VAL_POD_AS_BLOB(block_hash)


### PR DESCRIPTION
This is 32 bits on 32 bit platforms, but 64 bits on 64 bit platforms.