### PR TITLE
wipeable_string: call memwipe directly

### DIFF
--- a/contrib/epee/include/wipeable_string.h
+++ b/contrib/epee/include/wipeable_string.h
@@ -58,13 +58,10 @@ namespace epee
     wipeable_string &operator=(wipeable_string &&other);
     wipeable_string &operator=(const wipeable_string &other);
 
-    static void set_wipe(void *(*f)(void*, size_t)) { wipefunc = f; }
-
   private:
     void grow(size_t sz, size_t reserved = 0);
 
   private:
     std::vector<char> buffer;
-    static void *(*wipefunc)(void*, size_t);
   };
 }

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -552,8 +552,6 @@ std::string get_nix_version_display_string()
   }
   bool on_startup()
   {
-    wipeable_string::set_wipe(&memwipe);
-
     mlog_configure("", true);
 
     sanitize_locale();


### PR DESCRIPTION
since the original reason for the indirect call (that memwipe
was not in contrib) is now gone