### PR TITLE
command line: allow has_arg to handle arg_descriptor<bool,false,true>

### DIFF
--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -214,8 +214,8 @@ namespace command_line
     }
   }
 
-  template<typename T, bool required>
-  bool has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required>& arg)
+  template<typename T, bool required, bool dependent>
+  typename std::enable_if<!std::is_same<T, bool>::value, bool>::type has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required, dependent>& arg)
   {
     auto value = vm[arg.name];
     return !value.empty();
@@ -239,8 +239,8 @@ namespace command_line
     return vm[arg.name].template as<T>();
   }
  
-  template<>
-  inline bool has_arg<bool, false>(const boost::program_options::variables_map& vm, const arg_descriptor<bool, false>& arg)
+  template<bool dependent>
+  inline bool has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<bool, false, dependent>& arg)
   {
     return get_arg<bool, false>(vm, arg);
   }


### PR DESCRIPTION
I _think_ this is the correct fix for the build problem reported in #3296, even though I'm not the one who introduced the `bool dependent` template parameter for `arg_descriptor` (@mrwhythat did it).

While looking at it, I also realized that these function overloads `add_arg(description, arg, def, unique)` and `make_semantic(arg, def)` that take a default value `def` are never used in the codebase. If they were to be used, and with an argument dependent on another argument, i.e. `arg_descriptor<T, false, true>`, the build will fail because this declaration

```c++
  template<typename T>
  void add_arg(boost::program_options::options_description& description, const arg_descriptor<T, false>& arg, const T& def, bool unique = true)
```

implicitly sets the `bool dependent` parameter to `false`, which can be fixed by parameterizing `dependent` in addition to `T`. I'm not sure what to do with it (i.e. whether to delete it, fix it, or leave it), though.
