### PR TITLE
epee: Drop deprecated Boost.Thread header

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -41,7 +41,8 @@
 #include <boost/utility/value_init.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp> // TODO
-#include <boost/thread/v2/thread.hpp> // TODO
+#include <boost/thread/thread.hpp> // TODO
+#include <boost/thread/condition_variable.hpp> // TODO
 #include "misc_language.h"
 #include "pragma_comp_defs.h"
 

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -31,10 +31,11 @@
 #define __WINH_OBJ_H__
 
 #include <boost/chrono/duration.hpp>
+#include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/v2/thread.hpp>
+#include <boost/thread/thread.hpp>
 
 namespace epee
 {


### PR DESCRIPTION
In file included from src/cryptonote_basic/hardfork.cpp:33:
In file included from src/blockchain_db/blockchain_db.h:42:
In file included from src/cryptonote_basic/hardfork.h:31:
contrib/epee/include/syncobj.h:37:10: fatal error: 'boost/thread/v2/thread.hpp' file not found
#include <boost/thread/v2/thread.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/rpc/daemon_handler.cpp:29:
In file included from src/rpc/daemon_handler.h:36:
In file included from src/p2p/net_node.h:41:
In file included from contrib/epee/include/net/levin_server_cp2.h:32:
In file included from contrib/epee/include/net/abstract_tcp_server2.h:324:
contrib/epee/include/net/abstract_tcp_server2.inl:44:10: fatal error: 'boost/thread/v2/thread.hpp' file not found
#include <boost/thread/v2/thread.hpp> // TODO
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

contrib/epee/include/math_helper.h: In member function 'bool epee::math_helper::average<val, default_base>::set_base()':
contrib/epee/include/syncobj.h:227:56: error: 'sleep_for' is not a member of 'boost::this_thread'
 #define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
                                                        ^
contrib/epee/include/syncobj.h:227:56: note: in definition of macro 'CRITICAL_REGION_LOCAL'
 #define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
                                                        ^~~~~~~~~
contrib/epee/include/syncobj.h:227:56: note: suggested alternative: 'sleep'
 #define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
                                                        ^
contrib/epee/include/syncobj.h:227:56: note: in definition of macro 'CRITICAL_REGION_LOCAL'
 #define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
                                                        ^~~~~~~~~