### PR TITLE
Fix broken interactive daemon 'limit' commands plus RPC calls

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -380,8 +380,6 @@ bool t_command_parser_executor::set_limit(const std::vector<std::string>& args)
       std::cout << "failed to parse argument" << std::endl;
       return false;
   }
-  if (limit > 0)
-    limit *= 1024;
 
   return m_executor.set_limit(limit, limit);
 }
@@ -400,8 +398,6 @@ bool t_command_parser_executor::set_limit_up(const std::vector<std::string>& arg
       std::cout << "failed to parse argument" << std::endl;
       return false;
   }
-  if (limit > 0)
-    limit *= 1024;
 
   return m_executor.set_limit(0, limit);
 }
@@ -420,8 +416,6 @@ bool t_command_parser_executor::set_limit_down(const std::vector<std::string>& a
       std::cout << "failed to parse argument" << std::endl;
       return false;
   }
-  if (limit > 0)
-    limit *= 1024;
 
   return m_executor.set_limit(limit, 0);
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1176,8 +1176,8 @@ bool t_rpc_command_executor::get_limit()
     }
   }
 
-  tools::msg_writer() << "limit-down is " << res.limit_down/1024 << " kB/s";
-  tools::msg_writer() << "limit-up is " << res.limit_up/1024 << " kB/s";
+  tools::msg_writer() << "limit-down is " << res.limit_down << " kB/s";
+  tools::msg_writer() << "limit-up is " << res.limit_up << " kB/s";
   return true;
 }
 
@@ -1207,8 +1207,8 @@ bool t_rpc_command_executor::set_limit(int64_t limit_down, int64_t limit_up)
     }
   }
 
-  tools::msg_writer() << "Set limit-down to " << res.limit_down/1024 << " kB/s";
-  tools::msg_writer() << "Set limit-up to " << res.limit_up/1024 << " kB/s";
+  tools::msg_writer() << "Set limit-down to " << res.limit_down << " kB/s";
+  tools::msg_writer() << "Set limit-up to " << res.limit_up << " kB/s";
   return true;
 }
 
@@ -1235,7 +1235,7 @@ bool t_rpc_command_executor::get_limit_up()
     }
   }
 
-  tools::msg_writer() << "limit-up is " << res.limit_up/1024 << " kB/s";
+  tools::msg_writer() << "limit-up is " << res.limit_up << " kB/s";
   return true;
 }
 
@@ -1262,7 +1262,7 @@ bool t_rpc_command_executor::get_limit_down()
     }
   }
 
-  tools::msg_writer() << "limit-down is " << res.limit_down/1024 << " kB/s";
+  tools::msg_writer() << "limit-down is " << res.limit_down << " kB/s";
   return true;
 }
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -334,8 +334,8 @@ namespace nodetool
     cryptonote::network_type m_nettype;
   };
 
-    const int64_t default_limit_up = 2048;
-    const int64_t default_limit_down = 8192;
+    const int64_t default_limit_up = 2048;    // kB/s
+    const int64_t default_limit_down = 8192;  // kB/s
     extern const command_line::arg_descriptor<std::string> arg_p2p_bind_ip;
     extern const command_line::arg_descriptor<std::string, false, true, 2> arg_p2p_bind_port;
     extern const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1705,7 +1705,7 @@ namespace cryptonote
   {
     struct request
     {
-      int64_t limit_down;
+      int64_t limit_down;  // all limits (for get and set) are kB/s
       int64_t limit_up;
       
       BEGIN_KV_SERIALIZE_MAP()


### PR DESCRIPTION
The interactive daemon commands `limit`, `limit_up` and `limit_down` plus the corresponding RPC calls were basically broken since my own [PR #2866] was merged last December: When I corrected a bug and streamlined code in connection with the command-line parameter `--limit-rate`  I did not recognize that the code for the interactive commands and the RPC calls behind them needs also corrections:

Any limit given interactively or over RPC was still multiplied by 1024 which is wrong since [PR #2866].

Those multiplications confusingly look like they could have something to do with going from kilobytes/second to bytes/second and therefore needed, but in fact they just were part of some "fudging" necessary because of a then still unrecognized bug. Details see my December PR.