### PR TITLE
[RELEASE] simplewallet: fix restore height prompt that got disabled by #3175

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2581,6 +2581,11 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         r = new_wallet(vm, m_recovery_key, m_restore_deterministic_wallet, m_non_deterministic, old_language);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
     }
+
+    if (m_restoring && m_generate_from_json.empty())
+    {
+      m_wallet->explicit_refresh_from_block_height(!command_line::is_arg_defaulted(vm, arg_restore_height));
+    }
     if (!m_wallet->explicit_refresh_from_block_height() && m_restoring)
     {
       uint32_t version;


### PR DESCRIPTION
Because #3175 set the default value of `m_explicit_refresh_from_block_height` to `true`, any wallet restoration operations such as `monero-wallet-cli --restore-deterministic-wallet` would never ask for the restore height even when none is provided explicitly via `--restore-height`.