### PR TITLE
[RELEASE] Fix generating version.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ library archives (`.a`).
 | Dep          | Min. version  | Vendored | Debian/Ubuntu pkg  | Arch pkg     | Fedora            | Optional | Purpose        |
 | ------------ | ------------- | -------- | ------------------ | ------------ | ----------------- | -------- | -------------- |
 | GCC          | 4.7.3         | NO       | `build-essential`  | `base-devel` | `gcc`             | NO       |                |
-| CMake        | 3.2.0         | NO       | `cmake`            | `cmake`      | `cmake`           | NO       |                |
+| CMake        | 3.0.0         | NO       | `cmake`            | `cmake`      | `cmake`           | NO       |                |
 | pkg-config   | any           | NO       | `pkg-config`       | `base-devel` | `pkgconf`         | NO       |                |
 | Boost        | 1.58          | NO       | `libboost-all-dev` | `boost`      | `boost-devel`     | NO       | C++ libraries  |
 | OpenSSL      | basically any | NO       | `libssl-dev`       | `openssl`    | `openssl-devel`   | NO       | sha256 sum     |

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -37,14 +37,16 @@ if ("$Format:$" STREQUAL "")
   write_static_version_header("release")
 elseif (GIT_FOUND OR Git_FOUND)
   message(STATUS "Found Git: ${GIT_EXECUTABLE}")
-  add_custom_target(genversion ALL
+  add_custom_command(
+    OUTPUT            "${CMAKE_BINARY_DIR}/version.cpp"
     COMMAND           "${CMAKE_COMMAND}"
                       "-D" "GIT=${GIT_EXECUTABLE}"
                       "-D" "TO=${CMAKE_BINARY_DIR}/version.cpp"
                       "-P" "cmake/GenVersion.cmake"
-    BYPRODUCTS        "${CMAKE_BINARY_DIR}/version.cpp"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 else()
   message(STATUS "WARNING: Git was not found!")
   write_static_version_header("unknown")
 endif ()
+add_custom_target(genversion ALL
+  DEPENDS "${CMAKE_BINARY_DIR}/version.cpp")


### PR DESCRIPTION
Fix #3463, Also removes BYPRODUCT dependency on CMake 3.2
The requirement for CMake 3.2.0 was introduced erroneously
in commit e29282d and is no longer present