### PR TITLE
update mdb_strerror()/_WIN32  for "warning: function may return addre…

### DIFF
--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1629,12 +1629,19 @@ mdb_strerror(int err)
 	}
 #if RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
 	if (!ptr) ptr = malloc(MSGSIZE);
-	if (!ptr) return "MDB_CANNOT_PRTINT_ERR: No mem."
+	if (!ptr) return ("MDB_CANNOT_PRINT_ERR: No mem.");
 #endif
 	*ptr = 0;
 	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL, err, 0, ptr, MSGSIZE, (va_list *)buf+MSGSIZE);
+		NULL, err, 0, ptr, MSGSIZE, 
+#if RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_STACKHACK
+		       (va_list *)buf+MSGSIZE
+#else
+		       NULL
+#endif
+
+		      );
 	return ptr;
 #else
 	return strerror(err);

--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1599,6 +1599,7 @@ mdb_strerror(int err)
 #else
 	need proper RETLOCALVARPT_SOLUTION setting.
 #endif
+#endif
 	int i;
 	if (!err)
 		return ("Successful return: 0");

--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1588,14 +1588,14 @@ mdb_strerror(int err)
 #define PADSIZE	4096
 	char buf[MSGSIZE+PADSIZE], *ptr = buf;
 #elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_LIGHTLYTHREADEDAPP
-	static __declspec(thread) char buf[MSGSIZE];
+	static __thread char buf[MSGSIZE];
 	char *ptr = buf;
 #elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
 	/** BEWARE : There is no cleanup, i.e., "free(ptr);" 
 	 *           If this happens to be a problem, 
 	 *             make it global var and free in the destructor of a global obj instance.
 	 */
-	static __declspec(thread) char* ptr = NULL;
+	static __thread char* ptr = NULL;
 #else
 	need proper RETLOCALVARPT_SOLUTION setting.
 #endif

--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1575,13 +1575,29 @@ char *
 mdb_strerror(int err)
 {
 #ifdef _WIN32
+#define MSGSIZE	1024
+#define RETLOCALVARPTR_STACKHACK  1
+#define RETLOCALVARPTR_LIGHTLYTHREADEDAPP 2
+#define RETLOCALVARPTR_HEAVILYTHREADEDAPP 3
+#define RETLOCALVARPT_SOLUTION RETLOCALVARPTR_HEAVILYTHREADEDAPP
+#if RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_STACKHACK
 	/** HACK: pad 4KB on stack over the buf. Return system msgs in buf.
 	 *	This works as long as no function between the call to mdb_strerror
 	 *	and the actual use of the message uses more than 4K of stack.
 	 */
-#define MSGSIZE	1024
 #define PADSIZE	4096
 	char buf[MSGSIZE+PADSIZE], *ptr = buf;
+#elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_LIGHTLYTHREADEDAPP
+	static __declspec(thread) char buf[MSGSIZE];
+	char *ptr = buf;
+#elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
+	/** BEWARE : There is no cleanup, i.e., "free(ptr);" 
+	 *           If this happens to be a problem, 
+	 *             make it global var and free in the destructor of a global obj instance.
+	 */
+	static __declspec(thread) (char*) ptr = NULL;
+#else
+	need proper RETLOCALVARPT_SOLUTION setting.
 #endif
 	int i;
 	if (!err)
@@ -1610,7 +1626,11 @@ mdb_strerror(int err)
 	default:
 		;
 	}
-	buf[0] = 0;
+#elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
+	if (!ptr) ptr = malloc(MSGSIZE);
+	if (!ptr) return "MDB_CANNOT_PRTINT_ERR: No mem."
+#endif
+	*ptr = 0;
 	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL, err, 0, ptr, MSGSIZE, (va_list *)buf+MSGSIZE);

--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1595,7 +1595,7 @@ mdb_strerror(int err)
 	 *           If this happens to be a problem, 
 	 *             make it global var and free in the destructor of a global obj instance.
 	 */
-	static __declspec(thread) (char*) ptr = NULL;
+	static __declspec(thread) char* ptr = NULL;
 #else
 	need proper RETLOCALVARPT_SOLUTION setting.
 #endif
@@ -1627,7 +1627,7 @@ mdb_strerror(int err)
 	default:
 		;
 	}
-#elif RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
+#if RETLOCALVARPT_SOLUTION == RETLOCALVARPTR_HEAVILYTHREADEDAPP
 	if (!ptr) ptr = malloc(MSGSIZE);
 	if (!ptr) return "MDB_CANNOT_PRTINT_ERR: No mem."
 #endif


### PR DESCRIPTION
…function may return address of local variable [-Wreturn-local-addr]"

Proposed are two raw solutions in addition to current stackhack method :
- lightly threaded app. BEWARE: each thread will occupy MSGSIZE mem just for this function, and
- heavily threaded app. BEWARE: there is no cleanup. Should not be a problem except mem leak reporters could complain occasionally at app exit - only if the function needs to translate an OS error code. 

Both methods NEED testing since they are coded without proper build env.

Regards
