### PR TITLE
Fix broken build + refresh language files

### DIFF
--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -527,7 +527,7 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [<payment_id>] - Send all unlocked outputs below the threshold to an address</source>
+        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -961,7 +961,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [<payment_id>] - Send all unlocked balance to an address</source>
+        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -4,23 +4,23 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="55"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="65"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="63"/>
         <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="72"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="70"/>
         <source>Invalid payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="79"/>
-        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
+        <location filename="../src/wallet/api/address_book.cpp" line="77"/>
+        <source>Integrated address and long payment ID can&apos;t be used at the same time</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -37,32 +37,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="114"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="117"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="126"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="131"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
@@ -81,323 +81,324 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="141"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="151"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="164"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="170"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="176"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="179"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="181"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %s</source>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="942"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="952"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
         <source>Failed to add short payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="978"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1072"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="981"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1075"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="984"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1078"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1081"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
+        <source>not enough outputs for specified ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>found outputs to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
+        <source>Please sweep unmixable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
         <source>failed to get random outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="994"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1088"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="403"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="474"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="415"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="486"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="425"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="496"/>
         <source>No view key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="432"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="503"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="442"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="513"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="447"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="518"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="453"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="524"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="458"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="529"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="477"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="548"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="799"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <source>Failed to send import wallet request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="919"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="820"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="940"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="838"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="958"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="847"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="967"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="874"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="986"/>
+        <source>Key images can only be imported with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="999"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="987"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
+        <source>Failed to get subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
+        <source>Failed to set subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
         <source>failed to get random outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1003"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1097"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
+        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1012"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1106"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
-        <source>found outputs to mix</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1019"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1113"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1023"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1117"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1030"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1124"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1033"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1127"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1036"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1039"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1133"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1042"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1136"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1045"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1139"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1419"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1441"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1494"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1525"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
+        <source>Failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
+        <source>Failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1502"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Monero::WalletManagerImpl</name>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="192"/>
-        <source>failed to parse txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="199"/>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="206"/>
-        <source>failed to parse tx key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="217"/>
-        <source>failed to parse address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
-        <source>failed to get transaction from daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="238"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="245"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="250"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="257"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="313"/>
-        <source>error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>received</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>in txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="323"/>
-        <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="212"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="227"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="237"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="271"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -405,1227 +406,1748 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="76"/>
+        <location filename="../src/common/command_line.cpp" line="57"/>
         <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="71"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="38"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="39"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="41"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="42"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="66"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="43"/>
+        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="70"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="74"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="78"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> requires RFC server password --</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="479"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="697"/>
-        <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
-        <source>Stop mining in daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="699"/>
-        <source>Save current blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="701"/>
-        <source>Show current wallet balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
-        <source>Show blockchain height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
-        <source>Show current wallet public address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <source>Show this help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="811"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="416"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
         <source>usage: payment_id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="743"/>
-        <source>Generate a new random full size payment id - these will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="801"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="800"/>
-        <source>integer &gt;= 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
         <source>0, 1, 2, 3, or 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
         <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2092"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2121"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2643"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1297"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2671"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1368"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3074"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1699"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3165"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1671"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
         <source>transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1672"/>
-        <source>received </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3198"/>
         <source>unsupported transaction format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1718"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3219"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2186"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4462"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4470"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2262"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2533"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4527"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Failed to check for backlog: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <source>
+Transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
+        <source>Spending from address index %d
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3953"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4309"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3955"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3958"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3964"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3967"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3973"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2367"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2544"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4011"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4549"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3157"/>
-        <source>Not enough money in unlocked balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
-        <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Reason: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4149"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4424"/>
+        <source>failed to parse Payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4440"/>
+        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
+        <source>failed to parse key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
+        <source>No outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4504"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4586"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4601"/>
+        <source>donations are not enabled on the testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4702"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
+        <source> dummy output(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4797"/>
+        <source>usage: sign_transfer [export]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3137"/>
-        <source>daemon is busy. Please try again later</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1995"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="390"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="404"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
         <source>priority must be 0, 1, 2, 3, or 4 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1316"/>
         <source>priority must be 0, 1, 2, 3, or 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="540"/>
-        <source>priority must be 0, 1, 2, 3, or 4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
-        <source>Same as transfer, but using an older transaction building algorithm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
-        <source>donate [&lt;mixin_count&gt;] &lt;amount&gt; [payment_id] - Donate &lt;amount&gt; to the development team (donate.getmonero.org)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
-        <source>set_log &lt;level&gt;|&lt;categories&gt; - Change current log detail (level must be &lt;0-4&gt;)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
-        <source>address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)] - Print all entries in the address book, optionally adding/deleting an entry to/from it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
-        <source>show_transfers [in|out|pending|failed|pool] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="741"/>
-        <source>Show information about a transfer to/from this address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
-        <source>Change wallet password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
         <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="886"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
         <source>(Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2536"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
         <source>date format must be YYYY-MM-DD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2527"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
         <source>Is this okay?  (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
         <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1755"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2457"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2895"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2000"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2005"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2644"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1795"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <source>spent</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <source>global index</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
+        <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <source>tx id</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
+        <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1868"/>
-        <source>No incoming transfers</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
-        <source>No incoming available transfers</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1876"/>
-        <source>No incoming unavailable transfers</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
+        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1887"/>
-        <source>expected at least one payment ID</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="584"/>
+        <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
-        <source>payment</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
+        <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
-        <source>transaction</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <source>Cannot connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
-        <source>height</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <source>Current fee is %s monero per kB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
-        <source>unlock time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1908"/>
-        <source>No payments with id </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2280"/>
-        <source>failed to get blockchain height: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2016"/>
-        <source>failed to connect to the daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2034"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2060"/>
-        <source>failed to get output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
-        <source>
-Originating block heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
-        <source>
-|</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
-        <source>|
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2104"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2937"/>
-        <source>wrong number of arguments</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2744"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2298"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2762"/>
-        <source>No outputs found, or daemon is not ready</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2576"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2837"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
-        <source>failed to get random outputs to mix: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2518"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2969"/>
-        <source>Donating </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3053"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3077"/>
-        <source>This is a watch only wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4443"/>
-        <source>usage: show_transfer &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4557"/>
-        <source>Transaction ID not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="237"/>
-        <source>true</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="266"/>
-        <source>failed to parse refresh type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="367"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="467"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
-        <source>mixin must be an integer &gt;= 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="501"/>
-        <source>could not change default mixin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="545"/>
-        <source>could not change default priority</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
-        <source>Synchronize transactions and balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="702"/>
-        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="703"/>
-        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="706"/>
-        <source>transfer [&lt;priority&gt;] [&lt;mixin_count&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;] - Transfer &lt;amount&gt; to &lt;address&gt;. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
-        <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="708"/>
-        <source>Send all unmixable outputs to yourself with mixin 0</source>
+        <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
-        <source>Sign a transaction from a file</source>
+        <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="713"/>
-        <source>Submit a signed transaction from a file</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
-        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="718"/>
-        <source>Save wallet data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="719"/>
-        <source>Save a watch-only keys file</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
-        <source>Display private view key</source>
+        <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <source>Display private spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="722"/>
-        <source>Display Electrum-style mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="723"/>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value; merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="724"/>
-        <source>Rescan blockchain for spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="725"/>
-        <source>Get transaction key (r) for a given &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
-        <source>Generate a signature to prove payment to &lt;address&gt; in &lt;txid&gt; using the transaction secret key (r) without revealing it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="728"/>
-        <source>Check tx proof for payment going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="730"/>
-        <source>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Show unspent outputs within an optional amount range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="731"/>
-        <source>Rescan blockchain from scratch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="732"/>
-        <source>Set an arbitrary string note for a txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="733"/>
-        <source>Get a string note for a txid</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="762"/>
+        <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
-        <source>Show wallet status information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
-        <source>Sign the contents of a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="736"/>
-        <source>Verify a signature on the contents of a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="737"/>
-        <source>Export a signed set of key images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="738"/>
-        <source>Import signed key images list and verify their spent status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="739"/>
-        <source>Export a set of outputs owned by this wallet</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="767"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
-        <source>Import set of outputs owned by this wallet</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="773"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="802"/>
-        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <source>Your password is incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="806"/>
-        <source>monero, millinero, micronero, nanonero, piconero</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="851"/>
-        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="754"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
+        <source>usage: make_multisig &lt;threshold&gt; &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="794"/>
+        <source>Invalid threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <source>Another step is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <source>Send this multisig info to all other participants, then use finalize_multisig &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
+        <source>Error creating multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="822"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
+        <source> multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>This wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
+        <source>This wallet is already finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <source>usage: finalize_multisig &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="862"/>
+        <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
-        <source>Wallet and key files found, loading...</source>
+        <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="874"/>
-        <source>Key file found but not wallet file. Regenerating...</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
+        <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
-        <source>Key file not found. Failed to open wallet: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
+        <source>usage: export_multisig_info &lt;filename&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="894"/>
-        <source>Generating new wallet...</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
+        <source>Error exporting multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
+        <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
+        <source>usage: import_multisig_info &lt;filename1&gt; [&lt;filename2&gt;...] - one for each other participant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="953"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
+        <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <source>Electrum-style word list failed verification</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="969"/>
+        <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1063"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <source>No data supplied, cancelled</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="980"/>
+        <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1002"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2718"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3530"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4048"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4239"/>
-        <source>failed to parse address</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="985"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <source>failed to parse view key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
-        <source>failed to verify view key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
-        <source>view key does not match standard address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <source>account creation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
-        <source>failed to parse spend key secret key</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
+        <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1095"/>
-        <source>failed to verify spend key secret key</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
+        <source>usage: sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <source>Multisig error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source>usage: submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
-        <source>spend key does not match standard address</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1160"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
-        <source>failed to open account</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6750"/>
+        <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6751"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <source>usage: export_raw_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
+        <source>could not change default ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <source>Invalid height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1564"/>
+        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1565"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
+        <source>Stop mining in the daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <source>set_daemon &lt;host&gt;[:&lt;port&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1572"/>
+        <source>Set another daemon to connect to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <source>Save the current blockchain data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1582"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1585"/>
+        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1586"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1589"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
+        <source>Show the blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1625"/>
+        <source>sign_transfer &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3348"/>
-        <source>wallet is null</source>
+        <source>Sign a transaction from a &lt;file&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1262"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1311"/>
-        <source>invalid language choice entered. Please try again.
-</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1370"/>
-        <source>View key: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <source>account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt; 
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the walllet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1656"/>
+        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1660"/>
+        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <source>Save the wallet data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <source>Save a watch-only keys file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
+        <source>Display the private view key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Display the private spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <source>set &lt;option&gt; [&lt;value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <source>Available options:
+ seed language
+   Set the wallet&apos;s seed language.
+ always-confirm-transfers &lt;1|0&gt;
+   Whether to confirm unsplit txes.
+ print-ring-members &lt;1|0&gt;
+   Whether to print detailed information about ring members during confirmation.
+ store-tx-info &lt;1|0&gt;
+   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
+ default-ring-size &lt;n&gt;
+   Set the default ring size (default and minimum is 5).
+ auto-refresh &lt;1|0&gt;
+   Whether to automatically synchronize new blocks from the daemon.
+ refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
+   Set the wallet&apos;s refresh behaviour.
+ priority [0|1|2|3|4]
+   Set the fee too default/unimportant/normal/elevated/priority.
+ confirm-missing-payment-id &lt;1|0&gt;
+ ask-password &lt;1|0&gt;
+ unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
+   Set the default monero (sub-)unit.
+ min-outputs-count [n]
+   Try to keep at least that many outputs of value at least min-outputs-value.
+ min-outputs-value [n]
+   Try to keep at least min-outputs-count outputs of at least that value.
+ merge-destinations &lt;1|0&gt;
+   Whether to merge multiple payments to the same destination address.
+ confirm-backlog &lt;1|0&gt;
+   Whether to warn if there is transaction backlog.
+ confirm-backlog-threshold [n]
+   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
+ refresh-from-block-height [n]
+   Set the height before which to ignore blocks.
+ auto-low-priority &lt;1|0&gt;
+   Whether to automatically use the low priority fee level when it&apos;s safe to do so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1717"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
+        <source>get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1727"/>
+        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <source>get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1735"/>
+        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
+        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
+        <source>get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1748"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
+        <source>check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1754"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1757"/>
+        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
+        <source>Rescan the blockchain from scratch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1768"/>
+        <source>set_tx_note &lt;txid&gt; [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1769"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <source>get_tx_note &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>set_description [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1780"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <source>sign &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1793"/>
+        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>export_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1798"/>
+        <source>Export a signed set of key images to a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
+        <source>import_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1802"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
+        <source>export_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1806"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1809"/>
+        <source>import_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
+        <source>show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1825"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>make_multisig &lt;threshold&gt; &lt;string1&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1831"/>
+        <source>finalize_multisig &lt;string&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <source>export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1836"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <source>import_multisig_info &lt;filename&gt; [&lt;filename&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <source>sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
+        <source>submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1848"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1851"/>
+        <source>export_raw_multisig_tx &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <source>help [&lt;command&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2012"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2084"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>Enter seed encryption passphrase, empty if none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2259"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2350"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
+        <source>Secret spend key (%u of %u):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2550"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2551"/>
+        <source>Still apply restore height?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2582"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
 your current session&apos;s state. Otherwise, you might need to synchronize 
 your wallet again (your wallet keys are NOT at risk in any case).
@@ -1633,721 +2155,1464 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <source>You may want to remove the file &quot;%s&quot; and try again</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
+        <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
-        <source>failed to deinitialize wallet</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
+        <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1570"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
-        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <source>blockchain can&apos;t be saved: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2390"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2828"/>
-        <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1750"/>
-        <source>refresh error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
-        <source>Balance: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
-        <source>pubkey</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
-        <source>key image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
-        <source>unlocked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <source>ringct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <source>RingCT</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
-        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1990"/>
-        <source>failed to get spent status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
-        <source>the same transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
-        <source>blocks that are temporally very close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2206"/>
-        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
-        <source>usage: get_tx_proof &lt;txid&gt; &lt;dest_address&gt; [&lt;tx_key&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
-        <source>failed to parse tx_key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
-        <source>Tx secret key was found for the given txid, but you&apos;ve also provided another tx secret key which doesn&apos;t match the found one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
-        <source>Tx secret key wasn&apos;t found in the wallet file. Provide it as the optional third parameter if you have it elsewhere.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3330"/>
-        <source>Signature: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3508"/>
-        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3539"/>
-        <source>Signature header check error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3550"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3560"/>
-        <source>Signature decoding error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3602"/>
-        <source>Tx pubkey was not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3609"/>
-        <source>Good signature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
-        <source>Bad signature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3621"/>
-        <source>failed to generate key derivation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3994"/>
-        <source>usage: integrated_address [payment ID]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4017"/>
-        <source>Integrated address: account %s, payment ID %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4022"/>
-        <source>Standard address: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4027"/>
-        <source>failed to parse payment ID or address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4038"/>
-        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4070"/>
-        <source>failed to parse payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
-        <source>failed to parse index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
-        <source>Address book is empty.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4102"/>
-        <source>Index: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4103"/>
-        <source>Address: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4104"/>
-        <source>Payment ID: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4105"/>
-        <source>Description: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4115"/>
-        <source>usage: set_tx_note [txid] free text note</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4143"/>
-        <source>usage: get_tx_note [txid]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
-        <source>usage: sign &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4198"/>
-        <source>wallet is watch-only and cannot sign</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4207"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4374"/>
-        <source>failed to read file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4219"/>
-        <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
-        <source>Bad signature from </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4250"/>
-        <source>Good signature from </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4259"/>
-        <source>usage: export_key_images &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4264"/>
-        <source>wallet is watch-only and cannot export key images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4274"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4346"/>
-        <source>failed to save file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4285"/>
-        <source>Signed key images exported to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>usage: import_key_images &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4323"/>
-        <source>usage: export_outputs &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
-        <source>Outputs exported to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
-        <source>usage: import_outputs &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3818"/>
-        <source>amount is wrong: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2247"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
-        <source>expected number from 0 to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2378"/>
-        <source>Money successfully sent, transaction </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
-        <source>no connection to daemon. Please, make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2597"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3171"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>output amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>found outputs to mix</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2605"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
-        <source>transaction was not constructed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3191"/>
-        <source>one of destinations is zero</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
-        <source>Failed to find a suitable way to split transactions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2452"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2629"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
-        <source>unknown transfer error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <source>Sweeping </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2816"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3129"/>
-        <source>Money successfully sent, transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3022"/>
-        <source>Change goes to more than one address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
-        <source>%s change to %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3050"/>
-        <source>no change</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
-        <source>Transaction successfully signed to file </source>
+        <source>missing daemon URL argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3226"/>
-        <source>usage: get_tx_key &lt;txid&gt;</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4122"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4450"/>
-        <source>failed to parse txid</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3245"/>
-        <source>Tx key: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
-        <source>no tx keys found for this txid</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
+        <source>usage: balance [detail]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
-        <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3368"/>
-        <source>failed to parse tx key</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
+        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
-        <source>failed to get transaction from daemon</source>
+        <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <source>failed to parse transaction from daemon</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
-        <source>failed to validate transaction from daemon</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>tx id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3596"/>
-        <source>failed to get the right transaction from daemon</source>
+        <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3385"/>
-        <source>failed to generate key derivation from supplied parameters</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3427"/>
+        <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3471"/>
-        <source>error: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3431"/>
+        <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
-        <source>received</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3442"/>
+        <source>expected at least one payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
-        <source>in txid</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
-        <source>received nothing in txid</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>unlock time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3463"/>
+        <source>No payments with id </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3853"/>
+        <source>failed to get blockchain height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5259"/>
+        <source>failed to connect to the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3590"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
+        <source>
+Input %llu/%llu: amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
+        <source>failed to get output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3624"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
+        <source>
+Originating block heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <source>
+|</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
+        <source>|
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3662"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4184"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3724"/>
+        <source>wrong number of arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4479"/>
+        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>, txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4519"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4630"/>
+        <source>Donating </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
+        <source>This is a watch only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <source>usage: show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6673"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6708"/>
+        <source>Transaction ID not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="214"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="267"/>
+        <source>failed to parse refresh type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <source>could not change default priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
+        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
+        <source>monero, millinero, micronero, nanonero, piconero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
+        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
+        <source>Wallet and key files found, loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1998"/>
+        <source>Key file found but not wallet file. Regenerating...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2004"/>
+        <source>Key file not found. Failed to open wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
+        <source>Generating new wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
+        <source>Electrum-style word list failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
+        <source>No data supplied, cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
+        <source>failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
+        <source>failed to parse view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
+        <source>failed to verify view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
+        <source>view key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
+        <source>account creation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
+        <source>failed to parse spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
+        <source>failed to verify spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
+        <source>spend key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <source>failed to open account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4962"/>
+        <source>wallet is null</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2685"/>
+        <source>invalid language choice entered. Please try again.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
+        <source>View key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
+        <source>You may want to remove the file &quot;%s&quot; and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
+        <source>failed to deinitialize wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6410"/>
+        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3152"/>
+        <source>blockchain can&apos;t be saved: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
+        <source>no connection to daemon. Please make sure daemon is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
+        <source>refresh error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <source>Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
+        <source>pubkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
+        <source>key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
+        <source>unlocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>ringct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
+        <source>RingCT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
-        <source>WARNING: this transaction is not yet included in the blockchain!</source>
+        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3494"/>
-        <source>This transaction has %u confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
-        <source>WARNING: failed to determine number of confirmations!</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
-        <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
+        <source>blocks that are temporally very close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3778"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Good signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <source>Bad signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6046"/>
+        <source>usage: integrated_address [payment ID]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Standard address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6087"/>
+        <source>failed to parse payment ID or address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6098"/>
+        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <source>failed to parse payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6146"/>
+        <source>failed to parse index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <source>Address book is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
+        <source>Index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
+        <source>Address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <source>Payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <source>usage: set_tx_note [txid] free text note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6201"/>
+        <source>usage: get_tx_note [txid]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6304"/>
+        <source>usage: sign &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6309"/>
+        <source>wallet is watch-only and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
+        <source>failed to read file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5066"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5278"/>
+        <source>failed to load signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
+        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <source>wallet is watch-only and cannot generate the proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5161"/>
+        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
+        <source>usage: get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
+        <source>The reserve proof can be generated only by a full wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5253"/>
+        <source>usage: check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
+        <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5353"/>
+        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5490"/>
+        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
+        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
+        <source>There is no unspent output in the specified address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
+        <source> (no daemon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
+        <source> (out of sync)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5758"/>
+        <source>(Untitled account)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
+        <source>failed to parse index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <source>specify an index between 0 and </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5873"/>
+        <source>usage:
+  account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt;
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>
+Grand total:
+  Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>, unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
+        <source>Untagged accounts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5915"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
+        <source>Accounts with tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
+        <source>Tag&apos;s description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
+        <source> %c%8u %6s %21s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <source>----------------------------------------------------------------------------------</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <source>%15s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>Primary address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>(used)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>(Untitled address)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6022"/>
+        <source>&lt;index_min&gt; is already out of bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6027"/>
+        <source>&lt;index_max&gt; exceeds the bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6035"/>
+        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6065"/>
+        <source>Integrated addresses can only be created for account 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6077"/>
+        <source>Integrated address: %s, payment ID: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Subaddress: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
+        <source>usage: get_description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
+        <source>no description found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
+        <source>description found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
+        <source>Filename: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <source>Watch only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
+        <source>%u/%u multisig%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Testnet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
+        <source>This wallet is multisig and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6335"/>
+        <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <source>Bad signature from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <source>Good signature from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <source>usage: export_key_images &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <source>wallet is watch-only and cannot export key images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
+        <source>failed to save file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
+        <source>Signed key images exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6416"/>
+        <source>usage: import_key_images &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6447"/>
+        <source>usage: export_outputs &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6484"/>
+        <source>Outputs exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6492"/>
+        <source>usage: import_outputs &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <source>amount is wrong: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <source>expected number from 0 to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4079"/>
+        <source>Sweeping </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4559"/>
+        <source>Money successfully sent, transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4716"/>
+        <source>Change goes to more than one address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>%s change to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
+        <source>no change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4826"/>
+        <source>Transaction successfully signed to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4876"/>
+        <source>usage: get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <source>failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
+        <source>Tx key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4912"/>
+        <source>usage: get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5239"/>
+        <source>signature file saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5241"/>
+        <source>failed to save signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4953"/>
+        <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
+        <source>failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
+        <source>error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
+        <source>received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
+        <source>in txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5099"/>
+        <source>received nothing in txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5083"/>
+        <source>WARNING: this transaction is not yet included in the blockchain!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <source>This transaction has %u confirmations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
+        <source>WARNING: failed to determine number of confirmations!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5413"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>pending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
-        <source>usage: unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3869"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3870"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5606"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5646"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5647"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
         <source>Matching integrated address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>genms</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
+        <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
+        <source>Give threshold and participants at once as M/N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
+        <source>How many participants wil share parts of the multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
+        <source>How many signers are required to sign a valid transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
+        <source>Create testnet multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
+        <source>Generating %u %u/%u multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
+        <source>Error verifying multisig extra info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
+        <source>Error finalizing multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
+        <source>Generated multisig wallets for address </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
+        <source>Error creating multisig wallets: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
+        <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
+        <source>Error: expected N/M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
+        <source>Error: either --scheme or both of --threshold and --participants may be given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
+        <source>Error: --filename-base is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
+        <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
         <source>Generate incoming-only wallet from view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2356,242 +3621,252 @@ Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="120"/>
-        <source>Specify Electrum seed for wallet recovery/creation</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
+        <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
-        <source>Recover wallet using Electrum-style mnemonic seed</source>
+        <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
-        <source>Generate non-deterministic view and spend keys</source>
+        <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
-        <source>Enable commands which rely on a trusted daemon</source>
+        <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
-        <source>Allow communicating with a daemon that uses a different RPC version</source>
+        <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <source>Generate non-deterministic view and spend keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <source>Enable commands which rely on a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <source>Allow communicating with a daemon that uses a different RPC version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <source>The newly created transaction will not be relayed to the monero network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
         <source>Failed to initialize wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>tools::dns_utils</name>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="430"/>
-        <source>DNSSEC validation passed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="434"/>
-        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="437"/>
-        <source>For URL: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="439"/>
-        <source> Monero Address = </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="441"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="451"/>
-        <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="106"/>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="107"/>
+        <location filename="../src/wallet/wallet2.cpp" line="114"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Wallet password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="109"/>
+        <location filename="../src/wallet/wallet2.cpp" line="116"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="110"/>
+        <location filename="../src/wallet/wallet2.cpp" line="117"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="112"/>
+        <location filename="../src/wallet/wallet2.cpp" line="119"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <location filename="../src/wallet/wallet2.cpp" line="120"/>
         <source>Restricts to view-only commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="152"/>
+        <location filename="../src/wallet/wallet2.cpp" line="168"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="188"/>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="217"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Enter new password for the wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="464"/>
-        <source>failed to read wallet password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="227"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="115"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="111"/>
+        <location filename="../src/wallet/wallet2.cpp" line="118"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="233"/>
+        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <source>no password specified; use --prompt-for-password to prompt for a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
-        <location filename="../src/wallet/wallet2.cpp" line="331"/>
-        <location filename="../src/wallet/wallet2.cpp" line="373"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
+        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="380"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="276"/>
+        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
-        <location filename="../src/wallet/wallet2.cpp" line="343"/>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="290"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
+        <location filename="../src/wallet/wallet2.cpp" line="405"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="295"/>
+        <location filename="../src/wallet/wallet2.cpp" line="302"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="306"/>
-        <source>At least one of Electrum-style word list and private view key must be specified</source>
+        <location filename="../src/wallet/wallet2.cpp" line="319"/>
+        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="311"/>
+        <location filename="../src/wallet/wallet2.cpp" line="323"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="324"/>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
+        <location filename="../src/wallet/wallet2.cpp" line="342"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="347"/>
+        <location filename="../src/wallet/wallet2.cpp" line="352"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="356"/>
+        <location filename="../src/wallet/wallet2.cpp" line="360"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="403"/>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
+        <source>failed to parse address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source>Address must be specified in order to create watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="413"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="5205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2813"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2873"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2952"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2998"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3089"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3599"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3955"/>
+        <source>Primary account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="7914"/>
+        <source>No funds received in this tx.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="8607"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2599,94 +3874,125 @@ Outputs per *: </source>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="151"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
+        <source>Failed to create directory </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
+        <source>Failed to create directory %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="209"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1748"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
+        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
+        <source>This is the RPC monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1764"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1789"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1814"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1791"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1816"/>
-        <source>Saved ok</source>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
+        <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1794"/>
-        <source>Loaded ok</source>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
+        <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1798"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1805"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1809"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1811"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
+        <source>Failed to run wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1820"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2694,58 +4000,65 @@ Outputs per *: </source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4580"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="59"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="63"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="87"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="104"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="88"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="105"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="89"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="98"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="115"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="128"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="138"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="161"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="172"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="195"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="197"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="153"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="140"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -4,24 +4,24 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="55"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Adresse de destination invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="65"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="63"/>
         <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
         <translation>ID de paiement invalide. L&apos;identifiant de paiement court devrait seulement être utilisé dans une adresse intégrée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="72"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="70"/>
         <source>Invalid payment ID</source>
         <translation>ID de paiement invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="79"/>
-        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
-        <translation>Une adresse intégrée et un identifiant de paiement long ne peuvent pas être utilisés en même temps</translation>
+        <location filename="../src/wallet/api/address_book.cpp" line="77"/>
+        <source>Integrated address and long payment ID can&apos;t be used at the same time</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -37,32 +37,32 @@
         <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="114"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="117"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="126"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
         <source>. Reason: </source>
         <translation>. Raison : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
         <source>Unknown exception: </source>
         <translation>Exception inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="131"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
         <source>Unhandled exception</source>
         <translation>Exception non gérée</translation>
     </message>
@@ -81,323 +81,324 @@
         <translation>Échec de signature de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="141"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="151"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="164"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>envoi de %s à %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="170"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>sans destination</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="176"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="179"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="181"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %s</source>
-        <translation>%lu transactions chargées, pour %s, %s de frais, %s, %s, avec mixin minimum de %lu, %s</translation>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="942"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="952"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
         <source>Failed to add short payment id: </source>
         <translation>Échec de l&apos;ajout de l&apos;ID de paiement court : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="978"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1072"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="981"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1075"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="984"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1078"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1081"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
+        <source>not enough outputs for specified ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>found outputs to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
+        <source>Please sweep unmixable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
         <source>failed to get random outputs to mix</source>
         <translation>échec de la récupération de sorties aléatoires à mélanger</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="994"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1088"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="403"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="474"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="415"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="486"/>
         <source>failed to parse secret spend key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="425"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="496"/>
         <source>No view key supplied, cancelled</source>
         <translation>Pas de clé d&apos;audit fournie, annulation</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="432"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="503"/>
         <source>failed to parse secret view key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="442"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="513"/>
         <source>failed to verify secret spend key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="447"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="518"/>
         <source>spend key does not match address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="453"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="524"/>
         <source>failed to verify secret view key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="458"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="529"/>
         <source>view key does not match address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="477"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="548"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="799"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <source>Failed to send import wallet request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="919"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Échec du chargement des transaction non signées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="820"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="940"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="838"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="958"/>
         <source>Wallet is view only</source>
         <translation>Portefeuille d&apos;audit uniquement</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="847"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="967"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="874"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="986"/>
+        <source>Key images can only be imported with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="999"/>
         <source>Failed to import key images: </source>
         <translation>Échec de l&apos;importation des images de clé : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="987"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
+        <source>Failed to get subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
+        <source>Failed to set subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
         <source>failed to get random outputs to mix: %s</source>
         <translation>échec de la récupération de sorties aléatoires à mélanger : %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1003"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1097"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
+        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1012"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1106"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>pas assez de sorties pour le mixin spécifié</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>output amount</source>
         <translation>montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
-        <source>found outputs to mix</source>
-        <translation>sorties à mélanger trouvées</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1019"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1113"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>transaction was not constructed</source>
         <translation>la transaction n&apos;a pas été construite</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1023"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1117"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1030"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1124"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
         <source>one of destinations is zero</source>
         <translation>une des destinations est zéro</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1033"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1127"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1036"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
         <source>unknown transfer error: </source>
         <translation>erreur de transfert inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1039"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1133"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1042"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1136"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1045"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1139"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1419"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1441"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1494"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1525"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
+        <source>Failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished">aucune clé de transaction trouvée pour cet ID de transaction</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
+        <source>Failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1502"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished">Échec de l&apos;analyse de l&apos;adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Réexaminer les dépenses ne peut se faire qu&apos;avec un démon de confiance</translation>
     </message>
 </context>
 <context>
-    <name>Monero::WalletManagerImpl</name>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="192"/>
-        <source>failed to parse txid</source>
-        <translation>échec de l&apos;analyse de l&apos;ID de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="199"/>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="206"/>
-        <source>failed to parse tx key</source>
-        <translation>échec de l&apos;analyse de la clé de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="217"/>
-        <source>failed to parse address</source>
-        <translation>échec de l&apos;analyse de l&apos;adresse</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>échec de la récupération de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="238"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>échec de l&apos;analyse de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="245"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>échec de la validation de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="250"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>échec de la récupération de la bonne transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="257"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>échec de la génération de la dérivation de clé à partir des paramètres fournis</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="313"/>
-        <source>error: </source>
-        <translation>erreur : </translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>received</source>
-        <translation>a reçu</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>in txid</source>
-        <translation>dans la transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="323"/>
-        <source>received nothing in txid</source>
-        <translation>n&apos;a rien reçu dans la transaction</translation>
-    </message>
-</context>
-<context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="212"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
         <translation>Échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
         <translation>Échec de l&apos;analyse de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="227"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
         <translation>Échec de la vérification de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="237"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="271"/>
         <source>key does not match address</source>
         <translation>la clé ne correspond pas à l&apos;adresse</translation>
     </message>
@@ -405,1931 +406,3081 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="76"/>
+        <location filename="../src/common/command_line.cpp" line="57"/>
         <source>yes</source>
         <translation>oui</translation>
+    </message>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="71"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="38"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
         <source>Specify IP to bind RPC server</source>
         <translation>Spécifier l&apos;IP à laquelle lier le serveur RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="39"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="41"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Spécifier le nom_utilisateur[:mot_de_passe] requis pour le serveur RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="42"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Confirmer que la valeur de rpc-bind-ip n&apos;est PAS une IP de bouclage (locale)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="66"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="43"/>
+        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="70"/>
         <source>Invalid IP address given for --</source>
         <translation>Adresse IP invalide fournie pour --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="74"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="78"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation> autorise les connexions entrantes non cryptées venant de l&apos;extérieur. Considérez plutôt un tunnel SSH ou un proxy SSL. Outrepasser avec --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Username specified with --</source>
         <translation>Le nom d&apos;utilisateur spécifié avec --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> cannot be empty</source>
         <translation> ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> requires RFC server password --</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="479"/>
         <source>Commands: </source>
         <translation>Commandes : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>failed to read wallet password</source>
         <translation>échec de la lecture du mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
         <source>invalid password</source>
         <translation>mot de passe invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="697"/>
-        <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
-        <translation>start_mining [&lt;nombre_de_threads&gt;] - Démarrer l&apos;extraction minière dans le démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
-        <source>Stop mining in daemon</source>
-        <translation>Stopper l&apos;extraction minière dans le démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="699"/>
-        <source>Save current blockchain data</source>
-        <translation>Sauvegarder les données actuelles de la chaîne de blocs</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="701"/>
-        <source>Show current wallet balance</source>
-        <translation>Afficher le solde actuel du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
-        <source>Show blockchain height</source>
-        <translation>Afficher la hauteur de la chaîne de blocs</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
-        <source>Show current wallet public address</source>
-        <translation>Afficher l&apos;adresse publique du portefeuille actuel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <source>Show this help</source>
-        <translation>Afficher cette aide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed : requiert un argument. options disponibles : language</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="811"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set : argument(s) non reconnu(s)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
         <source>wallet file path not valid: </source>
         <translation>chemin du fichier portefeuille non valide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Tentative de génération ou de restauration d&apos;un portefeuille, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="416"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
         <source>usage: payment_id</source>
         <translation>usage : payment_id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
-        <translation>sweep_below &lt;montant_seuil&gt; [mixin] adresse [ID_paiement] - Envoyer toutes les sorties débloquées sous le seuil vers une adresse</translation>
-    </message>
-    <message>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value - merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
-        <translation type="obsolete">Options disponibles : seed language - définir la langue de la graine du portefeuille; always-confirm-transfers &lt;1|0&gt; - confirmer ou non les transactions non scindées; print-ring-members &lt;1|0&gt; - afficher ou non des informations détaillées sur les membres du cercle pendant la confirmation; store-tx-info &lt;1|0&gt; - sauvegarder ou non les informations des transactions sortantes (adresse de destination, ID de paiement, clé secrète de transaction) pour référence future; default-mixin &lt;n&gt; - définir le mixin par défaut (4 par défaut); auto-refresh &lt;1|0&gt; - synchroniser automatiquement ou non les nouveau blocs du démon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - définir le comportement du rafraîchissement du portefeuille; priority [0|1|2|3|4] - frais de transaction par défault/peu important/normal/élevé/prioritaire; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - définir la (sous-)unité monero par défaut; min-outputs-count [n] - essayer de garder au moins ce nombre de sortie d&apos;une valeur d&apos;au moins min-outputs-value; min-outputs-value [n] - essayer de garder au moins min-outputs-count sorties d&apos;une valeur d&apos;au moins ce montant; merge-destinations &lt;1|0&gt; - fusionner ou non de multiples paiements à une même adresse de destination</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="743"/>
-        <source>Generate a new random full size payment id - these will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids</source>
-        <translation>Générer un nouvel ID de paiement long aléatoire - ceux-ci seront non cryptés dans la chaîne de blocs, voir integrated_address pour les IDs de paiement courts cryptés</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
         <source>needs an argument</source>
         <translation>requiert un argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="801"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
         <source>0 or 1</source>
         <translation>0 ou 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="800"/>
-        <source>integer &gt;= 2</source>
-        <translation>entier &gt;= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
         <source>0, 1, 2, 3, or 4</source>
         <translation>0, 1, 2, 3 ou 4</translation>
     </message>
     <message>
-        <source>monero, millinero, micronero, nanop, piconero</source>
-        <translation type="obsolete">monero, millinero, micronero, nanonero, piconero</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
         <source>unsigned integer</source>
         <translation>entier non signé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
         <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>VEUILLEZ NOTER : les 25 mots suivants peuvent être utilisés pour restaurer votre portefeuille. Veuillez les écrire sur papier et les garder dans un endroit sûr. Ne les gardez pas dans un courriel ou dans un service de stockage de fichiers hors de votre contrôle.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2092"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet utilise --generate-new-wallet, pas --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2121"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>spécifiez un paramètre de récupération avec --electrum-seed=&quot;liste de mots ici&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>spécifiez un chemin de portefeuille avec --generate-new-wallet (pas --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>échec de la connexion du portefeuille au démon : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2643"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Le démon utilise une version majeure de RPC (%u) différente de celle du portefeuille (%u) : %s. Mettez l&apos;un des deux à jour, ou utilisez --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Liste des langues disponibles pour la graine de votre portefeuille :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1297"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2671"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation>Entrez le nombre correspondant à la langue de votre choix : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez dorénavant utiliser la nouvelle graine que nous fournissons.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1368"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
         <source>Generated new wallet: </source>
         <translation>Nouveau portefeuille généré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
         <source>Opened watch-only wallet</source>
         <translation>Ouverture du portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
         <source>Opened wallet</source>
         <translation>Ouverture du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez procéder à la mise à jour de votre portefeuille.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Le format de votre fichier portefeuille est en cours de mise à jour.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>failed to load wallet: </source>
         <translation>échec du chargement du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Utilisez la commande &quot;help&quot; pour voir la liste des commandes disponibles.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
         <source>Wallet data saved</source>
         <translation>Données du portefeuille sauvegardées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
         <source>Mining started in daemon</source>
         <translation>L&apos;extraction minière dans le démon a démarré</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3074"/>
         <source>mining has NOT been started: </source>
         <translation>l&apos;extraction minière n&apos;a PAS démarré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
         <source>Mining stopped in daemon</source>
         <translation>L&apos;extraction minière dans le démon a été stoppée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
         <source>mining has NOT been stopped: </source>
         <translation>l&apos;extraction minière n&apos;a PAS été stoppée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Blockchain saved</source>
         <translation>Chaîne de blocs sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1699"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3165"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
         <source>Height </source>
         <translation>Hauteur </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1671"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
         <source>transaction </source>
         <translation>transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1672"/>
-        <source>received </source>
-        <translation>reçu </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>spent </source>
         <translation>dépensé </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3198"/>
         <source>unsupported transaction format</source>
         <translation>format de transaction non supporté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1718"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3219"/>
         <source>Starting refresh...</source>
         <translation>Démarrage du rafraîchissement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
         <source>Refresh done, blocks received: </source>
         <translation>Rafraîchissement effectué, blocs reçus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2186"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
         <source>bad locked_blocks parameter:</source>
         <translation>mauvais paramètre locked_blocks :</translation>
     </message>
     <message>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="vanished" variants="yes">
-            <lengthvariant>Blocs vérrouillés trop élevé, 1000000 maximum (Ë</lengthvariant>
-            <lengthvariant>4 ans)</lengthvariant>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4462"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4470"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>échec de la définition de l&apos;ID de paiement, bien qu&apos;il ait été décodé correctement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2262"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2533"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4527"/>
         <source>transaction cancelled.</source>
         <translation>transaction annulée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Failed to check for backlog: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <source>
+Transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
+        <source>Spending from address index %d
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3953"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4309"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3955"/>
         <source>Sending %s.  </source>
         <translation>Envoi de %s. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3958"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Votre transaction doit être scindée en %llu transactions. Il en résulte que des frais de transaction doivent être appliqués à chaque transaction, pour un total de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3964"/>
         <source>The transaction fee is %s</source>
         <translation>Les frais de transaction sont de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3967"/>
         <source>, of which %s is dust from change</source>
         <translation>, dont %s est de la poussière de monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un total de %s de poussière de monnaie rendue sera envoyé à une adresse de poussière</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3973"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation>.
 Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s jours (en supposant 2 minutes par bloc)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2367"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2544"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4011"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4549"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3157"/>
-        <source>Not enough money in unlocked balance</source>
-        <translation>Pas assez de fonds dans le solde débloqué</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
-        <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
-        <translation>Échec de la recherche d&apos;une façon de créer les transactions. Ceci est généralement dû à de la poussière si petite qu&apos;elle de peut pas payer ses propre frais, à une tentative d&apos;envoi d&apos;un montant supérieur au solde débloqué, ou parce qu&apos;il n&apos;en reste pas assez pour les frais de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Reason: </source>
-        <translation>Raison : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
         <source>No unmixable outputs found</source>
         <translation>Aucune sortie non mélangeable trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4149"/>
         <source>No address given</source>
         <translation>Aucune adresse fournie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4424"/>
+        <source>failed to parse Payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4440"/>
+        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
+        <source>failed to parse key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
+        <source>No outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4504"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4586"/>
         <source>missing threshold amount</source>
         <translation>montant seuil manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>invalid amount threshold</source>
         <translation>montant seuil invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4601"/>
+        <source>donations are not enabled on the testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4702"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
         <source>sending %s to %s</source>
         <translation>envoi de %s à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
+        <source> dummy output(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
         <source>with no destinations</source>
         <translation>sans destination</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4797"/>
+        <source>usage: sign_transfer [export]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
         <source>Failed to sign transaction</source>
         <translation>Échec de signature de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
         <source>Failed to sign transaction: </source>
         <translation>Échec de signature de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3137"/>
-        <source>daemon is busy. Please try again later</source>
-        <translation>le démon est occupé. Veuillez réessayer plus tard</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1995"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de clé de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="390"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>Your original password was incorrect.</source>
         <translation>Votre mot de passe original est incorrect.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="404"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
         <source>Error with wallet rewrite: </source>
         <translation>Erreur avec la réécriture du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
         <source>priority must be 0, 1, 2, 3, or 4 </source>
         <translation>la priorité doit être 0, 1, 2, 3 ou 4 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1316"/>
         <source>priority must be 0, 1, 2, 3, or 4</source>
         <translation>la priorité doit être 0, 1, 2, 3 ou 4</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="540"/>
-        <source>priority must be 0, 1, 2, 3, or 4</source>
-        <translation>la priorité doit être 0, 1, 2, 3 ou 4</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
         <source>invalid unit</source>
         <translation>unité invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>nombre invalide : un entier non signé est attendu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
         <source>invalid value</source>
         <translation>valeur invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
-        <source>Same as transfer, but using an older transaction building algorithm</source>
-        <translation>Comme transfer, mais utilise an algorithme de construction de transaction plus ancien</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
-        <translation>sweep_all [mixin] adresse [ID_paiement] - Envoyer tout le solde débloqué à une adresse</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
-        <source>donate [&lt;mixin_count&gt;] &lt;amount&gt; [payment_id] - Donate &lt;amount&gt; to the development team (donate.getmonero.org)</source>
-        <translation>donate [&lt;mixin&gt;] &lt;montant&gt; [ID_paiement] - Donner &lt;montant&gt; à l&apos;équipe de développement (donate.getmonero.org)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
-        <source>set_log &lt;level&gt;|&lt;categories&gt; - Change current log detail (level must be &lt;0-4&gt;)</source>
-        <translation>set_log &lt;niveau&gt;|&lt;catégories&gt; - Changer les détails du journal (niveau entre &lt;0-4&gt;)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
-        <source>address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)] - Print all entries in the address book, optionally adding/deleting an entry to/from it</source>
-        <translation>address_book [(add (&lt;adresse&gt; [pid &lt;ID de paiement long ou court&gt;])|&lt;adresse integrée&gt; [&lt;description avec des espaces possible&gt;])|(delete &lt;index&gt;)] - Afficher toutes les entrées du carnet d&apos;adresses, éventuellement en y ajoutant/supprimant une entrée</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
-        <source>show_transfers [in|out|pending|failed|pool] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
-        <translation>show_transfers [in|out|pending|failed|pool] [&lt;hauteur_minimum&gt; [&lt;hauteur_maximum&gt;]] - Afficher les transferts entrants/sortants en précisant éventuellement un intervalle de hauteurs</translation>
-    </message>
-    <message>
-        <source>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Show unspent outputs within an optional amount range)</source>
-        <translation type="obsolete">unspent_outputs [&lt;montant_minimum&gt; &lt;montant_maximum&gt;] - Afficher les sorties non dépensées en précisant éventuellement un intervalle de montants</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="741"/>
-        <source>Show information about a transfer to/from this address</source>
-        <translation>Afficher les informations à propos d&apos;un transfert vers/de cette adresse</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
-        <source>Change wallet password</source>
-        <translation>Changer le mot de passe du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
         <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
         <translation>usage : set_log &lt;niveau_de_journalisation_0-4&gt; | &lt;catégories&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="886"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
         <source>(Y/Yes/N/No): </source>
         <translation>(Y/Yes/Oui/N/No/Non) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2536"/>
         <source>bad m_restore_height parameter: </source>
         <translation>mauvais paramètre m_restore_height : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
         <source>date format must be YYYY-MM-DD</source>
         <translation>le format de date doit être AAAA-MM-JJ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2527"/>
         <source>Restore height is: </source>
         <translation>La hauteur de restauration est : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
         <source>Is this okay?  (Y/Yes/N/No): </source>
         <translation>Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Password for new watch-only wallet</source>
         <translation>Mot de passe pour le nouveau portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
         <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
         <translation>arguments invalides. Veuillez utiliser start_mining [&lt;nombre_de_threads&gt;] [mine_en_arrière_plan] [ignorer_batterie], &lt;nombre_de_threads&gt; devrait être entre 1 et </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1755"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2457"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2895"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2000"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2005"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2644"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>refresh failed: </source>
         <translation>échec du rafraîchissement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Blocks received: </source>
         <translation>Blocs reçus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1795"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>unlocked balance: </source>
         <translation>solde débloqué : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>amount</source>
         <translation>montant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
+        <source>Unknown command: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
+        <source>Command usage: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <source>Command description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <source>wallet is multisig but not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
+        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="584"/>
+        <source>Failed to retrieve seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
+        <source>wallet is multisig and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <source>Cannot connect to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <source>Current fee is %s monero per kB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Error: failed to estimate backlog array size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <source>Error: bad estimated backlog array size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <source> (current)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
+        <source>No backlog at priority </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="762"/>
+        <source>This wallet is already multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="767"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="773"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <source>Your password is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="754"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
+        <source>usage: make_multisig &lt;threshold&gt; &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="794"/>
+        <source>Invalid threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <source>Another step is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <source>Send this multisig info to all other participants, then use finalize_multisig &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
+        <source>Error creating multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="822"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
+        <source> multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>This wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
+        <source>This wallet is already finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <source>usage: finalize_multisig &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="862"/>
+        <source>Failed to finalize multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <source>Failed to finalize multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
+        <source>This multisig wallet is not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
+        <source>usage: export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
+        <source>Error exporting multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
+        <source>Multisig info exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
+        <source>usage: import_multisig_info &lt;filename1&gt; [&lt;filename2&gt;...] - one for each other participant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
+        <source>Multisig info imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="969"/>
+        <source>Failed to import multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="980"/>
+        <source>Failed to update spent status after importing multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="985"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
+        <source>This is not a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
+        <source>usage: sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <source>Multisig error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source>usage: submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <source>Failed to load multisig transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1160"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6750"/>
+        <source>Transaction successfully submitted, transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6751"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <source>usage: export_raw_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
+        <source>could not change default ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <source>Invalid height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1564"/>
+        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1565"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
+        <source>Stop mining in the daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <source>set_daemon &lt;host&gt;[:&lt;port&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1572"/>
+        <source>Set another daemon to connect to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <source>Save the current blockchain data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1582"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1585"/>
+        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1586"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1589"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
+        <source>Show the blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1625"/>
+        <source>sign_transfer &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
+        <source>Sign a transaction from a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <source>Submit a signed transaction from a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <source>account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt; 
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the walllet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1656"/>
+        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1660"/>
+        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <source>Save the wallet data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <source>Save a watch-only keys file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
+        <source>Display the private view key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Display the private spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <source>set &lt;option&gt; [&lt;value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <source>Available options:
+ seed language
+   Set the wallet&apos;s seed language.
+ always-confirm-transfers &lt;1|0&gt;
+   Whether to confirm unsplit txes.
+ print-ring-members &lt;1|0&gt;
+   Whether to print detailed information about ring members during confirmation.
+ store-tx-info &lt;1|0&gt;
+   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
+ default-ring-size &lt;n&gt;
+   Set the default ring size (default and minimum is 5).
+ auto-refresh &lt;1|0&gt;
+   Whether to automatically synchronize new blocks from the daemon.
+ refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
+   Set the wallet&apos;s refresh behaviour.
+ priority [0|1|2|3|4]
+   Set the fee too default/unimportant/normal/elevated/priority.
+ confirm-missing-payment-id &lt;1|0&gt;
+ ask-password &lt;1|0&gt;
+ unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
+   Set the default monero (sub-)unit.
+ min-outputs-count [n]
+   Try to keep at least that many outputs of value at least min-outputs-value.
+ min-outputs-value [n]
+   Try to keep at least min-outputs-count outputs of at least that value.
+ merge-destinations &lt;1|0&gt;
+   Whether to merge multiple payments to the same destination address.
+ confirm-backlog &lt;1|0&gt;
+   Whether to warn if there is transaction backlog.
+ confirm-backlog-threshold [n]
+   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
+ refresh-from-block-height [n]
+   Set the height before which to ignore blocks.
+ auto-low-priority &lt;1|0&gt;
+   Whether to automatically use the low priority fee level when it&apos;s safe to do so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1717"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
+        <source>get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1727"/>
+        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <source>get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1735"/>
+        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
+        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
+        <source>get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1748"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
+        <source>check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1754"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1757"/>
+        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
+        <source>Rescan the blockchain from scratch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1768"/>
+        <source>set_tx_note &lt;txid&gt; [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1769"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <source>get_tx_note &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>set_description [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1780"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <source>sign &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1793"/>
+        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>export_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1798"/>
+        <source>Export a signed set of key images to a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
+        <source>import_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1802"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
+        <source>export_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1806"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1809"/>
+        <source>import_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
+        <source>show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1825"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>make_multisig &lt;threshold&gt; &lt;string1&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1831"/>
+        <source>finalize_multisig &lt;string&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <source>export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1836"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <source>import_multisig_info &lt;filename&gt; [&lt;filename&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <source>sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
+        <source>submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1848"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1851"/>
+        <source>export_raw_multisig_tx &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <source>help [&lt;command&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2012"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2084"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>Enter seed encryption passphrase, empty if none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2259"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2350"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished">échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished">échec de la vérification de la clé secrète d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
+        <source>Secret spend key (%u of %u):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2550"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2551"/>
+        <source>Still apply restore height?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2582"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <source>missing daemon URL argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
+        <source>usage: balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
+        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>spent</source>
         <translation>dépensé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>global index</source>
         <translation>index global</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>tx id</source>
         <translation>ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
         <source>No incoming transfers</source>
         <translation>Aucun transfert entrant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3427"/>
         <source>No incoming available transfers</source>
         <translation>Aucun transfert entrant disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1876"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3431"/>
         <source>No incoming unavailable transfers</source>
         <translation>Aucun transfert entrant non disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3442"/>
         <source>expected at least one payment ID</source>
         <translation>au moins un ID de paiement attendu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>payment</source>
         <translation>paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>transaction</source>
         <translation>transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>height</source>
         <translation>hauteur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>unlock time</source>
         <translation>durée de déverrouillage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1908"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3463"/>
         <source>No payments with id </source>
         <translation>Aucun paiement avec l&apos;ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3853"/>
         <source>failed to get blockchain height: </source>
         <translation>échec de la récupération de la hauteur de la chaîne de blocs : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5259"/>
         <source>failed to connect to the daemon</source>
         <translation>échec de la connexion au démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2034"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3590"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaction %llu/%llu : ID=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>
 Input %llu/%llu: amount=%s</source>
         <translation>
 Entrée %llu/%llu : montant=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2060"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
         <source>failed to get output: </source>
         <translation>échec de la récupération de la sortie : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3624"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>la hauteur du bloc d&apos;origine de la clé de la sortie ne devrait pas être supérieure à celle de la chaîne de blocs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
         <source>
 Originating block heights: </source>
         <translation>
 Hauteurs des blocs d&apos;origine : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Attention : Certaines clés d&apos;entrées étant dépensées sont issues de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3662"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, ce qui peut casser l&apos;anonymat du cercle de signature. Assurez-vous que c&apos;est intentionnel !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4184"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3724"/>
         <source>wrong number of arguments</source>
         <translation>mauvais nombre d&apos;arguments</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4479"/>
         <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
         <translation>Aucun ID de paiement n&apos;est inclus dans cette transaction. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2298"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Aucune sortie trouvée, ou le démon n&apos;est pas prêt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2576"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2837"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
-        <source>failed to get random outputs to mix: </source>
-        <translation>échec de la récupération de sorties aléatoires à mélanger : </translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2518"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>, txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Balayage de %s dans %llu transactions pour des frais totaux de %s. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4519"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Balayage de %s pour des frais totaux de %s. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4630"/>
         <source>Donating </source>
         <translation>Don de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3053"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Chargement de %lu transactions, pour %s, %s de frais, %s. %s, avec mixin minimum de %lu. %sEst-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
         <source>This is a watch only wallet</source>
         <translation>Ceci est un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
         <source>usage: show_transfer &lt;txid&gt;</source>
         <translation>usage : show_transfer &lt;ID_de_transaction&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6673"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6708"/>
         <source>Transaction ID not found</source>
         <translation>ID de transaction non trouvé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="237"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="214"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="267"/>
         <source>failed to parse refresh type</source>
         <translation>échec de l&apos;analyse du type de rafraîchissement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de graine</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>c&apos;est un portefeuille non déterministe et il n&apos;a pas de graine</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas transférer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
-        <source>mixin must be an integer &gt;= 2</source>
-        <translation>mixin doit être un entier &gt;= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="501"/>
-        <source>could not change default mixin</source>
-        <translation>échec du changement du mixin par défaut</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
         <source>could not change default priority</source>
         <translation>échec du changement de la priorité par défaut</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
-        <source>Synchronize transactions and balance</source>
-        <translation>Synchroniser les transactions et le solde</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="702"/>
-        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
-        <translation>incoming_transfers [available|unavailable] - Afficher les transferts entrants, soit tous soit filtrés par disponibilité</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="703"/>
-        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
-        <translation>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Affichier les paiements pour certains ID de paiement donnés</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="706"/>
-        <source>transfer [&lt;priority&gt;] [&lt;mixin_count&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;] - Transfer &lt;amount&gt; to &lt;address&gt;. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>transfer [&lt;priorité&gt;] [&lt;mixin&gt;] &lt;adresse&gt; &lt;montant&gt; [&lt;ID_paiement&gt;] - Transférer &lt;montant&gt; à &lt;adresse&gt;. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est élevée, plues les frais de transaction seront élévés. Les valeurs de priorité valies sont dans l&apos;ordre (de la plus basse à la plus élevée) : unimportant, normal, elevated, priority. Si ce paramètre est omis, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;mixin&gt; est le nombre d&apos;entrées supplémentaires à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être effectués d&apos;un coup en ajoutant &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, s&apos;il est inclus)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
-        <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
-        <translation>locked_transfer [&lt;mixin&gt;] &lt;adresse&gt; &lt;montant&gt; &lt;blocs_vérrous&gt;(Nombre de blocs pendant lequel vérrouiller la transaction, maximum 1000000) [&lt;ID_paiement&gt;]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="708"/>
-        <source>Send all unmixable outputs to yourself with mixin 0</source>
-        <translation>Envoyer toutes les sorties non méleangeables à vous-même avec un mixin de 0</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
-        <source>Sign a transaction from a file</source>
-        <translation>Signer une transaction d&apos;un fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="713"/>
-        <source>Submit a signed transaction from a file</source>
-        <translation>Soumettre une transaction signée d&apos;un fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
-        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation>integrated_address [PID] - Encoder un ID de paiement dans une adresse intégrée pour l&apos;adresse publique du portefeuille actuel (sans argument un ID de paiement aléatoire est utilisé), ou décoder une adresse intégrée en une adresse standard et un ID de paiement</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="718"/>
-        <source>Save wallet data</source>
-        <translation>Sauvegarder les données du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="719"/>
-        <source>Save a watch-only keys file</source>
-        <translation>Sauvegarder un fichier de clés d&apos;audit</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
-        <source>Display private view key</source>
-        <translation>Afficher la clé privée d&apos;audit</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <source>Display private spend key</source>
-        <translation>Afficher la clé privée de dépense</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="722"/>
-        <source>Display Electrum-style mnemonic seed</source>
-        <translation>Afficher la graine mnémonique de style Electrum</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="723"/>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value; merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
-        <translation>Options disponibles : seed language - définir la langue de la graine du portefeuille; always-confirm-transfers &lt;1|0&gt; - confirmer ou non les transactions non scindées; print-ring-members &lt;1|0&gt; - afficher ou non des informations détaillées sur les membres du cercle pendant la confirmation; store-tx-info &lt;1|0&gt; - sauvegarder ou non les informations des transactions sortantes (adresse de destination, ID de paiement, clé secrète de transaction) pour référence future; default-mixin &lt;n&gt; - définir le mixin par défaut (4 par défaut); auto-refresh &lt;1|0&gt; - synchroniser automatiquement ou non les nouveau blocs du démon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - définir le comportement du rafraîchissement du portefeuille; priority [0|1|2|3|4] - frais de transaction par défault/peu important/normal/élevé/prioritaire; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - définir la (sous-)unité monero par défaut; min-outputs-count [n] - essayer de garder au moins ce nombre de sortie d&apos;une valeur d&apos;au moins min-outputs-value; min-outputs-value [n] - essayer de garder au moins min-outputs-count sorties d&apos;une valeur d&apos;au moins ce montant; merge-destinations &lt;1|0&gt; - fusionner ou non de multiples paiements à une même adresse de destination</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="724"/>
-        <source>Rescan blockchain for spent outputs</source>
-        <translation>Réexaminer la chaîne de blocs pour trouver les sorties dépensées</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="725"/>
-        <source>Get transaction key (r) for a given &lt;txid&gt;</source>
-        <translation>Obtenir la clé de transaction (r) pour un &lt;ID_de_transaction&gt; donné</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation>Vérifier le montant allant à &lt;adresse&gt; dans &lt;ID_de_transaction&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
-        <source>Generate a signature to prove payment to &lt;address&gt; in &lt;txid&gt; using the transaction secret key (r) without revealing it</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="728"/>
-        <source>Check tx proof for payment going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="730"/>
-        <source>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Show unspent outputs within an optional amount range</source>
-        <translation>unspent_outputs [&lt;montant_minimum&gt; &lt;montant_maximum&gt;] - Afficher les sorties non dépensées en précisant éventuellement un intervalle de montants</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="731"/>
-        <source>Rescan blockchain from scratch</source>
-        <translation>Réexaminer la chaîne de blocs depuis le début</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="732"/>
-        <source>Set an arbitrary string note for a txid</source>
-        <translation>Définir une note arbitraire pour un ID de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="733"/>
-        <source>Get a string note for a txid</source>
-        <translation>Obtenir une note pour un ID de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
-        <source>Show wallet status information</source>
-        <translation>Afficher les informations sur le statut du portefuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
-        <source>Sign the contents of a file</source>
-        <translation>Signer le contenu d&apos;un fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="736"/>
-        <source>Verify a signature on the contents of a file</source>
-        <translation>Vérifier une signature du contenu d&apos;un fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="737"/>
-        <source>Export a signed set of key images</source>
-        <translation>Exporter un ensemble signé d&apos;images de clé</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="738"/>
-        <source>Import signed key images list and verify their spent status</source>
-        <translation>Importer un ensemble signé d&apos;images de clé et vérifier leurs statuts de dépense</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="739"/>
-        <source>Export a set of outputs owned by this wallet</source>
-        <translation>Exporter un ensemble de sorties possédées par ce portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
-        <source>Import set of outputs owned by this wallet</source>
-        <translation>Importer un ensemble de sorties possédées par ce portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="802"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (le plus lent, aucune supposition); optimize-coinbase (rapide, suppose que la récompense de bloc est payée à une unique adresse); no-coinbase (le plus rapide, suppose que l&apos;on ne reçoit aucune récompense de bloc), default (comme optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nom de portefeuille non valide. Veuillez réessayer ou utilisez Ctrl-C pour quitter.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Fichier portefeuille et fichier de clés trouvés, chargement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="874"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1998"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Fichier de clés trouvé mais pas le fichier portefeuille. Régénération...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2004"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Fichier de clés non trouvé. Échec de l&apos;ouverture du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
         <source>Generating new wallet...</source>
         <translation>Génération du nouveau portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
-        <translation>impossible de spécifier plus d&apos;une option parmis --generate-new-wallet=&quot;nom_du_portefeuille&quot;, --wallet-file=&quot;nom_du_portefeuille&quot;, --generate-from-view-key=&quot;nom_du_portefeuille&quot;, --generate-from-json=&quot;nom_du_fichier_json&quot; et --generate-from-keys=&quot;nom_du_portefeuille&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="953"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
-        <translation>impossible de spécifier à la fois --restore-deterministic-wallet et --non-deterministic</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1063"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
         <source>No data supplied, cancelled</source>
         <translation>Pas de données fournies, annulation</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1002"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2718"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3530"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4048"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
         <source>account creation failed</source>
         <translation>échec de la création du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
         <source>failed to open account</source>
         <translation>échec de l&apos;ouverture du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1579"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4962"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1262"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
-        <translation>Le démon n&apos;est pas démarré ou un mauvais port a été passé. Veuillez vous assurer que le démon fonctionne ou redémarrez le portefeuille avec l&apos;adresse de démon correcte.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2685"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>choix de langue passé invalide. Veuillez réessayer.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
         <source>View key: </source>
         <translation>Clé d&apos;audit : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation>Votre portefeuille a été généré !
-Pour commencer la synchronisation avec le démon, utilisez la commande &quot;refresh&quot;.
-Utilisez la commande &quot;help&quot; pour voir la liste des commandes disponibles.
-Utilisez toujours la commande &quot;exit&quot; pour fermer monero-wallet-cli afin de sauvegarder
-l&apos;état actuel de votre session. Sinon vous pourriez avoir besoin de synchroniser
-votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent rien).
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Vous pourriez vouloir supprimer le fichier &quot;%s&quot; et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
         <source>failed to deinitialize wallet</source>
         <translation>échec de la désinitialisation du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1570"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6410"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>cette commande requiert un démon de confiance. Activer avec --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3152"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>la chaîne de blocs ne peut pas être sauvegardée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2390"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
         <source>refresh error: </source>
         <translation>erreur du rafraîchissement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
         <source>Balance: </source>
         <translation>Solde : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>pubkey</source>
         <translation>clé publique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>key image</source>
         <translation>image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>unlocked</source>
         <translation>déverrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>T</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>locked</source>
         <translation>vérrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
         <source>failed to get spent status</source>
         <translation>échec de la récupération du statut de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>the same transaction</source>
         <translation>la même transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>blocks that are temporally very close</source>
         <translation>blocs très proches dans le temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2206"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3778"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
-        <source>usage: get_tx_proof &lt;txid&gt; &lt;dest_address&gt; [&lt;tx_key&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
-        <source>failed to parse tx_key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
-        <source>Tx secret key was found for the given txid, but you&apos;ve also provided another tx secret key which doesn&apos;t match the found one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
-        <source>Tx secret key wasn&apos;t found in the wallet file. Provide it as the optional third parameter if you have it elsewhere.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3330"/>
-        <source>Signature: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3508"/>
-        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3539"/>
-        <source>Signature header check error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3550"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3560"/>
-        <source>Signature decoding error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3602"/>
-        <source>Tx pubkey was not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3621"/>
-        <source>failed to generate key derivation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6046"/>
         <source>usage: integrated_address [payment ID]</source>
         <translation>usage : integrated_address [ID paiement]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4017"/>
-        <source>Integrated address: account %s, payment ID %s</source>
-        <translation>Adresse intégrée : compte %s, ID de paiement %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>Standard address: </source>
         <translation>Adresse standard : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4027"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6087"/>
         <source>failed to parse payment ID or address</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement ou de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6098"/>
         <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
         <translation>usage : address_book [(add (&lt;adresse&gt; [pid &lt;ID de paiement long ou court&gt;])|&lt;adresse integrée&gt; [&lt;description avec des espaces possible&gt;])|(delete &lt;index&gt;)]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
         <source>failed to parse payment ID</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6146"/>
         <source>failed to parse index</source>
         <translation>échec de l&apos;analyse de l&apos;index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <source>Address book is empty.</source>
         <translation>Le carnet d&apos;adresses est vide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
         <source>Index: </source>
         <translation>Index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
         <source>Address: </source>
         <translation>Adresse : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
         <source>Payment ID: </source>
         <translation>ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
         <source>Description: </source>
         <translation>Description : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
         <source>usage: set_tx_note [txid] free text note</source>
         <translation>usage : set_tx_note [ID transaction] note de texte libre</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6201"/>
         <source>usage: get_tx_note [txid]</source>
         <translation>usage : get_tx_note [ID transaction]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6304"/>
         <source>usage: sign &lt;filename&gt;</source>
         <translation>usage : sign &lt;fichier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4198"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6309"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4207"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5066"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5278"/>
+        <source>failed to load signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
+        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <source>wallet is watch-only and cannot generate the proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5161"/>
+        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
+        <source>usage: get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
+        <source>The reserve proof can be generated only by a full wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5253"/>
+        <source>usage: check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
+        <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5353"/>
+        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5490"/>
+        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
+        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
+        <source>There is no unspent output in the specified address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
+        <source> (no daemon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
+        <source> (out of sync)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5758"/>
+        <source>(Untitled account)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
+        <source>failed to parse index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <source>specify an index between 0 and </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5873"/>
+        <source>usage:
+  account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt;
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>
+Grand total:
+  Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>, unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
+        <source>Untagged accounts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5915"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
+        <source>Accounts with tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
+        <source>Tag&apos;s description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
+        <source> %c%8u %6s %21s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <source>----------------------------------------------------------------------------------</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <source>%15s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>Primary address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>(used)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>(Untitled address)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6022"/>
+        <source>&lt;index_min&gt; is already out of bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6027"/>
+        <source>&lt;index_max&gt; exceeds the bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6035"/>
+        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6065"/>
+        <source>Integrated addresses can only be created for account 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6077"/>
+        <source>Integrated address: %s, payment ID: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Subaddress: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
+        <source>usage: get_description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
+        <source>no description found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
+        <source>description found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
+        <source>Filename: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <source>Watch only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
+        <source>%u/%u multisig%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Testnet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
+        <source>This wallet is multisig and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6335"/>
         <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
         <translation>usage : verify &lt;fichier&gt; &lt;adresse&gt; &lt;signature&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
         <source>Bad signature from </source>
         <translation>Mauvaise signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
         <source>Good signature from </source>
         <translation>Bonne signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
         <source>usage: export_key_images &lt;filename&gt;</source>
         <translation>usage : export_key_images &lt;fichier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas exporter les images de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4274"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
         <source>Signed key images exported to </source>
         <translation>Images de clé signées exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6416"/>
         <source>usage: import_key_images &lt;filename&gt;</source>
         <translation>usage : import_key_images &lt;fichier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6447"/>
         <source>usage: export_outputs &lt;filename&gt;</source>
         <translation>usage : export_outputs &lt;fichier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6484"/>
         <source>Outputs exported to </source>
         <translation>Sorties exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6492"/>
         <source>usage: import_outputs &lt;filename&gt;</source>
         <translation>usage : import_outputs &lt;fichier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
         <source>amount is wrong: </source>
         <translation>montant erroné : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2247"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
         <source>expected number from 0 to </source>
         <translation>attend un nombre de 0 à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2378"/>
-        <source>Money successfully sent, transaction </source>
-        <translation>Fonds envoyés avec succès, transaction </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
-        <source>no connection to daemon. Please, make sure daemon is running.</source>
-        <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2597"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3171"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>pas assez de sorties pour le mixin spécifié</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>output amount</source>
-        <translation>montant de la sortie</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>found outputs to mix</source>
-        <translation>sorties à mélanger trouvées</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2605"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
-        <source>transaction was not constructed</source>
-        <translation>la transaction n&apos;a pas été construite</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3191"/>
-        <source>one of destinations is zero</source>
-        <translation>une des destinations est zéro</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
-        <source>Failed to find a suitable way to split transactions</source>
-        <translation>Échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2452"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2629"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
-        <source>unknown transfer error: </source>
-        <translation>erreur de transfert inconnue : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4079"/>
         <source>Sweeping </source>
         <translation>Balayage de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation>Balayage de %s pour des frais totaux de %s. Est-ce correct ? (Y/Yes/Oui/N/No/Non)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2816"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4559"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fonds envoyés avec succès, transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4716"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4826"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaction signée avec succès dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4876"/>
         <source>usage: get_tx_key &lt;txid&gt;</source>
         <translation>usage : get_tx_key &lt;ID transaction&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4122"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>failed to parse txid</source>
         <translation>échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3245"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
         <source>Tx key: </source>
         <translation>Clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4912"/>
+        <source>usage: get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5239"/>
+        <source>signature file saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5241"/>
+        <source>failed to save signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4953"/>
         <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
         <translation>usage : check_tx_key &lt;ID transaction&gt; &lt;clé transaction&gt; &lt;adresse&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3368"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
         <source>failed to parse tx key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>échec de la récupération de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>échec de l&apos;analyse de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>échec de la validation de la transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3596"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>échec de la récupération de la bonne transaction du démon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3385"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>échec de la génération de la dérivation de clé à partir des paramètres fournis</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
         <source>error: </source>
         <translation>erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>received</source>
         <translation>a reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>in txid</source>
         <translation>dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5099"/>
         <source>received nothing in txid</source>
         <translation>n&apos;a rien reçu dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5083"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>ATTENTION : cette transaction n&apos;est pas encore inclue dans la chaîne de blocs !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>This transaction has %u confirmations</source>
         <translation>Cette transaction a %u confirmations</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>ATTENTION : échec de la détermination du nombre de confirmations !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
-        <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation>usage : show_transfers [in|out|all|pending|failed] [&lt;hauteur_minimum&gt; [&lt;hauteur_maximum&gt;]]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
         <source>bad min_height parameter:</source>
         <translation>mauvais paramètre hauteur_minimum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5413"/>
         <source>bad max_height parameter:</source>
         <translation>mauvais paramètre hauteur_maximum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
         <source>in</source>
         <translation>reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>out</source>
         <translation>payé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>failed</source>
         <translation>échoué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>pending</source>
         <translation>en attente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
-        <source>usage: unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;]</source>
-        <translation>usage : unspent_outputs [&lt;montant_minimum&gt; &lt;montant_maximum&gt;]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;montant_minimum&gt; doit être inférieur à &lt;montant_maximum&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>, number of keys: </source>
         <translation>, nombre de clés : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Min block height: </source>
         <translation>
 Hauteur de bloc minimum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>
 Max block height: </source>
         <translation>
 Hauteur de bloc maximum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>
 Min amount found: </source>
         <translation>
 Montant minimum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3869"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>
 Max amount found: </source>
         <translation>
 Montant maximum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3870"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5606"/>
         <source>
 Total count: </source>
         <translation>
 Compte total : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5646"/>
         <source>
 Bin size: </source>
         <translation>
 Taille de classe : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5647"/>
         <source>
 Outputs per *: </source>
         <translation>
 Sorties par * : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
         <source>count
   ^
 </source>
@@ -2338,67 +3489,156 @@ Sorties par * : </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; hauteur de bloc
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
         <source>wallet</source>
         <translation>portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
         <source>Random payment ID: </source>
         <translation>ID de paiement aléatoire : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
         <source>Matching integrated address: </source>
         <translation>Adresse intégrée correspondante : </translation>
     </message>
 </context>
 <context>
+    <name>genms</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
+        <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
+        <source>Give threshold and participants at once as M/N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
+        <source>How many participants wil share parts of the multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
+        <source>How many signers are required to sign a valid transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
+        <source>Create testnet multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
+        <source>Generating %u %u/%u multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
+        <source>Error verifying multisig extra info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
+        <source>Error finalizing multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
+        <source>Generated multisig wallets for address </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
+        <source>Error creating multisig wallets: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
+        <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
+        <source>Error: expected N/M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
+        <source>Error: either --scheme or both of --threshold and --participants may be given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
+        <source>Error: --filename-base is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
+        <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Générer un nouveau portefeuille et le sauvegarder dans &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Générer un portefeuille d&apos;audit à partir d&apos;une clé d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <source>Generate deterministic wallet from spend key</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="118"/>
@@ -2406,242 +3646,252 @@ Sorties par * : </translation>
         <translation>Générer un portefeuille à partir de clés privées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
+        <source>Generate a master wallet from multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <source>Language for mnemonic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Spécifier la graine Electrum pour la récupération/création d&apos;un portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Récupérer un portefeuille en utilisant une graine mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Générer des clés d&apos;audit et de dépense non déterministes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Activer les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Autoriser la communication avec un démon utilisant une version de RPC différente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
         <source>Restore from specific blockchain height</source>
         <translation>Restaurer à partir d&apos;une hauteur de bloc spécifique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <source>The newly created transaction will not be relayed to the monero network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
         <source>possibly lost connection to daemon</source>
         <translation>connexion avec le démon peut-être perdue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
         <source>Failed to initialize wallet</source>
         <translation>Échec de l&apos;initialisation du portefeuille</translation>
     </message>
 </context>
 <context>
-    <name>tools::dns_utils</name>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="430"/>
-        <source>DNSSEC validation passed</source>
-        <translation>validation DNSSEC réussie</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="434"/>
-        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
-        <translation>ATTENTION : validation DNSSEC échouée, cette adresse pourrait ne pas être correcte !</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="437"/>
-        <source>For URL: </source>
-        <translation>Pour l&apos;URL : </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="439"/>
-        <source> Monero Address = </source>
-        <translation> Adresse Monero = </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="441"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation>Est-ce correct ? (Y/n) </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="451"/>
-        <source>you have cancelled the transfer request</source>
-        <translation>vous avez annulé la requête de transfert</translation>
-    </message>
-</context>
-<context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="106"/>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Utiliser l&apos;instance de démon située à &lt;hôte&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="107"/>
+        <location filename="../src/wallet/wallet2.cpp" line="114"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Utiliser l&apos;instance de démon située à l&apos;hôte &lt;arg&gt; au lieu de localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Wallet password</source>
-        <translation>Mot de passe du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="109"/>
+        <location filename="../src/wallet/wallet2.cpp" line="116"/>
         <source>Wallet password file</source>
         <translation>Fichier mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="110"/>
+        <location filename="../src/wallet/wallet2.cpp" line="117"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Utiliser l&apos;instance de démon située au port &lt;arg&gt; au lieu de 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="112"/>
+        <location filename="../src/wallet/wallet2.cpp" line="119"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Pour testnet, le démon doit aussi être lancé avec l&apos;option --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <location filename="../src/wallet/wallet2.cpp" line="120"/>
         <source>Restricts to view-only commands</source>
         <translation>Restreindre aux commandes en lecture-seule</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="152"/>
+        <location filename="../src/wallet/wallet2.cpp" line="168"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>impossible de spécifier l&apos;hôte ou le port du démon plus d&apos;une fois</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="188"/>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --password et --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="217"/>
         <source>the password file specified could not be read</source>
         <translation>le fichier mot de passe spécifié n&apos;a pas pu être lu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Enter new password for the wallet</source>
-        <translation>Entrez le mot de passe du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="464"/>
-        <source>failed to read wallet password</source>
-        <translation>échec de la lecture du mot de passe du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="227"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Failed to load file </source>
         <translation>Échec du chargement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="115"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Mot de passe du portefeuille (échapper/citer si nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="111"/>
+        <location filename="../src/wallet/wallet2.cpp" line="118"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Spécifier le nom_utilisateur:[mot_de_passe] pour le client RPC du démon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="233"/>
+        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <source>no password specified; use --prompt-for-password to prompt for a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Failed to parse JSON</source>
         <translation>Échec de l&apos;analyse JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u trop récente, on comprend au mieux %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
-        <location filename="../src/wallet/wallet2.cpp" line="331"/>
-        <location filename="../src/wallet/wallet2.cpp" line="373"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
+        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="380"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="276"/>
+        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
-        <location filename="../src/wallet/wallet2.cpp" line="343"/>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="290"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
+        <location filename="../src/wallet/wallet2.cpp" line="405"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="295"/>
+        <location filename="../src/wallet/wallet2.cpp" line="302"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="306"/>
-        <source>At least one of Electrum-style word list and private view key must be specified</source>
-        <translation>Au moins une des listes de mots de style Electrum ou clé privée d&apos;audit doit être spécifiée</translation>
+        <location filename="../src/wallet/wallet2.cpp" line="319"/>
+        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="311"/>
+        <location filename="../src/wallet/wallet2.cpp" line="323"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Liste de mots de style Electrum et clé privée spécifiées en même temps</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="324"/>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>invalid address</source>
         <translation>adresse invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
+        <location filename="../src/wallet/wallet2.cpp" line="342"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="347"/>
+        <location filename="../src/wallet/wallet2.cpp" line="352"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="356"/>
+        <location filename="../src/wallet/wallet2.cpp" line="360"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossible de générer un portefeuille obsolète à partir de JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="403"/>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
+        <source>failed to parse address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source>Address must be specified in order to create watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="413"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="5205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2813"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2873"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2952"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2998"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3089"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3599"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3955"/>
+        <source>Primary account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="7914"/>
+        <source>No funds received in this tx.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="8607"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
@@ -2649,94 +3899,125 @@ Sorties par * : </translation>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="151"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
+        <source>Failed to create directory </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
+        <source>Failed to create directory %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Cannot specify --</source>
         <translation>Impossible de spécifier --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source> and --</source>
         <translation> et --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>Failed to create file </source>
         <translation>Échec de la création du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>. Check permissions or remove file</source>
         <translation>. Vérifiez les permissions ou supprimez le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="209"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
         <source>Error writing to file </source>
         <translation>Erreur d&apos;écriture dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>RPC username/password is stored in file </source>
         <translation>nom_utilisateur/mot_de_passe RPC sauvegardé dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1748"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
+        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
+        <source>This is the RPC monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --wallet-file et --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file, --generate-from-json ou --wallet-dir doit être spécifié</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1764"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
         <source>Loading wallet...</source>
         <translation>Chargement du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1789"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1814"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
         <source>Saving wallet...</source>
         <translation>Sauvegarde du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1791"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1816"/>
-        <source>Saved ok</source>
-        <translation>Sauvegarde réussie</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
+        <source>Successfully saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1794"/>
-        <source>Loaded ok</source>
-        <translation>Chargement OK</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
+        <source>Successfully loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1798"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
         <source>Wallet initialization failed: </source>
         <translation>Échec de l&apos;initialisation du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1805"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Échec de l&apos;initialisation du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1809"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
         <source>Starting wallet RPC server</source>
         <translation>Démarrage du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1811"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
+        <source>Failed to run wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
         <source>Stopped wallet RPC server</source>
         <translation>Arrêt du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1820"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
         <source>Failed to save wallet: </source>
         <translation>Échec de la sauvegarde du portefeuille : </translation>
     </message>
@@ -2744,58 +4025,65 @@ Sorties par * : </translation>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4580"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
         <source>Wallet options</source>
         <translation>Options du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="59"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Générer un portefeuille à partir d&apos;un fichier au format JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="63"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>Utiliser le portefeuille &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="87"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="104"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Nombre maximum de threads à utiliser pour les travaux en parallèle</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="88"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="105"/>
         <source>Specify log file</source>
         <translation>Spécifier le fichier journal</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="89"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>Config file</source>
         <translation>Fichier de configuration</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="98"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="115"/>
         <source>General options</source>
         <translation>Options générales</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="128"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="138"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="161"/>
         <source>Can&apos;t find config file </source>
         <translation>Impossible de trouver le fichier de configuration </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="172"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="195"/>
         <source>Logging to: </source>
         <translation>Journalisation dans : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="197"/>
         <source>Logging to %s</source>
         <translation>Journalisation dans %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="153"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="140"/>
         <source>Usage:</source>
         <translation>Usage :</translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -527,8 +527,8 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [<payment_id>] - Send all unlocked outputs below the threshold to an address</source>
-        <translation>sweep_below &lt;montant_seuil&gt; [mixin] adresse [<ID_paiement>] - Envoyer toutes les sorties débloquées sous le seuil vers une adresse</translation>
+        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
+        <translation>sweep_below &lt;montant_seuil&gt; [mixin] adresse [ID_paiement] - Envoyer toutes les sorties débloquées sous le seuil vers une adresse</translation>
     </message>
     <message>
         <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value - merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
@@ -982,8 +982,8 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [<payment_id>] - Send all unlocked balance to an address</source>
-        <translation>sweep_all [mixin] adresse [<ID_paiement>] - Envoyer tout le solde débloqué à une adresse</translation>
+        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
+        <translation>sweep_all [mixin] adresse [ID_paiement] - Envoyer tout le solde débloqué à une adresse</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -4,24 +4,24 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="55"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Indirizzo destinatario non valido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="65"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="63"/>
         <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
         <translation>ID pagamento non valido. Il pagamento ID corto dovrebbe essere usato solo in un indirizzo integrato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="72"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="70"/>
         <source>Invalid payment ID</source>
         <translation>ID pagamento non valido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="79"/>
-        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
-        <translation>Indirizzo integrato e ID pagamento lungo non possono essere usati nello stesso momento</translation>
+        <location filename="../src/wallet/api/address_book.cpp" line="77"/>
+        <source>Integrated address and long payment ID can&apos;t be used at the same time</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -37,32 +37,32 @@
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="114"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>Il daemon è impegnato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="117"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>Nessuna connessione con il daemon. Controlla che sia operativo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>La transazione %s è stata respinta dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="126"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
         <source>. Reason: </source>
         <translation>. Motivo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
         <source>Unknown exception: </source>
         <translation>Eccezione sconosciuta: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="131"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
         <source>Unhandled exception</source>
         <translation>Eccezione non gestita</translation>
     </message>
@@ -81,323 +81,324 @@
         <translation>Firma transazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="141"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="151"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento ha effetto su più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="164"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>inviando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="170"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="176"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="179"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>nessuna modifica</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="181"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %s</source>
-        <translation>Caricato %lu transazioni, per %s, commissione %s, %s, %s, %s, con mixin %lu. %s</translation>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="942"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>L&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="952"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
         <source>Failed to add short payment id: </source>
         <translation>Impossibile aggiungere id pagamento corto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="978"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1072"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="981"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1075"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Accertati che sia operativo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="984"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1078"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1081"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
+        <source>not enough outputs for specified ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>found outputs to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
+        <source>Please sweep unmixable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
         <source>failed to get random outputs to mix</source>
         <translation>impossibile recuperare outputs random da mixare</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="994"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1088"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>non hai abbastanza fondi da trasferire, sono disponibili solo %s, ammontare inviato %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="403"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="474"/>
         <source>failed to parse address</source>
         <translation>parsing indirizzo fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="415"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="486"/>
         <source>failed to parse secret spend key</source>
         <translation>impossibile fare il parsing della chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="425"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="496"/>
         <source>No view key supplied, cancelled</source>
         <translation>Non è stata fornita nessuna chiave di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="432"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="503"/>
         <source>failed to parse secret view key</source>
         <translation>impossibile fare il parsing della chiave segreta di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="442"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="513"/>
         <source>failed to verify secret spend key</source>
         <translation>impossibile verificare chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="447"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="518"/>
         <source>spend key does not match address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="453"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="524"/>
         <source>failed to verify secret view key</source>
         <translation>verifica chiave segreta di visualizzazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="458"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="529"/>
         <source>view key does not match address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="477"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="548"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="799"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <source>Failed to send import wallet request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="919"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Caricamento transazioni non firmate fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="820"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="940"/>
         <source>Failed to load transaction from file</source>
         <translation>Caricamento transazione da file fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="838"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="958"/>
         <source>Wallet is view only</source>
         <translation>Il portafoglio è di tipo solo visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="847"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="967"/>
         <source>failed to save file </source>
         <translation>impossibile salvare il file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="874"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="986"/>
+        <source>Key images can only be imported with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="999"/>
         <source>Failed to import key images: </source>
         <translation>Impossibile importare immagini chiave: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="987"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
+        <source>Failed to get subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
+        <source>Failed to set subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
         <source>failed to get random outputs to mix: %s</source>
         <translation>impossibile recuperare outputs casuali da mixare: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1003"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1097"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
+        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>non hai abbastanza fondi da trasferire, disponibili solo %s, ammontare transazione %s = %s + %s (commissione)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1012"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1106"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>outputs insufficienti per il numero di mixaggi specificato </translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>output amount</source>
         <translation>ammontare output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
-        <source>found outputs to mix</source>
-        <translation>trovati outputs da mixare</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1019"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1113"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>transaction was not constructed</source>
         <translation>transazione non costruita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1023"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1117"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transazione %s è stata rifiutata dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1030"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1124"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
         <source>one of destinations is zero</source>
         <translation>una delle destinazioni è zero</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1033"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1127"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>impossibile trovare un modo per dividere le transazioni</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1036"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
         <source>unknown transfer error: </source>
         <translation>errore trasferimento sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1039"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1133"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1042"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1136"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1045"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1139"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1419"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1441"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1494"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1525"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
+        <source>Failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished">nessuna chiave tx trovata per questo txid</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
+        <source>Failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1502"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished">Parsing indirizzo fallito</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>&quot;Riscannerizza spesi&quot; può essere utilizzato solo da un daemon fidato</translation>
     </message>
 </context>
 <context>
-    <name>Monero::WalletManagerImpl</name>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="192"/>
-        <source>failed to parse txid</source>
-        <translation>analisi txid fallita</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="199"/>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="206"/>
-        <source>failed to parse tx key</source>
-        <translation>parsing chiave tx fallito</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="217"/>
-        <source>failed to parse address</source>
-        <translation>parsing indirizzo fallito</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>impossibile recuperare la transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="238"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>impossibile fare il parsing della transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="245"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>convalida transazione dal daemon fallita</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="250"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>impossibile recuperare la giusta transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="257"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>impossibile generare derivazione chiave dai parametri forniti</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="313"/>
-        <source>error: </source>
-        <translation>errore: </translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>received</source>
-        <translation>ricevuto</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>in txid</source>
-        <translation>in txid</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="323"/>
-        <source>received nothing in txid</source>
-        <translation>nulla ricevuto in txid</translation>
-    </message>
-</context>
-<context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="212"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
         <translation>Parsing indirizzo fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
         <translation>Parsing chiave fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="227"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
         <translation>verifica chiave fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="237"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="271"/>
         <source>key does not match address</source>
         <translation>la chiave non corrisponde all&apos;indirizzo</translation>
     </message>
@@ -405,1969 +406,3228 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="76"/>
+        <location filename="../src/common/command_line.cpp" line="57"/>
         <source>yes</source>
         <translation>sì</translation>
+    </message>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="71"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="38"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
         <source>Specify IP to bind RPC server</source>
         <translation>Specificare IP da associare al server RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="39"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="41"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Specifica username[:password] richiesta per server RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="42"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Conferma valore rpc-bind-ip NON è un loopback IP (locale)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="66"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="43"/>
+        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="70"/>
         <source>Invalid IP address given for --</source>
         <translation>Indirizzo IP non valido dato per --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="74"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="78"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation>permette connessioni esterne non criptate in entrata. Considera in alternativa un tunnel SSH o un proxy SSL. Sovrascrivi con --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Username specified with --</source>
         <translation>Nome utente specificato con --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> cannot be empty</source>
         <translation> non può essere vuoto</translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> requires RFC server password --</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="479"/>
         <source>Commands: </source>
         <translation>Comandi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>failed to read wallet password</source>
         <translation>impossibile leggere la password del portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
         <source>invalid password</source>
         <translation>password non valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="697"/>
-        <source>start_mining [&lt;number_of_threads&gt;] - Start mining in daemon</source>
-        <translation>start_mining [&lt;number_of_threads&gt;] - Avvia mining nel daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
-        <source>Stop mining in daemon</source>
-        <translation>Interrompi mining nel daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="699"/>
-        <source>Save current blockchain data</source>
-        <translation>Salva dati correnti blockchain</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="701"/>
-        <source>Show current wallet balance</source>
-        <translation>Mostra bilancio portafoglio attuale</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
-        <source>Show blockchain height</source>
-        <translation>Mostra &quot;altezza&quot; blockchain</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
-        <source>Show current wallet public address</source>
-        <translation>Mostra indirizzo pubblico del portafoglio corrente</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <source>Show this help</source>
-        <translation>Mostra questo aiuto</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>imposta seed: richiede una definizione. opzioni disponibili: lingua</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="811"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>set: unrecognized argument(s)</source>
         <translation>imposta: definizione/i non riconosciuta/e</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
         <source>wallet file path not valid: </source>
         <translation>percorso file portafoglio non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Sto tentando di generare o ripristinare il portafoglio, ma i(l) file specificato/i esiste/esistono già. Sto uscendo per non rischiare di sovrascrivere.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="416"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
         <source>usage: payment_id</source>
         <translation>uso: payment_id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
-        <translation>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Invia tutti gli outputs sbloccati sotto la soglia specificata a un indirizzo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
-        <source>Generate a signature to prove payment to &lt;address&gt; in &lt;txid&gt; using the transaction secret key (r) without revealing it</source>
-        <translation>Genera una firma per provare un pagamento a &lt;address&gt; in &lt;txid&gt; usando la chiave di transazione (r) senza rivelarla</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="728"/>
-        <source>Check tx proof for payment going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation>Verifica prova tx per pagamento inviato a &lt;indirizzo&gt; in &lt;txid&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="743"/>
-        <source>Generate a new random full size payment id - these will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids</source>
-        <translation>Genera un nuovo id pagamento casuale di dimensione completa - queste non saranno criptate nel blockchain, considera integrated_address per payment ids corti crittati</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
         <source>needs an argument</source>
         <translation>ha bisogno di un argomento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="801"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
         <source>0 or 1</source>
         <translation>0 o 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="800"/>
-        <source>integer &gt;= 2</source>
-        <translation>integrale &gt;= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
         <source>0, 1, 2, 3, or 4</source>
         <translation>0, 1, 2, 3, o 4</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
         <source>unsigned integer</source>
         <translation>integrale non firmato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
         <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>ATTENZIONE: le seguenti 25 parole possono essere usate per ripristinare il tuo portafoglio. Scrivile e conservale da qualche parte al sicuro.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2121"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>specificare un parametro di ripristino con --electrum-seed=&quot;lista parole qui&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>impossibile connettere il portafoglio al daemon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2643"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Il daemon usa una versione principale RPC (%u) diversa da quella del portafoglio (%u): %s. Aggiorna una delle due, o usa --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista delle lingue disponibili per il seed del tuo portafoglio:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1297"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2671"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation>Inserisci il numero corrispondente al linguaggio da te scelto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Hai usato una versione obsoleta del portafoglio. Per favore usa il nuovo seed che ti abbiamo fornito.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1368"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
         <source>Generated new wallet: </source>
         <translation>Nuovo portafoglio generato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
         <source>Opened watch-only wallet</source>
         <translation>Portafoglio solo-vista aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
         <source>Opened wallet</source>
         <translation>Portafoglio aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Stai utilizzando una versione disapprovata del portafoglio. Per favore procedi nell&apos;upgrade del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Stai utilizzando una versione disapprovata del portafoglio. Il formato del tuo portafoglio sta venendo aggiornato adesso.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>failed to load wallet: </source>
         <translation>impossibile caricare portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Usa il comando &quot;help&quot; per visualizzare la lista dei comandi disponibili.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
         <source>Wallet data saved</source>
         <translation>Dati del portafoglio salvati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
         <source>Mining started in daemon</source>
         <translation>Mining avviato nel daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3074"/>
         <source>mining has NOT been started: </source>
         <translation>il mining NON è stato avviato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
         <source>Mining stopped in daemon</source>
         <translation>Mining nel daemon interrotto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
         <source>mining has NOT been stopped: </source>
         <translation>il mining NON è stato interrotto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Blockchain saved</source>
         <translation>Blockchain salvata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1699"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3165"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
         <source>Height </source>
         <translation>Blocco </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1671"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
         <source>transaction </source>
         <translation>transazione </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1672"/>
-        <source>received </source>
-        <translation>ricevuto/i </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>spent </source>
         <translation>speso/i </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3198"/>
         <source>unsupported transaction format</source>
         <translation>formato transazione non supportato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1718"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3219"/>
         <source>Starting refresh...</source>
         <translation>Sto iniziando il refresh...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
         <source>Refresh done, blocks received: </source>
         <translation>Refresh finito, blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2186"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento ha un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
         <source>bad locked_blocks parameter:</source>
         <translation>parametro locked_blocks non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4462"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>una singola transazione non può usare più di un id pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4470"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>impossibile impostare id pagamento, anche se è stato decodificado correttamente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2262"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2533"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4527"/>
         <source>transaction cancelled.</source>
         <translation>transazione cancellata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3955"/>
         <source>Sending %s.  </source>
         <translation>Sto inviando %s. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3958"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>La tua transazione deve essere divisa in %llu transazioni. Una commissione verrà applicata per ogni transazione, per un totale di %s commissioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3964"/>
         <source>The transaction fee is %s</source>
         <translation>La commissione per la transazione è %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3967"/>
         <source>, of which %s is dust from change</source>
         <translation>, della quale %s è polvere dovuta allo scambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un totale di %s in polvere verrà inviato all&apos;indirizzo della polvere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3973"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation>.
 Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s giorni (supponendo 2 minuti per blocco)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2367"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2544"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4011"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4549"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transazioni/e non firmata/e scritte/a con successo su file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3157"/>
-        <source>Not enough money in unlocked balance</source>
-        <translation>Non hai abbastanza fondi nel bilancio sbloccato</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
-        <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
-        <translation>Impossibile creare transazioni. Questo succede di solito perchè l&apos;ammontare di polvere è così piccolo da non poter pagare le proprie commissioni, oppure stai provando a mandare più fondi di quelli che possiedi nel bilancio sbloccato, o non hai aggiunto abbastanza commissioni</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Reason: </source>
-        <translation>Motivo: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation>impossibile trovare un modo adatto per dividere le transazioni</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
         <source>No unmixable outputs found</source>
         <translation>Nessun output non-mixabile trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4149"/>
         <source>No address given</source>
         <translation>Non è stato fornito nessun indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4702"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
         <source>sending %s to %s</source>
         <translation>sto mandando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
+        <source> dummy output(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4797"/>
+        <source>usage: sign_transfer [export]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
         <source>Failed to sign transaction</source>
         <translation>Impossibile firmare transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
         <source>Failed to sign transaction: </source>
         <translation>Impossibile firmare transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
         <source>Failed to load transaction from file</source>
         <translation>Caricamento transazione da file fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3137"/>
-        <source>daemon is busy. Please try again later</source>
-        <translation>il daemon è occupato. Prova più tardi</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1995"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>il portafoglio è solo-vista e non ha una chiave di spesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="390"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>Your original password was incorrect.</source>
         <translation>La tua password originale era scorretta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="404"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
         <source>Error with wallet rewrite: </source>
         <translation>Errore riscrittura wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
         <source>priority must be 0, 1, 2, 3, or 4 </source>
         <translation>la priorità deve essere 0, 1, 2, 3, or 4 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1316"/>
         <source>priority must be 0, 1, 2, 3, or 4</source>
         <translation>la priorità deve essere 0, 1, 2, 3, or 4</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="540"/>
-        <source>priority must be 0, 1, 2, 3, or 4</source>
-        <translation>la priorità deve essere 0, 1, 2, 3, or 4</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
         <source>invalid unit</source>
         <translation>unità invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>conteggio invalido: deve essere un integrale non firmato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
         <source>invalid value</source>
         <translation>valore invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
-        <source>Same as transfer, but using an older transaction building algorithm</source>
-        <translation>Lo stesso di transfer, ma usando un vecchio algoritmo per costruire la transazione</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
-        <translation>sweep_all [mixin] address [payment_id] - Manda tutto il bilancio sbloccato ad un indirizzo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
-        <source>donate [&lt;mixin_count&gt;] &lt;amount&gt; [payment_id] - Donate &lt;amount&gt; to the development team (donate.getmonero.org)</source>
-        <translation>donate [&lt;mixin_count&gt;] &lt;amount&gt; [payment_id] - Dona &lt;amount&gt; al team di sviluppo (donate.getmonero.org)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
-        <source>set_log &lt;level&gt;|&lt;categories&gt; - Change current log detail (level must be &lt;0-4&gt;)</source>
-        <translation>set_log &lt;level&gt;|&lt;categories&gt; - Cambia livello dettaglio log (il livello deve essere &lt;0-4&gt;)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
-        <source>address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)] - Print all entries in the address book, optionally adding/deleting an entry to/from it</source>
-        <translation>address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)] - Mostra tutte le voci nella rubrica, hai l&apos;opzione di aggiungere/eliminare delle voci</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
-        <source>show_transfers [in|out|pending|failed|pool] [&lt;min_height&gt; [&lt;max_height&gt;]] - Show incoming/outgoing transfers within an optional height range</source>
-        <translation>show_transfers [in|out|pending|failed|pool] [&lt;min_height&gt; [&lt;max_height&gt;]] - Mostra trasferimenti in entrata/uscita entro un altezza del blocco opzionale</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="741"/>
-        <source>Show information about a transfer to/from this address</source>
-        <translation>Mostra informazioni riguardo un trasferimento da/per questo indirizzo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
-        <source>Change wallet password</source>
-        <translation>Cambia password portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
         <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
         <translation>uso: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="886"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
         <source>(Y/Yes/N/No): </source>
         <translation>(S/Sì/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2536"/>
         <source>bad m_restore_height parameter: </source>
         <translation>parametro m_restore_height non corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
         <source>date format must be YYYY-MM-DD</source>
         <translation>il formato della data deve essere YYYY-MM-DD</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2527"/>
         <source>Restore height is: </source>
         <translation>Ripristina altezza è: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
         <source>Is this okay?  (Y/Yes/N/No): </source>
         <translation>Va bene? (S/Sì/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Password for new watch-only wallet</source>
         <translation>Password per il nuovo portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
         <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
         <translation>argomenti invalidi. Usa start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; dovrebbe risultare da 1 a </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1755"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2457"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2895"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2000"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2005"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2644"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>refresh failed: </source>
         <translation>refresh fallito: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Blocks received: </source>
         <translation>Blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1795"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>unlocked balance: </source>
         <translation>bilancio sbloccato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>amount</source>
         <translation>ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
+        <source>Unknown command: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
+        <source>Command usage: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <source>Command description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <source>wallet is multisig but not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
+        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="584"/>
+        <source>Failed to retrieve seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
+        <source>wallet is multisig and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <source>Cannot connect to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <source>Current fee is %s monero per kB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Error: failed to estimate backlog array size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <source>Error: bad estimated backlog array size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <source> (current)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
+        <source>No backlog at priority </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="762"/>
+        <source>This wallet is already multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="767"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="773"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <source>Your password is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="754"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
+        <source>usage: make_multisig &lt;threshold&gt; &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="794"/>
+        <source>Invalid threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <source>Another step is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <source>Send this multisig info to all other participants, then use finalize_multisig &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
+        <source>Error creating multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="822"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
+        <source> multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>This wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
+        <source>This wallet is already finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <source>usage: finalize_multisig &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="862"/>
+        <source>Failed to finalize multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <source>Failed to finalize multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
+        <source>This multisig wallet is not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
+        <source>usage: export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
+        <source>Error exporting multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
+        <source>Multisig info exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
+        <source>usage: import_multisig_info &lt;filename1&gt; [&lt;filename2&gt;...] - one for each other participant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
+        <source>Multisig info imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="969"/>
+        <source>Failed to import multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="980"/>
+        <source>Failed to update spent status after importing multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="985"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
+        <source>This is not a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
+        <source>usage: sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <source>Multisig error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source>usage: submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <source>Failed to load multisig transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1160"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6750"/>
+        <source>Transaction successfully submitted, transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6751"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <source>usage: export_raw_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
+        <source>could not change default ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <source>Invalid height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1564"/>
+        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1565"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
+        <source>Stop mining in the daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <source>set_daemon &lt;host&gt;[:&lt;port&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1572"/>
+        <source>Set another daemon to connect to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <source>Save the current blockchain data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1582"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1585"/>
+        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1586"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1589"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
+        <source>Show the blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1625"/>
+        <source>sign_transfer &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
+        <source>Sign a transaction from a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <source>Submit a signed transaction from a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <source>account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt; 
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the walllet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1656"/>
+        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1660"/>
+        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <source>Save the wallet data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <source>Save a watch-only keys file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
+        <source>Display the private view key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Display the private spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <source>set &lt;option&gt; [&lt;value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <source>Available options:
+ seed language
+   Set the wallet&apos;s seed language.
+ always-confirm-transfers &lt;1|0&gt;
+   Whether to confirm unsplit txes.
+ print-ring-members &lt;1|0&gt;
+   Whether to print detailed information about ring members during confirmation.
+ store-tx-info &lt;1|0&gt;
+   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
+ default-ring-size &lt;n&gt;
+   Set the default ring size (default and minimum is 5).
+ auto-refresh &lt;1|0&gt;
+   Whether to automatically synchronize new blocks from the daemon.
+ refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
+   Set the wallet&apos;s refresh behaviour.
+ priority [0|1|2|3|4]
+   Set the fee too default/unimportant/normal/elevated/priority.
+ confirm-missing-payment-id &lt;1|0&gt;
+ ask-password &lt;1|0&gt;
+ unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
+   Set the default monero (sub-)unit.
+ min-outputs-count [n]
+   Try to keep at least that many outputs of value at least min-outputs-value.
+ min-outputs-value [n]
+   Try to keep at least min-outputs-count outputs of at least that value.
+ merge-destinations &lt;1|0&gt;
+   Whether to merge multiple payments to the same destination address.
+ confirm-backlog &lt;1|0&gt;
+   Whether to warn if there is transaction backlog.
+ confirm-backlog-threshold [n]
+   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
+ refresh-from-block-height [n]
+   Set the height before which to ignore blocks.
+ auto-low-priority &lt;1|0&gt;
+   Whether to automatically use the low priority fee level when it&apos;s safe to do so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1717"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
+        <source>get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1727"/>
+        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <source>get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1735"/>
+        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
+        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
+        <source>get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1748"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
+        <source>check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1754"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1757"/>
+        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
+        <source>Rescan the blockchain from scratch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1768"/>
+        <source>set_tx_note &lt;txid&gt; [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1769"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <source>get_tx_note &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>set_description [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1780"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <source>sign &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1793"/>
+        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>export_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1798"/>
+        <source>Export a signed set of key images to a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
+        <source>import_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1802"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
+        <source>export_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1806"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1809"/>
+        <source>import_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
+        <source>show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1825"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>make_multisig &lt;threshold&gt; &lt;string1&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1831"/>
+        <source>finalize_multisig &lt;string&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <source>export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1836"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <source>import_multisig_info &lt;filename&gt; [&lt;filename&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <source>sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
+        <source>submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1848"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1851"/>
+        <source>export_raw_multisig_tx &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <source>help [&lt;command&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2012"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2084"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>Enter seed encryption passphrase, empty if none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2259"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2350"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished">impossibile fare il parsing della chiave segreta di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished">verifica chiave segreta di visualizzazione fallita</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
+        <source>Secret spend key (%u of %u):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2550"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2551"/>
+        <source>Still apply restore height?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2582"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <source>missing daemon URL argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
+        <source>usage: balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
+        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>spent</source>
         <translation>spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>global index</source>
         <translation>indice globale</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>tx id</source>
         <translation>tx id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
         <source>No incoming transfers</source>
         <translation>Nessun trasferimento in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3427"/>
         <source>No incoming available transfers</source>
         <translation>Nessun trasferimento in entrata disponibile</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1876"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3431"/>
         <source>No incoming unavailable transfers</source>
         <translation>Nessun trasferimento indisponibile in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3442"/>
         <source>expected at least one payment ID</source>
         <translation>deve esserci almeno un payment ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>payment</source>
         <translation>pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>transaction</source>
         <translation>transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>height</source>
         <translation>altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>unlock time</source>
         <translation>tempo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1908"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3463"/>
         <source>No payments with id </source>
         <translation>Nessun pagamento con id </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3853"/>
         <source>failed to get blockchain height: </source>
         <translation>impossibile recuperare altezza blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5259"/>
         <source>failed to connect to the daemon</source>
         <translation>impossibile connettersi al daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2034"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3590"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transazione %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>
 Input %llu/%llu: amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2060"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
         <source>failed to get output: </source>
         <translation>impossibile recuperare output: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3624"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>l&apos;altezza del blocco di origine della chiave di output non dovrebbe essere più alta dell&apos;altezza della blockchain</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
         <source>
 Originating block heights: </source>
         <translation>
 Originando blocchi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Avviso: alcune chiavi di input spese vengono da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3662"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, che potrebbe compromettere l&apos;anonimità della ring signature. Assicurati di farlo intenzionalmente!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4184"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3724"/>
         <source>wrong number of arguments</source>
         <translation>numero di argomenti errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4479"/>
         <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
         <translation>Nessun id pagamento è incluso in questa transazione. Questo è corretto? (S/Sì/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2298"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Nessun output trovato, o il daemon non è pronto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2576"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2837"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
-        <source>failed to get random outputs to mix: </source>
-        <translation>impossibile recuperare output casuali da mixare: </translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2518"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>, txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Sto eseguendo lo sweep di %s nelle transazioni %llu per un totale commissioni di %s.  Va bene?  (S/Sì/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4519"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Sto eseguendo lo sweep di %s per un totale commissioni di %s.  Va bene?  (S/Sì/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4630"/>
         <source>Donating </source>
         <translation>Donando </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3053"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Caricate %lu transazioni, per %s, commissioni %s, %s, %s, con mixaggio %lu. %sQuesto è corretto? (S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
         <source>This is a watch only wallet</source>
         <translation>Questo è un portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
         <source>usage: show_transfer &lt;txid&gt;</source>
         <translation>uso: show_transfer &lt;txid&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6673"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6708"/>
         <source>Transaction ID not found</source>
         <translation>ID transazione non trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="237"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="214"/>
         <source>true</source>
         <translation>vero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="267"/>
         <source>failed to parse refresh type</source>
         <translation>impossibile fare il parsing del tipo di refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>il portafoglio è solo-vista e non possiede un seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>il portafoglio è non-deterministico e non possiede un seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>il portafoglio è solo-vista e non può eseguire trasferimenti</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
-        <source>mixin must be an integer &gt;= 2</source>
-        <translation>mixin deve essere un integrale &gt;= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="501"/>
-        <source>could not change default mixin</source>
-        <translation>impossibile cambiare mixin standard</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
         <source>could not change default priority</source>
         <translation>impossibile cambiare priorità standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
-        <source>Synchronize transactions and balance</source>
-        <translation>Sincronizzare transazioni e bilancio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="702"/>
-        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
-        <translation>incoming_transfers [available|unavailable] - Mostra trasferimenti in entrata, tutti o filtrati per disponibilità</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="703"/>
-        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Show payments for given payment ID[s]</source>
-        <translation>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;] - Mostra pagamenti per gli/l&apos; ID fornito/i</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="706"/>
-        <source>transfer [&lt;priority&gt;] [&lt;mixin_count&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;] - Transfer &lt;amount&gt; to &lt;address&gt;. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;mixin_count&gt; is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>transfer [&lt;priority&gt;] [&lt;mixin_count&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;] - Transfer &lt;amount&gt; to &lt;address&gt;. &lt;priority&gt; è la priorità della transazione. Maggiore è la priorità, maggiori saranno le tasse per la transazione. Valori validi in ordini di priorità (dal più basso al più alto) sono:unimportant, normal, elevated, priority. se omesso, verrà usato il valore standard (vedi il comando &quot;set priority&quot;). &lt;mixin_count&gt; è il numero di inputs extra da inludere per intracciabilità. Puoi eseguire pagamenti multipli in una volta aggiungendo &lt;address_2&gt; &lt;amount_2&gt; etcetera (prima dell&apos; ID pagamento, se incluso)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
-        <source>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id&gt;]</source>
-        <translation>locked_transfer [&lt;mixin_count&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt;(Numero di blocchi durante i quali bloccare la transazione, max 1000000) [&lt;payment_id&gt;]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="708"/>
-        <source>Send all unmixable outputs to yourself with mixin 0</source>
-        <translation>Manda tutti gli outputs non spendibili a te stesso con mixaggio 0</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
-        <source>Sign a transaction from a file</source>
-        <translation>Firma una transazione da file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="713"/>
-        <source>Submit a signed transaction from a file</source>
-        <translation>Invia una transazione firmata da file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
-        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation>integrated_address [PID] - Codifica un ID pagamento in un indirizzo integrato per l&apos;indirizzo pubblico del portafoglio corrente (nessun parametro usa un payment ID casuale), oppure decodifica un indirizzo integrato in indirizzo standard e payment ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="718"/>
-        <source>Save wallet data</source>
-        <translation>Salva i dati del portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="719"/>
-        <source>Save a watch-only keys file</source>
-        <translation>Salva una chiave solo-vista</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
-        <source>Display private view key</source>
-        <translation>Visualizza chiave di visualizzazione privata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <source>Display private spend key</source>
-        <translation>Visualizza chiave di spesa privata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="722"/>
-        <source>Display Electrum-style mnemonic seed</source>
-        <translation>Visualizza il seed mnemonico in stile Electrum</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="723"/>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0&gt; - whether to confirm unsplit txes; print-ring-members &lt;1|0&gt; - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0&gt; - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n&gt; - set default mixin (default is 4); auto-refresh &lt;1|0&gt; - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value; merge-destinations &lt;1|0&gt; - whether to merge multiple payments to the same destination address</source>
-        <translation>Opzioni disponibili: seed language - seleziona lingua del seed per il portafoglio; always-confirm-transfers &lt;1|0&gt; - se confermare unsplit txes; print-ring-members &lt;1|0&gt; - se mostrare informazioni dettagliate sui ring members durante le conferme; store-tx-info &lt;1|0&gt; - se salvare le informazioni tx in uscita (indirizzo di destinazione, payment ID, chiave tx segreta) per riferimento futuro; default-mixin &lt;n&gt; - imposta default mixin (default è 4); auto-refresh &lt;1|0&gt; - se sincronizzare automaticamente i nuovi blocchi dal daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt; - imposta modalità wallet refresh; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0&gt;; ask-password &lt;1|0&gt;; unit &lt;monero|millinero|micronero|nanonero|piconero&gt; - imposta default monero (sub-)unit; min-outputs-count [n] - cerca di mantenere come minimo tanti outputs quanti il valore di min-outputs-value; min-outputs-value [n] - cerca di mantenere i min-outputs-count outputs come minimo a questo valore; merge-destinations &lt;1|0&gt; - se fondere pagamenti multipli allo stessp indirizzo di destinazione</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="724"/>
-        <source>Rescan blockchain for spent outputs</source>
-        <translation>Riscannerizza blockchain in cerca di outputs spesi</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="725"/>
-        <source>Get transaction key (r) for a given &lt;txid&gt;</source>
-        <translation>Ricevi una chiave transazione (r) per ogni &lt;txid&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <source>Check amount going to &lt;address&gt; in &lt;txid&gt;</source>
-        <translation>Controlla l&apos;ammontare che va da &lt;address&gt; a &lt;txid&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="730"/>
-        <source>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Show unspent outputs within an optional amount range</source>
-        <translation>unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;] - Mostra gli outputs non spesi entro un intervallo di valori opzionale</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="731"/>
-        <source>Rescan blockchain from scratch</source>
-        <translation>Avvia scansione blockchain dal principio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="732"/>
-        <source>Set an arbitrary string note for a txid</source>
-        <translation>Imposta una stringa arbitraria per un txid</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="733"/>
-        <source>Get a string note for a txid</source>
-        <translation>Ricevi una stringa di annotazione per un txid</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
-        <source>Show wallet status information</source>
-        <translation>Visualizza informazioni sulla stato del portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
-        <source>Sign the contents of a file</source>
-        <translation>Firma il contenuto di un file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="736"/>
-        <source>Verify a signature on the contents of a file</source>
-        <translation>Verifica firma sul contesto del file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="737"/>
-        <source>Export a signed set of key images</source>
-        <translation>Esporta un set di chiavi firmate</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="738"/>
-        <source>Import signed key images list and verify their spent status</source>
-        <translation>Importa immagine firmata della lista chiavi e verifica lo status degli spesi</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="739"/>
-        <source>Export a set of outputs owned by this wallet</source>
-        <translation>Esporta un set di outputs posseduti da questo portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
-        <source>Import set of outputs owned by this wallet</source>
-        <translation>Importa un set di outputs posseduti da questo portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="802"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>completo (più lento, nessuna ipotesi); optimize-coinbase (veloce, ipotizza che l&apos;intero coinbase viene pagato ad un indirizzo singolo); no-coinbase (il più veloce, ipotizza di non ricevere una transazione coinbase), default (come optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nome del portafoglio non valido. Prova di nuovo o usa Ctrl-C per uscire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Portafoglio e chiavi trovate, sto caricando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="874"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1998"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Ho trovato la chiave ma non il portafoglio. Sto rigenerando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2004"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Chiave non trovata. Impossibile aprire portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
         <source>Generating new wallet...</source>
         <translation>Sto generando un nuovo portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
-        <translation>non puoi specificare più di un --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; e --generate-from-keys=&quot;wallet_name&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="953"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
-        <translation>impossibile specificare sia --restore-deterministic-wallet che --non-deterministic</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2092"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet usa --generate-new-wallet, non --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
         <source>Electrum-style word list failed verification</source>
         <translation>La lista di parole stile Electrum ha fallito la verifica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1063"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
         <source>No data supplied, cancelled</source>
         <translation>Nessun dato fornito, cancellato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1002"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2718"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3530"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4048"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>failed to parse address</source>
         <translation>impossibile fare il parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
         <source>account creation failed</source>
         <translation>creazione dell&apos;account fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>specifica un percorso per il portafoglio con --generate-new-wallet (non --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
         <source>failed to open account</source>
         <translation>impossibile aprire account</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1579"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4962"/>
         <source>wallet is null</source>
         <translation>il portafoglio è nullo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1262"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
-        <translation>Il daemon non è partito o è settato con la porta sbagliata. Assicurati che il daemon stia funzionando o fai ripartire il wallet con l&apos;indirizzo corretto del daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2685"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>linguaggio selezionato scorretto. Prova di nuovo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
         <source>View key: </source>
         <translation>Chiave di visualizzazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation>Il tuo portafoglio è stato generato!
-Per iniziare a sincronizzarlo con il daemon, usa il comando &quot;refresh&quot;.
-Usa il comando &quot;help&quot; per vedere la lista dei comandi disponibili.
-Usa sempre il comando &quot;exit&quot; quando chiudi monero-wallet-cli per salvare
-lo stato della tua sessione &apos;s corrente. Altrimenti potresti dover sincronizzare 
-di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono a rischio in sessun caso).</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Potresti voler rimuovere il file &quot;%s&quot; e provare di nuovo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
         <source>failed to deinitialize wallet</source>
         <translation>deinizializzazione portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1570"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6410"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>questo comando richiede un daemon fidato. Abilita questa opzione con --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3152"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>impossibile salvare la blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2390"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Assicurati che sia in funzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
         <source>refresh error: </source>
         <translation>errore refresh: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
         <source>Balance: </source>
         <translation>Bilancio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>pubkey</source>
         <translation>pubkey</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>key image</source>
         <translation>immagine chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>unlocked</source>
         <translation>sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>locked</source>
         <translation>bloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
         <source>failed to get spent status</source>
         <translation>impossibile recuperare status spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>the same transaction</source>
         <translation>la stessa transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>blocks that are temporally very close</source>
         <translation>i blocchi che sono temporalmente molto vicini</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2206"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3778"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation>I blocchi bloccati sono troppo alti, max 1000000 (˜4 anni)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Failed to check for backlog: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <source>
+Transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
+        <source>Spending from address index %d
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3953"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4309"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4424"/>
+        <source>failed to parse Payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4440"/>
+        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
+        <source>failed to parse key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
+        <source>No outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4504"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4586"/>
         <source>missing threshold amount</source>
         <translation>manca la soglia massima dell&apos;ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>invalid amount threshold</source>
         <translation>ammontare soglia invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4601"/>
+        <source>donations are not enabled on the testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4716"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento va a più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
-        <source>usage: get_tx_proof &lt;txid&gt; &lt;dest_address&gt; [&lt;tx_key&gt;]</source>
-        <translation>uso: get_tx_proof &lt;txid&gt; &lt;dest_address&gt; [&lt;tx_key&gt;]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
-        <source>failed to parse tx_key</source>
-        <translation>impossibile fare il parsing del tx_key</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
-        <source>Tx secret key was found for the given txid, but you&apos;ve also provided another tx secret key which doesn&apos;t match the found one.</source>
-        <translation>Una chiave tx segreta è stata trovata per il txid fornito, ma hai anche fornito un&apos;altra chiave segreta tx che non corrsisponde a quella trovata.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
-        <source>Tx secret key wasn&apos;t found in the wallet file. Provide it as the optional third parameter if you have it elsewhere.</source>
-        <translation>Chiave segreta tx non trovata nel file del portafoglio. Forniscila come terzo parametro opzionale se la conservi da qualche altra parte.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3330"/>
-        <source>Signature: </source>
-        <translation>Firma: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3508"/>
-        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation>uso: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3539"/>
-        <source>Signature header check error</source>
-        <translation>Errore controllo firma intestazione</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3550"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3560"/>
-        <source>Signature decoding error</source>
-        <translation>Errore decodificazione firma</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3602"/>
-        <source>Tx pubkey was not found</source>
-        <translation>Chiave pubblica tx non trovata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Good signature</source>
         <translation>Firma valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
         <source>Bad signature</source>
         <translation>Firma invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3621"/>
-        <source>failed to generate key derivation</source>
-        <translation>generazione derivazione chiave fallita</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6046"/>
         <source>usage: integrated_address [payment ID]</source>
         <translation>uso: integrated_address [ID pagamento]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4017"/>
-        <source>Integrated address: account %s, payment ID %s</source>
-        <translation>Indirizzo integrato: account %s, ID pagamento %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>Standard address: </source>
         <translation>Indirizzo standard: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4027"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6087"/>
         <source>failed to parse payment ID or address</source>
         <translation>impossibile fare il parsing di ID pagamento o indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6098"/>
         <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
         <translation>uso: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
         <source>failed to parse payment ID</source>
         <translation>impossibile fare il parsing di ID pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6146"/>
         <source>failed to parse index</source>
         <translation>impossibile fare il parsing dell&apos;indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <source>Address book is empty.</source>
         <translation>La rubrica è vuota.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
         <source>Index: </source>
         <translation>Indice: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
         <source>Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
         <source>Payment ID: </source>
         <translation>ID Pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
         <source>Description: </source>
         <translation>Descrizione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
         <source>usage: set_tx_note [txid] free text note</source>
         <translation>uso: set_tx_note [txid] free text note</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6201"/>
         <source>usage: get_tx_note [txid]</source>
         <translation>uso: get_tx_note [txid]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6304"/>
         <source>usage: sign &lt;filename&gt;</source>
         <translation>uso: sign &lt;filename&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4198"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6309"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>il portafoglio è solo-vista e non può firmare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4207"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
         <source>failed to read file </source>
         <translation>impossibile leggere il file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5066"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5278"/>
+        <source>failed to load signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
+        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <source>wallet is watch-only and cannot generate the proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5161"/>
+        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
+        <source>usage: get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
+        <source>The reserve proof can be generated only by a full wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5253"/>
+        <source>usage: check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
+        <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5353"/>
+        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5490"/>
+        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
+        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
+        <source>There is no unspent output in the specified address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
+        <source> (no daemon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
+        <source> (out of sync)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5758"/>
+        <source>(Untitled account)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
+        <source>failed to parse index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <source>specify an index between 0 and </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5873"/>
+        <source>usage:
+  account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt;
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>
+Grand total:
+  Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>, unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
+        <source>Untagged accounts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5915"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
+        <source>Accounts with tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
+        <source>Tag&apos;s description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
+        <source> %c%8u %6s %21s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <source>----------------------------------------------------------------------------------</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <source>%15s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>Primary address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>(used)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>(Untitled address)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6022"/>
+        <source>&lt;index_min&gt; is already out of bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6027"/>
+        <source>&lt;index_max&gt; exceeds the bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6035"/>
+        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6065"/>
+        <source>Integrated addresses can only be created for account 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6077"/>
+        <source>Integrated address: %s, payment ID: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Subaddress: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
+        <source>usage: get_description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
+        <source>no description found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
+        <source>description found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
+        <source>Filename: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <source>Watch only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
+        <source>%u/%u multisig%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Testnet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
+        <source>This wallet is multisig and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6335"/>
         <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
         <translation>uso: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
         <source>Bad signature from </source>
         <translation>Firma non valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
         <source>Good signature from </source>
         <translation>Firma valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
         <source>usage: export_key_images &lt;filename&gt;</source>
         <translation>uso: export_key_images &lt;filename&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>il portafoglio è solo-vista e non può esportare immagini chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4274"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
         <source>failed to save file </source>
         <translation>impossibile salvare file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
         <source>Signed key images exported to </source>
         <translation>Chiave immagine firmata esportata in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6416"/>
         <source>usage: import_key_images &lt;filename&gt;</source>
         <translation>uso: import_key_images &lt;filename&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6447"/>
         <source>usage: export_outputs &lt;filename&gt;</source>
         <translation>uso: export_outputs &lt;filename&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6484"/>
         <source>Outputs exported to </source>
         <translation>Outputs esportati in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6492"/>
         <source>usage: import_outputs &lt;filename&gt;</source>
         <translation>uso: import_outputs &lt;filename&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
         <source>amount is wrong: </source>
         <translation>l&apos;ammontare non è corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2247"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
         <source>expected number from 0 to </source>
         <translation>deve essere un numero da 0 a </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2378"/>
-        <source>Money successfully sent, transaction </source>
-        <translation>Fondi inviati con successo, transazione </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
-        <source>no connection to daemon. Please, make sure daemon is running.</source>
-        <translation>nessuna connessione con il daemon, assicurati che stia funzionando.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2597"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3171"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>non ci sono abbastanza output per lo specificato mixin_count</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>output amount</source>
-        <translation>ammontare output</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>found outputs to mix</source>
-        <translation>trovati outputs da mixare</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2605"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
-        <source>transaction was not constructed</source>
-        <translation>la transazione non è stata costruita</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>la transazione %s è stata respinta dal daemon con status: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3191"/>
-        <source>one of destinations is zero</source>
-        <translation>una delle destinazioni è zero</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
-        <source>Failed to find a suitable way to split transactions</source>
-        <translation>Impossibile trovare un modo corretto per dividere le transazioni</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2452"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2629"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
-        <source>unknown transfer error: </source>
-        <translation>errore trasferimento sconosciuto: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4079"/>
         <source>Sweeping </source>
         <translation>Eseguendo lo sweeping </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation>Eseguendo lo sweeping di %s per un totale commissioni di %s. Va bene? (S/Sì/N/No)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2816"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4559"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fondi inviati con successo, transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
         <source>no change</source>
         <translation>nessun cambiamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4826"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transazione firmata con successo nel file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4876"/>
         <source>usage: get_tx_key &lt;txid&gt;</source>
         <translation>uso: get_tx_key &lt;txid&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4122"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>failed to parse txid</source>
         <translation>parsing txid fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3245"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
         <source>Tx key: </source>
         <translation>Chiave Tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4912"/>
+        <source>usage: get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5239"/>
+        <source>signature file saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5241"/>
+        <source>failed to save signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4953"/>
         <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
         <translation>uso: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3368"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
         <source>failed to parse tx key</source>
         <translation>impossibile fare il parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>impossibile recuperare transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>impossibile fare il parsing della transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>convalida transazione dal daemon fallita</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3596"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>impossibile recuperare la corretta transazione dal daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3385"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>impossibile generare chiave derivazione dai parametri forniti</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
         <source>error: </source>
         <translation>errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>received</source>
         <translation>ricevuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>in txid</source>
         <translation>in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5099"/>
         <source>received nothing in txid</source>
         <translation>nulla ricevuto in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5083"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>AVVISO: questa transazione non è ancora inclusa nella blockchain!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>This transaction has %u confirmations</source>
         <translation>Questa transazione ha %u conferme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>AVVISO: impossibile determinare il numero di conferme!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
-        <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation>uso: show_transfers [in|out|all|pending|failed] [&lt;min_height&gt; [&lt;max_height&gt;]]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
         <source>bad min_height parameter:</source>
         <translation>parametro min_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5413"/>
         <source>bad max_height parameter:</source>
         <translation>parametro max_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>out</source>
         <translation>out</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>failed</source>
         <translation>fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>pending</source>
         <translation>in attesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
-        <source>usage: unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;]</source>
-        <translation>uso: unspent_outputs [&lt;min_amount&gt; &lt;max_amount&gt;]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_amount&gt; dovrebbe essere più piccolo di &lt;max_amount&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>
 Amount: </source>
         <translation>
 Ammontare: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>, number of keys: </source>
         <translation>, numero di chiavi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Min block height: </source>
         <translation>
 Altezza minima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>
 Max block height: </source>
         <translation>
 Altezza massima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>
 Min amount found: </source>
         <translation>
 Ammontare minimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3869"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>
 Max amount found: </source>
         <translation>
 Ammontare massimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3870"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5606"/>
         <source>
 Total count: </source>
         <translation>
 Conto totale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5646"/>
         <source>
 Bin size: </source>
         <translation>
 Dimensione Bin: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5647"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
         <source>wallet</source>
         <translation>portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
         <source>Random payment ID: </source>
         <translation>ID pagamento casuale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
         <source>Matching integrated address: </source>
         <translation>Indirizzo integrato corrispondente: </translation>
     </message>
 </context>
 <context>
+    <name>genms</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
+        <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
+        <source>Give threshold and participants at once as M/N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
+        <source>How many participants wil share parts of the multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
+        <source>How many signers are required to sign a valid transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
+        <source>Create testnet multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
+        <source>Generating %u %u/%u multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
+        <source>Error verifying multisig extra info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
+        <source>Error finalizing multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
+        <source>Generated multisig wallets for address </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
+        <source>Error creating multisig wallets: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
+        <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
+        <source>Error: expected N/M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
+        <source>Error: either --scheme or both of --threshold and --participants may be given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
+        <source>Error: --filename-base is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
+        <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Genera un nuovo portafoglio e salvalo in &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Genera un portafoglio solo-ricezione da chiave di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <source>Generate deterministic wallet from spend key</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="118"/>
@@ -2375,242 +3635,252 @@ Outputs per *: </source>
         <translation>Genera portafoglio da chiavi private</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
+        <source>Generate a master wallet from multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <source>Language for mnemonic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Specifica il seed stile Electrum per recuperare/creare il portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Recupera portafoglio usando il seed mnemonico stile-Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Crea chiavi di visualizzione e chiavi di spesa non-deterministiche</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Abilita comandi dipendenti da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Permetti comunicazioni con un daemon che usa una versione RPC differente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
         <source>Restore from specific blockchain height</source>
         <translation>Ripristina da specifico blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <source>The newly created transaction will not be relayed to the monero network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è occupato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
         <source>possibly lost connection to daemon</source>
         <translation>possibile perdita di connessione con il daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
         <source>Error: </source>
         <translation>Errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
         <source>Failed to initialize wallet</source>
         <translation>Inizializzazione wallet fallita</translation>
     </message>
 </context>
 <context>
-    <name>tools::dns_utils</name>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="430"/>
-        <source>DNSSEC validation passed</source>
-        <translation>Convalida DNSSEC passata</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="434"/>
-        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
-        <translation>AVVISO: convalida DNSSEC fallita, questo indirizzo potrebbe non essere corretto!</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="437"/>
-        <source>For URL: </source>
-        <translation>Per URL: </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="439"/>
-        <source> Monero Address = </source>
-        <translation> Indirizzo Monero = </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="441"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation>Va bene? (S/n) </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="451"/>
-        <source>you have cancelled the transfer request</source>
-        <translation>hai cancellato la richiesta di transferimento</translation>
-    </message>
-</context>
-<context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="106"/>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Usa instanza daemon in &lt;host&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="107"/>
+        <location filename="../src/wallet/wallet2.cpp" line="114"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Usa istanza daemon all&apos;host &lt;arg&gt; invece che localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Wallet password</source>
-        <translation>Password portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="109"/>
+        <location filename="../src/wallet/wallet2.cpp" line="116"/>
         <source>Wallet password file</source>
         <translation>File password portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="110"/>
+        <location filename="../src/wallet/wallet2.cpp" line="117"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Usa istanza daemon alla porta &lt;arg&gt; invece che alla 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="112"/>
+        <location filename="../src/wallet/wallet2.cpp" line="119"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Per testnet. Il daemon può anche essere lanciato con la flag --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <location filename="../src/wallet/wallet2.cpp" line="120"/>
         <source>Restricts to view-only commands</source>
         <translation>Restringi a comandi di tipo solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="152"/>
+        <location filename="../src/wallet/wallet2.cpp" line="168"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>non puoi specificare la porta o l&apos;host del daemon più di una volta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="188"/>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>non puoi specificare più di un --password e --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="217"/>
         <source>the password file specified could not be read</source>
         <translation>il file password specificato non può essere letto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Enter new password for the wallet</source>
-        <translation>Inserisci una nuova password per il portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="464"/>
-        <source>failed to read wallet password</source>
-        <translation>impossibile leggere password portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="227"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Failed to load file </source>
         <translation>Impossibile caricare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="115"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Wallet password (escape/quote se necessario)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="111"/>
+        <location filename="../src/wallet/wallet2.cpp" line="118"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Specificare username[:password] per client del daemon RPC</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="233"/>
+        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <source>no password specified; use --prompt-for-password to prompt for a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Failed to parse JSON</source>
         <translation>Impossibile fare il parsing di JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>La versione %u è troppo recente, possiamo comprendere solo fino alla versione %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing di chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
-        <location filename="../src/wallet/wallet2.cpp" line="331"/>
-        <location filename="../src/wallet/wallet2.cpp" line="373"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
+        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="380"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="276"/>
+        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
-        <location filename="../src/wallet/wallet2.cpp" line="343"/>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="290"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
+        <location filename="../src/wallet/wallet2.cpp" line="405"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="295"/>
+        <location filename="../src/wallet/wallet2.cpp" line="302"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Verifica lista di parole stile-Electrum fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="306"/>
-        <source>At least one of Electrum-style word list and private view key must be specified</source>
-        <translation>Almeno una parola della lista stile-Electrum e una chiave privata di visualizzazione devono essere specificate</translation>
+        <location filename="../src/wallet/wallet2.cpp" line="319"/>
+        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="311"/>
+        <location filename="../src/wallet/wallet2.cpp" line="323"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Specificate entrambe lista parole stile-Electrum e chiave/i privata/e </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="324"/>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>invalid address</source>
         <translation>indirizzo invalido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
+        <location filename="../src/wallet/wallet2.cpp" line="342"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="347"/>
+        <location filename="../src/wallet/wallet2.cpp" line="352"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="356"/>
+        <location filename="../src/wallet/wallet2.cpp" line="360"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossibile creare portafogli disapprovati da JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="403"/>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
+        <source>failed to parse address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source>Address must be specified in order to create watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="413"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="5205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2813"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2873"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2952"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2998"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3089"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3599"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3955"/>
+        <source>Primary account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="7914"/>
+        <source>No funds received in this tx.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="8607"/>
         <source>failed to read file </source>
         <translation>lettura file fallita</translation>
     </message>
@@ -2618,94 +3888,125 @@ Outputs per *: </source>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="151"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
+        <source>Failed to create directory </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
+        <source>Failed to create directory %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Cannot specify --</source>
         <translation>Impossibile specificare --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source> and --</source>
         <translation> e --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>Failed to create file </source>
         <translation>Impossibile creare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>. Check permissions or remove file</source>
         <translation>. Controlla permessi o rimuovi il file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="209"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
         <source>Error writing to file </source>
         <translation>Errore durante scrittura su file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>RPC username/password is stored in file </source>
         <translation>Username/password RPC conservato nel file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1748"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
+        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
+        <source>This is the RPC monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Non puoi specificare più di un --wallet-file e --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Devi specificare --wallet-file o --generate-from-json o --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1764"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
         <source>Loading wallet...</source>
         <translation>Sto caricando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1789"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1814"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
         <source>Saving wallet...</source>
         <translation>Sto salvando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1791"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1816"/>
-        <source>Saved ok</source>
-        <translation>Salvato con successo</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
+        <source>Successfully saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1794"/>
-        <source>Loaded ok</source>
-        <translation>Caricato con successo</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
+        <source>Successfully loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1798"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
         <source>Wallet initialization failed: </source>
         <translation>Inizializzazione portafoglio fallita: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1805"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Inizializzazione server RPC portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1809"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
         <source>Starting wallet RPC server</source>
         <translation>Server RPC portafoglio in avvio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1811"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
+        <source>Failed to run wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
         <source>Stopped wallet RPC server</source>
         <translation>Server RPC portafoglio arrestato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1820"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
         <source>Failed to save wallet: </source>
         <translation>Impossibile salvare portafoglio: </translation>
     </message>
@@ -2713,58 +4014,65 @@ Outputs per *: </source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4580"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
         <source>Wallet options</source>
         <translation>Opzioni portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="59"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Genera portafoglio da file JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="63"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>Usa portafoglio &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="87"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="104"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Numero massimo di threads da utilizzare per un lavoro parallelo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="88"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="105"/>
         <source>Specify log file</source>
         <translation>Specificare file di log</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="89"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>Config file</source>
         <translation>File configurazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="98"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="115"/>
         <source>General options</source>
         <translation>Opzioni generali</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="128"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="138"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="161"/>
         <source>Can&apos;t find config file </source>
         <translation>Impossibile trovare file configurazione </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="172"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="195"/>
         <source>Logging to: </source>
         <translation>Sto salvando il Log in: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="197"/>
         <source>Logging to %s</source>
         <translation>Sto salvando il Log in %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="153"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="140"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -527,8 +527,8 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [<payment_id>] - Send all unlocked outputs below the threshold to an address</source>
-        <translation>sweep_below &lt;amount_threshold&gt; [mixin] address [<payment_id>] - Invia tutti gli outputs sbloccati sotto la soglia specificata a un indirizzo</translation>
+        <source>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
+        <translation>sweep_below &lt;amount_threshold&gt; [mixin] address [payment_id] - Invia tutti gli outputs sbloccati sotto la soglia specificata a un indirizzo</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
@@ -952,8 +952,8 @@ Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s gi
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [<payment_id>] - Send all unlocked balance to an address</source>
-        <translation>sweep_all [mixin] address [<payment_id>] - Manda tutto il bilancio sbloccato ad un indirizzo</translation>
+        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
+        <translation>sweep_all [mixin] address [payment_id] - Manda tutto il bilancio sbloccato ad un indirizzo</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -1,27 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE TS []>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="55"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Ogiltig måladress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="65"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="63"/>
         <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
         <translation>Ogiltigt betalnings-ID. Kort betalnings-ID ska endast användas i en integrerad adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="72"/>
+        <location filename="../src/wallet/api/address_book.cpp" line="70"/>
         <source>Invalid payment ID</source>
         <translation>Ogiltigt betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="79"/>
-        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
-        <translation>Integrerad adress och långt betalnings-ID kan inte användas samtidigt</translation>
+        <location filename="../src/wallet/api/address_book.cpp" line="77"/>
+        <source>Integrated address and long payment ID can&apos;t be used at the same time</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -37,32 +37,32 @@
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="114"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="117"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="126"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
         <source>. Reason: </source>
         <translation>. Orsak: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
         <source>Unknown exception: </source>
         <translation>Okänt undantag: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="131"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
         <source>Unhandled exception</source>
         <translation>Ohanterat undantag</translation>
     </message>
@@ -81,323 +81,324 @@
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="141"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="151"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till mer än en adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="164"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="170"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="176"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="179"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="181"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %s</source>
-        <translation>Läste in %lu transaktioner, för %s, avgift %s, %s, %s, med minsta mixin %lu. %s</translation>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="942"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En 16- eller 64-teckens hex-sträng förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="952"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
         <source>Failed to add short payment id: </source>
         <translation>Det gick inte att lägga till kort betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="978"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1072"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="981"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1075"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="984"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1078"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1081"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
+        <source>not enough outputs for specified ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>found outputs to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
+        <source>Please sweep unmixable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
         <source>failed to get random outputs to mix</source>
         <translation>det gick inte att hämta slumpmässiga utgångar att mixa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="994"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1088"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>inte tillräckligt med pengar för överföring, endast tillgängligt %s, skickat belopp %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="403"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="474"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="415"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="486"/>
         <source>failed to parse secret spend key</source>
         <translation>det gick inte att parsa hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="425"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="496"/>
         <source>No view key supplied, cancelled</source>
         <translation>Ingen visningsnyckel angiven, avbruten</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="432"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="503"/>
         <source>failed to parse secret view key</source>
         <translation>det gick inte att parsa hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="442"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="513"/>
         <source>failed to verify secret spend key</source>
         <translation>det gick inte att verifiera hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="447"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="518"/>
         <source>spend key does not match address</source>
         <translation>spendernyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="453"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="524"/>
         <source>failed to verify secret view key</source>
         <translation>det gick inte att verifiera hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="458"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="529"/>
         <source>view key does not match address</source>
         <translation>visningsnyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="477"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="548"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="799"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <source>Failed to send import wallet request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="919"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Det gick inte att läsa in osignerade transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="820"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="940"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="838"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="958"/>
         <source>Wallet is view only</source>
         <translation>Plånboken är endast för granskning</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="847"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="967"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="874"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="986"/>
+        <source>Key images can only be imported with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="999"/>
         <source>Failed to import key images: </source>
         <translation>det gick inte att importera nyckelavbildningar: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="987"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
+        <source>Failed to get subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
+        <source>Failed to set subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
         <source>failed to get random outputs to mix: %s</source>
         <translation>det gick inte att hitta slumpmässiga utgångar att mixa: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1003"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1097"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
+        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>ej tillräckligt med pengar för överföring, endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1012"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1106"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>inte tillräckligt många utgångar för angiven mixin_count</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>output amount</source>
         <translation>utgångens belopp</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1014"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
-        <source>found outputs to mix</source>
-        <translation>hittade utgångar att mixa</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1019"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1113"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>transaction was not constructed</source>
         <translation>transaktionen konstruerades inte</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1023"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1117"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1030"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1124"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
         <source>one of destinations is zero</source>
         <translation>ett av målen är noll</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1033"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1127"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1036"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
         <source>unknown transfer error: </source>
         <translation>okänt överföringsfel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1039"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1133"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1042"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1136"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1045"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1139"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1419"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1441"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1494"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1525"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
+        <source>Failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished">inga tx-nycklar kunde hittas för detta txid</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
+        <source>Failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1502"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished">Det gick inte att parsa adressen</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Genomsök efter spenderade kan endast användas med en betrodd daemon</translation>
     </message>
 </context>
 <context>
-    <name>Monero::WalletManagerImpl</name>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="192"/>
-        <source>failed to parse txid</source>
-        <translation>det gick inte att parsa transaktions-id</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="199"/>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="206"/>
-        <source>failed to parse tx key</source>
-        <translation>det gick inte att parsa transaktionsnyckeln</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="217"/>
-        <source>failed to parse address</source>
-        <translation>det gick inte att parsa adressen</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="227"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>det gick inte att hämta transaktion från daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="238"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>det gick inte att parsa transaktion från daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="245"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>det gick inte att validera transaktion från daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="250"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>det gick inte att hämta rätt transaktion från daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="257"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>det gick inte att skapa nyckelhärledning från angivna parametrar</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="313"/>
-        <source>error: </source>
-        <translation>fel: </translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>received</source>
-        <translation>mottaget</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="319"/>
-        <source>in txid</source>
-        <translation>i transaktions-id</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet_manager.cpp" line="323"/>
-        <source>received nothing in txid</source>
-        <translation>tog emot ingenting i transaktions-id</translation>
-    </message>
-</context>
-<context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="212"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
         <translation>Det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
         <translation>Det gick inte att parsa nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="227"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
         <translation>det gick inte att verifiera nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="237"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="271"/>
         <source>key does not match address</source>
         <translation>nyckeln matchar inte adressen</translation>
     </message>
@@ -405,1911 +406,3080 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="76"/>
+        <location filename="../src/common/command_line.cpp" line="57"/>
         <source>yes</source>
         <translation>ja</translation>
+    </message>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="71"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="38"/>
-        <source>Specify ip to bind rpc server</source>
-        <translation>Ange IP-adress för att binda till RPC-server</translation>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <source>Specify IP to bind RPC server</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="39"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="41"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Ange användarnamn[:lösenord] som krävs av RPC-servern</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="42"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Bekräftelsevärde för rpc-bind-ip är INTE ett lokalt (loopback) IP</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="66"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="43"/>
+        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="70"/>
         <source>Invalid IP address given for --</source>
         <translation>Ogiltig IP-adress angiven för --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="74"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="78"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation> tillåter inkommande okrypterade externa anslutningar. Överväg att använda SSH-tunnel eller SSL-proxy istället. Åsidosätt med --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Username specified with --</source>
         <translation>Användarnamn angivet med --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="89"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> cannot be empty</source>
         <translation> kan inte vara tomt</translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> requires RFC server password --</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="479"/>
         <source>Commands: </source>
         <translation>Kommandon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>failed to read wallet password</source>
         <translation>det gick inte att läsa lösenord för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
         <source>invalid password</source>
         <translation>ogiltigt lösenord</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="697"/>
-        <source>start_mining [&lt;number_of_threads>] - Start mining in daemon</source>
-        <translation>start_mining [&lt;antal_trådar>] - Starta brytning i daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="698"/>
-        <source>Stop mining in daemon</source>
-        <translation>Avbryt brytning i daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="699"/>
-        <source>Save current blockchain data</source>
-        <translation>Spara aktuella blockkedje-data</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="701"/>
-        <source>Show current wallet balance</source>
-        <translation>Visa aktuellt saldo för plånboken</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
-        <source>Show blockchain height</source>
-        <translation>Visa blockkedjans höjd</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
-        <source>Show current wallet public address</source>
-        <translation>Visa plånbokens aktuella öppna adress</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <source>Show this help</source>
-        <translation>Visa denna hjälp</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed: behöver ett argument. tillgängliga alternativ: språk</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="811"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set: okända argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
         <source>wallet file path not valid: </source>
         <translation>ogiltig sökväg till plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Försöker skapa eller återställa plånbok, men angivna filer existerar.  Avslutar för att inte riskera att skriva över någonting.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="416"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
         <source>usage: payment_id</source>
         <translation>användning: payment_id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="710"/>
-        <source>sweep_below &lt;amount_threshold> [mixin] address [payment_id] - Send all unlocked outputs below the threshold to an address</source>
-        <translation>sweep_below &lt;tröskelbelopp> [mixin] &lt;adress> [&lt;betalnings_ID>] - Skicka alla upplåsta utgångar under tröskelbeloppet till en adress</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="743"/>
-        <source>Generate a new random full size payment id - these will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids</source>
-        <translation>Skapa ett nytt slumpmässigt betalnings-ID av full storlek - dessa kommer att vara okrypterade på blockkedjan, se integrated_address för krypterade korta betalnings-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="774"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
         <source>needs an argument</source>
         <translation>kräver ett argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="798"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="801"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="804"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
         <source>0 or 1</source>
         <translation>0 eller 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="800"/>
-        <source>integer >= 2</source>
-        <translation>heltal >= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
         <source>0, 1, 2, 3, or 4</source>
         <translation>0, 1, 2, 3 eller 4</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
         <source>unsigned integer</source>
         <translation>positivt heltal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="912"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
         <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>OBSERVERA: följande 25 ord kan användas för att återfå tillgång till din plånbok. Skriv ner och spara dem på ett säkert ställe. Spara dem inte i din e-post eller på något lagringsutrymme som du inte har direkt kontroll över.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2092"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet använder --generate-new-wallet, inte --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2121"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>ange en återställningsparameter med --electrum-seed=&quot;ordlista här&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>ange sökväg till en plånbok med --generate-new-wallet (inte --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>plånboken kunde inte ansluta till daemonen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2643"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Daemonen använder en högre version av RPC (%u) än plånboken (%u): %s. Antingen uppdatera en av dem, eller använd --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista över tillgängliga språk för din plånboks frö:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1297"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2671"/>
         <source>Enter the number corresponding to the language of your choice: </source>
         <translation>Ange det tal som motsvarar det språk du vill använda: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Använd det nya frö som vi tillhandahåller.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1368"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1425"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
         <source>Generated new wallet: </source>
         <translation>Ny plånbok skapad: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
         <source>Opened watch-only wallet</source>
         <translation>Öppnade plånbok för granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
         <source>Opened wallet</source>
         <translation>Öppnade plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Fortsätt för att uppgradera din plånbok.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Plånbokens filformat kommer nu att uppgraderas.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>failed to load wallet: </source>
         <translation>det gick inte att läsa in plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1497"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Använd kommandot &quot;help&quot; för att se en lista över tillgängliga kommandon.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
         <source>Wallet data saved</source>
         <translation>Plånboksdata sparades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
         <source>Mining started in daemon</source>
         <translation>Brytning startad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3074"/>
         <source>mining has NOT been started: </source>
         <translation>brytning har INTE startats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
         <source>Mining stopped in daemon</source>
         <translation>Brytning stoppad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
         <source>mining has NOT been stopped: </source>
         <translation>brytning har INTE stoppats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Blockchain saved</source>
         <translation>Blockkedjan sparad</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1699"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3165"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
         <source>Height </source>
         <translation>Höjd </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1671"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
         <source>transaction </source>
         <translation>transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1672"/>
-        <source>received </source>
-        <translation>mottaget </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1689"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>spent </source>
         <translation>spenderad </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3198"/>
         <source>unsupported transaction format</source>
         <translation>transaktionsformatet stöds inte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1718"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3219"/>
         <source>Starting refresh...</source>
         <translation>Startar uppdatering …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
         <source>Refresh done, blocks received: </source>
         <translation>Uppdatering färdig, mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2186"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En 16- eller 64-teckens hex-sträng förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
         <source>bad locked_blocks parameter:</source>
         <translation>dålig parameter för locked_blocks:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4462"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>en enstaka transaktion kan inte använda mer än ett betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4470"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>det gick inte att upprätta betalnings-ID, trots att det avkodades korrekt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2262"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2533"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4527"/>
         <source>transaction cancelled.</source>
         <translation>transaktion avbröts.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Failed to check for backlog: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <source>
+Transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
+        <source>Spending from address index %d
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3953"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4309"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3955"/>
         <source>Sending %s.  </source>
         <translation>Skickar %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3958"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Transaktionen behöver delas upp i %llu transaktioner.  Detta kommer att göra att en transaktionsavgift läggs till varje transaktion, med ett totalt belopp på %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3964"/>
         <source>The transaction fee is %s</source>
         <translation>Transaktionsavgiften är %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3967"/>
         <source>, of which %s is dust from change</source>
         <translation>, varav %s är damm från växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Ett total belopp på %s från växeldamm kommer att skickas till damm-adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3973"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation>.
 Denna transaktion kommer att låsas upp vid block %llu, om ungefär %s dagar (förutsatt en blocktid på 2 minuter)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2367"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2544"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4011"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4549"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Osignerade transaktioner skrevs till fil: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3157"/>
-        <source>Not enough money in unlocked balance</source>
-        <translation>Inte tillräckligt med pengar i upplåst saldo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
-        <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
-        <translation>Det gick inte att hitta något sätt att skapa transaktioner. Detta beror vanligtvis på damm som är så litet att det inte kan betala för sig självt i avgifter, eller ett försök att skicka mer pengar än upplåst saldo, eller att inte lämna tillräckligt för att täcka avgifterna</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2612"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Reason: </source>
-        <translation>Orsak: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation>det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2503"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
         <source>No unmixable outputs found</source>
         <translation>Inga omixbara utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4149"/>
         <source>No address given</source>
         <translation>Ingen adress har angivits</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2921"/>
-        <source>missing amount threshold</source>
-        <translation>beloppströskel saknas</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>invalid amount threshold</source>
         <translation>ogiltig beloppströskel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4702"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
         <source>Failed to sign transaction</source>
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
         <source>Failed to sign transaction: </source>
         <translation>Det gick inte att signera transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3137"/>
-        <source>daemon is busy. Please try later</source>
-        <translation>daemonen är upptagen. Försök senare</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1995"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>plånboken är enbart för granskning och har ingen spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="390"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>Your original password was incorrect.</source>
         <translation>Ditt ursprungliga lösenord var fel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="404"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
         <source>Error with wallet rewrite: </source>
         <translation>Fel vid återskrivning av plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
         <source>priority must be 0, 1, 2, 3, or 4 </source>
         <translation>prioritet måste vara 0, 1, 2, 3 eller 4 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="525"/>
-        <source>priority must be 0, 1, 2, 3,or 4</source>
-        <translation>prioritet måste vara 0, 1, 2, 3 eller 4</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="540"/>
-        <source>priority must be 0, 1, 2 3,or 4</source>
-        <translation>prioritet måste vara 0, 1, 2, 3 eller 4</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
         <source>invalid unit</source>
         <translation>ogiltig enhet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>ogiltigt värde för count: måste vara ett heltal utan tecken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
         <source>invalid value</source>
         <translation>ogiltigt värde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="705"/>
-        <source>Same as transfer, but using an older transaction building algorithm</source>
-        <translation>Samma som transfer, men använder en äldre algoritm för att bygga transaktionen</translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
+        <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
+        <translation>användning: set_log &lt;loggnivå_nummer_0-4&gt; | &lt;kategorier&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>sweep_all [mixin] address [payment_id] - Send all unlocked balance to an address</source>
-        <translation>sweep_all [mixin] adress [betalnings_id] - Skicka allt upplåst saldo till en adress</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
-        <source>donate [&lt;mixin_count>] &lt;amount> [payment_id] - Donate &lt;amount> to the development team (donate.getmonero.org)</source>
-        <translation>donate [&lt;mixin_antal>] &lt;belopp> [&lt;betalnings_id>] - Donera &lt;belopp> till utvecklingsteamet (donate.getmonero.org)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
-        <source>set_log &lt;level>|&lt;categories> - Change current log detail (level must be &lt;0-4>)</source>
-        <translation>set_log &lt;nivå>|&lt;kategorier> - Ändra detaljnivån för aktuell logg (nivå måste vara 0-4)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
-        <source>address_book [(add (&lt;address> [pid &lt;long or short payment id>])|&lt;integrated address> [&lt;description possibly with whitespaces>])|(delete &lt;index>)] - Print all entries in the address book, optionally adding/deleting an entry to/from it</source>
-        <translation>address_book [(add (&lt;adress> [pid &lt;långt eller kort betalnings-ID>])|&lt;integrerad adress> [&lt;beskrivning eventuellt med blanktecken>])|(delete &lt;index>)] - Skriv ut alla poster i adressboken, eventuellt lägg till/ta bort en post till/från den</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
-        <source>show_transfers [in|out|pending|failed|pool] [&lt;min_height> [&lt;max_height>]] - Show incoming/outgoing transfers within an optional height range</source>
-        <translation>show_transfers [in|out|pending|failed|pool] [&lt;min_höjd> [&lt;max_höjd>]] - Visa inkommande/utgående överföringar inom ett valfritt höjdintervall</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="741"/>
-        <source>Show information about a transfer to/from this address</source>
-        <translation>Visa information om en överföring till/från denna adress</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
-        <source>Change wallet password</source>
-        <translation>Ändra lösenord för plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="820"/>
-        <source>usage: set_log &lt;log_level_number_0-4> | &lt;categories></source>
-        <translation>användning: set_log &lt;loggnivå_nummer_0-4> | &lt;kategorier></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="886"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
         <source>(Y/Yes/N/No): </source>
         <translation>(J/Ja/N/Nej): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2536"/>
         <source>bad m_restore_height parameter: </source>
         <translation>dålig parameter för m_restore_height: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
         <source>date format must be YYYY-MM-DD</source>
         <translation>datumformat måste vara ÅÅÅÅ-MM-DD</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2527"/>
         <source>Restore height is: </source>
         <translation>Återställningshöjd är: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
         <source>Is this okay?  (Y/Yes/N/No): </source>
         <translation>Är detta okej?  (J/Ja/N/Nej): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Password for new watch-only wallet</source>
         <translation>Lösenord för ny granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
-        <source>invalid arguments. Please use start_mining [&lt;number_of_threads>] [do_bg_mining] [ignore_battery], &lt;number_of_threads> should be from 1 to </source>
-        <translation>ogiltiga argument. Använd start_mining [&lt;antal_trådar>] [do_bg_mining] [ignore_battery], &lt;antal_trådar> ska vara från 1 till </translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
+        <translation>ogiltiga argument. Använd start_mining [&lt;antal_trådar&gt;] [do_bg_mining] [ignore_battery], &lt;antal_trådar&gt; ska vara från 1 till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1755"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2457"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2895"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3205"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2000"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2005"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2467"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2644"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>refresh failed: </source>
         <translation>det gick inte att att uppdatera: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Blocks received: </source>
         <translation>Mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1795"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>unlocked balance: </source>
         <translation>upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>amount</source>
         <translation>belopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
+        <source>Unknown command: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
+        <source>Command usage: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <source>Command description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <source>wallet is multisig but not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
+        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="584"/>
+        <source>Failed to retrieve seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
+        <source>wallet is multisig and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <source>Cannot connect to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <source>Current fee is %s monero per kB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Error: failed to estimate backlog array size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <source>Error: bad estimated backlog array size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <source> (current)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
+        <source>No backlog at priority </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="762"/>
+        <source>This wallet is already multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="767"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="773"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <source>Your password is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="754"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
+        <source>usage: make_multisig &lt;threshold&gt; &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="794"/>
+        <source>Invalid threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <source>Another step is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <source>Send this multisig info to all other participants, then use finalize_multisig &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
+        <source>Error creating multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="822"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
+        <source> multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>This wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
+        <source>This wallet is already finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <source>usage: finalize_multisig &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="862"/>
+        <source>Failed to finalize multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <source>Failed to finalize multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
+        <source>This multisig wallet is not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
+        <source>usage: export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
+        <source>Error exporting multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
+        <source>Multisig info exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
+        <source>usage: import_multisig_info &lt;filename1&gt; [&lt;filename2&gt;...] - one for each other participant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
+        <source>Multisig info imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="969"/>
+        <source>Failed to import multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="980"/>
+        <source>Failed to update spent status after importing multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="985"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
+        <source>This is not a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
+        <source>usage: sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <source>Multisig error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source>usage: submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <source>Failed to load multisig transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1160"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6750"/>
+        <source>Transaction successfully submitted, transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6751"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <source>usage: export_raw_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
+        <source>could not change default ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1316"/>
+        <source>priority must be 0, 1, 2, 3, or 4</source>
+        <translation type="unfinished">prioritet måste vara 0, 1, 2, 3 eller 4  {0, 1, 2, 3,?} {4?}</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <source>Invalid height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1564"/>
+        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1565"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
+        <source>Stop mining in the daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <source>set_daemon &lt;host&gt;[:&lt;port&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1572"/>
+        <source>Set another daemon to connect to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <source>Save the current blockchain data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1582"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1585"/>
+        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1586"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1589"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
+        <source>Show the blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1625"/>
+        <source>sign_transfer &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
+        <source>Sign a transaction from a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <source>Submit a signed transaction from a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <source>account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt; 
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the walllet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1656"/>
+        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1660"/>
+        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <source>Save the wallet data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <source>Save a watch-only keys file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
+        <source>Display the private view key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Display the private spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <source>set &lt;option&gt; [&lt;value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <source>Available options:
+ seed language
+   Set the wallet&apos;s seed language.
+ always-confirm-transfers &lt;1|0&gt;
+   Whether to confirm unsplit txes.
+ print-ring-members &lt;1|0&gt;
+   Whether to print detailed information about ring members during confirmation.
+ store-tx-info &lt;1|0&gt;
+   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
+ default-ring-size &lt;n&gt;
+   Set the default ring size (default and minimum is 5).
+ auto-refresh &lt;1|0&gt;
+   Whether to automatically synchronize new blocks from the daemon.
+ refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
+   Set the wallet&apos;s refresh behaviour.
+ priority [0|1|2|3|4]
+   Set the fee too default/unimportant/normal/elevated/priority.
+ confirm-missing-payment-id &lt;1|0&gt;
+ ask-password &lt;1|0&gt;
+ unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
+   Set the default monero (sub-)unit.
+ min-outputs-count [n]
+   Try to keep at least that many outputs of value at least min-outputs-value.
+ min-outputs-value [n]
+   Try to keep at least min-outputs-count outputs of at least that value.
+ merge-destinations &lt;1|0&gt;
+   Whether to merge multiple payments to the same destination address.
+ confirm-backlog &lt;1|0&gt;
+   Whether to warn if there is transaction backlog.
+ confirm-backlog-threshold [n]
+   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
+ refresh-from-block-height [n]
+   Set the height before which to ignore blocks.
+ auto-low-priority &lt;1|0&gt;
+   Whether to automatically use the low priority fee level when it&apos;s safe to do so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1717"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
+        <source>get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1727"/>
+        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <source>get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1735"/>
+        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
+        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
+        <source>get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1748"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
+        <source>check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1754"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1757"/>
+        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
+        <source>Rescan the blockchain from scratch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1768"/>
+        <source>set_tx_note &lt;txid&gt; [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1769"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <source>get_tx_note &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>set_description [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1780"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <source>sign &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1793"/>
+        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>export_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1798"/>
+        <source>Export a signed set of key images to a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
+        <source>import_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1802"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
+        <source>export_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1806"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1809"/>
+        <source>import_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
+        <source>show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1825"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>make_multisig &lt;threshold&gt; &lt;string1&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1831"/>
+        <source>finalize_multisig &lt;string&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <source>export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1836"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <source>import_multisig_info &lt;filename&gt; [&lt;filename&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <source>sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
+        <source>submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1848"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1851"/>
+        <source>export_raw_multisig_tx &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <source>help [&lt;command&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2012"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2084"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>Enter seed encryption passphrase, empty if none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2259"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2350"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished">det gick inte att parsa hemlig visningsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished">det gick inte att verifiera hemlig visningsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
+        <source>Secret spend key (%u of %u):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2550"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2551"/>
+        <source>Still apply restore height?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2582"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2685"/>
+        <source>invalid language choice entered. Please try again.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <source>missing daemon URL argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
+        <source>usage: balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
+        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>spent</source>
         <translation>spenderad</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>global index</source>
         <translation>globalt index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>tx id</source>
         <translation>tx-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
         <source>No incoming transfers</source>
         <translation>Inga inkommande överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3427"/>
         <source>No incoming available transfers</source>
         <translation>Inga inkommande tillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1876"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3431"/>
         <source>No incoming unavailable transfers</source>
         <translation>Inga inkommande otillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1887"/>
-        <source>expected at least one payment_id</source>
-        <translation>åtminstone ett payment_id förväntades</translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>, txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>payment</source>
         <translation>betalning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>transaction</source>
         <translation>transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>height</source>
         <translation>höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1896"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>unlock time</source>
         <translation>upplåsningstid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1908"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3463"/>
         <source>No payments with id </source>
         <translation>Inga betalningar med ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3853"/>
         <source>failed to get blockchain height: </source>
         <translation>det gick inte att hämta blockkedjans höjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5259"/>
         <source>failed to connect to the daemon</source>
         <translation>det gick inte att ansluta till daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2034"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3590"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaktion %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>
 Input %llu/%llu: amount=%s</source>
         <translation>
 Ingång %llu/%llu: belopp=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2060"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
         <source>failed to get output: </source>
         <translation>det gick inte att hämta utgång: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3624"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>utgångsnyckelns ursprungsblockhöjd får inte vara högre än blockkedjans höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
         <source>
 Originating block heights: </source>
         <translation>
 Ursprungsblockhöjder: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2087"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Varning: Några ingångsnycklar som spenderas kommer från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3662"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, vilket kan bryta ringsignaturens anonymitet. Se till att detta är avsiktligt!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3724"/>
         <source>wrong number of arguments</source>
         <translation>fel antal argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4479"/>
         <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
         <translation>Inget betalnings-ID har inkluderats med denna transaktion. Är detta okej?  (J/Ja/N/Nej): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2298"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Inga utgångar hittades, eller så är daemonen inte redo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2576"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2837"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
-        <source>failed to get random outputs to mix: </source>
-        <translation>det gick inte att hitta slumpmässiga utgångar att mixa: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2518"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Sveper upp %s i %llu transaktioner för en total avgift på %s.  Är detta okej?  (J/Ja/N/Nej): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4519"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
         <translation>Sveper upp %s för en total avgift på %s.  Är detta okej?  (J/Ja/N/Nej): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4630"/>
         <source>Donating </source>
         <translation>Donerar </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3053"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min mixin %lu. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Läste in %lu transaktioner, för %s, avgift %s, %s, %s, med minsta mixin %lu. %sÄr detta okej? (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
         <source>This is a watch only wallet</source>
         <translation>Detta är en granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4443"/>
-        <source>usage: show_transfer &lt;txid></source>
-        <translation>användning: show_transfer &lt;transaktions-ID></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <source>usage: show_transfer &lt;txid&gt;</source>
+        <translation>användning: show_transfer &lt;transaktions-ID&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6673"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6708"/>
         <source>Transaction ID not found</source>
         <translation>Transaktions-ID kunde inte hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="237"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="214"/>
         <source>true</source>
         <translation>sant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="267"/>
         <source>failed to parse refresh type</source>
         <translation>det gick inte att parsa uppdateringstyp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>plånboken är enbart för granskning och saknar frö</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="353"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>plånboken är icke-deterministisk och saknar frö</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>plånboken är enbart för granskning och kan inte göra överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
-        <source>mixin must be an integer >= 2</source>
-        <translation>mixin måste vara ett heltal >= 2</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="501"/>
-        <source>could not change default mixin</source>
-        <translation>det gick inte att ändra standardinställning för mixin</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
         <source>could not change default priority</source>
         <translation>Det gick inte att ändra standardinställning för prioritet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
-        <source>Synchronize transactions and balance</source>
-        <translation>Synkronisera transaktioner och saldo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="702"/>
-        <source>incoming_transfers [available|unavailable] - Show incoming transfers, all or filtered by availability</source>
-        <translation>incoming_transfers [available|unavailable] - Visa inkommande överföringar, alla eller filtrerade efter tillgänglighet</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="703"/>
-        <source>payments &lt;PID_1> [&lt;PID_2> ... &lt;PID_N>] - Show payments for given payment ID[s]</source>
-        <translation>payments &lt;B_ID_1> [&lt;B_ID_2> … &lt;B_ID_N>] - Visa betalningar för angivna betalnings-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="706"/>
-        <source>transfer [&lt;priority>] [&lt;mixin_count>] &lt;address> &lt;amount> [&lt;payment_id>] - Transfer &lt;amount> to &lt;address>. &lt;priority> is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;mixin_count> is the number of extra inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2> &lt;amount_2> etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>transfer [&lt;prioritet>] [&lt;mixin_antal>] &lt;adress> &lt;belopp> [&lt;betalnings_id>] - Överför &lt;belopp> till &lt;adress>. &lt;prioritet> är transaktionens prioritet. Ju högre prioritet, desto högre transaktionsavgift. Giltiga värden i prioritetsordning (från lägsta till högsta) är: unimportant, normal, elevated, priority. Om det utelämnas kommer standardvärdet (se kommandot &quot;set priority&quot;) att användas. &lt;mixin_antal> är det antal extra ingångar som ska inkluderas för att uppnå ospårbarhet. Flera betalningar kan göras på en gång genom att lägga till &lt;adress_2> &lt;belopp_2> etcetera (före betalnings-ID, om det inkluderas)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="707"/>
-        <source>locked_transfer [&lt;mixin_count>] &lt;addr> &lt;amount> &lt;lockblocks>(Number of blocks to lock the transaction for, max 1000000) [&lt;payment_id>]</source>
-        <translation>locked_transfer [&lt;mixin_antal>] &lt;adress> &lt;belopp> &lt;låsblock>(Antal block som transaktionen ska låsas för, max 1000000) [&lt;betalnings_id>]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="708"/>
-        <source>Send all unmixable outputs to yourself with mixin 0</source>
-        <translation>Skicka alla omixbara utgångar till dig själv med mixin 0</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
-        <source>Sign a transaction from a file</source>
-        <translation>Signera en transaktion från en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="713"/>
-        <source>Submit a signed transaction from a file</source>
-        <translation>Skicka en signerad transaktion från en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
-        <source>integrated_address [PID] - Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation>integrated_address [PID] - Koda ett betalnings-ID till en integrerad adress för den aktuella plånbokens öppna adress (utan argument används ett slumpmässigt betalnings-ID), eller avkoda en integrerad adress till standardadress och betalnings-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="718"/>
-        <source>Save wallet data</source>
-        <translation>Spara plånboksdata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="719"/>
-        <source>Save a watch-only keys file</source>
-        <translation>Spara en fil med granskningsnycklar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
-        <source>Display private view key</source>
-        <translation>Visa privat visningsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <source>Display private spend key</source>
-        <translation>Visa privat spendernyckel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="722"/>
-        <source>Display Electrum-style mnemonic seed</source>
-        <translation>Visa minnesfrö (Electrum-typ)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="723"/>
-        <source>Available options: seed language - set wallet seed language; always-confirm-transfers &lt;1|0> - whether to confirm unsplit txes; print-ring-members &lt;1|0> - whether to print detailed information about ring members during confirmation; store-tx-info &lt;1|0> - whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference; default-mixin &lt;n> - set default mixin (default is 4); auto-refresh &lt;1|0> - whether to automatically sync new blocks from the daemon; refresh-type &lt;full|optimize-coinbase|no-coinbase|default> - set wallet refresh behaviour; priority [0|1|2|3|4] - default/unimportant/normal/elevated/priority fee; confirm-missing-payment-id &lt;1|0>; ask-password &lt;1|0>; unit &lt;monero|millinero|micronero|nanonero|piconero> - set default monero (sub-)unit; min-outputs-count [n] - try to keep at least that many outputs of value at least min-outputs-value; min-outputs-value [n] - try to keep at least min-outputs-count outputs of at least that value; merge-destinations &lt;1|0> - whether to merge multiple payments to the same destination address</source>
-        <translation>Tillgängliga alternativ: seed language - ange språk för plånbokens frö; always-confirm-transfers &lt;1|0> - huruvida ej delade transaktioner ska bekräftas; print-ring-members &lt;1|0> - huruvida detaljerad information om ringmedlemmar ska skrivas ut vid bekräftelse; store-tx-info &lt;1|0> - huruvida info om utgående transaktioner ska sparas (måladress, betalnings-ID, hemlig transaktionsnyckel) för framtida referens; default-mixin &lt;n> - ange standardvärde för mixin (standard är 4); auto-refresh &lt;1|0> - huruvida nya block från daemonen ska synkas automatiskt; refresh-type &lt;full|optimize-coinbase|no-coinbase|default> - ange uppdateringsbeteende för plånbok; priority [0|1|2|3|4] - standard/oviktigt/normal/förhöjd/prioritetsavgift; confirm-missing-payment-id &lt;1|0>; ask-password &lt;1|0>; unit &lt;monero|millinero|micronero|nanonero|piconero> - ange standardvärde för monero-(under-)enhet; min-outputs-count [n] - försök behålla åtminstone så många utgångar med ett värde på åtminstone min-outputs-value; min-outputs-value [n] - försök behålla åtminstone min-outputs-count utgångar av åtminstone detta värde; merge-destinations &lt;1|0> - huruvida flera betalningar till samma måladress ska slås samman</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="724"/>
-        <source>Rescan blockchain for spent outputs</source>
-        <translation>Genomsök blockkedjan igen för spenderade utgångar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="725"/>
-        <source>Get transaction key (r) for a given &lt;txid></source>
-        <translation>Hämta transaktionsnyckel (r) för ett givet &lt;transaktions-ID></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <source>Check amount going to &lt;address> in &lt;txid></source>
-        <translation>Kontrollera belopp som går till &lt;adress> i &lt;transaktions-ID></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="727"/>
-        <source>Generate a signature to prove payment to &lt;address> in &lt;txid> using the transaction secret key (r) without revealing it</source>
-        <translation>Skapa en signatur för att bevisa betalning till &lt;adress> i &lt;transaktions-ID> genom att använda hemlig nyckel för transaktion (r) utan att avslöja den</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="728"/>
-        <source>Check tx proof for payment going to &lt;address> in &lt;txid></source>
-        <translation>Kontrollera transaktionsbevis för betalning som går till &lt;adress> i &lt;transaktions-ID></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="730"/>
-        <source>unspent_outputs [&lt;min_amount> &lt;max_amount>] - Show unspent outputs within an optional amount range</source>
-        <translation>unspent_outputs [&lt;min_belopp> &lt;max_belopp>] - Visa ej spenderade utgångar inom ett valfritt beloppsintervall</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="731"/>
-        <source>Rescan blockchain from scratch</source>
-        <translation>Genomsök blockkedjan från början</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="732"/>
-        <source>Set an arbitrary string note for a txid</source>
-        <translation>Ange en godtycklig sträng som anteckning för ett transaktions-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="733"/>
-        <source>Get a string note for a txid</source>
-        <translation>Hämta en stränganteckning för ett transaktions-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
-        <source>Show wallet status information</source>
-        <translation>Visa statusinformation för plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
-        <source>Sign the contents of a file</source>
-        <translation>Signera innehållet i en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="736"/>
-        <source>Verify a signature on the contents of a file</source>
-        <translation>Verifera signaturen för innehållet i en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="737"/>
-        <source>Export a signed set of key images</source>
-        <translation>Exportera en signerad uppsättning nyckelavbildningar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="738"/>
-        <source>Import signed key images list and verify their spent status</source>
-        <translation>Importera lista med signerade nyckelavbildningar och verifera deras spenderingsstatus</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="739"/>
-        <source>Export a set of outputs owned by this wallet</source>
-        <translation>Exportera en uppsättning utgångar som ägs av denna plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
-        <source>Import set of outputs owned by this wallet</source>
-        <translation>Importera en uppsättning utgångar som ägs av denna plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="802"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (långsammast, inga antaganden); optimize-coinbase (snabb, antar att hela coinbase-transaktionen betalas till en enda adress); no-coinbase (snabbast, antar att ingen coinbase-transaktion tas emot), default (samma som optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="851"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Plånbokens namn ej giltigt. Försök igen eller använd Ctrl-C för att avsluta.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Plånbok och nyckelfil hittades, läser in …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="874"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1998"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Nyckelfil hittades men inte plånboksfilen. Återskapar …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2004"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Nyckelfilen kunde inte hittas. Det gick inte att öppna plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
         <source>Generating new wallet...</source>
         <translation>Skapar ny plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-keys=&quot;wallet_name&quot;</source>
-        <translation>det går inte att ange mer än en av --generate-new-wallet=&quot;plånboksnamn&quot;, --wallet-file=&quot;plånboksnamn&quot;, --generate-from-view-key=&quot;plånboksnamn&quot;, --generate-from-json=&quot;json-filnamn&quot; och --generate-from-keys=&quot;plånboksnamn&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="953"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
-        <translation>det går inte att ange både --restore-deterministic-wallet och --non-deterministic</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
         <source>Electrum-style word list failed verification</source>
         <translation>det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1063"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
         <source>No data supplied, cancelled</source>
         <translation>Ingen data angiven, avbryter</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1002"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1054"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2718"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3530"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4048"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1031"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
         <source>view key does not match standard address</source>
         <translation>visningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
         <source>account creation failed</source>
         <translation>det gick inte att skapa konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
         <source>failed to open account</source>
         <translation>det gick inte att öppna konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1579"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4962"/>
         <source>wallet is null</source>
         <translation>plånbok är null</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1262"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
-        <translation>Antingen har daemonen inte startat eller så angavs fel port. Se till att daemonen kör eller starta om plånboken med korrekt daemonadress.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1311"/>
-        <source>invalid language choice passed. Please try again.
-</source>
-        <translation>ogiltigt språkval angavs. Försök igen.
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
         <source>View key: </source>
         <translation>Visningsnyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1385"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation>Din plånbok har skapats!
-För att starta synkronisering med daemonen, använd kommandot &quot;refresh&quot;.
-Använd kommandot &quot;help&quot; för att se en lista över tillgängliga kommandon.
-Använd alltid kommandot &quot;exit&quot; när du stänger monero-wallet-cli så att ditt aktuella sessionstillstånd sparas. Annars kan du bli tvungen att synkronisera
-din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som helst).
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Du kan också vilja ta bort filen &quot;%s&quot; och försöka igen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
         <source>failed to deinitialize wallet</source>
         <translation>det gick inte att avinitiera plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1570"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6410"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>detta kommando kräver en betrodd daemon. Aktivera med --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3152"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>blockkedjan kan inte sparas: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2563"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2824"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2390"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
         <source>refresh error: </source>
         <translation>fel vid uppdatering: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
         <source>Balance: </source>
         <translation>Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>pubkey</source>
         <translation>öppen nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>key image</source>
         <translation>nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>unlocked</source>
         <translation>upplåst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1846"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>T</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3442"/>
+        <source>expected at least one payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format, en 16- eller 64-teckens hex-sträng förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
         <source>failed to get spent status</source>
         <translation>det gick inte att hämta spenderingsstatus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>the same transaction</source>
         <translation>samma transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>blocks that are temporally very close</source>
         <translation>block som ligger väldigt nära varandra i tiden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2206"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4184"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3778"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation>Låsta block för högt, max 1000000 (˜~4 år)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
-        <source>usage: get_tx_proof &lt;txid> &lt;dest_address> [&lt;tx_key>]</source>
-        <translation>användning: get_tx_proof &lt;txid> &lt;måladress> [&lt;tx_key>]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
-        <source>failed to parse tx_key</source>
-        <translation>det gick inte att parsa tx_nyckel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
-        <source>Tx secret key was found for the given txid, but you&apos;ve also provided another tx secret key which doesn&apos;t match the found one.</source>
-        <translation>Hemlig transaktionsnyckel hittades för det givna txid, men du har också angivit en annan hemlig transaktionsnyckel som inte matchar den hittade nyckeln.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
-        <source>Tx secret key wasn&apos;t found in the wallet file. Provide it as the optional third parameter if you have it elsewhere.</source>
-        <translation>Den hemliga transaktionsnyckeln kunde inte hittas i plånboksfilen. Ange den som den valfria tredje parametern om du har den någon annanstans.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3330"/>
-        <source>Signature: </source>
-        <translation>Signatur: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3508"/>
-        <source>usage: check_tx_proof &lt;txid> &lt;address> &lt;signature></source>
-        <translation>användning: check_tx_proof &lt;txid> &lt;adress> &lt;signatur></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3539"/>
-        <source>Signature header check error</source>
-        <translation>Fel vid kontroll av signaturhuvud</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3550"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3560"/>
-        <source>Signature decoding error</source>
-        <translation>nFel vid avkodning av signatur</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3602"/>
-        <source>Tx pubkey was not found</source>
-        <translation>Transaktionens öppna nyckel kunde inte hittas</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Good signature</source>
         <translation>Bra signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
         <source>Bad signature</source>
         <translation>Dålig signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3621"/>
-        <source>failed to generate key derivation</source>
-        <translation>det gick inte att skapa nyckelhärledning</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6046"/>
         <source>usage: integrated_address [payment ID]</source>
         <translation>användning: integrated_address [betalnings-ID]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4017"/>
-        <source>Integrated address: account %s, payment ID %s</source>
-        <translation>Integrerad adress: konto %s, betalnings-ID %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>Standard address: </source>
         <translation>Standardadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4027"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6087"/>
         <source>failed to parse payment ID or address</source>
         <translation>det gick inte att parsa betalnings-ID eller adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4038"/>
-        <source>usage: address_book [(add (&lt;address> [pid &lt;long or short payment id>])|&lt;integrated address> [&lt;description possibly with whitespaces>])|(delete &lt;index>)]</source>
-        <translation>användning: address_book [(add (&lt;adress> [pid &lt;långt eller kort betalnings-ID>])|&lt;Integrerad adress> [&lt;beskrivning eventuellt med blanktecken>])|(delete &lt;index>)]</translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6098"/>
+        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation>användning: address_book [(add (&lt;adress&gt; [pid &lt;långt eller kort betalnings-ID&gt;])|&lt;Integrerad adress&gt; [&lt;beskrivning eventuellt med blanktecken&gt;])|(delete &lt;index&gt;)]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
         <source>failed to parse payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6146"/>
         <source>failed to parse index</source>
         <translation>det gick inte att parsa index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <source>Address book is empty.</source>
         <translation>Adressboken är tom.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
         <source>Index: </source>
         <translation>Index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
         <source>Address: </source>
         <translation>Adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
         <source>Payment ID: </source>
         <translation>Betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
         <source>Description: </source>
         <translation>Beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
         <source>usage: set_tx_note [txid] free text note</source>
         <translation>användning: set_tx_note [txid] fri textanteckning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6201"/>
         <source>usage: get_tx_note [txid]</source>
         <translation>användning: get_tx_note [txid]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
-        <source>usage: sign &lt;filename></source>
-        <translation>användning: sign &lt;filnamn></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6304"/>
+        <source>usage: sign &lt;filename&gt;</source>
+        <translation>användning: sign &lt;filnamn&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4198"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6309"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>plånboken är enbart för granskning och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4207"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4219"/>
-        <source>usage: verify &lt;filename> &lt;address> &lt;signature></source>
-        <translation>användning: verify &lt;filnamn> &lt;adress> &lt;signatur></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5066"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5278"/>
+        <source>failed to load signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
+        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <source>wallet is watch-only and cannot generate the proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5161"/>
+        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
+        <source>usage: get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
+        <source>The reserve proof can be generated only by a full wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5253"/>
+        <source>usage: check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
+        <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5353"/>
+        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5490"/>
+        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
+        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
+        <source>There is no unspent output in the specified address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
+        <source> (no daemon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
+        <source> (out of sync)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5758"/>
+        <source>(Untitled account)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
+        <source>failed to parse index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <source>specify an index between 0 and </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5873"/>
+        <source>usage:
+  account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt;
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>
+Grand total:
+  Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>, unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
+        <source>Untagged accounts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5915"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
+        <source>Accounts with tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
+        <source>Tag&apos;s description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
+        <source> %c%8u %6s %21s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <source>----------------------------------------------------------------------------------</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <source>%15s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>Primary address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>(used)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>(Untitled address)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6022"/>
+        <source>&lt;index_min&gt; is already out of bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6027"/>
+        <source>&lt;index_max&gt; exceeds the bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6035"/>
+        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6065"/>
+        <source>Integrated addresses can only be created for account 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6077"/>
+        <source>Integrated address: %s, payment ID: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Subaddress: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
+        <source>usage: get_description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
+        <source>no description found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
+        <source>description found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
+        <source>Filename: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <source>Watch only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
+        <source>%u/%u multisig%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Testnet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
+        <source>This wallet is multisig and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6335"/>
+        <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation>användning: verify &lt;filnamn&gt; &lt;adress&gt; &lt;signatur&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
         <source>Bad signature from </source>
         <translation>Dålig signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
         <source>Good signature from </source>
         <translation>Bra signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4259"/>
-        <source>usage: export_key_images &lt;filename></source>
-        <translation>användning: export_key_images &lt;filnamn></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <source>usage: export_key_images &lt;filename&gt;</source>
+        <translation>användning: export_key_images &lt;filnamn&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>plånboken är enbart för granskning och kan inte exportera nyckelavbildningar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4274"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
         <source>Signed key images exported to </source>
         <translation>Signerade nyckelavbildningar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>usage: import_key_images &lt;filename></source>
-        <translation>användning: import_key_images &lt;filnamn></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6416"/>
+        <source>usage: import_key_images &lt;filename&gt;</source>
+        <translation>användning: import_key_images &lt;filnamn&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4323"/>
-        <source>usage: export_outputs &lt;filename></source>
-        <translation>användning: export_outputs &lt;filnamn></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6447"/>
+        <source>usage: export_outputs &lt;filename&gt;</source>
+        <translation>användning: export_outputs &lt;filnamn&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6484"/>
         <source>Outputs exported to </source>
         <translation>Utgångar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
-        <source>usage: import_outputs &lt;filename></source>
-        <translation>användning: import_outputs &lt;filnamn></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6492"/>
+        <source>usage: import_outputs &lt;filename&gt;</source>
+        <translation>användning: import_outputs &lt;filnamn&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
         <source>amount is wrong: </source>
         <translation>beloppet är fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2247"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
         <source>expected number from 0 to </source>
         <translation>förväntades: ett tal från 0 till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2378"/>
-        <source>Money successfully sent, transaction </source>
-        <translation>Pengar skickades, transaktion </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
-        <source>no connection to daemon. Please, make sure daemon is running.</source>
-        <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2597"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3171"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>inte tillräckligt många utgångar för angiven mixin_count</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>output amount</source>
-        <translation>utgångens belopp</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3174"/>
-        <source>found outputs to mix</source>
-        <translation>hittade utgångar att mixa</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2605"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
-        <source>transaction was not constructed</source>
-        <translation>transaktionen konstruerades inte</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>transaktionen %s avvisades av daemonen med status: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3191"/>
-        <source>one of destinations is zero</source>
-        <translation>ett av målen är noll</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
-        <source>Failed to find a suitable way to split transactions</source>
-        <translation>Det gick inte att hitta ett passande sätt att dela upp transaktioner</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2452"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2629"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
-        <source>unknown transfer error: </source>
-        <translation>okänt överföringsfel: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4079"/>
         <source>Sweeping </source>
         <translation>Sveper upp </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation>Sveper upp %s för en total avgift på %s.  Är detta okej?  (J/Ja/N/Nej)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2816"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4559"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Pengar skickades, transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4716"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till mer än en adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4826"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaktionen signerades till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3226"/>
-        <source>usage: get_tx_key &lt;txid></source>
-        <translation>användning: get_tx_key &lt;transaktions-ID></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4424"/>
+        <source>failed to parse Payment ID</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3519"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4122"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4440"/>
+        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
+        <source>failed to parse key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
+        <source>No outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4504"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4586"/>
+        <source>missing threshold amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4601"/>
+        <source>donations are not enabled on the testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
+        <source> dummy output(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4797"/>
+        <source>usage: sign_transfer [export]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4876"/>
+        <source>usage: get_tx_key &lt;txid&gt;</source>
+        <translation>användning: get_tx_key &lt;transaktions-ID&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>failed to parse txid</source>
         <translation>det gick inte att parsa transaktions-id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3245"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
         <source>Tx key: </source>
         <translation>Tx-nyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
-        <source>usage: check_tx_key &lt;txid> &lt;txkey> &lt;address></source>
-        <translation>användning: check_tx_key &lt;txid> &lt;txnyckel> &lt;adress></translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4912"/>
+        <source>usage: get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3368"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5239"/>
+        <source>signature file saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5241"/>
+        <source>failed to save signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4953"/>
+        <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation>användning: check_tx_key &lt;txid&gt; &lt;txnyckel&gt; &lt;adress&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
         <source>failed to parse tx key</source>
         <translation>det gick inte att parsa transaktionsnyckeln</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
-        <source>failed to get transaction from daemon</source>
-        <translation>det gick inte att hämta transaktion från daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <source>failed to parse transaction from daemon</source>
-        <translation>det gick inte att parsa transaktion från daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
-        <source>failed to validate transaction from daemon</source>
-        <translation>det gick inte att validera transaktion från daemon</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3596"/>
-        <source>failed to get the right transaction from daemon</source>
-        <translation>det gick inte att hämta rätt transaktion från daemonen</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3385"/>
-        <source>failed to generate key derivation from supplied parameters</source>
-        <translation>det gick inte att skapa nyckelhärledning från angivna parametrar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
         <source>error: </source>
         <translation>fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>received</source>
         <translation>mottaget</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>in txid</source>
         <translation>i transaktions-id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5099"/>
         <source>received nothing in txid</source>
         <translation>tog emot ingenting i transaktions-id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5083"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>VARNING: denna transaktion är ännu inte inkluderad i blockkedjan!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>This transaction has %u confirmations</source>
         <translation>Transaktionen har %u bekräftelser</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>VARNING: det gick inte att avgöra antal bekräftelser!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
-        <source>usage: show_transfers [in|out|all|pending|failed] [&lt;min_height> [&lt;max_height>]]</source>
-        <translation>användning: show_transfers [in|out|all|pending|failed] [&lt;min_höjd> [&lt;max_höjd>]]</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
         <source>bad min_height parameter:</source>
         <translation>dålig parameter för min_height:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5413"/>
         <source>bad max_height parameter:</source>
         <translation>dålig parameter för max_height:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3760"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>out</source>
         <translation>ut</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>failed</source>
         <translation>misslyckades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3798"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>pending</source>
         <translation>väntar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
-        <source>usage: unspent_outputs [&lt;min_amount> &lt;max_amount>]</source>
-        <translation>användning: unspent_outputs [&lt;min_belopp> &lt;max_belopp>]</translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
+        <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
+        <translation>&lt;min_belopp&gt; måste vara mindre än &lt;max_belopp&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <source>&lt;min_amount> should be smaller than &lt;max_amount></source>
-        <translation>&lt;min_belopp> måste vara mindre än &lt;max_belopp></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>
 Amount: </source>
         <translation>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>, number of keys: </source>
         <translation>, antal nycklar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
         <source> </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Min block height: </source>
         <translation>
 Minblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>
 Max block height: </source>
         <translation>
 Maxblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3868"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>
 Min amount found: </source>
         <translation>
 Minbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3869"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>
 Max amount found: </source>
         <translation>
 Maxbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3870"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5606"/>
         <source>
 Total count: </source>
         <translation>
 Totalt antal: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5646"/>
         <source>
 Bin size: </source>
         <translation>
 Storlek för binge: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5647"/>
         <source>
 Outputs per *: </source>
         <translation>
 Utgångar per *: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
         <source>count
   ^
 </source>
@@ -2318,67 +3488,156 @@ Utgångar per *: </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
-        <source>+--> block height
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
+        <source>+--&gt; block height
 </source>
-        <translation>+--> blockhöjd
+        <translation>+--&gt; blockhöjd
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
         <source>  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3969"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
         <source>wallet</source>
         <translation>plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="420"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
         <source>Random payment ID: </source>
         <translation>Slumpmässigt betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
         <source>Matching integrated address: </source>
         <translation>Matchande integrerad adress: </translation>
     </message>
 </context>
 <context>
+    <name>genms</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
+        <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
+        <source>Give threshold and participants at once as M/N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
+        <source>How many participants wil share parts of the multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
+        <source>How many signers are required to sign a valid transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
+        <source>Create testnet multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
+        <source>Generating %u %u/%u multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
+        <source>Error verifying multisig extra info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
+        <source>Error finalizing multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
+        <source>Generated multisig wallets for address </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
+        <source>Error creating multisig wallets: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
+        <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
+        <source>Error: expected N/M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
+        <source>Error: either --scheme or both of --threshold and --participants may be given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
+        <source>Error: --filename-base is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
+        <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>sw</name>
     <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
+        <source>Generate new wallet and save it to &lt;arg&gt;</source>
+        <translation>Skapa ny plånbok och spara den till &lt;arg&gt;</translation>
+    </message>
+    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
-        <source>Generate new wallet and save it to &lt;arg></source>
-        <translation>Skapa ny plånbok och spara den till &lt;arg></translation>
+        <source>Generate incoming-only wallet from view key</source>
+        <translation>Skapa granskningsplånbok från visningsnyckel</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
-        <source>Generate incoming-only wallet from view key</source>
-        <translation>Skapa granskningsplånbok från visningsnyckel</translation>
+        <source>Generate deterministic wallet from spend key</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="118"/>
@@ -2386,242 +3645,252 @@ Utgångar per *: </translation>
         <translation>Skapa plånbok från privata nycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
+        <source>Generate a master wallet from multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <source>Language for mnemonic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Ange Electrum-frö för att återställa/skapa plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Återställ plånbok genom användning av minnesfrö (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Skapa non-deterministic visnings- och spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Aktivera kommandon som kräver en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Tillåt kommunikation med en daemon som använder en annan version av RPC</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
         <source>Restore from specific blockchain height</source>
         <translation>Återställ från angiven blockkedjehöjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <source>The newly created transaction will not be relayed to the monero network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
         <source>possibly lost connection to daemon</source>
         <translation>anslutning till daemonen kan ha tappats</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
         <source>Error: </source>
         <translation>Fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
         <source>Failed to initialize wallet</source>
         <translation>Det gick inte att initiera plånbok</translation>
     </message>
 </context>
 <context>
-    <name>tools::dns_utils</name>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="430"/>
-        <source>DNSSEC validation passed</source>
-        <translation>DNSSEC-validering godkänd</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="434"/>
-        <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
-        <translation>VARNING: DNSSEC-verifiering misslyckades, denna adress kanske inte är korrekt!</translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="437"/>
-        <source>For URL: </source>
-        <translation>För URL: </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="439"/>
-        <source> Monero Address = </source>
-        <translation> Monero-adress = </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="441"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation>är det OK? (J/n) </translation>
-    </message>
-    <message>
-        <location filename="../src/common/dns_utils.cpp" line="451"/>
-        <source>you have cancelled the transfer request</source>
-        <translation>du har avbrutit överföringsbegäran</translation>
-    </message>
-</context>
-<context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="106"/>
-        <source>Use daemon instance at &lt;host>:&lt;port></source>
-        <translation>Använd daemoninstans på &lt;värddator>:&lt;port></translation>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
+        <translation>Använd daemoninstans på &lt;värddator&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="107"/>
-        <source>Use daemon instance at host &lt;arg> instead of localhost</source>
-        <translation>Använd daemon-instansen på värddator &lt;arg> istället för localhost</translation>
+        <location filename="../src/wallet/wallet2.cpp" line="114"/>
+        <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
+        <translation>Använd daemon-instansen på värddator &lt;arg&gt; istället för localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Wallet password</source>
-        <translation>Lösenord för plånboken</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="109"/>
+        <location filename="../src/wallet/wallet2.cpp" line="116"/>
         <source>Wallet password file</source>
         <translation>Lösenordsfil för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="110"/>
-        <source>Use daemon instance at port &lt;arg> instead of 18081</source>
-        <translation>Använd daemon-instansen på port &lt;arg> istället för 18081</translation>
+        <location filename="../src/wallet/wallet2.cpp" line="117"/>
+        <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
+        <translation>Använd daemon-instansen på port &lt;arg&gt; istället för 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="112"/>
+        <location filename="../src/wallet/wallet2.cpp" line="119"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>För testnet. Daemonen måste också startas med flaggan --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <location filename="../src/wallet/wallet2.cpp" line="120"/>
         <source>Restricts to view-only commands</source>
         <translation>Begränsar till granskningskommandon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="152"/>
+        <location filename="../src/wallet/wallet2.cpp" line="168"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>det går inte ange värd eller port för daemonen mer än en gång</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="188"/>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>det går inte att ange mer än en av --password och --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="217"/>
         <source>the password file specified could not be read</source>
         <translation>det gick inte att läsa angiven lösenordsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="460"/>
-        <source>Enter new wallet password</source>
-        <translation>Ange nytt lösenord för plånboken</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="464"/>
-        <source>failed to read wallet password</source>
-        <translation>det gick inte att läsa lösenord för plånboken</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet2.cpp" line="227"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Failed to load file </source>
         <translation>Det gick inte att läsa in fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="108"/>
+        <location filename="../src/wallet/wallet2.cpp" line="115"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Lösenord för plånboken (använd escape-sekvenser eller citattecken efter behov)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="111"/>
+        <location filename="../src/wallet/wallet2.cpp" line="118"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Ange användarnamn[:lösenord] för RPC-klient till daemonen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="233"/>
+        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <source>no password specified; use --prompt-for-password to prompt for a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Failed to parse JSON</source>
         <translation>Det gick inte att parsa JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u är för ny, vi förstår bara upp till %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
-        <location filename="../src/wallet/wallet2.cpp" line="331"/>
-        <location filename="../src/wallet/wallet2.cpp" line="373"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
+        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="380"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig visningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="276"/>
+        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
-        <location filename="../src/wallet/wallet2.cpp" line="343"/>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="290"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
+        <location filename="../src/wallet/wallet2.cpp" line="405"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="295"/>
+        <location filename="../src/wallet/wallet2.cpp" line="302"/>
         <source>Electrum-style word list failed verification</source>
         <translation>det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="306"/>
-        <source>At least one of Electrum-style word list and private view key must be specified</source>
-        <translation>Åtminstone en av ordlista av Electrum-typ och privat visningsnyckel måste anges</translation>
+        <location filename="../src/wallet/wallet2.cpp" line="319"/>
+        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="311"/>
+        <location filename="../src/wallet/wallet2.cpp" line="323"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Både ordlista av Electrum-typ och privat nyckel har angivits</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="324"/>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>invalid address</source>
         <translation>ogiltig adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="335"/>
+        <location filename="../src/wallet/wallet2.cpp" line="342"/>
         <source>view key does not match standard address</source>
         <translation>visningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="347"/>
+        <location filename="../src/wallet/wallet2.cpp" line="352"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="356"/>
+        <location filename="../src/wallet/wallet2.cpp" line="360"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Det går inte att skapa inaktuella plånböcker från JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="403"/>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
+        <source>failed to parse address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source>Address must be specified in order to create watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="413"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="5205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2813"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2873"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2952"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2998"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3089"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3599"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3955"/>
+        <source>Primary account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="7914"/>
+        <source>No funds received in this tx.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="8607"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
@@ -2629,153 +3898,191 @@ Utgångar per *: </translation>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="151"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
+        <source>Failed to create directory </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
+        <source>Failed to create directory %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Cannot specify --</source>
         <translation>Det går inte att ange --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="171"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source> and --</source>
         <translation> och --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>Failed to create file </source>
         <translation>Det gick inte att skapa fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="198"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>. Check permissions or remove file</source>
         <translation>. Kontrollera behörigheter eller ta bort filen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="209"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
         <source>Error writing to file </source>
         <translation>Fel vid skrivning till fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>RPC username/password is stored in file </source>
         <translation>Användarnamn/lösenord för RPC har sparats i fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1748"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
+        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
+        <source>This is the RPC monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Det går inte att ange mer än en av --wallet-file och --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Måste ange --wallet-file eller --generate-from-json eller --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1764"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
         <source>Loading wallet...</source>
         <translation>Läser in plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1789"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1814"/>
-        <source>Storing wallet...</source>
-        <translation>Sparar plånbok …</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
+        <source>Saving wallet...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1791"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1816"/>
-        <source>Stored ok</source>
-        <translation>Sparad ok</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
+        <source>Successfully saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1794"/>
-        <source>Loaded ok</source>
-        <translation>Inläst ok</translation>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
+        <source>Successfully loaded</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1798"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
+        <source>Failed to initialize wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
+        <source>Starting wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
+        <source>Failed to run wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
+        <source>Stopped wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
+        <source>Failed to save wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
         <source>Wallet initialization failed: </source>
         <translation>Det gick inte att initiera plånbok: </translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1805"/>
-        <source>Failed to initialize wallet rpc server</source>
-        <translation>Det gick inte att initiera RPC-servern för plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1809"/>
-        <source>Starting wallet rpc server</source>
-        <translation>Startar RPC-servern för plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1811"/>
-        <source>Stopped wallet rpc server</source>
-        <translation>Stoppade RPC-servern för plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1820"/>
-        <source>Failed to store wallet: </source>
-        <translation>Det gick inte att spara plånbok: </translation>
     </message>
 </context>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="1715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4580"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
         <source>Wallet options</source>
         <translation>Alternativ för plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="59"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Skapa plånbok från fil i JSON-format</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="63"/>
-        <source>Use wallet &lt;arg></source>
-        <translation>Använd plånbok &lt;arg></translation>
+        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
+        <source>Use wallet &lt;arg&gt;</source>
+        <translation>Använd plånbok &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="87"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="104"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Max antal trådar att använda för ett parallellt jobb</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="88"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="105"/>
         <source>Specify log file</source>
         <translation>Ange loggfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="89"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>Config file</source>
         <translation>Konfigurationsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="98"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="115"/>
         <source>General options</source>
         <translation>Allmänna alternativ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="128"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="138"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="161"/>
         <source>Can&apos;t find config file </source>
         <translation>Det gick inte att hitta konfigurationsfilen </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="172"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="195"/>
         <source>Logging to: </source>
         <translation>Loggar till: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="197"/>
         <source>Logging to %s</source>
         <translation>Loggar till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="153"/>
+        <location filename="../src/wallet/wallet_args.cpp" line="140"/>
         <source>Usage:</source>
         <translation>Användning:</translation>
     </message>


### PR DESCRIPTION
Build error solved changing a couple of strings from `[<payment_id>]` to `[payment_id]`.

Refreshed using a tweaked `build-translations.sh` script
