### PR TITLE
simplewallet: ignore ^C while in password entry

### DIFF
--- a/contrib/epee/include/readline_buffer.h
+++ b/contrib/epee/include/readline_buffer.h
@@ -34,7 +34,7 @@ namespace rdln
   {
   public:
     suspend_readline();
-    ~suspend_readline();
+    virtual ~suspend_readline();
   private:
     readline_buffer* m_buffer;
     bool m_restart;


### PR DESCRIPTION
It would be nice to cancel password entry, but that seems a bit
more involved, so left for later. For now, this avoids exiting
and leaving the console in "hidden" mode, and apparently fixes
a segfault (which I could not reproduce).