### PR TITLE
add .load() to make Boost 1.67 happy with its new is_integral check on...

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1752,7 +1752,7 @@ void WalletImpl::refreshThreadFunc()
         // if auto refresh enabled, we wait for the "m_refreshIntervalSeconds" interval.
         // if not - we wait forever
         if (m_refreshIntervalMillis > 0) {
-            boost::posix_time::milliseconds wait_for_ms(m_refreshIntervalMillis);
+            boost::posix_time::milliseconds wait_for_ms(m_refreshIntervalMillis.load());
             m_refreshCV.timed_wait(lock, wait_for_ms);
         } else {
             m_refreshCV.wait(lock);


### PR DESCRIPTION
...subsecond_duration

System: macOS 10.13.4
Boost: 1.67

As per this commit from [intensecoin](https://github.com/valiant1x/intensecoin/pull/86/commits/e1fe653725f0517131befbb6655c571ced219f46) the new boost version 1.67 has to be fixed again to make [monero-gui](https://github.com/monero-project/monero-gui) build successfully.

Referencing my [monero-gui issue](https://github.com/monero-project/monero-gui/issues/1335) as well.

All credits to @iedemam for sharing this.


As a side-note: I had to select monero branch `master` instead of `release-v0.12` to cirvumvent the missing [boost header error](https://github.com/monero-project/monero/issues/3663) and make monero-gui build successfully.

To reproduce: in monero-gui `get_libwallet_api.sh` replace line 20
`git -C $MONERO_DIR checkout release-v0.12`
with
`git -C $MONERO_DIR checkout master`
