### PR TITLE
Remove redundant monerod testnet options

### DIFF
--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -59,7 +59,6 @@ int main(int argc, char* argv[])
   tools::on_startup();
 
   boost::filesystem::path default_data_path {tools::get_default_data_dir()};
-  boost::filesystem::path default_testnet_data_path {default_data_path / "testnet"};
   boost::filesystem::path output_file_path;
 
   po::options_description desc_cmd_only("Command line options");
@@ -73,8 +72,7 @@ int main(int argc, char* argv[])
   const command_line::arg_descriptor<bool> arg_blocks_dat = {"blocksdat", "Output in blocks.dat format", blocks_dat};
 
 
-  command_line::add_arg(desc_cmd_sett, cryptonote::arg_data_dir, default_data_path.string());
-  command_line::add_arg(desc_cmd_sett, cryptonote::arg_testnet_data_dir, default_testnet_data_path.string());
+  command_line::add_arg(desc_cmd_sett, cryptonote::arg_data_dir);
   command_line::add_arg(desc_cmd_sett, arg_output_file);
   command_line::add_arg(desc_cmd_sett, cryptonote::arg_testnet_on);
   command_line::add_arg(desc_cmd_sett, arg_log_level);
@@ -118,8 +116,7 @@ int main(int argc, char* argv[])
 
   std::string m_config_folder;
 
-  auto data_dir_arg = opt_testnet ? cryptonote::arg_testnet_data_dir : cryptonote::arg_data_dir;
-  m_config_folder = command_line::get_arg(vm, data_dir_arg);
+  m_config_folder = command_line::get_arg(vm, cryptonote::arg_data_dir);
 
   std::string db_type = command_line::get_arg(vm, arg_database);
   if (!cryptonote::blockchain_valid_db_type(db_type))

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -671,8 +671,7 @@ int main(int argc, char* argv[])
   }
 
   opt_testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
-  auto data_dir_arg = opt_testnet ? cryptonote::arg_testnet_data_dir : cryptonote::arg_data_dir;
-  m_config_folder = command_line::get_arg(vm, data_dir_arg);
+  m_config_folder = command_line::get_arg(vm, cryptonote::arg_data_dir);
   db_arg_str = command_line::get_arg(vm, arg_database);
 
   mlog_configure(mlog_get_default_log_path("monero-blockchain-import.log"), true);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -74,9 +74,13 @@ namespace cryptonote
   const command_line::arg_descriptor<std::string, false, true> arg_data_dir = {
     "data-dir"
   , "Specify data directory"
-  , arg_testnet_on
-  , (boost::filesystem::path(tools::get_default_data_dir()) / "testnet").string()
   , tools::get_default_data_dir()
+  , arg_testnet_on
+  , [](bool testnet, bool defaulted, std::string val) {
+      if (testnet)
+        return (boost::filesystem::path(val) / "testnet").string();
+      return val;
+    }
   };
   const command_line::arg_descriptor<bool> arg_offline = {
     "offline"

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -66,18 +66,17 @@ DISABLE_VS_WARNINGS(4355)
 
 namespace cryptonote
 {
-  const command_line::arg_descriptor<std::string> arg_data_dir = {
-    "data-dir"
-  , "Specify data directory"
-  };
-  const command_line::arg_descriptor<std::string> arg_testnet_data_dir = {
-    "testnet-data-dir"
-  , "Specify testnet data directory"
-  };
   const command_line::arg_descriptor<bool, false> arg_testnet_on  = {
     "testnet"
   , "Run on testnet. The wallet must be launched with --testnet flag."
   , false
+  };
+  const command_line::arg_descriptor<std::string, false, true> arg_data_dir = {
+    "data-dir"
+  , "Specify data directory"
+  , arg_testnet_on
+  , (boost::filesystem::path(tools::get_default_data_dir()) / "testnet").string()
+  , tools::get_default_data_dir()
   };
   const command_line::arg_descriptor<bool> arg_offline = {
     "offline"
@@ -229,8 +228,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------
   void core::init_options(boost::program_options::options_description& desc)
   {
-    command_line::add_arg(desc, arg_data_dir, tools::get_default_data_dir());
-    command_line::add_arg(desc, arg_testnet_data_dir, (boost::filesystem::path(tools::get_default_data_dir()) / "testnet").string());
+    command_line::add_arg(desc, arg_data_dir);
 
     command_line::add_arg(desc, arg_test_drop_download);
     command_line::add_arg(desc, arg_test_drop_download_height);
@@ -256,8 +254,7 @@ namespace cryptonote
   {
     m_testnet = command_line::get_arg(vm, arg_testnet_on);
 
-    auto data_dir_arg = m_testnet ? arg_testnet_data_dir : arg_data_dir;
-    m_config_folder = command_line::get_arg(vm, data_dir_arg);
+    m_config_folder = command_line::get_arg(vm, arg_data_dir);
 
     auto data_dir = boost::filesystem::path(m_config_folder);
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -58,8 +58,7 @@ namespace cryptonote
      const std::pair<uint8_t, uint64_t> *hard_forks;
    };
 
-  extern const command_line::arg_descriptor<std::string> arg_data_dir;
-  extern const command_line::arg_descriptor<std::string> arg_testnet_data_dir;
+  extern const command_line::arg_descriptor<std::string, false, true> arg_data_dir;
   extern const command_line::arg_descriptor<bool, false> arg_testnet_on;
   extern const command_line::arg_descriptor<bool> arg_offline;
 

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -76,16 +76,12 @@ namespace daemon_args
       , "127.0.0.1"
   };
 
-  const command_line::arg_descriptor<std::string> arg_zmq_rpc_bind_port = {
+  const command_line::arg_descriptor<std::string, false, true> arg_zmq_rpc_bind_port = {
     "zmq-rpc-bind-port"
-      , "Port for ZMQ RPC server to listen on"
-      , std::to_string(config::ZMQ_RPC_DEFAULT_PORT)
-  };
-
-  const command_line::arg_descriptor<std::string> arg_zmq_testnet_rpc_bind_port = {
-    "zmq-testnet-rpc-bind-port"
-      , "Port for testnet ZMQ RPC server to listen on"
-      , std::to_string(config::testnet::ZMQ_RPC_DEFAULT_PORT)
+  , "Port for ZMQ RPC server to listen on"
+  , cryptonote::arg_testnet_on
+  , std::to_string(config::testnet::ZMQ_RPC_DEFAULT_PORT)
+  , std::to_string(config::ZMQ_RPC_DEFAULT_PORT)
   };
 
 }  // namespace daemon_args

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -31,20 +31,35 @@
 
 #include "common/command_line.h"
 #include "cryptonote_config.h"
+#include "daemonizer/daemonizer.h"
 
 namespace daemon_args
 {
   std::string const WINDOWS_SERVICE_NAME = "Monero Daemon";
 
-  const command_line::arg_descriptor<std::string> arg_config_file = {
+  const command_line::arg_descriptor<std::string, false, true> arg_config_file = {
     "config-file"
   , "Specify configuration file"
-  , std::string(CRYPTONOTE_NAME ".conf")
+  , (daemonizer::get_default_data_dir() / std::string(CRYPTONOTE_NAME ".conf")).string()
+  , cryptonote::arg_testnet_on
+  , [](bool testnet, bool defaulted, std::string val) {
+      if (testnet && defaulted)
+        return (daemonizer::get_default_data_dir() / "testnet" /
+                std::string(CRYPTONOTE_NAME ".conf")).string();
+      return val;
+    }
   };
-  const command_line::arg_descriptor<std::string> arg_log_file = {
+  const command_line::arg_descriptor<std::string, false, true> arg_log_file = {
     "log-file"
   , "Specify log file"
-  , ""
+  , (daemonizer::get_default_data_dir() / std::string(CRYPTONOTE_NAME ".log")).string()
+  , cryptonote::arg_testnet_on
+  , [](bool testnet, bool defaulted, std::string val) {
+      if (testnet && defaulted)
+        return (daemonizer::get_default_data_dir() / "testnet" /
+                std::string(CRYPTONOTE_NAME ".log")).string();
+      return val;
+    }
   };
   const command_line::arg_descriptor<std::size_t> arg_max_log_file_size = {
     "max-log-file-size"
@@ -79,9 +94,13 @@ namespace daemon_args
   const command_line::arg_descriptor<std::string, false, true> arg_zmq_rpc_bind_port = {
     "zmq-rpc-bind-port"
   , "Port for ZMQ RPC server to listen on"
-  , cryptonote::arg_testnet_on
-  , std::to_string(config::testnet::ZMQ_RPC_DEFAULT_PORT)
   , std::to_string(config::ZMQ_RPC_DEFAULT_PORT)
+  , cryptonote::arg_testnet_on
+  , [](bool testnet, bool defaulted, std::string val) {
+      if (testnet && defaulted)
+        return std::to_string(config::testnet::ZMQ_RPC_DEFAULT_PORT);
+      return val;
+    }
   };
 
 }  // namespace daemon_args

--- a/src/daemon/core.h
+++ b/src/daemon/core.h
@@ -69,8 +69,7 @@ public:
   std::string get_config_subdir() const
   {
     bool testnet = command_line::get_arg(m_vm_HACK, cryptonote::arg_testnet_on);
-    auto p2p_bind_arg = testnet ? nodetool::arg_testnet_p2p_bind_port : nodetool::arg_p2p_bind_port;
-    std::string port = command_line::get_arg(m_vm_HACK, p2p_bind_arg);
+    std::string port = command_line::get_arg(m_vm_HACK, nodetool::arg_p2p_bind_port);
     if ((!testnet && port != std::to_string(::config::P2P_DEFAULT_PORT))
         || (testnet && port != std::to_string(::config::testnet::P2P_DEFAULT_PORT))) {
       return port;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -77,10 +77,10 @@ public:
 
     const auto testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
     const auto restricted = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_restricted_rpc);
-    const auto main_rpc_port = command_line::get_arg(vm, testnet ? cryptonote::core_rpc_server::arg_testnet_rpc_bind_port : cryptonote::core_rpc_server::arg_rpc_bind_port);
+    const auto main_rpc_port = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_rpc_bind_port);
     rpcs.emplace_back(new t_rpc{vm, core, p2p, restricted, testnet, main_rpc_port, "core"});
 
-    auto restricted_rpc_port_arg = testnet ? cryptonote::core_rpc_server::arg_testnet_rpc_restricted_bind_port : cryptonote::core_rpc_server::arg_rpc_restricted_bind_port;
+    auto restricted_rpc_port_arg = cryptonote::core_rpc_server::arg_rpc_restricted_bind_port;
     if(!command_line::is_arg_defaulted(vm, restricted_rpc_port_arg))
     {
       auto restricted_rpc_port = command_line::get_arg(vm, restricted_rpc_port_arg);
@@ -101,15 +101,7 @@ t_daemon::t_daemon(
   )
   : mp_internals{new t_internals{vm}}
 {
-  bool testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
-  if (testnet)
-  {
-    zmq_rpc_bind_port = command_line::get_arg(vm, daemon_args::arg_zmq_testnet_rpc_bind_port);
-  }
-  else
-  {
-    zmq_rpc_bind_port = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_port);
-  }
+  zmq_rpc_bind_port = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_port);
   zmq_rpc_bind_address = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_ip);
 }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -73,20 +73,15 @@ int main(int argc, char const * argv[])
     po::options_description core_settings("Settings");
     po::positional_options_description positional_options;
     {
-      bf::path default_data_dir = daemonizer::get_default_data_dir();
-      bf::path default_testnet_data_dir = {default_data_dir / "testnet"};
-
       // Misc Options
 
       command_line::add_arg(visible_options, command_line::arg_help);
       command_line::add_arg(visible_options, command_line::arg_version);
       command_line::add_arg(visible_options, daemon_args::arg_os_version);
-      bf::path default_conf = default_data_dir / std::string(CRYPTONOTE_NAME ".conf");
-      command_line::add_arg(visible_options, daemon_args::arg_config_file, default_conf.string());
+      command_line::add_arg(visible_options, daemon_args::arg_config_file);
 
       // Settings
-      bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
-      command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
+      command_line::add_arg(core_settings, daemon_args::arg_log_file);
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
       command_line::add_arg(core_settings, daemon_args::arg_max_log_file_size);
       command_line::add_arg(core_settings, daemon_args::arg_max_concurrency);

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -92,7 +92,6 @@ int main(int argc, char const * argv[])
       command_line::add_arg(core_settings, daemon_args::arg_max_concurrency);
       command_line::add_arg(core_settings, daemon_args::arg_zmq_rpc_bind_ip);
       command_line::add_arg(core_settings, daemon_args::arg_zmq_rpc_bind_port);
-      command_line::add_arg(core_settings, daemon_args::arg_zmq_testnet_rpc_bind_port);
 
       daemonizer::init_options(hidden_options, visible_options);
       daemonize::t_executor::init_options(core_settings);
@@ -154,10 +153,6 @@ int main(int argc, char const * argv[])
       return 0;
     }
 
-    bool testnet_mode = command_line::get_arg(vm, cryptonote::arg_testnet_on);
-
-    auto data_dir_arg = testnet_mode ? cryptonote::arg_testnet_data_dir : cryptonote::arg_data_dir;
-
     // data_dir
     //   default: e.g. ~/.bitmonero/ or ~/.bitmonero/testnet
     //   if data-dir argument given:
@@ -166,7 +161,7 @@ int main(int argc, char const * argv[])
 
     // Create data dir if it doesn't exist
     boost::filesystem::path data_dir = boost::filesystem::absolute(
-        command_line::get_arg(vm, data_dir_arg));
+        command_line::get_arg(vm, cryptonote::arg_data_dir));
 
     // FIXME: not sure on windows implementation default, needs further review
     //bf::path relative_path_base = daemonizer::get_relative_path_base(vm);
@@ -226,10 +221,6 @@ int main(int argc, char const * argv[])
         const cryptonote::rpc_args::descriptors arg{};
         auto rpc_ip_str = command_line::get_arg(vm, arg.rpc_bind_ip);
         auto rpc_port_str = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_rpc_bind_port);
-        if (testnet_mode)
-        {
-          rpc_port_str = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_testnet_rpc_bind_port);
-        }
 
         uint32_t rpc_ip;
         uint16_t rpc_port;

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -37,9 +37,13 @@ namespace nodetool
     const command_line::arg_descriptor<std::string, false, true> arg_p2p_bind_port = {
         "p2p-bind-port"
       , "Port for p2p network protocol"
-      , cryptonote::arg_testnet_on
-      , std::to_string(config::testnet::P2P_DEFAULT_PORT)
       , std::to_string(config::P2P_DEFAULT_PORT)
+      , cryptonote::arg_testnet_on
+      , [](bool testnet, bool defaulted, std::string val) {
+          if (testnet && defaulted)
+            return std::to_string(config::testnet::P2P_DEFAULT_PORT);
+          return val;
+        }
       };
     const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port  = {"p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0};
     const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -34,15 +34,12 @@
 namespace nodetool
 {
     const command_line::arg_descriptor<std::string> arg_p2p_bind_ip        = {"p2p-bind-ip", "Interface for p2p network protocol", "0.0.0.0"};
-    const command_line::arg_descriptor<std::string> arg_p2p_bind_port = {
+    const command_line::arg_descriptor<std::string, false, true> arg_p2p_bind_port = {
         "p2p-bind-port"
       , "Port for p2p network protocol"
-      , std::to_string(config::P2P_DEFAULT_PORT)
-      };
-    const command_line::arg_descriptor<std::string> arg_testnet_p2p_bind_port = {
-        "testnet-p2p-bind-port"
-      , "Port for testnet p2p network protocol"
+      , cryptonote::arg_testnet_on
       , std::to_string(config::testnet::P2P_DEFAULT_PORT)
+      , std::to_string(config::P2P_DEFAULT_PORT)
       };
     const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port  = {"p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0};
     const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -337,8 +337,7 @@ namespace nodetool
     const int64_t default_limit_up = 2048;
     const int64_t default_limit_down = 8192;
     extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ip;
-    extern const command_line::arg_descriptor<std::string> arg_p2p_bind_port;
-    extern const command_line::arg_descriptor<std::string> arg_testnet_p2p_bind_port;
+    extern const command_line::arg_descriptor<std::string, false, true> arg_p2p_bind_port;
     extern const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port;
     extern const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip;
     extern const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -75,7 +75,6 @@ namespace nodetool
   {
     command_line::add_arg(desc, arg_p2p_bind_ip);
     command_line::add_arg(desc, arg_p2p_bind_port, false);
-    command_line::add_arg(desc, arg_testnet_p2p_bind_port, false);
     command_line::add_arg(desc, arg_p2p_external_port);
     command_line::add_arg(desc, arg_p2p_allow_local_ip);
     command_line::add_arg(desc, arg_p2p_add_peer);
@@ -263,12 +262,8 @@ namespace nodetool
       const boost::program_options::variables_map& vm
     )
   {
-    m_testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
-
-    auto p2p_bind_arg = m_testnet ? arg_testnet_p2p_bind_port : arg_p2p_bind_port;
-
     m_bind_ip = command_line::get_arg(vm, arg_p2p_bind_ip);
-    m_port = command_line::get_arg(vm, p2p_bind_arg);
+    m_port = command_line::get_arg(vm, arg_p2p_bind_port);
     m_external_port = command_line::get_arg(vm, arg_p2p_external_port);
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
     m_no_igd = command_line::get_arg(vm, arg_no_igd);
@@ -504,8 +499,7 @@ namespace nodetool
     }
     MDEBUG("Number of seed nodes: " << m_seed_nodes.size());
 
-    auto config_arg = m_testnet ? cryptonote::arg_testnet_data_dir : cryptonote::arg_data_dir;
-    m_config_folder = command_line::get_arg(vm, config_arg);
+    m_config_folder = command_line::get_arg(vm, cryptonote::arg_data_dir);
 
     if ((!m_testnet && m_port != std::to_string(::config::P2P_DEFAULT_PORT))
         || (m_testnet && m_port != std::to_string(::config::testnet::P2P_DEFAULT_PORT))) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -73,8 +73,6 @@ namespace cryptonote
   {
     command_line::add_arg(desc, arg_rpc_bind_port);
     command_line::add_arg(desc, arg_rpc_restricted_bind_port);
-    command_line::add_arg(desc, arg_testnet_rpc_bind_port);
-    command_line::add_arg(desc, arg_testnet_rpc_restricted_bind_port);
     command_line::add_arg(desc, arg_restricted_rpc);
     command_line::add_arg(desc, arg_bootstrap_daemon_address);
     command_line::add_arg(desc, arg_bootstrap_daemon_login);
@@ -2075,27 +2073,17 @@ namespace cryptonote
   }
   //------------------------------------------------------------------------------------------------------------------------------
 
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_bind_port = {
+  const command_line::arg_descriptor<std::string, false, true> core_rpc_server::arg_rpc_bind_port = {
       "rpc-bind-port"
     , "Port for RPC server"
+    , cryptonote::arg_testnet_on
+    , std::to_string(config::testnet::RPC_DEFAULT_PORT)
     , std::to_string(config::RPC_DEFAULT_PORT)
     };
 
   const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_restricted_bind_port = {
       "rpc-restricted-bind-port"
     , "Port for restricted RPC server"
-    , ""
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_testnet_rpc_bind_port = {
-      "testnet-rpc-bind-port"
-    , "Port for testnet RPC server"
-    , std::to_string(config::testnet::RPC_DEFAULT_PORT)
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_testnet_rpc_restricted_bind_port = {
-      "testnet-rpc-restricted-bind-port"
-    , "Port for testnet restricted RPC server"
     , ""
     };
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2076,9 +2076,13 @@ namespace cryptonote
   const command_line::arg_descriptor<std::string, false, true> core_rpc_server::arg_rpc_bind_port = {
       "rpc-bind-port"
     , "Port for RPC server"
-    , cryptonote::arg_testnet_on
-    , std::to_string(config::testnet::RPC_DEFAULT_PORT)
     , std::to_string(config::RPC_DEFAULT_PORT)
+    , cryptonote::arg_testnet_on
+    , [](bool testnet, bool defaulted, std::string val) {
+        if (testnet && defaulted)
+          return std::to_string(config::testnet::RPC_DEFAULT_PORT);
+        return val;
+      }
     };
 
   const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_restricted_bind_port = {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -53,10 +53,8 @@ namespace cryptonote
   {
   public:
 
-    static const command_line::arg_descriptor<std::string> arg_rpc_bind_port;
+    static const command_line::arg_descriptor<std::string, false, true> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
-    static const command_line::arg_descriptor<std::string> arg_testnet_rpc_bind_port;
-    static const command_line::arg_descriptor<std::string> arg_testnet_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_login;

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -80,8 +80,7 @@ int main(int argc, char* argv[])
 
 
   po::options_description desc("Allowed options");
-  // tools::get_default_data_dir() can't be called during static initialization
-  command_line::add_arg(desc, cryptonote::arg_data_dir, tools::get_default_data_dir());
+  command_line::add_arg(desc, cryptonote::arg_data_dir);
   nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<tests::proxy_core> >::init_options(desc);
 
   po::variables_map vm;


### PR DESCRIPTION
Implements proposal in #3054, namely:

- [x] implements `arg_descriptor` for options that depend on another `bool` option;
- [x] removes following options in favor of their corresponding options dependent on `testnet`:
  - [x] `testnet-rpc-bind-port`,
  - [x] `testnet-rpc-restricted-bind-port`,
  - [x] `testnet-data-dir`,
  - [x] `testnet-p2p-bind-port`,
  - [x] `zmq-testnet-rpc-bind-port`.
