### PR TITLE
wallet-cli: Do not ask for scan_from_height if it is explicitly set to zero.

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2413,7 +2413,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         r = new_wallet(vm, m_recovery_key, m_restore_deterministic_wallet, m_non_deterministic, old_language);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
     }
-    if (!m_restore_height && m_restoring)
+    if (!m_wallet->explicit_refresh_from_block_height() && m_restoring)
     {
       uint32_t version;
       bool connected = try_connect_to_daemon(false, &version);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -361,6 +361,7 @@ std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file,
 
     wallet.reset(make_basic(vm, opts, password_prompter).release());
     wallet->set_refresh_from_block_height(field_scan_from_height);
+    wallet->explicit_refresh_from_block_height(field_scan_from_height_found);
 
     try
     {
@@ -605,6 +606,7 @@ wallet2::wallet2(bool testnet, bool restricted):
   m_refresh_type(RefreshOptimizeCoinbase),
   m_auto_refresh(true),
   m_refresh_from_block_height(0),
+  m_explicit_refresh_from_block_height(true),
   m_confirm_missing_payment_id(true),
   m_ask_password(true),
   m_min_output_count(0),

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -550,6 +550,9 @@ namespace tools
     void set_refresh_from_block_height(uint64_t height) {m_refresh_from_block_height = height;}
     uint64_t get_refresh_from_block_height() const {return m_refresh_from_block_height;}
 
+    void explicit_refresh_from_block_height(bool expl) {m_explicit_refresh_from_block_height = expl;}
+    bool explicit_refresh_from_block_height() const {return m_explicit_refresh_from_block_height;}
+
     // upper_transaction_size_limit as defined below is set to 
     // approximately 125% of the fixed minimum allowable penalty
     // free block size. TODO: fix this so that it actually takes
@@ -1082,6 +1085,9 @@ namespace tools
     RefreshType m_refresh_type;
     bool m_auto_refresh;
     uint64_t m_refresh_from_block_height;
+    // If m_refresh_from_block_height is explicitly set to zero we need this to differentiate it from the case that
+    // m_refresh_from_block_height was defaulted to zero.*/
+    bool m_explicit_refresh_from_block_height;
     bool m_confirm_missing_payment_id;
     bool m_ask_password;
     uint32_t m_min_output_count;


### PR DESCRIPTION
Fixes #3080.
Please let me know if there is anything wrong with this approach.