### PR TITLE
daemon: fix readline interfering with std::cerr usage

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -262,6 +262,9 @@ int main(int argc, char const * argv[])
         }
         else
         {
+#ifdef HAVE_READLINE
+          rdln::suspend_readline pause_readline;
+#endif
           std::cerr << "Unknown command: " << command.front() << std::endl;
           return 1;
         }


### PR DESCRIPTION
Once readline is initialized, std::cerr's operator<< will
output a 0xff byte for unknown reasons.