### PR TITLE
Add Boost Chrono library to common

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(common
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
     ${Boost_REGEX_LIBRARY}
+    ${Boost_CHRONO_LIBRARY}
   PRIVATE
     ${OPENSSL_LIBRARIES}
     ${EXTRA_LIBRARIES})


### PR DESCRIPTION
Should fix #3706 -- I was able to reproduce the issue and then fix it with this commit (`make debug`).

It appears that boost::this_thread::sleep_for (present in the Boost Threads library) has references to boost::chrono::steady_clock::now() , which was causing building with shared libraries to fail.