### PR TITLE
[monerod][Tested Working][Request Execution] Added blocks remaining count and percent of advancment during syncronisation

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1167,8 +1167,20 @@ skip:
                 + " blocks/sec), " + std::to_string(m_block_queue.get_data_size() / 1048576.f) + " MB queued";
             if (ELPP->vRegistry()->allowed(el::Level::Debug, "sync-info"))
               timing_message += std::string(": ") + m_block_queue.get_overview();
-            MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+            if(m_core.get_target_blockchain_height() == 0){
+              MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
                 << timing_message);
+            } else {
+              const int completition_percent = (m_core.get_current_blockchain_height() * 100 / m_core.get_target_blockchain_height());
+              if(completition_percent < 99) {//printing completion percent only if % is < of 99 cause for 99 >= this is useless
+                MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+                  << " (" << completition_percent << "% " << (m_core.get_target_blockchain_height() - m_core.get_current_blockchain_height())
+                  << " blocks remaining)" << timing_message);
+              } else {
+                MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+                  << timing_message);
+              }
+            }
           }
         }
       }
@@ -1747,3 +1759,4 @@ skip:
     m_core.stop();
   }
 } // namespace
+


### PR DESCRIPTION
Before :
```
[76.204.26.194:18080 OUT]  Synced 20801/1597463
```
Now :
```
[201.153.31.87:18080 OUT]  Synced 35371/1597473 2% (1562102 blocks remaining)
```
Tested on Ubuntu 17.10 (amd64), Ubuntu 18.04 (amd64) and working for both (not very incredible, I just add some text processioning).
It was requested in #4014 
This pr is clone of #4017 