### PR TITLE
simplewallet: add optional trusted/untrusted argument to set_daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,8 @@ setting the following configuration parameters and environment variables:
    as well.
 * Do NOT pass `--detach` when running through torsocks with systemd, (see
   [utils/systemd/monerod.service](utils/systemd/monerod.service) for details).
+* If you use the wallet with a Tor daemon via the loopback IP (eg, 127.0.0.1:9050),
+  then use `--untrusted-daemon` unless it is your own hidden service.
 
 Example command line to start monerod through Tor:
 

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -657,6 +657,13 @@ std::string get_nix_version_display_string()
 
   bool is_local_address(const std::string &address)
   {
+    // always assume Tor/I2P addresses to be untrusted by default
+    if (boost::ends_with(address, ".onion") || boost::ends_with(address, ".i2p"))
+    {
+      MDEBUG("Address '" << address << "' is Tor/I2P, non local");
+      return false;
+    }
+
     // extract host
     epee::net_utils::http::url_content u_c;
     if (!epee::net_utils::parse_url(address, u_c))


### PR DESCRIPTION
Otherwise the previous daemon's trustedness would carry over.
If not specified, the local address check is performed again.