### PR TITLE
cmake: set API header install path to what Qt wallet expects

### DIFF
--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -86,4 +86,4 @@ else()
 endif()
 
 install(FILES ${wallet_api_headers}
-    DESTINATION include/wallet)
+    DESTINATION include/wallet/api)


### PR DESCRIPTION
qt wallet has `include <wallet/api/wallet_api2.h>`