### PR TITLE
wallet: do not log by default if we're not asked to log to console

### DIFF
--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -185,6 +185,10 @@ namespace wallet_args
     {
       mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());
     }
+    else if (!log_to_console)
+    {
+      mlog_set_categories("");
+    }
 
     if (notice)
       Print(print) << notice << ENDL;


### PR DESCRIPTION
This means monero-wallet-rpc still does, but the user level program
does not.