### PR TITLE
epee get_ns_count: cast to uint64_t before multiplying 10^9 to avoid …

### DIFF
--- a/contrib/epee/include/misc_os_dependent.h
+++ b/contrib/epee/include/misc_os_dependent.h
@@ -75,13 +75,13 @@ namespace misc_utils
                 clock_get_time(cclock, &mts);
                 mach_port_deallocate(mach_task_self(), cclock);
 
-                return (mts.tv_sec * 1000000000) + (mts.tv_nsec);
+                return ((uint64_t)mts.tv_sec * 1000000000) + (mts.tv_nsec);
 #else
                 struct timespec ts;
                 if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
                         return 0;
                 }
-                return (ts.tv_sec * 1000000000) + (ts.tv_nsec);
+                return ((uint64_t)ts.tv_sec * 1000000000) + (ts.tv_nsec);
 #endif
         }
 


### PR DESCRIPTION
…overflow