### PR TITLE
Unbreak build against Boost 1.67

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -41,7 +41,8 @@
 #include <boost/utility/value_init.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp> // TODO
-#include <boost/thread/v2/thread.hpp> // TODO
+#include <boost/thread/thread.hpp> // TODO
+#include <boost/thread/condition_variable.hpp> // TODO
 #include "misc_language.h"
 #include "pragma_comp_defs.h"
 

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -31,10 +31,11 @@
 #define __WINH_OBJ_H__
 
 #include <boost/chrono/duration.hpp>
+#include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/v2/thread.hpp>
+#include <boost/thread/thread.hpp>
 
 namespace epee
 {


### PR DESCRIPTION
Regressed by boostorg/thread@fea3e33128aa. Fixes #3663.

`<boost/thread/condition_variable.hpp>` is already used by the project without checking `BOOST_VERSION`:
https://github.com/monero-project/monero/blob/6f6521ad7a9832788e07f7f7d181ba29b010e311/src/common/threadpool.h#L30-L32
https://github.com/monero-project/monero/blob/6f6521ad7a9832788e07f7f7d181ba29b010e311/src/wallet/api/wallet.h#L38-L40
