### PR TITLE
wallet2: add sweep_mixable functionality

### DIFF
--- a/contrib/rlwrap/monerocommands_monero-wallet-cli.txt
+++ b/contrib/rlwrap/monerocommands_monero-wallet-cli.txt
@@ -26,6 +26,7 @@ start_mining
 status
 stop_mining
 sweep_all
+sweep_mixable
 sweep_unmixable
 transfer
 transfer_original

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -156,7 +156,9 @@ namespace cryptonote
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);
     bool sweep_single(const std::vector<std::string> &args);
+    bool sweep_mixable(const std::vector<std::string> &args);
     bool sweep_unmixable(const std::vector<std::string> &args);
+    bool sweep_only_mixable_or_unmixable(const std::vector<std::string> &args, bool mixable);
     bool donate(const std::vector<std::string> &args);
     bool sign_transfer(const std::vector<std::string> &args);
     bool submit_transfer(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -703,6 +703,7 @@ namespace tools
     bool sign_multisig_tx_from_file(const std::string &filename, std::vector<crypto::hash> &txids, std::function<bool(const multisig_tx_set&)> accept_func);
     bool sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto::hash> &txids);
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);
+    std::vector<pending_tx> create_mixable_sweep_transactions(bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
     bool check_connection(uint32_t *version = NULL, uint32_t timeout = 200000);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
@@ -1121,6 +1122,7 @@ namespace tools
     void set_unspent(size_t idx);
     void get_outs(std::vector<std::vector<get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count);
     bool tx_add_fake_output(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, uint64_t global_index, const crypto::public_key& tx_public_key, const rct::key& mask, uint64_t real_index, bool unlocked) const;
+    std::vector<pending_tx> create_mixable_or_unmixable_sweep_transactions(bool trusted_daemon, bool mixable);
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
     bool should_pick_a_second_output(bool use_rct, size_t n_transfers, const std::vector<size_t> &unused_transfers_indices, const std::vector<size_t> &unused_dust_indices) const;
     std::vector<size_t> get_only_rct(const std::vector<size_t> &unused_dust_indices, const std::vector<size_t> &unused_transfers_indices) const;


### PR DESCRIPTION
I'm not sure if `m_wallet->create_mixable_sweep_transactions(m_trusted_daemon)` does what it says it does. Possibly this is including unmixable (non-RCT?) transactions.. maybe someone wants to verify if this pull request implements https://github.com/monero-project/monero/issues/3202 properly? ^_^