### PR TITLE
Wallet API: add dependency on ICU_LIBRARIES (followup #3313)

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -113,7 +113,8 @@ if (BUILD_GUI_DEPS)
             cncrypto
             ringct
             checkpoints
-            version)
+            version
+            ${ICU_LIBRARIES})
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt


### PR DESCRIPTION
I *think* this is causing a linker error when building the GUI on Windows.

CC: @rbrunner7 