### PR TITLE
Base58 bug fix - encode_block

### DIFF
--- a/src/common/base58.cpp
+++ b/src/common/base58.cpp
@@ -139,7 +139,7 @@ namespace tools
 
         uint64_t num = uint_8be_to_64(reinterpret_cast<const uint8_t*>(block), size);
         int i = static_cast<int>(encoded_block_sizes[size]) - 1;
-        while (0 < num)
+        while (0 <= i)
         {
           uint64_t remainder = num % alphabet_size;
           num /= alphabet_size;


### PR DESCRIPTION
Hi,

I suspect there is a bug in the `tools::base58::encode_block`. The while loop is:

```
while (0 < num)
```

The `num` is 64bit unsigned integer reconstructed from the block buffer. The thing is the `num` can be < 0 before all block size digits are set - when num is small, some digits in the memory remain uninitialized. 

Therefore the while should be the following so all block digits are set:

```
while(0 <= i)
```

Example:

When encoding the following address (12 for mainnet, spend key, view key, checksum):

```
12639050436fa36c8288706771412c5972461578d564188cd7fc6f81d6973d064fa461afe66fb23879936d7225051bebbf7f3ae0c801a90bb99fbb346b2fd4d7027891bec8
```

the base58 encoding should look like the following:

```
45PwgoUKaDHNqLL8o3okzLL7biv7GqPVmd8LTcTrYVrMEKdSYwFcyJfMLSRpfU3nh8Z2m81FJD4sUY3nXCdGe61k1HAp8T1
```

But the thing is due to the bug, during the last block encoding the `num = 10612752072` is zero before the `b[88]` is set. 
I.e, due to `log(num, 58) = 5.685` the 7th digit is not set and remain unitialized.
The last block should have been `1HAp8T1` but it is `?HAp8T1`.

As I don't have any more time to analyze it any further, please take it from here. I wanted to check out the unit tests and validate the patch / find how come this was not detected before. 

This bug could have some nasty consequences, i.e., for some keys the valid address won't be generated due to invalid checksum. 

Thanks for considering the PR.





