### PR TITLE
Add a space in mining to testnet/stagenet string

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -314,7 +314,7 @@ bool t_command_parser_executor::start_mining(const std::vector<std::string>& arg
     return true;
   }
   if(nettype != cryptonote::MAINNET)
-    std::cout << "Mining to a " << (nettype == cryptonote::TESTNET ? "testnet" : "stagenet") << "address, make sure this is intentional!" << std::endl;
+    std::cout << "Mining to a " << (nettype == cryptonote::TESTNET ? "testnet" : "stagenet") << " address, make sure this is intentional!" << std::endl;
   uint64_t threads_count = 1;
   bool do_background_mining = false;  
   bool ignore_battery = false;  


### PR DESCRIPTION
Otherwise it looks like `Mining to a testnetaddress, make sure this is intentional!`.