### PR TITLE
Wallet API: remove unused enum Priority from UnsignedTransaction

### DIFF
--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -105,13 +105,6 @@ struct UnsignedTransaction
         Status_Critical
     };
 
-    enum Priority {
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
-        Priority_Last
-    };
-
     virtual ~UnsignedTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;


### PR DESCRIPTION
`UnsignedTransaction::Priority` introduced in #1541 seems unused and redundant as the priority list is already defined in `PendingTransaction::Priority` which is used in `createTransaction()` etc.

TBH I don't understand why the priority enum was defined under `PendingTransaction` instead of being on its own, and why the priority had to be defined this way instead of simply using `uint32_t` in the first place. This was done long time ago in #915, and the API is already in use, so I guess it's not so easy to make changes to the API, though.
