### PR TITLE
connection_context: initialize m_last_request_time to current time

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -40,7 +40,7 @@ namespace cryptonote
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
-        m_callback_request_count(0), m_last_known_hash(crypto::null_hash) {}
+        m_last_request_time(boost::posix_time::microsec_clock::universal_time()), m_callback_request_count(0), m_last_known_hash(crypto::null_hash) {}
 
     enum state
     {


### PR DESCRIPTION
This prevents spurious early peer drops