### PR TITLE
wallet rpc: show fees when querying incoming transfers

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -252,6 +252,7 @@ namespace tools
     {
       crypto::hash m_tx_hash;
       uint64_t m_amount;
+      uint64_t m_fee;
       uint64_t m_block_height;
       uint64_t m_unlock_time;
       uint64_t m_timestamp;
@@ -1144,7 +1145,7 @@ BOOST_CLASS_VERSION(tools::wallet2::transfer_details, 9)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info, 1)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info::LR, 0)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_tx_set, 1)
-BOOST_CLASS_VERSION(tools::wallet2::payment_details, 2)
+BOOST_CLASS_VERSION(tools::wallet2::payment_details, 3)
 BOOST_CLASS_VERSION(tools::wallet2::pool_payment_details, 1)
 BOOST_CLASS_VERSION(tools::wallet2::unconfirmed_transfer_details, 7)
 BOOST_CLASS_VERSION(tools::wallet2::confirmed_transfer_details, 5)
@@ -1409,6 +1410,12 @@ namespace boost
         return;
       }
       a & x.m_subaddr_index;
+      if (ver < 3)
+      {
+        x.m_fee = 0;
+        return;
+      }
+      a & x.m_fee;
     }
 
     template <class Archive>

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -254,7 +254,7 @@ namespace tools
     entry.timestamp = pd.m_timestamp;
     entry.amount = pd.m_amount;
     entry.unlock_time = pd.m_unlock_time;
-    entry.fee = 0; // TODO
+    entry.fee = pd.m_fee;
     entry.note = m_wallet->get_tx_note(pd.m_tx_hash);
     entry.type = "in";
     entry.subaddr_index = pd.m_subaddr_index;
@@ -317,7 +317,7 @@ namespace tools
     entry.timestamp = pd.m_timestamp;
     entry.amount = pd.m_amount;
     entry.unlock_time = pd.m_unlock_time;
-    entry.fee = 0; // TODO
+    entry.fee = pd.m_fee;
     entry.note = m_wallet->get_tx_note(pd.m_tx_hash);
     entry.double_spend_seen = ppd.m_double_spend_seen;
     entry.type = "pool";


### PR DESCRIPTION
Note that the new `fee` field will still be shown as 0 for incoming transfers that have been scanned previously (you could do `rescan_bc` to force updating them, if you like).

Also, the light wallet mode is unsupported at the moment (since the MyMonero/OpenMonero API doesn't seem to provide the fee information).
