### PR TITLE
add and use constant time 32 byte equality function

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ library archives (`.a`).
 | libzmq       | 3.0.0         | NO       | `libzmq3-dev`      | `zeromq`     | `cppzmq-devel`    | NO       | ZeroMQ library |
 | OpenPGM      | ?             | NO       | `libpgm-dev`       | `libpgm`     | `openpgm-devel`   | NO       | For ZeroMQ     |
 | libunbound   | 1.4.16        | YES      | `libunbound-dev`   | `unbound`    | `unbound-devel`   | NO       | DNS resolver   |
-| libsodium    | ?             | NO       | `libsodium-dev`    | ?            | `libsodium-devel` | NO       | libsodium      |
+| libsodium    | ?             | NO       | `libsodium-dev`    | ?            | `libsodium-devel` | NO       | cryptography   |
 | libunwind    | any           | NO       | `libunwind8-dev`   | `libunwind`  | `libunwind-devel` | YES      | Stack traces   |
 | liblzma      | any           | NO       | `liblzma-dev`      | `xz`         | `xz-devel`        | YES      | For libunwind  |
 | libreadline  | 6.3.0         | NO       | `libreadline6-dev` | `readline`   | `readline-devel`  | YES      | Input editing  |

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(cncrypto
   PUBLIC
     epee
     ${Boost_SYSTEM_LIBRARY}
+    ${SODIUM_LIBRARY}
   PRIVATE
     ${EXTRA_LIBRARIES})
 

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -283,6 +283,6 @@ namespace crypto {
 }
 
 CRYPTO_MAKE_HASHABLE(public_key)
-CRYPTO_MAKE_HASHABLE(secret_key)
+CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(secret_key)
 CRYPTO_MAKE_HASHABLE(key_image)
 CRYPTO_MAKE_COMPARABLE(signature)

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -136,7 +136,8 @@ namespace hw {
     }
 
     bool operator==(const crypto::key_derivation &d0, const crypto::key_derivation &d1) {
-      return !memcmp(&d0, &d1, sizeof(d0));
+      static_assert(sizeof(crypto::key_derivation) == 32, "key_derivation must be 32 bytes");
+      return !crypto_verify_32((const unsigned char*)&d0, (const unsigned char*)&d1);
     }
 
     /* ===================================================================== */

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <iostream>
 #include <cinttypes>
+#include <sodium/crypto_verify_32.h>
 
 extern "C" {
 #include "crypto/crypto-ops.h"
@@ -81,7 +82,7 @@ namespace rct {
         unsigned char operator[](int i) const {
             return bytes[i];
         }
-        bool operator==(const key &k) const { return !memcmp(bytes, k.bytes, sizeof(bytes)); }
+        bool operator==(const key &k) const { return !crypto_verify_32(bytes, k.bytes); }
         unsigned char bytes[32];
     };
     typedef std::vector<key> keyV; //vector of keys
@@ -524,16 +525,16 @@ namespace rct {
     static inline const crypto::secret_key rct2sk(const rct::key &k) { return (const crypto::secret_key&)k; }
     static inline const crypto::key_image rct2ki(const rct::key &k) { return (const crypto::key_image&)k; }
     static inline const crypto::hash rct2hash(const rct::key &k) { return (const crypto::hash&)k; }
-    static inline bool operator==(const rct::key &k0, const crypto::public_key &k1) { return !memcmp(&k0, &k1, 32); }
-    static inline bool operator!=(const rct::key &k0, const crypto::public_key &k1) { return memcmp(&k0, &k1, 32); }
+    static inline bool operator==(const rct::key &k0, const crypto::public_key &k1) { return !crypto_verify_32(k0.bytes, (const unsigned char*)&k1); }
+    static inline bool operator!=(const rct::key &k0, const crypto::public_key &k1) { return crypto_verify_32(k0.bytes, (const unsigned char*)&k1); }
 }
 
 
 namespace cryptonote {
-    static inline bool operator==(const crypto::public_key &k0, const rct::key &k1) { return !memcmp(&k0, &k1, 32); }
-    static inline bool operator!=(const crypto::public_key &k0, const rct::key &k1) { return memcmp(&k0, &k1, 32); }
-    static inline bool operator==(const crypto::secret_key &k0, const rct::key &k1) { return !memcmp(&k0, &k1, 32); }
-    static inline bool operator!=(const crypto::secret_key &k0, const rct::key &k1) { return memcmp(&k0, &k1, 32); }
+    static inline bool operator==(const crypto::public_key &k0, const rct::key &k1) { return !crypto_verify_32((const unsigned char*)&k0, k1.bytes); }
+    static inline bool operator!=(const crypto::public_key &k0, const rct::key &k1) { return crypto_verify_32((const unsigned char*)&k0, k1.bytes); }
+    static inline bool operator==(const crypto::secret_key &k0, const rct::key &k1) { return !crypto_verify_32((const unsigned char*)&k0, k1.bytes); }
+    static inline bool operator!=(const crypto::secret_key &k0, const rct::key &k1) { return crypto_verify_32((const unsigned char*)&k0, k1.bytes); }
 }
 
 namespace rct {

--- a/tests/performance_tests/equality.h
+++ b/tests/performance_tests/equality.h
@@ -30,53 +30,43 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstring>
-#include <functional>
+#include <string.h>
 #include <sodium/crypto_verify_32.h>
 
-#define CRYPTO_MAKE_COMPARABLE(type) \
-namespace crypto { \
-  inline bool operator==(const type &_v1, const type &_v2) { \
-    return !memcmp(&_v1, &_v2, sizeof(_v1)); \
-  } \
-  inline bool operator!=(const type &_v1, const type &_v2) { \
-    return !operator==(_v1, _v2); \
-  } \
-}
+struct memcmp32
+{
+  static const size_t loop_count = 1000000000;
+  static int call(const unsigned char *k0, const unsigned char *k1){ return memcmp(k0, k1, 32); }
+};
 
-#define CRYPTO_MAKE_COMPARABLE_CONSTANT_TIME(type) \
-namespace crypto { \
-  inline bool operator==(const type &_v1, const type &_v2) { \
-    static_assert(sizeof(_v1) == 32, "constant time comparison is only implenmted for 32 bytes"); \
-    return crypto_verify_32((const unsigned char*)&_v1, (const unsigned char*)&_v2) == 0; \
-  } \
-  inline bool operator!=(const type &_v1, const type &_v2) { \
-    return !operator==(_v1, _v2); \
-  } \
-}
+struct verify32
+{
+  static const size_t loop_count = 10000000;
+  static int call(const unsigned char *k0, const unsigned char *k1){ return crypto_verify_32(k0, k1); }
+};
 
-#define CRYPTO_DEFINE_HASH_FUNCTIONS(type) \
-namespace crypto { \
-  static_assert(sizeof(std::size_t) <= sizeof(type), "Size of " #type " must be at least that of size_t"); \
-  inline std::size_t hash_value(const type &_v) { \
-    return reinterpret_cast<const std::size_t &>(_v); \
-  } \
-} \
-namespace std { \
-  template<> \
-  struct hash<crypto::type> { \
-    std::size_t operator()(const crypto::type &_v) const { \
-      return reinterpret_cast<const std::size_t &>(_v); \
-    } \
-  }; \
-}
+template<typename f, bool equal>
+class test_equality
+{
+public:
+  static const size_t loop_count = f::loop_count;
 
-#define CRYPTO_MAKE_HASHABLE(type) \
-CRYPTO_MAKE_COMPARABLE(type) \
-CRYPTO_DEFINE_HASH_FUNCTIONS(type)
+  bool init()
+  {
+    for (int n = 0; n < 32; ++n)
+      k0[n] = n;
+    for (int n = 0; n < 32; ++n)
+      k1[n] = equal ? n : n + 1;
+    return true;
+  }
 
-#define CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(type) \
-CRYPTO_MAKE_COMPARABLE_CONSTANT_TIME(type) \
-CRYPTO_DEFINE_HASH_FUNCTIONS(type)
+  bool test()
+  {
+    return equal == !f::call(k0, k1);
+  }
+
+private:
+  unsigned char k0[32];
+  unsigned char k1[32];
+};
 

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -51,6 +51,7 @@
 #include "sc_reduce32.h"
 #include "cn_fast_hash.h"
 #include "rct_mlsag.h"
+#include "equality.h"
 
 namespace po = boost::program_options;
 
@@ -150,6 +151,11 @@ int main(int argc, char** argv)
   TEST_PERFORMANCE3(filter, test_ringct_mlsag, 1, 5, true);
   TEST_PERFORMANCE3(filter, test_ringct_mlsag, 1, 10, true);
   TEST_PERFORMANCE3(filter, test_ringct_mlsag, 1, 100, true);
+
+  TEST_PERFORMANCE2(filter, test_equality, memcmp32, true);
+  TEST_PERFORMANCE2(filter, test_equality, memcmp32, false);
+  TEST_PERFORMANCE2(filter, test_equality, verify32, false);
+  TEST_PERFORMANCE2(filter, test_equality, verify32, false);
 
   std::cout << "Tests finished. Elapsed time: " << timer.elapsed_ms() / 1000 << " sec" << std::endl;
 

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -81,3 +81,18 @@ TEST(Crypto, null_keys)
   ASSERT_EQ(memcmp(crypto::null_skey.data, zero, 32), 0);
   ASSERT_EQ(memcmp(crypto::null_pkey.data, zero, 32), 0);
 }
+
+TEST(Crypto, verify_32)
+{
+  // all bytes are treated the same, so we can brute force just one byte
+  unsigned char k0[32] = {0}, k1[32] = {0};
+  for (unsigned int i0 = 0; i0 < 256; ++i0)
+  {
+    k0[0] = i0;
+    for (unsigned int i1 = 0; i1 < 256; ++i1)
+    {
+      k1[0] = i1;
+      ASSERT_EQ(!crypto_verify_32(k0, k1), i0 == i1);
+    }
+  }
+}


### PR DESCRIPTION
Oddly, it looks like while it's way slower than memcmp, the timings for both different and equal are pretty similar for both.