### PR TITLE
Use GNU Readline if installed on OSX via Homebrew

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -23,7 +23,7 @@
 
 find_path(Readline_ROOT_DIR
     NAMES include/readline/readline.h
-    PATHS /opt/local/ /usr/local/ /usr/
+    PATHS /usr/local/opt/readline/ /opt/local/ /usr/local/ /usr/
     NO_DEFAULT_PATH
 )
 


### PR DESCRIPTION
Hi,

I noticed that even if GNU Readline is installed through Homebrew, the CMakefile won't pick it up. This is due to Homebrew sensibly not symlinking the readline libraries, as it can cause conflict with system libs.

This commit queries Homebrew for the GNU Readline location (exactly the same as the OpenSSL library detection) and allows the build process to successfully use it.