### PR TITLE
handle ^D and ^C while password prompting

### DIFF
--- a/src/common/password.h
+++ b/src/common/password.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <string>
+#include <atomic>
 #include <boost/optional/optional.hpp>
 #include "wipeable_string.h"
 
@@ -49,6 +50,7 @@ namespace tools
 
     //! \return A password from stdin TTY prompt or `std::cin` pipe.
     static boost::optional<password_container> prompt(bool verify, const char *mesage = "Password");
+    static std::atomic<bool> is_prompting;
 
     password_container(const password_container&) = delete;
     password_container(password_container&& rhs) = default;

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -153,8 +153,12 @@ namespace tools
       }
       return r;
 #else
+      static struct sigaction sa;
+      memset(&sa, 0, sizeof(struct sigaction));
+      sa.sa_handler = posix_handler;
+      sa.sa_flags = 0;
       /* Only blocks SIGINT, SIGTERM and SIGPIPE */
-      signal(SIGINT, posix_handler);
+      sigaction(SIGINT, &sa, NULL);
       signal(SIGTERM, posix_handler);
       signal(SIGPIPE, SIG_IGN);
       m_handler = t;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -638,6 +638,8 @@ bool simple_wallet::change_password(const std::vector<std::string> &args)
 
   // prompts for a new password, pass true to verify the password
   const auto pwd_container = default_password_prompter(true);
+  if(!pwd_container)
+    return true;
 
   try
   {
@@ -6806,6 +6808,11 @@ int main(int argc, char* argv[])
   else
   {
     tools::signal_handler::install([&w](int type) {
+      if (tools::password_container::is_prompting.load())
+      {
+        // must be prompting for password so return and let the signal stop prompt
+        return;
+      }
 #ifdef WIN32
       if (type == CTRL_C_EVENT)
 #else


### PR DESCRIPTION
This fixes an issue during entering a password and user pressing ^D or ^C. These are now honored and exit the password prompt.

Credit to @vtnerd also.
