### PR TITLE
wallet/rpc: Deprecate 'sweep_dust' command in favor of 'sweep_unmixable'

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -854,7 +854,7 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool wallet_rpc_server::on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er)
+  bool wallet_rpc_server::on_sweep_unmixable(const wallet_rpc::COMMAND_RPC_SWEEP_UNMIXABLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_UNMIXABLE::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
     if (m_wallet->restricted())
@@ -877,6 +877,14 @@ namespace tools
       return false;
     }
     return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  // TODO: Deprecated
+  bool wallet_rpc_server::on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er)
+  {
+    bool ok = this->on_sweep_unmixable(req, res, er);
+    res.deprecation_notice = "This RPC command is deprecated and will be removed soon. Please use 'sweep_unmixable' instead.";
+    return ok;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er)

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -84,6 +84,7 @@ namespace tools
         MAP_JON_RPC_WE("getheight",          on_getheight,          wallet_rpc::COMMAND_RPC_GET_HEIGHT)
         MAP_JON_RPC_WE("transfer",           on_transfer,           wallet_rpc::COMMAND_RPC_TRANSFER)
         MAP_JON_RPC_WE("transfer_split",     on_transfer_split,     wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT)
+        MAP_JON_RPC_WE("sweep_unmixable",    on_sweep_unmixable,    wallet_rpc::COMMAND_RPC_SWEEP_UNMIXABLE)
         MAP_JON_RPC_WE("sweep_dust",         on_sweep_dust,         wallet_rpc::COMMAND_RPC_SWEEP_DUST)
         MAP_JON_RPC_WE("sweep_all",          on_sweep_all,          wallet_rpc::COMMAND_RPC_SWEEP_ALL)
         MAP_JON_RPC_WE("sweep_single",       on_sweep_single,       wallet_rpc::COMMAND_RPC_SWEEP_SINGLE)
@@ -153,6 +154,7 @@ namespace tools
       bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er);
       bool on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_TRANSFER::response& res, epee::json_rpc::error& er);
       bool on_transfer_split(const wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::request& req, wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::response& res, epee::json_rpc::error& er);
+      bool on_sweep_unmixable(const wallet_rpc::COMMAND_RPC_SWEEP_UNMIXABLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_UNMIXABLE::response& res, epee::json_rpc::error& er);
       bool on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er);
       bool on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er);
       bool on_sweep_single(const wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -492,7 +492,7 @@ namespace wallet_rpc
     };
   };
 
-  struct COMMAND_RPC_SWEEP_DUST
+  struct COMMAND_RPC_SWEEP_UNMIXABLE
   {
     struct request
     {
@@ -528,6 +528,7 @@ namespace wallet_rpc
       std::list<std::string> tx_metadata_list;
       std::string multisig_txset;
 
+      // Keep in sync with COMMAND_RPC_SWEEP_DUST::response (deprecated)
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
         KV_SERIALIZE(tx_key_list)
@@ -536,6 +537,25 @@ namespace wallet_rpc
         KV_SERIALIZE(tx_blob_list)
         KV_SERIALIZE(tx_metadata_list)
         KV_SERIALIZE(multisig_txset)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
+  struct COMMAND_RPC_SWEEP_DUST : COMMAND_RPC_SWEEP_UNMIXABLE
+  {
+    struct response : COMMAND_RPC_SWEEP_UNMIXABLE::response
+    {
+      std::string deprecation_notice;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash_list)
+        KV_SERIALIZE(tx_key_list)
+        KV_SERIALIZE(amount_list)
+        KV_SERIALIZE(fee_list)
+        KV_SERIALIZE(tx_blob_list)
+        KV_SERIALIZE(tx_metadata_list)
+        KV_SERIALIZE(multisig_txset)
+        KV_SERIALIZE(deprecation_notice)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
For consistency, the command should be named 'sweep_unmixable' as found
in simplewallet.