### PR TITLE
gtest: Fix compilation on MinGW with pthread /googletest#621

### DIFF
--- a/tests/gtest/cmake/internal_utils.cmake
+++ b/tests/gtest/cmake/internal_utils.cmake
@@ -46,7 +46,7 @@ endmacro()
 # Google Mock.  You can tweak these definitions to suit your need.  A
 # variable's value is empty before it's explicitly assigned to.
 macro(config_compiler_and_linker)
-  if (NOT gtest_disable_pthreads)
+  if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
     find_package(Threads)
   endif()

--- a/tests/gtest/include/gtest/internal/gtest-port.h
+++ b/tests/gtest/include/gtest/internal/gtest-port.h
@@ -1553,10 +1553,7 @@ class GTEST_API_ Notification {
 };
 # endif  // GTEST_HAS_NOTIFICATION_
 
-// On MinGW, we can have both GTEST_OS_WINDOWS and GTEST_HAS_PTHREAD
-// defined, but we don't want to use MinGW's pthreads implementation, which
-// has conformance problems with some versions of the POSIX standard.
-# if GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
+# if GTEST_HAS_PTHREAD
 
 // As a C-function, ThreadFuncWithCLinkage cannot be templated itself.
 // Consequently, it cannot select a correct instantiation of ThreadWithParam


### PR DESCRIPTION
Compile errors on Windows were reported by @iDunk5400 in https://github.com/monero-project/monero/pull/3245#issuecomment-364563419, but somehow the problem was never addressed since then.

```
In file included from C:/msys64/home/monero/tests/gtest/include/gtest/internal/gtest-internal.h:40:0,
                 from C:/msys64/home/monero/tests/gtest/include/gtest/gtest.h:58,
                 from C:/msys64/home/monero/tests/gtest/src/gtest-all.cc:39:
C:/msys64/home/monero/tests/gtest/include/gtest/internal/gtest-port.h:1782:3: error: 'AutoHandle' does not name a type; did you mean 'mutable'?
   AutoHandle thread_;
   ^~~~~~~~~~
   mutable
In file included from C:/msys64/home/monero/tests/gtest/src/gtest-all.cc:43:0:
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc:637:3: error: 'AutoHandle' does not name a type; did you mean 'LocalHandle'?
   AutoHandle write_handle_;
   ^~~~~~~~~~
   LocalHandle
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc:639:3: error: 'AutoHandle' does not name a type; did you mean 'LocalHandle'?
   AutoHandle child_handle_;
   ^~~~~~~~~~
   LocalHandle
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc:644:3: error: 'AutoHandle' does not name a type; did you mean 'LocalHandle'?
   AutoHandle event_handle_;
   ^~~~~~~~~~
   LocalHandle
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc: In member function 'virtual int testing::internal::WindowsDeathTest::Wait()':
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc:656:36: error: 'child_handle_' was not declared in this scope
   const HANDLE wait_handles[2] = { child_handle_.Get(), event_handle_.Get() };
                                    ^~~~~~~~~~~~~
C:/msys64/home/monero/tests/gtest/src/gtest-death-test.cc:656:36: note: suggested alternative: 'wait_handles'
   const HANDLE wait_handles[2] = { child_handle_.Get(), event_handle_.Get() };
                                    ^~~~~~~~~~~~~
                                    wait_handles

...
```

As a quick workaround, I've applied the un-merged upstream patch https://github.com/google/googletest/pull/621 (deemed as duplicate of https://github.com/google/googletest/pull/721). But it seems that the vendored gtest codebase is periodically updated by @fluffypony, so maybe this patch is not the right way to handle this issue.
