### PR TITLE
blockchain: don't try to use hash check array after it's freed

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3753,6 +3753,10 @@ uint64_t Blockchain::prevalidate_block_hashes(uint64_t height, const std::list<c
   if (height >= m_blocks_hash_of_hashes.size() * HASH_OF_HASHES_STEP)
     return hashes.size();
 
+  // if we're getting old blocks, we might have jettisoned the hashes already
+  if (m_blocks_hash_check.empty())
+    return hashes.size();
+
   // find hashes encompassing those block
   size_t first_index = height / HASH_OF_HASHES_STEP;
   size_t last_index = (height + hashes.size() - 1) / HASH_OF_HASHES_STEP;


### PR DESCRIPTION
It's freed when we've synced past its end, but we might still
find an old chain somewhere