### PR TITLE
[RELEASE] core: fix sending to the source address with a short payment id

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -189,6 +189,8 @@ namespace cryptonote
       addr = i.addr;
       ++count;
     }
+    if (count == 0 && change_addr)
+      return change_addr->m_view_public_key;
     return addr.m_view_public_key;
   }
   //---------------------------------------------------------------


### PR DESCRIPTION
It would fail to send, thinking it needs a destination address,
since the destination matches the change address in this case.