### PR TITLE
wallet2: fix use_fork_rules() when querying version that is defined b…

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7398,7 +7398,7 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks) const
   result = m_node_rpc_proxy.get_earliest_height(version, earliest_height);
   throw_on_rpc_response_error(result, "get_hard_fork_info");
 
-  bool close_enough = height >=  earliest_height - early_blocks; // start using the rules that many blocks beforehand
+  bool close_enough = height >=  earliest_height - early_blocks && earliest_height != std::numeric_limits<uint64_t>::max(); // start using the rules that many blocks beforehand
   if (close_enough)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else


### PR DESCRIPTION
…ut not enabled yet

Found this bug while testing the stagenet which is currently on v2 but the hard fork schedule up to v7 is defined.

When `uint64_t earliest_height` equals `std::numeric_limits<uint64_t>::max()` and `int64_t early_blocks` is negative, `earliest_height - early_blocks` overflows.
