### PR TITLE
wallet2: only try to remove temp address file if it was created

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3025,7 +3025,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   add_subaddress_account(tr("Primary account"));
 
   if (!wallet_.empty())
-    store();
+    store(create_address_file);
 }
 
 /*!
@@ -3083,7 +3083,7 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const epee::wip
   add_subaddress_account(tr("Primary account"));
 
   if (!wallet_.empty())
-    store();
+    store(create_address_file);
 
   return retval;
 }
@@ -3178,7 +3178,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   add_subaddress_account(tr("Primary account"));
 
   if (!wallet_.empty())
-    store();
+    store(create_address_file);
 }
 
 /*!
@@ -3230,7 +3230,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   add_subaddress_account(tr("Primary account"));
 
   if (!wallet_.empty())
-    store();
+    store(create_address_file);
 }
 
 /*!
@@ -3927,12 +3927,12 @@ std::string wallet2::path() const
   return m_wallet_file;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::store()
+void wallet2::store(bool create_address_file)
 {
-  store_to("", epee::wipeable_string());
+  store_to("", epee::wipeable_string(), create_address_file);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::store_to(const std::string &path, const epee::wipeable_string &password)
+void wallet2::store_to(const std::string &path, const epee::wipeable_string &password, bool create_address_file)
 {
   trim_hashchain();
 
@@ -4009,10 +4009,13 @@ void wallet2::store_to(const std::string &path, const epee::wipeable_string &pas
     if (!r) {
       LOG_ERROR("error removing file: " << old_keys_file);
     }
-    // remove old address file
-    r = boost::filesystem::remove(old_address_file);
-    if (!r) {
-      LOG_ERROR("error removing file: " << old_address_file);
+    // remove old address file if it was created
+    if(create_address_file)
+    {
+      r = boost::filesystem::remove(old_address_file);
+      if (!r) {
+        LOG_ERROR("error removing file: " << old_address_file);
+      }
     }
   } else {
     // save to new file

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -561,13 +561,13 @@ namespace tools
     void rewrite(const std::string& wallet_name, const epee::wipeable_string& password);
     void write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password, std::string &new_keys_filename);
     void load(const std::string& wallet, const epee::wipeable_string& password);
-    void store();
+    void store(bool create_address_file = false);
     /*!
      * \brief store_to  Stores wallet to another file(s), deleting old ones
      * \param path      Path to the wallet file (keys and address filenames will be generated based on this filename)
      * \param password  Password to protect new wallet (TODO: probably better save the password in the wallet object?)
      */
-    void store_to(const std::string &path, const epee::wipeable_string &password);
+    void store_to(const std::string &path, const epee::wipeable_string &password, bool create_address_file = false);
 
     std::string path() const;
 


### PR DESCRIPTION
After #3315 the address.txt file is no longer created by default so we shouldn't be trying to delete a file if it was never created.