### PR TITLE
simplewallet: do not call a RPC when displaying the prompt

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5862,8 +5862,7 @@ std::string simple_wallet::get_prompt() const
 {
   std::string addr_start = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0}).substr(0, 6);
   std::string prompt = std::string("[") + tr("wallet") + " " + addr_start;
-  uint32_t version;
-  if (!m_wallet->check_connection(&version))
+  if (!m_wallet->check_connection(NULL))
     prompt += tr(" (no daemon)");
   else if (!m_wallet->is_synced())
     prompt += tr(" (out of sync)");


### PR DESCRIPTION
Speeds up refresh when you have a lot of in/out transactions