### PR TITLE
p2p: fix fallback seed node usage

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -316,6 +316,7 @@ namespace nodetool
     std::list<epee::net_utils::network_address>   m_priority_peers;
     std::vector<epee::net_utils::network_address> m_exclusive_peers;
     std::vector<epee::net_utils::network_address> m_seed_nodes;
+    bool m_fallback_seed_nodes_added;
     std::list<nodetool::peerlist_entry> m_command_line_peers;
     uint64_t m_peer_livetime;
     //keep connections to initiate some interactions


### PR DESCRIPTION
Those were added to the seed nodes list even when they had already
been added. Moreover, the current index was not reset after they
were added, typically causing previous seeds to be used, and some
of those fallback seeds to not be tried.