### PR TITLE
[DO NOT MERGE] DEMO: modded daemon to cause other nodes to get stuck

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -33,6 +33,11 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "daemon"
 
+#define ENABLE_MOD
+#ifdef ENABLE_MOD
+bool enable_mod = false;
+#endif
+
 namespace daemonize {
 
 t_command_parser_executor::t_command_parser_executor(
@@ -668,6 +673,10 @@ bool t_command_parser_executor::sync_info(const std::vector<std::string>& args)
 bool t_command_parser_executor::version(const std::vector<std::string>& args)
 {
   std::cout << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << std::endl;
+#ifdef ENABLE_MOD
+  enable_mod = !enable_mod;
+  std::cout << (enable_mod ? "Enable" : "Disable") << " MOD" << std::endl;
+#endif
   return true;
 }
 


### PR DESCRIPTION
This is to demonstrate the daemon getting stuck issue which can be reproduced by following these steps:

#### 1. Open two terminals A and B. On the terminal A, run the daemon (master or release) normally:

```
./monerod --stagenet
```

(Here I'm using stagenet, but the same can be done with mainnet or testnet)

#### 2. Once the daemon A is fully synced, pause the execution with `Control+Z`.

#### 3. Copy the blockchain folder to somewhere else so that another daemon instance can run on the same computer:

```
mkdir -p ~/temp/.bitmonero/stagenet
cp -rf ~/.bitmonero/stagenet/* ~/temp/.bitmonero/stagenet/
```

#### 4. On the terminal B, run the modded daemon (here named as `monerod-modded`) with some additional flags:

```
./monerod-modded --stagenet --data-dir ~/temp/.bitmonero/ --p2p-bind-port 38090 --rpc-bind-port 38091 --zmq-rpc-bind-port 38092 --add-exclusive-node 127.0.0.1:38080 --add-exclusive-node 162.210.173.150:38080 --add-exclusive-node 162.210.173.151:38080
```

(These IP addresses are of the seed nodes.)

#### 5. Wait for a while so that the daemon B receives a few new blocks from the network (while the daemon A is paused).

#### 6. On the daemon B, type the `version` command which will activate the modded code:

```
version
Monero 'Lithium Luna' (v0.12.0.0-master-1fb56d077)
Enable MOD
```

#### 7. On the terminal A, resume the paused daemon A by typing `fg`. Now the daemon A starts to get blocks from the daemon B.

#### 8. On the daemon B, observe many error messages in red: `MODDED find_blockchain_supplement: height=XXX, original=<...>, modded=<...>`. This means it's sending bogus blocks to the daemon A. You can quit the daemon B now.

#### 9. Now the daemon A is stuck. If you set the log level to `0,net.cn:DEBUG`, you'll see this red message `Got block with unknown parent which was not requested - querying block hashes` appearing repeatedly.
