### PR TITLE
Some fixes for HardFork

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -394,9 +394,9 @@ uint8_t HardFork::get_next_version() const
 {
   CRITICAL_REGION_LOCAL(lock);
   uint64_t height = db.height();
-  for (unsigned int n = heights.size() - 1; n > 0; --n) {
-    if (height >= heights[n].height) {
-      return heights[n < heights.size() - 1 ? n + 1 : n].version;
+  for (auto i = heights.rbegin(); i != heights.rend(); ++i) {
+    if (height >= i->height) {
+      return (i == heights.rbegin() ? i : (i - 1))->version;
     }
   }
   return original_version;

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -379,11 +379,15 @@ uint8_t HardFork::get_ideal_version(uint64_t height) const
 
 uint64_t HardFork::get_earliest_ideal_height_for_version(uint8_t version) const
 {
-  for (unsigned int n = heights.size() - 1; n > 0; --n) {
-    if (heights[n].version <= version)
-      return heights[n].height;
+  uint64_t height = std::numeric_limits<uint64_t>::max();
+  for (auto i = heights.rbegin(); i != heights.rend(); ++i) {
+    if (i->version >= version) {
+      height = i->height;
+    } else {
+      break;
+    }
   }
-  return 0;
+  return height;
 }
 
 uint8_t HardFork::get_next_version() const

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -554,3 +554,28 @@ TEST(get, higher)
     ASSERT_EQ(hf.get_ideal_version(7), 3);
 }
 
+TEST(get, earliest_ideal_height)
+{
+    TestDB db;
+    HardFork hf(db, 1, 0, 1, 1, 4, 50);
+
+    //                      v  h  t
+    ASSERT_TRUE(hf.add_fork(1, 0, 0));
+    ASSERT_TRUE(hf.add_fork(2, 2, 1));
+    ASSERT_TRUE(hf.add_fork(5, 5, 2));
+    ASSERT_TRUE(hf.add_fork(6, 10, 3));
+    ASSERT_TRUE(hf.add_fork(9, 15, 4));
+    hf.init();
+
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(1), 0);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(2), 2);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(3), 5);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(4), 5);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(5), 5);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(6), 10);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(7), 15);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(8), 15);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(9), 15);
+    ASSERT_EQ(hf.get_earliest_ideal_height_for_version(10), std::numeric_limits<uint64_t>::max());
+}
+

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -256,6 +256,35 @@ TEST(check_for_height, Success)
   }
 }
 
+TEST(get, next_version)
+{
+  TestDB db;
+  HardFork hf(db);
+
+  ASSERT_TRUE(hf.add_fork(1, 0, 0));
+  ASSERT_TRUE(hf.add_fork(2, 5, 1));
+  ASSERT_TRUE(hf.add_fork(4, 10, 2));
+  hf.init();
+
+  for (uint64_t h = 0; h <= 4; ++h) {
+    ASSERT_EQ(2, hf.get_next_version());
+    db.add_block(mkblock(hf, h, 1), 0, 0, 0, crypto::hash());
+    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+  }
+
+  for (uint64_t h = 5; h <= 9; ++h) {
+    ASSERT_EQ(4, hf.get_next_version());
+    db.add_block(mkblock(hf, h, 2), 0, 0, 0, crypto::hash());
+    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+  }
+
+  for (uint64_t h = 10; h <= 15; ++h) {
+    ASSERT_EQ(4, hf.get_next_version());
+    db.add_block(mkblock(hf, h, 4), 0, 0, 0, crypto::hash());
+    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+  }
+}
+
 TEST(states, Success)
 {
   TestDB db;


### PR DESCRIPTION
I encountered the problem with `get_earliest_ideal_height_for_version()` while working on the rebase of Aeon (see https://github.com/aeonix/aeon-rebase/pull/4), where it is planned to bump the hf version from v1 to v7 at once.

Some unit tests are also added.