### PR TITLE
wallet: fixes and tweaks to the save_watch_only_command

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3143,7 +3143,17 @@ bool simple_wallet::save_watch_only(const std::vector<std::string> &args/* = std
     return true;
   }
 
-  m_wallet->write_watch_only_wallet(m_wallet_file, pwd_container->password());
+  try
+  {
+    std::string new_keys_filename;
+    m_wallet->write_watch_only_wallet(m_wallet_file, pwd_container->password(), new_keys_filename);
+    success_msg_writer() << tr("Watch only wallet saved as: ") << new_keys_filename;
+  }
+  catch (const std::exception &e)
+  {
+    fail_msg_writer() << tr("Failed to save watch only wallet: ") << e.what();
+    return true;
+  }
   return true;
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3415,15 +3415,15 @@ void wallet2::rewrite(const std::string& wallet_name, const epee::wipeable_strin
  * \param wallet_name Base name of wallet file
  * \param password    Password for wallet file
  */
-void wallet2::write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password)
+void wallet2::write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password, std::string &new_keys_filename)
 {
   prepare_file_names(wallet_name);
   boost::system::error_code ignored_ec;
-  std::string filename = m_keys_file + "-watchonly";
-  bool watch_only_keys_file_exists = boost::filesystem::exists(filename, ignored_ec);
-  THROW_WALLET_EXCEPTION_IF(watch_only_keys_file_exists, error::file_save_error, filename);
-  bool r = store_keys(filename, password, true);
-  THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, filename);
+  new_keys_filename = m_wallet_file + "-watchonly.keys";
+  bool watch_only_keys_file_exists = boost::filesystem::exists(new_keys_filename, ignored_ec);
+  THROW_WALLET_EXCEPTION_IF(watch_only_keys_file_exists, error::file_save_error, new_keys_filename);
+  bool r = store_keys(new_keys_filename, password, true);
+  THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, new_keys_filename);
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::wallet_exists(const std::string& file_path, bool& keys_file_exists, bool& wallet_file_exists)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -548,7 +548,7 @@ namespace tools
      * \param password    Password for wallet file
      */
     void rewrite(const std::string& wallet_name, const epee::wipeable_string& password);
-    void write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password);
+    void write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password, std::string &new_keys_filename);
     void load(const std::string& wallet, const epee::wipeable_string& password);
     void store();
     /*!


### PR DESCRIPTION
- save the new keys file as FOO-watchonly.keys, not FOO.keys-watchonly
- catch any exception (eg, I/O errors) and error out
- print the new keys filename in simplewallet