### PR TITLE
Fix Dockerfile sha256sum errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # builder stage
 FROM ubuntu:16.04 as builder
 
-RUN apt-get update && \
+RUN set -ex && \
+    apt-get update && \
     apt-get --no-install-recommends --yes install \
         ca-certificates \
         cmake \
@@ -24,8 +25,9 @@ WORKDIR /usr/local
 ARG BOOST_VERSION=1_66_0
 ARG BOOST_VERSION_DOT=1.66.0
 ARG BOOST_HASH=5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9
-RUN curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
-    && echo "${BOOST_HASH} boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
+RUN set -ex \
+    && curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+    && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
     && tar -xvf boost_${BOOST_VERSION}.tar.bz2 \
     && cd boost_${BOOST_VERSION} \
     && ./bootstrap.sh \
@@ -35,8 +37,9 @@ ENV BOOST_ROOT /usr/local/boost_${BOOST_VERSION}
 # OpenSSL
 ARG OPENSSL_VERSION=1.0.2n
 ARG OPENSSL_HASH=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
-RUN curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
-    && echo "${OPENSSL_HASH} openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
+RUN set -ex \
+    && curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
     && ./Configure linux-x86_64 no-shared --static -fPIC \
@@ -47,7 +50,8 @@ ENV OPENSSL_ROOT_DIR=/usr/local/openssl-${OPENSSL_VERSION}
 # ZMQ
 ARG ZMQ_VERSION=v4.2.3
 ARG ZMQ_HASH=3226b8ebddd9c6c738ba42986822c26418a49afb
-RUN git clone https://github.com/zeromq/libzmq.git -b ${ZMQ_VERSION} \
+RUN set -ex \
+    && git clone https://github.com/zeromq/libzmq.git -b ${ZMQ_VERSION} \
     && cd libzmq \
     && test `git rev-parse HEAD` = ${ZMQ_HASH} || exit 1 \
     && ./autogen.sh \
@@ -58,7 +62,8 @@ RUN git clone https://github.com/zeromq/libzmq.git -b ${ZMQ_VERSION} \
 
 # zmq.hpp
 ARG CPPZMQ_HASH=6aa3ab686e916cb0e62df7fa7d12e0b13ae9fae6
-RUN git clone https://github.com/zeromq/cppzmq.git -b ${ZMQ_VERSION} \
+RUN set -ex \
+    && git clone https://github.com/zeromq/cppzmq.git -b ${ZMQ_VERSION} \
     && cd cppzmq \
     && test `git rev-parse HEAD` = ${CPPZMQ_HASH} || exit 1 \
     && mv *.hpp /usr/local/include
@@ -66,8 +71,9 @@ RUN git clone https://github.com/zeromq/cppzmq.git -b ${ZMQ_VERSION} \
 # Readline
 ARG READLINE_VERSION=7.0
 ARG READLINE_HASH=750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334
-RUN curl -s -O https://ftp.gnu.org/gnu/readline/readline-${READLINE_VERSION}.tar.gz \
-    && echo "${READLINE_HASH} readline-${READLINE_VERSION}.tar.gz" | sha256sum -c \
+RUN set -ex \
+    && curl -s -O https://ftp.gnu.org/gnu/readline/readline-${READLINE_VERSION}.tar.gz \
+    && echo "${READLINE_HASH}  readline-${READLINE_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf readline-${READLINE_VERSION}.tar.gz \
     && cd readline-${READLINE_VERSION} \
     && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure \
@@ -77,7 +83,8 @@ RUN curl -s -O https://ftp.gnu.org/gnu/readline/readline-${READLINE_VERSION}.tar
 # Sodium
 ARG SODIUM_VERSION=1.0.16
 ARG SODIUM_HASH=675149b9b8b66ff44152553fb3ebf9858128363d
-RUN git clone https://github.com/jedisct1/libsodium.git -b ${SODIUM_VERSION} \
+RUN set -ex \
+    && git clone https://github.com/jedisct1/libsodium.git -b ${SODIUM_VERSION} \
     && cd libsodium \
     && test `git rev-parse HEAD` = ${SODIUM_HASH} || exit 1 \
     && ./autogen.sh \
@@ -90,13 +97,18 @@ WORKDIR /src
 COPY . .
 
 ARG NPROC
-RUN rm -rf build && \
-    if [ -z "$NPROC" ];then make -j$(nproc) release-static;else make -j$NPROC release-static;fi
+RUN set -ex && \
+    rm -rf build && \
+    if [ -z "$NPROC" ] ; \
+    then make -j$(nproc) release-static ; \
+    else make -j$NPROC release-static ; \
+    fi
 
 # runtime stage
 FROM ubuntu:16.04
 
-RUN apt-get update && \
+RUN set -ex && \
+    apt-get update && \
     apt-get --no-install-recommends --yes install ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt
@@ -114,4 +126,4 @@ VOLUME /wallet
 EXPOSE 18080
 EXPOSE 18081
 
-ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"] 
+ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"]


### PR DESCRIPTION
During some builds I noticed that `sha256sum` was failing because it expects two spaces between the filename and hash, _and_ this was not causing `docker build` to fail.

This PR seeks to fix those `sha256sum` checks, as well as add `set -ex` to catch this, and other, errors in the future.