### PR TITLE
Fix PCSC discovery under Windows/MSYS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,9 +452,12 @@ link_directories(${LIBUNWIND_LIBRARY_DIRS})
 
 # Final setup for libpcsc
 if (PCSC_FOUND) 
+  message(STATUS "Using PCSC include dir at ${PCSC_INCLUDE_DIR}")
   add_definitions(-DHAVE_PCSC)
   include_directories(${PCSC_INCLUDE_DIR})
   link_directories(${LIBPCSC_LIBRARY_DIRS})
+else (PCSC_FOUND)
+  message(STATUS "Could not find PCSC")
 endif()
 
 if(MSVC)

--- a/cmake/FindPCSC.cmake
+++ b/cmake/FindPCSC.cmake
@@ -18,6 +18,9 @@ ENDIF (NOT WIN32)
 
 FIND_PATH(PCSC_INCLUDE_DIR winscard.h
   HINTS
+  IF (WIN32)
+  ${MSYS2_FOLDER}/mingw64/x86_64-w64-mingw32/include
+  ENDIF (WIN32)
   /usr/include/PCSC
   ${PC_PCSC_INCLUDEDIR}
   ${PC_PCSC_INCLUDE_DIRS}
@@ -26,6 +29,9 @@ FIND_PATH(PCSC_INCLUDE_DIR winscard.h
 
 FIND_LIBRARY(PCSC_LIBRARY NAMES pcsclite libpcsclite WinSCard PCSC
   HINTS
+  IF (WIN32)
+  ${MSYS2_FOLDER}/mingw64/x86_64-w64-mingw32/lib
+  ENDIF (WIN32)
   ${PC_PCSC_LIBDIR}
   ${PC_PCSC_LIBRARY_DIRS}
   )

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -48,6 +48,15 @@ namespace hw {
     /* ===================================================================== */
     /* ===                           Debug                              ==== */
     /* ===================================================================== */
+    #ifdef WIN32
+    static char *pcsc_stringify_error(LONG rv) {
+     static __thread char out[20];
+     sprintf_s(out, sizeof(out), "0x%08lX", rv);
+
+     return out;
+    }
+    #endif
+
     void set_apdu_verbose(bool verbose) {
       apdu_verbose = verbose;
     }

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -33,8 +33,13 @@
 #include <cstddef>
 #include <string>
 #include "device.hpp"
+#ifdef WIN32
+#include <winscard.h>
+#define MAX_ATR_SIZE            33
+#else
 #include <PCSC/winscard.h>
 #include <PCSC/wintypes.h>
+#endif
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 


### PR DESCRIPTION
Fix PCSC/WinSCard compilation under windows.

 - In FindPCSC.cmake, It seems FIND_PATH doesnot correclty handle the msys mount point. So use the LETTER: variant by using MSYS2_FOLDER variable.

- Add some #warning if PCSC and/or Ledger device is disabled.
