### PR TITLE
simplewallet: new --use-english-language-names flag

### DIFF
--- a/src/mnemonics/chinese_simplified.h
+++ b/src/mnemonics/chinese_simplified.h
@@ -72,7 +72,7 @@ namespace Language
   class Chinese_Simplified: public Base
   {
   public:
-    Chinese_Simplified(): Base("简体中文 (中国)", std::vector<std::string>({
+    Chinese_Simplified(): Base("简体中文 (中国)", "Chinese (simplified)", std::vector<std::string>({
       "的",
       "一",
       "是",

--- a/src/mnemonics/dutch.h
+++ b/src/mnemonics/dutch.h
@@ -49,7 +49,7 @@ namespace Language
   class Dutch: public Base
   {
   public:
-    Dutch(): Base("Nederlands", std::vector<std::string>({
+    Dutch(): Base("Nederlands", "Dutch", std::vector<std::string>({
         "aalglad",
         "aalscholver",
         "aambeeld",

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -445,13 +445,9 @@ namespace crypto
       return bytes_to_words(src.data, sizeof(src), words, language_name);
     }
 
-    /*!
-     * \brief Gets a list of seed languages that are supported.
-     * \param languages The vector is set to the list of languages.
-     */
-    void get_language_list(std::vector<std::string> &languages)
+    std::vector<const Language::Base*> get_language_list()
     {
-      std::vector<Language::Base*> language_instances({
+      static const std::vector<const Language::Base*> language_instances({
         Language::Singleton<Language::German>::instance(),
         Language::Singleton<Language::English>::instance(),
         Language::Singleton<Language::Spanish>::instance(),
@@ -465,10 +461,20 @@ namespace crypto
         Language::Singleton<Language::Esperanto>::instance(),
         Language::Singleton<Language::Lojban>::instance()
       });
-      for (std::vector<Language::Base*>::iterator it = language_instances.begin();
+      return language_instances;
+    }
+
+    /*!
+     * \brief Gets a list of seed languages that are supported.
+     * \param languages The vector is set to the list of languages.
+     */
+    void get_language_list(std::vector<std::string> &languages, bool english)
+    {
+      const std::vector<const Language::Base*> language_instances = get_language_list();
+      for (std::vector<const Language::Base*>::const_iterator it = language_instances.begin();
         it != language_instances.end(); it++)
       {
-        languages.push_back((*it)->get_language_name());
+        languages.push_back(english ? (*it)->get_english_language_name() : (*it)->get_language_name());
       }
     }
 
@@ -483,6 +489,18 @@ namespace crypto
       boost::algorithm::trim(seed);
       boost::split(word_list, seed, boost::is_any_of(" "), boost::token_compress_on);
       return word_list.size() != (seed_length + 1);
+    }
+
+    std::string get_english_name_for(const std::string &name)
+    {
+      const std::vector<const Language::Base*> language_instances = get_language_list();
+      for (std::vector<const Language::Base*>::const_iterator it = language_instances.begin();
+        it != language_instances.end(); it++)
+      {
+        if ((*it)->get_language_name() == name)
+          return (*it)->get_english_language_name();
+      }
+      return "<language not found>";
     }
 
   }

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -106,8 +106,9 @@ namespace crypto
     /*!
      * \brief Gets a list of seed languages that are supported.
      * \param languages A vector is set to the list of languages.
+     * \param english whether to get the names in English or the language language
      */
-    void get_language_list(std::vector<std::string> &languages);
+    void get_language_list(std::vector<std::string> &languages, bool english = false);
 
     /*!
      * \brief Tells if the seed passed is an old style seed or not.
@@ -115,6 +116,13 @@ namespace crypto
      * \return      true if the seed passed is a old style seed false if not.
      */
     bool get_is_old_style_seed(std::string seed);
+
+    /*!
+     * \brief Returns the name of a language in English
+     * \param  name the name of the language in its own language
+     * \return      the name of the language in English
+     */
+    std::string get_english_name_for(const std::string &name);
   }
 }
 

--- a/src/mnemonics/english.h
+++ b/src/mnemonics/english.h
@@ -49,7 +49,7 @@ namespace Language
   class English: public Base
   {
   public:
-    English(): Base("English", std::vector<std::string>({
+    English(): Base("English", "English", std::vector<std::string>({
         "abbey",
         "abducts",
         "ability",

--- a/src/mnemonics/english_old.h
+++ b/src/mnemonics/english_old.h
@@ -51,7 +51,7 @@ namespace Language
   class EnglishOld: public Base
   {
   public:
-    EnglishOld(): Base("EnglishOld", std::vector<std::string>({
+    EnglishOld(): Base("EnglishOld", "English (old)", std::vector<std::string>({
         "like",
         "just",
         "love",

--- a/src/mnemonics/esperanto.h
+++ b/src/mnemonics/esperanto.h
@@ -58,7 +58,7 @@ namespace Language
   class Esperanto: public Base
   {
   public:
-    Esperanto(): Base("Esperanto", std::vector<std::string>({
+    Esperanto(): Base("Esperanto", "Esperanto", std::vector<std::string>({
       "abako",
       "abdiki",
       "abelo",

--- a/src/mnemonics/french.h
+++ b/src/mnemonics/french.h
@@ -49,7 +49,7 @@ namespace Language
   class French: public Base
   {
   public:
-    French(): Base("Français", std::vector<std::string>({
+    French(): Base("Français", "French", std::vector<std::string>({
         "abandon",
         "abattre",
         "aboi",

--- a/src/mnemonics/german.h
+++ b/src/mnemonics/german.h
@@ -51,7 +51,7 @@ namespace Language
   class German: public Base
   {
   public:
-    German(): Base("Deutsch", std::vector<std::string>({
+    German(): Base("Deutsch", "German", std::vector<std::string>({
         "Abakus",
         "Abart",
         "abbilden",

--- a/src/mnemonics/italian.h
+++ b/src/mnemonics/italian.h
@@ -51,7 +51,7 @@ namespace Language
   class Italian: public Base
   {
   public:
-    Italian(): Base("Italiano", std::vector<std::string>({
+    Italian(): Base("Italiano", "Italian", std::vector<std::string>({
         "abbinare",
         "abbonato",
         "abisso",

--- a/src/mnemonics/japanese.h
+++ b/src/mnemonics/japanese.h
@@ -71,7 +71,7 @@ namespace Language
   class Japanese: public Base
   {
   public:
-    Japanese(): Base("日本語", std::vector<std::string>({
+    Japanese(): Base("日本語", "Japanese", std::vector<std::string>({
         "あいこくしん",
         "あいさつ",
         "あいだ",

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -82,6 +82,7 @@ namespace Language
     std::unordered_map<std::string, uint32_t> word_map; /*!< hash table to find word's index */
     std::unordered_map<std::string, uint32_t> trimmed_word_map; /*!< hash table to find word's trimmed index */
     std::string language_name; /*!< Name of language */
+    std::string english_language_name; /*!< Name of language */
     uint32_t unique_prefix_length; /*!< Number of unique starting characters to trim the wordlist to when matching */
     /*!
      * \brief Populates the word maps after the list is ready.
@@ -122,10 +123,11 @@ namespace Language
       }
     }
   public:
-    Base(const char *language_name, const std::vector<std::string> &words, uint32_t prefix_length):
+    Base(const char *language_name, const char *english_language_name, const std::vector<std::string> &words, uint32_t prefix_length):
       word_list(words),
       unique_prefix_length(prefix_length),
-      language_name(language_name)
+      language_name(language_name),
+      english_language_name(english_language_name)
     {
     }
     virtual ~Base()
@@ -162,6 +164,14 @@ namespace Language
     const std::string &get_language_name() const
     {
       return language_name;
+    }
+    /*!
+     * \brief Returns the name of the language in English.
+     * \return Name of the language.
+     */
+    const std::string &get_english_language_name() const
+    {
+      return english_language_name;
     }
     /*!
      * \brief Returns the number of unique starting characters to be used for matching.

--- a/src/mnemonics/lojban.h
+++ b/src/mnemonics/lojban.h
@@ -56,7 +56,7 @@ namespace Language
   class Lojban: public Base
   {
   public:
-    Lojban(): Base("Lojban", std::vector<std::string>({
+    Lojban(): Base("Lojban", "Lojban", std::vector<std::string>({
       "backi",
       "bacru",
       "badna",

--- a/src/mnemonics/portuguese.h
+++ b/src/mnemonics/portuguese.h
@@ -72,7 +72,7 @@ namespace Language
   class Portuguese: public Base
   {
   public:
-    Portuguese(): Base("Português", std::vector<std::string>({
+    Portuguese(): Base("Português", "Portuguese", std::vector<std::string>({
         "abaular",
         "abdominal",
         "abeto",

--- a/src/mnemonics/russian.h
+++ b/src/mnemonics/russian.h
@@ -51,7 +51,7 @@ namespace Language
   class Russian: public Base
   {
   public:
-    Russian(): Base("русский язык", std::vector<std::string>({
+    Russian(): Base("русский язык", "Russian", std::vector<std::string>({
         "абажур",
         "абзац",
         "абонент",

--- a/src/mnemonics/spanish.h
+++ b/src/mnemonics/spanish.h
@@ -72,7 +72,7 @@ namespace Language
   class Spanish: public Base
   {
   public:
-    Spanish(): Base("Español", std::vector<std::string>({
+    Spanish(): Base("Español", "Spanish", std::vector<std::string>({
         "ábaco",
         "abdomen",
         "abeja",

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -135,6 +135,7 @@ namespace
   const command_line::arg_descriptor<bool> arg_do_not_relay = {"do-not-relay", sw::tr("The newly created transaction will not be relayed to the monero network"), false};
   const command_line::arg_descriptor<bool> arg_create_address_file = {"create-address-file", sw::tr("Create an address file for new wallets"), false};
   const command_line::arg_descriptor<std::string> arg_subaddress_lookahead = {"subaddress-lookahead", tools::wallet2::tr("Set subaddress lookahead sizes to <major>:<minor>"), ""};
+  const command_line::arg_descriptor<bool> arg_use_english_language_names = {"use-english-language-names", sw::tr("Display English language names"), false};
 
   const command_line::arg_descriptor< std::vector<std::string> > arg_command = {"command", ""};
 
@@ -2321,7 +2322,10 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
 {
   if (args.empty())
   {
-    success_msg_writer() << "seed = " << m_wallet->get_seed_language();
+    std::string seed_language = m_wallet->get_seed_language();
+    if (m_use_english_language_names)
+      seed_language = crypto::ElectrumWords::get_english_name_for(seed_language);
+    success_msg_writer() << "seed = " << seed_language;
     success_msg_writer() << "always-confirm-transfers = " << m_wallet->always_confirm_transfers();
     success_msg_writer() << "print-ring-members = " << m_wallet->print_ring_members();
     success_msg_writer() << "store-tx-info = " << m_wallet->store_tx_info();
@@ -3108,6 +3112,7 @@ bool simple_wallet::handle_command_line(const boost::program_options::variables_
   m_restore_height                = command_line::get_arg(vm, arg_restore_height);
   m_do_not_relay                  = command_line::get_arg(vm, arg_do_not_relay);
   m_subaddress_lookahead          = command_line::get_arg(vm, arg_subaddress_lookahead);
+  m_use_english_language_names    = command_line::get_arg(vm, arg_use_english_language_names);
   m_restoring                     = !m_generate_from_view_key.empty() ||
                                     !m_generate_from_spend_key.empty() ||
                                     !m_generate_from_keys.empty() ||
@@ -3154,8 +3159,9 @@ std::string simple_wallet::get_mnemonic_language()
   std::vector<std::string> language_list;
   std::string language_choice;
   int language_number = -1;
-  crypto::ElectrumWords::get_language_list(language_list);
+  crypto::ElectrumWords::get_language_list(language_list, m_use_english_language_names);
   std::cout << tr("List of available languages for your wallet's seed:") << std::endl;
+  std::cout << tr("If your display freezes, exit blind with ^C, then run again with --use-english-language-names") << std::endl;
   int ii;
   std::vector<std::string>::iterator it;
   for (it = language_list.begin(), ii = 0; it != language_list.end(); it++, ii++)
@@ -7422,6 +7428,7 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_params, arg_do_not_relay);
   command_line::add_arg(desc_params, arg_create_address_file);
   command_line::add_arg(desc_params, arg_subaddress_lookahead);
+  command_line::add_arg(desc_params, arg_use_english_language_names);
 
   po::positional_options_description positional_options;
   positional_options.add(arg_command.name, -1);

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -334,6 +334,7 @@ namespace cryptonote
     bool m_restoring;           // are we restoring, by whatever method?
     uint64_t m_restore_height;  // optional
     bool m_do_not_relay;
+    bool m_use_english_language_names;
 
     epee::console_handlers_binder m_cmd_binder;
 


### PR DESCRIPTION
On some Windows systems, displaying language names in their own
languages freezes the display.