### PR TITLE
wallet2: recover from index out of hashchain bounds error

### DIFF
--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -70,6 +70,7 @@ namespace tools
     //         get_out_indexes_error
     //         tx_parse_error
     //         get_tx_pool_error
+    //         out_of_hashchain_bounds_error
     //       transfer_error *
     //         get_random_outs_general_error
     //         not_enough_unlocked_money
@@ -392,6 +393,16 @@ namespace tools
     {
       explicit get_tx_pool_error(std::string&& loc)
         : refresh_error(std::move(loc), "error getting transaction pool")
+      {
+      }
+
+      std::string to_string() const { return refresh_error::to_string(); }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct out_of_hashchain_bounds_error : public refresh_error
+    {
+      explicit out_of_hashchain_bounds_error(std::string&& loc)
+        : refresh_error(std::move(loc), "Index out of bounds of of hashchain")
       {
       }
 


### PR DESCRIPTION
This can happen when there's a very large reorg on the daemon
(ie, on testnet)