### PR TITLE
check_spend_proof

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8414,8 +8414,9 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
   }
   std::vector<std::vector<crypto::signature>> signatures = { std::vector<crypto::signature>(1) };
   const size_t sig_len = tools::base58::encode(std::string((const char *)&signatures[0][0], sizeof(crypto::signature))).size();
-  THROW_WALLET_EXCEPTION_IF(sig_str.size() != header_len + num_sigs * sig_len,
-    error::wallet_internal_error, "incorrect signature size");
+  if( sig_str.size() != header_len + num_sigs * sig_len ) {
+    return false;
+  }
 
   // decode base58
   signatures.clear();


### PR DESCRIPTION
My intention is to mitigate #3761 by returning "bad signature", rather than throwing an error, as the error is triggered inappropriately in the case of checking the signature against a different txid than the one used to create the signature. This causes issues for monerophp: https://github.com/monero-integrations/monerophp/issues/72 & my temp fix: https://github.com/monero-integrations/monerophp/pull/74