### PR TITLE
Account: fix wiping fake spend key

### DIFF
--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -157,7 +157,7 @@ DISABLE_VS_WARNINGS(4244 4345)
   void account_base::create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey)
   {
     crypto::secret_key fake;
-    memset(&fake, 0, sizeof(fake));
+    fake.scrub();
     create_from_keys(address, fake, viewkey);
   }
   //-----------------------------------------------------------------


### PR DESCRIPTION
Use secret key member function to wipe the spend key in a watch-only account.
Fixes compiler error about using `memset` on a non-trivial type:
```
/monero/src/cryptonote_basic/account.cpp: In member function 'void cryptonote::account_base::create_from_viewkey(const cryptonote:
:account_public_address&, const secret_key&)':                                                                                              
/monero/src/cryptonote_basic/account.cpp:160:34: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 
'using secret_key = struct tools::scrubbed<crypto::ec_scalar>' {aka 'struct tools::scrubbed<crypto::ec_scalar>'}; use assignment or value-in
itialization instead [-Werror=class-memaccess]                                                                                              
     memset(&fake, 0, sizeof(fake));                                                                                                        
                                  ^                                                                                                         
```