### PR TITLE
Ensure m_timestamps has the correct number for computing difficulty

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -760,7 +760,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   //    then when the next block difficulty is queried, push the latest height data and
   //    pop the oldest one from the list. This only requires 1x read per height instead
   //    of doing 735 (DIFFICULTY_BLOCKS_COUNT).
-  if (m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1))
+  if (m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1) && m_timestamps.size() >= DIFFICULTY_BLOCKS_COUNT)
   {
     uint64_t index = height - 1;
     m_timestamps.push_back(m_db->get_block_timestamp(index));


### PR DESCRIPTION
This patch is included in https://github.com/monero-project/monero/pull/2887 but is valid standalone, and fixes an issue caused if/when a fork's difficulty block count exceeds the previous fork as part of a protocol change.
Monero's current count of 720 is high, so this is defensive code in the case the protocol goes lower in one version then higher in another.