### PR TITLE
wallet2: handle no blocks returned in refresh to mean no new blocks

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2182,6 +2182,11 @@ void wallet2::refresh(uint64_t start_height, uint64_t & blocks_fetched, bool& re
       std::list<cryptonote::block_complete_entry> next_blocks;
       std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> next_o_indices;
       bool error = false;
+      if (blocks.empty())
+      {
+        refreshed = false;
+        break;
+      }
       tpool.submit(&waiter, [&]{pull_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, next_blocks, next_o_indices, error);});
 
       process_blocks(blocks_start_height, blocks, o_indices, added_blocks);


### PR DESCRIPTION
This is not a possible return from the daemon, but I want this in
now so all wallets handle this when the daemon starts doing so.