### PR TITLE
README: update Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,9 @@ Installing a snap is very quick. Snaps are secure. They are isolated with all of
 
         guix package -i monero
 
-* OS X via [Homebrew](http://brew.sh)
+* macOS via [Homebrew](https://brew.sh/)
 
-        brew tap sammy007/cryptonight
-        brew install monero --build-from-source
+        brew install --build-from-source monero
 
 * Docker
 


### PR DESCRIPTION
Remove reference to [sammy007/cryptonight](https://github.com/sammy007/homebrew-cryptonight) in favor of default Homebrew repository [homebrew/core](https://github.com/Homebrew/homebrew-core).

CC @moneromooo-monero 