### PR TITLE
Bugfix : Missing i18n import in simplewallet

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -44,6 +44,7 @@
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "wallet/wallet2.h"
 #include "console_handler.h"
+#include "common/i18n.h"
 #include "common/password.h"
 #include "crypto/crypto.h"  // for definition of crypto::secret_key
 


### PR DESCRIPTION
Missing i18n import in simplewallet.h after last merges.
Should fix monero core build (issue #3183) along with PR #3185.