### PR TITLE
Add Windows debug build options to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,14 @@ debug-static-all:
 	mkdir -p build/debug
 	cd build/debug && cmake -D BUILD_TESTS=ON -D STATIC=ON -D CMAKE_BUILD_TYPE=Debug ../.. && $(MAKE)
 
+debug-static-win64:
+	mkdir -p build/release
+	cd build/release && cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj -G "MSYS Makefiles" -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=../../cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=c:/msys64 ../.. && $(MAKE)
+
+debug-static-win32:
+	mkdir -p build/release
+	cd build/release && cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj -G "MSYS Makefiles" -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x32" -D CMAKE_TOOLCHAIN_FILE=../../cmake/32-bit-toolchain.cmake -D MSYS2_FOLDER=c:/msys32 ../.. && $(MAKE)
+
 cmake-release:
 	mkdir -p build/release
 	cd build/release && cmake -D CMAKE_BUILD_TYPE=Release ../..


### PR DESCRIPTION
Had to edit the makefile to add these when doing a debug build on Windows, figured they might as well be in by default.