### PR TITLE
simple-wallet-cli: warnings about missing key images for watchonly wallet

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3923,6 +3923,8 @@ bool simple_wallet::show_balance_unlocked(bool detailed)
   std::string extra;
   if (m_wallet->has_multisig_partial_key_images())
     extra = tr(" (Some owned outputs have partial key images - import_multisig_info needed)");
+  else if (m_wallet->has_unknown_key_images())
+    extra += tr(" (Some owned outputs have missing key images - import_key_images needed)");
   success_msg_writer() << tr("Currently selected account: [") << m_current_subaddress_account << tr("] ") << m_wallet->get_subaddress_label({m_current_subaddress_account, 0});
   const std::string tag = m_wallet->get_account_tags().second[m_current_subaddress_account];
   success_msg_writer() << tr("Tag: ") << (tag.empty() ? std::string{tr("(No tag assigned)")} : tag);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3611,6 +3611,14 @@ bool wallet2::has_multisig_partial_key_images() const
   return false;
 }
 
+bool wallet2::has_unknown_key_images() const
+{
+  for (const auto &td: m_transfers)
+    if (!td.m_key_image_known)
+      return true;
+  return false;
+}
+
 /*!
  * \brief Rewrites to the wallet file for wallet upgrade (doesn't generate key, assumes it's already there)
  * \param wallet_name Name of wallet file (should exist)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -653,6 +653,7 @@ namespace tools
     bool watch_only() const { return m_watch_only; }
     bool multisig(bool *ready = NULL, uint32_t *threshold = NULL, uint32_t *total = NULL) const;
     bool has_multisig_partial_key_images() const;
+    bool has_unknown_key_images() const;
     bool get_multisig_seed(std::string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
     bool key_on_device() const { return m_key_on_device; }
 


### PR DESCRIPTION
references https://github.com/monero-project/monero/issues/2954