### PR TITLE
readme - explain building master vs. release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Build
 
+### IMPORTANT 
+
+These builds are of the master branch, which is used for active development and can be either unstable or incompatible with release software. Please compile release branches.
+
 | Operating System      | Processor | Status |
 | --------------------- | -------- |--------|
 | Ubuntu 16.04          |  i686    | [![Ubuntu 16.04 i686](https://build.getmonero.org/png?builder=monero-static-ubuntu-i686)](https://build.getmonero.org/builders/monero-static-ubuntu-i686)
@@ -210,9 +214,10 @@ invokes cmake commands as needed.
 #### On Linux and OS X
 
 * Install the dependencies
-* Change to the root of the source code directory and build:
+* Change to the root of the source code directory, change to the most recent release branch, and build:
 
         cd monero
+        git checkout v0.12.2.0
         make
 
     *Optional*: If your machine has several cores and enough memory, enable
@@ -222,6 +227,12 @@ invokes cmake commands as needed.
 
     *Note*: If cmake can not find zmq.hpp file on OS X, installing `zmq.hpp` from
     https://github.com/zeromq/cppzmq to `/usr/local/include` should fix that error.
+    
+    *Note*: The instructions above will compile the most stable release of the
+    Monero software. If you would like to use and test the most recent software,
+    use ```git checkout master```. The master branch may contain updates that are
+    both unstable and incompatible with release software, though testing is always 
+    encouraged. 
 
 * The resulting executables can be found in `build/release/bin`
 
@@ -268,7 +279,7 @@ Tested on a Raspberry Pi Zero with a clean install of minimal Raspbian Stretch (
 ```
         git clone https://github.com/monero-project/monero.git
 	cd monero
-	git checkout tags/v0.11.1.0
+	git checkout tags/v0.12.2.0
 ```
 * Build:
 ```


### PR DESCRIPTION
Update readme to explain and warn about building master, and encourage (via example) to build release branches.  

Also updated instance where example build instructions had 0.11.0 as the most recent release.