### PR TITLE
rpc: fix get_output_distribution cache for the cumulative case

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2112,6 +2112,13 @@ namespace cryptonote
           {
             res.distributions.push_back({amount, slot.start_height, slot.distribution, slot.base});
             found = true;
+            if (req.cumulative)
+            {
+              auto &distribution = res.distributions.back().distribution;
+              distribution[0] += slot.base;
+              for (size_t n = 1; n < distribution.size(); ++n)
+                distribution[n] += distribution[n-1];
+            }
             break;
           }
         }


### PR DESCRIPTION
The distribution was not converted to cumulative after a cache hit