### PR TITLE
crypto: add missing include (WIN32)

### DIFF
--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -42,6 +42,7 @@ static void generate_system_random_bytes(size_t n, void *result);
 
 #include <windows.h>
 #include <wincrypt.h>
+#include <stdio.h>
 
 static void generate_system_random_bytes(size_t n, void *result) {
   HCRYPTPROV prov;


### PR DESCRIPTION
Fixes building on Windows.