### PR TITLE
typo: fix error message typos in wallet2.cpp

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -321,7 +321,7 @@ std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file,
     // compatibility checks
     if (!field_seed_found && !field_viewkey_found && !field_spendkey_found)
     {
-      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("At least one of Electrum-style word list and private view key and private spend key must be specified"));
+      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("At least one of either an Electrum-style word list, private view key, or private spend key must be specified"));
     }
     if (field_seed_found && (field_viewkey_found || field_spendkey_found))
     {


### PR DESCRIPTION
Simple fixes. ~~I assume that line 258 should say "go" and not "grok".~~ On line 324 it doesn't sound right to say "you need at least one of x *and* y *and* z" it would sounds better to say "you need at least one of x *or* y *or* z"