### PR TITLE
systemd,readme: torsocks config for service

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -8,11 +8,27 @@ Group=monero
 WorkingDirectory=~
 RuntimeDirectory=monero
 
+# Clearnet config
+#
 Type=forking
 PIDFile=/run/monero/monerod.pid
-
 ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf \
     --detach --pidfile /run/monero/monerod.pid
+
+# Tor config
+#
+## We have to use simple, not forking, because we cannot pass --detach
+## because stderr/stdout is not available when detached, but torsocks
+## attempts to write to it, and fails with 'invalid argument', causing
+## monerod to fail.
+#Type=simple
+#Environment=DNS_PUBLIC=tcp
+## The following is needed only when accessing wallet from a different
+## host in the LAN, VPN, etc, the RPC must bind to 0.0.0.0, but
+## by default torsocks only allows binding to localhost.
+#Environment=TORSOCKS_ALLOW_INBOUND=1
+#ExecStart=/usr/bin/torsocks /usr/bin/monerod --config-file /etc/monerod.conf \
+#    --non-interactive
 
 Restart=always
 


### PR DESCRIPTION
Add Tor config to systemd service. Mention no `--detach` when torsocks+systemd in README. Edit README text for structure. The Tails text is still inconsistent: text says TORSOCKS_ALLOW_INBOUND=1 is needed but the command doesn't include it. I didn't test on Tails, so I didn't change it.