### PR TITLE
wallet2: No longer create '.address.txt' files for non-testnet wallets

### DIFF
--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -73,11 +73,12 @@ namespace
   const command_line::arg_descriptor<uint32_t> arg_threshold = {"threshold", genms::tr("How many signers are required to sign a valid transaction"), 0};
   const command_line::arg_descriptor<bool, false> arg_testnet = {"testnet", genms::tr("Create testnet multisig wallets"), false};
   const command_line::arg_descriptor<bool, false> arg_stagenet = {"stagenet", genms::tr("Create stagenet multisig wallets"), false};
+  const command_line::arg_descriptor<bool, false> arg_create_address_file = {"create-address-file", genms::tr("Create an address file for new wallets"), false};
 
   const command_line::arg_descriptor< std::vector<std::string> > arg_command = {"command", ""};
 }
 
-static bool generate_multisig(uint32_t threshold, uint32_t total, const std::string &basename, network_type nettype)
+static bool generate_multisig(uint32_t threshold, uint32_t total, const std::string &basename, network_type nettype, bool create_address_file)
 {
   tools::msg_writer() << (boost::format(genms::tr("Generating %u %u/%u multisig wallets")) % total % threshold % total).str();
 
@@ -92,7 +93,7 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
       std::string name = basename + "-" + std::to_string(n + 1);
       wallets[n].reset(new tools::wallet2(nettype));
       wallets[n]->init("");
-      wallets[n]->generate(name, pwd_container->password(), rct::rct2sk(rct::skGen()), false, false);
+      wallets[n]->generate(name, pwd_container->password(), rct::rct2sk(rct::skGen()), false, false, create_address_file);
     }
 
     // gather the keys
@@ -171,6 +172,7 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_params, arg_participants);
   command_line::add_arg(desc_params, arg_testnet);
   command_line::add_arg(desc_params, arg_stagenet);
+  command_line::add_arg(desc_params, arg_create_address_file);
 
   const auto vm = wallet_args::main(
    argc, argv,
@@ -241,7 +243,8 @@ int main(int argc, char* argv[])
     tools::fail_msg_writer() << genms::tr("Error: unsupported scheme: only N/N and N-1/N are supported");
     return 1;
   }
-  if (!generate_multisig(threshold, total, basename, testnet ? TESTNET : stagenet ? STAGENET : MAINNET))
+  bool create_address_file = command_line::get_arg(*vm, arg_create_address_file);
+  if (!generate_multisig(threshold, total, basename, testnet ? TESTNET : stagenet ? STAGENET : MAINNET, create_address_file))
     return 1;
 
   return 0;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -449,44 +449,48 @@ namespace tools
 
     /*!
      * \brief  Generates a wallet or restores one.
-     * \param  wallet_        Name of wallet file
-     * \param  password       Password of wallet file
-     * \param  multisig_data  The multisig restore info and keys
+     * \param  wallet_              Name of wallet file
+     * \param  password             Password of wallet file
+     * \param  multisig_data        The multisig restore info and keys
+     * \param  create_address_file  Whether to create an address file
      */
     void generate(const std::string& wallet_, const epee::wipeable_string& password,
-      const std::string& multisig_data);
+      const std::string& multisig_data, bool create_address_file = false);
 
     /*!
      * \brief Generates a wallet or restores one.
-     * \param  wallet_        Name of wallet file
-     * \param  password       Password of wallet file
-     * \param  recovery_param If it is a restore, the recovery key
-     * \param  recover        Whether it is a restore
-     * \param  two_random     Whether it is a non-deterministic wallet
-     * \return                The secret key of the generated wallet
+     * \param  wallet_              Name of wallet file
+     * \param  password             Password of wallet file
+     * \param  recovery_param       If it is a restore, the recovery key
+     * \param  recover              Whether it is a restore
+     * \param  two_random           Whether it is a non-deterministic wallet
+     * \param  create_address_file  Whether to create an address file
+     * \return                      The secret key of the generated wallet
      */
     crypto::secret_key generate(const std::string& wallet, const epee::wipeable_string& password,
       const crypto::secret_key& recovery_param = crypto::secret_key(), bool recover = false,
-      bool two_random = false);
+      bool two_random = false, bool create_address_file = false);
     /*!
      * \brief Creates a wallet from a public address and a spend/view secret key pair.
-     * \param  wallet_        Name of wallet file
-     * \param  password       Password of wallet file
-     * \param  viewkey        view secret key
-     * \param  spendkey       spend secret key
+     * \param  wallet_              Name of wallet file
+     * \param  password             Password of wallet file
+     * \param  viewkey              view secret key
+     * \param  spendkey             spend secret key
+     * \param  create_address_file  Whether to create an address file
      */
     void generate(const std::string& wallet, const epee::wipeable_string& password,
       const cryptonote::account_public_address &account_public_address,
-      const crypto::secret_key& spendkey, const crypto::secret_key& viewkey);
+      const crypto::secret_key& spendkey, const crypto::secret_key& viewkey, bool create_address_file = false);
     /*!
      * \brief Creates a watch only wallet from a public address and a view secret key.
-     * \param  wallet_        Name of wallet file
-     * \param  password       Password of wallet file
-     * \param  viewkey        view secret key
+     * \param  wallet_              Name of wallet file
+     * \param  password             Password of wallet file
+     * \param  viewkey              view secret key
+     * \param  create_address_file  Whether to create an address file
      */
     void generate(const std::string& wallet, const epee::wipeable_string& password,
       const cryptonote::account_public_address &account_public_address,
-      const crypto::secret_key& viewkey = crypto::secret_key());
+      const crypto::secret_key& viewkey = crypto::secret_key(), bool create_address_file = false);
     /*!
      * \brief Restore a wallet hold by an HW.
      * \param  wallet_        Name of wallet file


### PR DESCRIPTION
Previously, a file containing the unencrypted Monero address was
created in the wallet's directory. This file is only used for testing
purposes and might pose as a privacy risk.