### PR TITLE
rapidjson: fix gcc8 build failure

### DIFF
--- a/external/rapidjson/document.h
+++ b/external/rapidjson/document.h
@@ -1936,7 +1936,12 @@ private:
         if (count) {
             GenericValue* e = static_cast<GenericValue*>(allocator.Malloc(count * sizeof(GenericValue)));
             SetElementsPointer(e);
+RAPIDJSON_DIAG_PUSH
+#if defined(__GNUC__) && __GNUC__ >= 8
+RAPIDJSON_DIAG_OFF(class-memaccess) // ignore complains from gcc that no trivial copy constructor exists.
+#endif
             std::memcpy(e, values, count * sizeof(GenericValue));
+RAPIDJSON_DIAG_POP
         }
         else
             SetElementsPointer(0);
@@ -1949,7 +1954,12 @@ private:
         if (count) {
             Member* m = static_cast<Member*>(allocator.Malloc(count * sizeof(Member)));
             SetMembersPointer(m);
+RAPIDJSON_DIAG_PUSH
+#if defined(__GNUC__) && __GNUC__ >= 8
+RAPIDJSON_DIAG_OFF(class-memaccess) // ignore complains from gcc that no trivial copy constructor exists.
+#endif
             std::memcpy(m, members, count * sizeof(Member));
+RAPIDJSON_DIAG_POP
         }
         else
             SetMembersPointer(0);


### PR DESCRIPTION
Resolves the rapidjson build issue in https://github.com/monero-project/monero/issues/3797 (https://github.com/janisozaur/rapidjson/commit/20f8604ee6cd078c1cb2346148c69c0c2c160db2 was apparently not merged into master).