### PR TITLE
monerod: do not log to tmpdir in daemon mode

### DIFF
--- a/src/daemonizer/CMakeLists.txt
+++ b/src/daemonizer/CMakeLists.txt
@@ -54,6 +54,10 @@ else()
   )
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-DDEBUG_TMPDIR_LOG=1)
+endif()
+
 monero_private_headers(daemonizer
   ${daemonizer_private_headers})
 monero_add_library(daemonizer

--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -115,6 +115,7 @@ void fork(const std::string & pidfile)
     quit("Unable to open /dev/null");
   }
 
+#ifdef DEBUG_TMPDIR_LOG
   // Send standard output to a log file.
   const char *tmpdir = getenv("TMPDIR");
   if (!tmpdir)
@@ -133,6 +134,7 @@ void fork(const std::string & pidfile)
   {
     quit("Unable to dup output descriptor");
   }
+#endif
 }
 
 } // namespace posix

--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -15,7 +15,6 @@ ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf \
     --detach --pidfile /run/monero/monerod.pid
 
 Restart=always
-PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
~~The logging to /tmp/bitmonero.daemon.stdout.stderr caused segfaults if the /tmp mount was full~~ (#2851).

Now the daemon is only logging to /tmp/bitmonero.daemon.stdout.stderr in the debug builds.