### PR TITLE
wallet: fix default mixin (4 -> 6)

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -60,7 +60,7 @@ namespace Monero {
 
 namespace {
     // copy-pasted from simplewallet
-    static const size_t DEFAULT_MIXIN = 4;
+    static const size_t DEFAULT_MIXIN = 6;
     static const int    DEFAULT_REFRESH_INTERVAL_MILLIS = 1000 * 10;
     // limit maximum refresh interval as one minute
     static const int    MAX_REFRESH_INTERVAL_MILLIS = 1000 * 60 * 1;


### PR DESCRIPTION
DEFAULT_MIXIN is currently set to 4 (ringsize 5,) but should be 6 (ringsize 7) for 0.12 "Lithium Luna"

credits to endogenic for pointing this out

rebase of #3514