### PR TITLE
simplewallet: don't show daemon connection error twice when starting

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3797,7 +3797,7 @@ void simple_wallet::on_skip_transaction(uint64_t height, const crypto::hash &txi
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::refresh_main(uint64_t start_height, bool reset, bool is_init)
 {
-  if (!try_connect_to_daemon())
+  if (!try_connect_to_daemon(is_init))
     return true;
 
   LOCK_IDLE_SCOPE();


### PR DESCRIPTION
Currently the same error message `Error: wallet failed to connect to daemon: [daemon]. Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the 'set_daemon' command.` is shown twice on wallet startup if the wallet can't connect to a daemon/node. This is because it calls `try_connect_to_daemon()` and can't connect so it show's the message, the does the same thing again when it calls `refresh_main`. This PR silences the error message when `refresh_main` is called from `simple_wallet::run` since it has already been shown when calling `try_connect_to_daemon` the first time.