### PR TITLE
After-merge fix for default p2p bind port

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -262,6 +262,7 @@ namespace nodetool
       const boost::program_options::variables_map& vm
     )
   {
+    m_testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
     m_bind_ip = command_line::get_arg(vm, arg_p2p_bind_ip);
     m_port = command_line::get_arg(vm, arg_p2p_bind_port);
     m_external_port = command_line::get_arg(vm, arg_p2p_external_port);


### PR DESCRIPTION
Restore the assignment to `m_testnet` that was added in #3196 and accidentally lost during rebase in #3170. Fix for #3283.