### PR TITLE
Fix for compile error on freebsd `const basic_string`

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
       "blackball-db-dir", "Specify blackball database directory",
       get_default_db_path(),
       {{ &arg_testnet_on, &arg_stagenet_on }},
-      [](std::array<bool, 2> testnet_stagenet, bool defaulted, std::string val) {
+      [](std::array<bool, 2> testnet_stagenet, bool defaulted, std::string val)->std::string {
         if (testnet_stagenet[0])
           return (boost::filesystem::path(val) / "testnet").string();
         else if (testnet_stagenet[1])


### PR DESCRIPTION
Fixes error message on freebsd that not all return values in the lambda are of the same type

Fixes #3645 

`return type basic_string<[3 * ...]> must match previous return type const basic_string<[3 * ...]> when lambda expression has unspecified explicit return type`