### PR TITLE
[RELEASE] wallet2.cpp: #include <mutex> needed for std::unique_lock

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -31,6 +31,7 @@
 #include <numeric>
 #include <random>
 #include <tuple>
+#include <mutex>
 #include <boost/format.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/utility/value_init.hpp>


### PR DESCRIPTION
Followup for #3478

Without it, I got the following compile error on Windows:
```
monero/src/wallet/wallet2.cpp:7871:8: error: 'unique_lock' is not a member of 'std'
   std::unique_lock<hw::device> hwdev_lock (hwdev);
        ^~~~~~~~~~~
monero/src/wallet/wallet2.cpp:7871:8: note: suggested alternative: 'unique_copy'
   std::unique_lock<hw::device> hwdev_lock (hwdev);
        ^~~~~~~~~~~
        unique_copy
monero/src/wallet/wallet2.cpp:7871:30: error: expected primary-expression before '>' token
   std::unique_lock<hw::device> hwdev_lock (hwdev);
                              ^
monero/src/wallet/wallet2.cpp:7871:32: error: 'hwdev_lock' was not declared in this scope
   std::unique_lock<hw::device> hwdev_lock (hwdev);
                                ^~~~~~~~~~
monero/src/wallet/wallet2.cpp:7871:32: note: suggested alternative: 'hwdev'
   std::unique_lock<hw::device> hwdev_lock (hwdev);
                                ^~~~~~~~~~
                                hwdev
```
