### PR TITLE
Add submodule init and update to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,14 @@ else()
   message(STATUS "Building without build tag")
 endif()
 
+if(NOT MANUAL_SUBMODULES)
+  find_package(Git)
+  if(GIT_FOUND)
+    message(STATUS "Initializing submodules")
+    execute_process(COMMAND git "submodule" "update" "--init" "--recursive" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  endif()
+endif()
+
 set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 

--- a/README.md
+++ b/README.md
@@ -194,13 +194,12 @@ build the library binary manually. This can be done with the following command `
 
 ### Cloning the repository
 
-Clone recursively to pull-in needed submodule(s):
+Clone the repository from github to get the monero source code:
 
-`$ git clone --recursive https://github.com/monero-project/monero`
+`$ git clone https://github.com/monero-project/monero`
 
-If you already have a repo cloned, initialize and update:
-
-`$ cd monero && git submodule init && git submodule update`
+Submodules are fetched automatically in the cmake script. If you wish to
+control this manually, run cmake with `cmake -DMANUAL_SUBMODULES=ON`
 
 ### Build instructions
 


### PR DESCRIPTION
Instead of making the user update and init submodules manually, add a step in cmake that does it.
Also gets rid of the extra step in the documentation, it is now enough to just clone the repo.