### PR TITLE
memwipe: add missing #include <stdio.h>

### DIFF
--- a/contrib/epee/src/memwipe.c
+++ b/contrib/epee/src/memwipe.c
@@ -31,6 +31,7 @@
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #ifdef HAVE_EXPLICIT_BZERO
 #include <strings.h>


### PR DESCRIPTION
After #3187 was merged, I see the following error on Mac:

```
monero/contrib/epee/src/memwipe.c:55:13: error: use of undeclared identifier 'stderr'
    fprintf(stderr, "Error: memset_s failed\n");
```
