### PR TITLE
tests: Add braces to prevent compiler warning

### DIFF
--- a/tests/unit_tests/memwipe.cpp
+++ b/tests/unit_tests/memwipe.cpp
@@ -47,7 +47,10 @@ static void test(bool wipe)
   if ((intptr_t)quux == foop)
   {
     MDEBUG(std::hex << std::setw(8) << std::setfill('0') << *(uint32_t*)quux);
-    if (wipe) ASSERT_TRUE(memcmp(quux, "bar", 3));
+    if (wipe)
+    {
+      ASSERT_TRUE(memcmp(quux, "bar", 3));
+    }
   }
   else MWARNING("We did not get the same location, cannot check");
   free(quux);


### PR DESCRIPTION
The `ASSERT_TRUE` macro expands to an `if`/`else` statement which means the `else` is ambiguous without the braces.

I was compiling with `-Wall -Werror`.