### PR TITLE
threadpool: treat message in waiter's dtor as warning instead of error and make it optional

### DIFF
--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -84,14 +84,18 @@ int threadpool::get_max_concurrency() {
 
 threadpool::waiter::~waiter()
 {
+  if (warn_in_dtor)
   {
     boost::unique_lock<boost::mutex> lock(mt);
     if (num)
-      MERROR("wait should have been called before waiter dtor - waiting now");
+      MWARNING("wait should have been called before waiter dtor - waiting now");
   }
   try
   {
-    wait();
+    if (wait_in_dtor)
+    {
+      wait();
+    }
   }
   catch (const std::exception &e)
   {

--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -53,11 +53,13 @@ public:
     boost::mutex mt;
     boost::condition_variable cv;
     int num;
+    bool warn_in_dtor;
+    bool wait_in_dtor;
     public:
     void inc();
     void dec();
     void wait();  //! Wait for a set of tasks to finish.
-    waiter() : num(0){}
+    waiter(bool warn_in_dtor = true, bool wait_in_dtor = true) : num(0), warn_in_dtor(warn_in_dtor), wait_in_dtor(wait_in_dtor) {}
     ~waiter();
   };
 


### PR DESCRIPTION
add option to not call wait() in waiter's dtor
