### PR TITLE
Custom ringdb path

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -599,7 +599,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
             // Rebuilding wallet cache, using refresh height from .keys file
             m_rebuildWalletCache = true;
         }
-        m_wallet->set_ring_database(get_default_ringdb_path());
+        m_wallet->get_ring_database();
         m_wallet->load(path, password);
 
         m_password = password;
@@ -1950,6 +1950,10 @@ bool WalletImpl::unblackballOutput(const std::string &pubkey)
         return false;
     }
     return true;
+}
+
+string WalletImpl::setRingDatabase(const std::string &filename) {
+    m_wallet->set_ring_database(filename);
 }
 
 bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ring) const

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -165,7 +165,7 @@ public:
     virtual bool lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status);
     virtual bool blackballOutputs(const std::vector<std::string> &pubkeys, bool add);
     virtual bool unblackballOutput(const std::string &pubkey);
-    virtual void setRingDatabase(const std::string &filename) const;
+    virtual void setRingDatabase(const std::string &filename);
     virtual bool getRing(const std::string &key_image, std::vector<uint64_t> &ring) const;
     virtual bool getRings(const std::string &txid, std::vector<std::pair<std::string, std::vector<uint64_t>>> &rings) const;
     virtual bool setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative);

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -165,6 +165,7 @@ public:
     virtual bool lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status);
     virtual bool blackballOutputs(const std::vector<std::string> &pubkeys, bool add);
     virtual bool unblackballOutput(const std::string &pubkey);
+    virtual void setRingDatabase(const std::string &filename) const;
     virtual bool getRing(const std::string &key_image, std::vector<uint64_t> &ring) const;
     virtual bool getRings(const std::string &txid, std::vector<std::pair<std::string, std::vector<uint64_t>>> &rings) const;
     virtual bool setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative);
@@ -229,4 +230,3 @@ private:
 namespace Bitmonero = Monero;
 
 #endif
-

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -763,6 +763,9 @@ struct Wallet
     //! unblackballs an output
     virtual bool unblackballOutput(const std::string &pubkey) = 0;
 
+    //! set default ring db path/filename
+    virtual void setRingDatabase(const std::string &filename) = 0;
+
     //! gets the ring used for a key image, if any
     virtual bool getRing(const std::string &key_image, std::vector<uint64_t> &ring) const = 0;
 
@@ -1013,4 +1016,3 @@ struct WalletManagerFactory
 }
 
 namespace Bitmonero = Monero;
-

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5478,7 +5478,7 @@ void wallet2::set_ring_database(const std::string &filename)
     m_ringdb.reset(new tools::ringdb(m_ring_database, epee::string_tools::pod_to_hex(get_block_hash(b))));
 }
 
-std::string wallet2::get_ring_database() const
+std::string wallet2::get_ring_database()
 {
   if(!m_ring_database)
     m_ring_database = get_default_ringdb_path();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5478,6 +5478,13 @@ void wallet2::set_ring_database(const std::string &filename)
     m_ringdb.reset(new tools::ringdb(m_ring_database, epee::string_tools::pod_to_hex(get_block_hash(b))));
 }
 
+std::string wallet2::get_ring_database() const
+{
+  if(!m_ring_database)
+    m_ring_database = get_default_ringdb_path();
+  return m_ring_database;
+}
+
 bool wallet2::add_rings(const crypto::chacha_key &key, const cryptonote::transaction_prefix &tx)
 {
   if (!m_ringdb)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5480,7 +5480,7 @@ void wallet2::set_ring_database(const std::string &filename)
 
 std::string wallet2::get_ring_database()
 {
-  if(!m_ring_database)
+  if(m_ring_database.empty())
     m_ring_database = get_default_ringdb_path();
   return m_ring_database;
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1062,7 +1062,7 @@ namespace tools
     }
 
     void set_ring_database(const std::string &filename);
-    const std::string get_ring_database() const { return m_ring_database; }
+    std::string get_ring_database() const;
     bool get_ring(const crypto::key_image &key_image, std::vector<uint64_t> &outs);
     bool get_rings(const crypto::hash &txid, std::vector<std::pair<crypto::key_image, std::vector<uint64_t>>> &outs);
     bool set_ring(const crypto::key_image &key_image, const std::vector<uint64_t> &outs, bool relative);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1062,7 +1062,7 @@ namespace tools
     }
 
     void set_ring_database(const std::string &filename);
-    std::string get_ring_database() const;
+    std::string get_ring_database();
     bool get_ring(const crypto::key_image &key_image, std::vector<uint64_t> &outs);
     bool get_rings(const crypto::hash &txid, std::vector<std::pair<crypto::key_image, std::vector<uint64_t>>> &outs);
     bool set_ring(const crypto::key_image &key_image, const std::vector<uint64_t> &outs, bool relative);


### PR DESCRIPTION
On Android the default dir that is set for the ring db is put somewhere which has Read-Only access.
This change should allow the default ring db to be manually set if needed in this circumstance.