### PR TITLE
[RELEASE] Add cli option to set range of subaddress lookahead

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -135,6 +135,7 @@ namespace cryptonote
     bool set_auto_low_priority(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_segregate_pre_fork_outputs(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_key_reuse_mitigation2(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_subaddress_lookahead(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);
@@ -320,6 +321,7 @@ namespace cryptonote
     std::string m_generate_from_json;
     std::string m_mnemonic_language;
     std::string m_import_path;
+    std::string m_subaddress_lookahead;
 
     std::string m_electrum_seed;  // electrum-style seed parameter
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -635,6 +635,7 @@ namespace tools
     std::string get_subaddress_label(const cryptonote::subaddress_index& index) const;
     void set_subaddress_label(const cryptonote::subaddress_index &index, const std::string &label);
     void set_subaddress_lookahead(size_t major, size_t minor);
+    std::pair<size_t, size_t> get_subaddress_lookahead() const { return {m_subaddress_lookahead_major, m_subaddress_lookahead_minor}; }
     /*!
      * \brief Tells if the wallet file is deprecated.
      */


### PR DESCRIPTION
Add command line option allowing to restrict the default sub-address lookahead in order to avoid hours of set-up when creating a HW based wallet.