### PR TITLE
M/N multisig support

### DIFF
--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -130,8 +130,8 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
       ss << "  " << name << std::endl;
     }
 
-    // finalize step if needed
-    if (!extra_info[0].empty())
+    //exchange keys unless exchange_multisig_keys returns no extra info
+    while (!extra_info[0].empty())
     {
       std::unordered_set<crypto::public_key> pkeys;
       std::vector<crypto::public_key> signers(total);
@@ -145,11 +145,7 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
       }
       for (size_t n = 0; n < total; ++n)
       {
-        if (!wallets[n]->finalize_multisig(pwd_container->password(), pkeys, signers))
-        {
-          tools::fail_msg_writer() << genms::tr("Error finalizing multisig");
-          return false;
-        }
+          extra_info[n] = wallets[n]->exchange_multisig_keys(pwd_container->password(), pkeys, signers);
       }
     }
 
@@ -244,11 +240,6 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  if (threshold != total-1 && threshold != total)
-  {
-    tools::fail_msg_writer() << genms::tr("Error: unsupported scheme: only N/N and N-1/N are supported");
-    return 1;
-  }
   bool create_address_file = command_line::get_arg(*vm, arg_create_address_file);
   if (!generate_multisig(threshold, total, basename, testnet ? TESTNET : stagenet ? STAGENET : MAINNET, create_address_file))
     return 1;

--- a/src/multisig/multisig.cpp
+++ b/src/multisig/multisig.cpp
@@ -84,6 +84,43 @@ namespace cryptonote
     }
   }
   //-----------------------------------------------------------------
+  std::vector<crypto::public_key> generate_multisig_derivations(const account_keys &keys, const std::vector<crypto::public_key> &derivations)
+  {
+    std::vector<crypto::public_key> multisig_keys;
+    crypto::secret_key blinded_skey = get_multisig_blinded_secret_key(keys.m_spend_secret_key);
+    for (const auto &k: derivations)
+    {
+      rct::key d = rct::scalarmultKey(rct::pk2rct(k), rct::sk2rct(blinded_skey));
+      multisig_keys.push_back(rct::rct2pk(d));
+    }
+
+    return multisig_keys;
+  }
+  //-----------------------------------------------------------------
+  crypto::secret_key calculate_multisig_signer_key(const std::vector<crypto::secret_key>& multisig_keys)
+  {
+    rct::key secret_key = rct::zero();
+    for (const auto &k: multisig_keys)
+    {
+      sc_add(secret_key.bytes, secret_key.bytes, (const unsigned char*)k.data);
+    }
+
+    return rct::rct2sk(secret_key);
+  }
+  //-----------------------------------------------------------------
+  std::vector<crypto::secret_key> calculate_multisig_keys(const std::vector<crypto::public_key>& derivations)
+  {
+    std::vector<crypto::secret_key> multisig_keys;
+    multisig_keys.reserve(derivations.size());
+
+    for (const auto &k: derivations)
+    {
+      multisig_keys.emplace_back(get_multisig_blinded_secret_key(rct::rct2sk(rct::pk2rct(k))));
+    }
+
+    return multisig_keys;
+  }
+  //-----------------------------------------------------------------
   crypto::secret_key generate_multisig_view_secret_key(const crypto::secret_key &skey, const std::vector<crypto::secret_key> &skeys)
   {
     rct::key view_skey = rct::sk2rct(get_multisig_blinded_secret_key(skey));
@@ -92,7 +129,7 @@ namespace cryptonote
     return rct::rct2sk(view_skey);
   }
   //-----------------------------------------------------------------
-  crypto::public_key generate_multisig_N1_N_spend_public_key(const std::vector<crypto::public_key> &pkeys)
+  crypto::public_key generate_multisig_M_N_spend_public_key(const std::vector<crypto::public_key> &pkeys)
   {
     rct::key spend_public_key = rct::identity();
     for (const auto &pk: pkeys)
@@ -141,4 +178,9 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------
+  uint32_t multisig_rounds_required(uint32_t participants, uint32_t threshold)
+  {
+    CHECK_AND_ASSERT_THROW_MES(participants >= threshold, "participants must be greater or equal than threshold");
+    return participants - threshold + 1;
+  }
 }

--- a/src/multisig/multisig.h
+++ b/src/multisig/multisig.h
@@ -41,9 +41,31 @@ namespace cryptonote
   crypto::secret_key get_multisig_blinded_secret_key(const crypto::secret_key &key);
   void generate_multisig_N_N(const account_keys &keys, const std::vector<crypto::public_key> &spend_keys, std::vector<crypto::secret_key> &multisig_keys, rct::key &spend_skey, rct::key &spend_pkey);
   void generate_multisig_N1_N(const account_keys &keys, const std::vector<crypto::public_key> &spend_keys, std::vector<crypto::secret_key> &multisig_keys, rct::key &spend_skey, rct::key &spend_pkey);
+  /**
+   * @brief generate_multisig_derivations performs common DH key derivation.
+   *    Each middle round in M/N scheme is DH exchange of public multisig keys of other participants multiplied by secret spend key of current participant.
+   *    this functions does the following: new multisig key = secret spend * public multisig key
+   * @param keys - current wallet's keys
+   * @param derivations - public multisig keys of other participants
+   * @return new public multisig keys derived from previous round. This data needs to be exchange with other participants
+   */
+  std::vector<crypto::public_key> generate_multisig_derivations(const account_keys &keys, const std::vector<crypto::public_key> &derivations);
+  crypto::secret_key calculate_multisig_signer_key(const std::vector<crypto::secret_key>& derivations);
+  /**
+   * @brief calculate_multisig_keys. Calculates secret multisig keys from others' participants ones as follows: mi = H(Mi)
+   * @param derivations - others' participants public multisig keys.
+   * @return vector of current wallet's multisig secret keys
+   */
+  std::vector<crypto::secret_key> calculate_multisig_keys(const std::vector<crypto::public_key>& derivations);
   crypto::secret_key generate_multisig_view_secret_key(const crypto::secret_key &skey, const std::vector<crypto::secret_key> &skeys);
-  crypto::public_key generate_multisig_N1_N_spend_public_key(const std::vector<crypto::public_key> &pkeys);
+  /**
+   * @brief generate_multisig_M_N_spend_public_key calculates multisig wallet's spend public key by summing all of public multisig keys
+   * @param pkeys unique public multisig keys
+   * @return multisig wallet's spend public key
+   */
+  crypto::public_key generate_multisig_M_N_spend_public_key(const std::vector<crypto::public_key> &pkeys);
   bool generate_multisig_key_image(const account_keys &keys, size_t multisig_key_index, const crypto::public_key& out_key, crypto::key_image& ki);
   void generate_multisig_LR(const crypto::public_key pkey, const crypto::secret_key &k, crypto::public_key &L, crypto::public_key &R);
   bool generate_multisig_composite_key_image(const account_keys &keys, const std::unordered_map<crypto::public_key, cryptonote::subaddress_index>& subaddresses, const crypto::public_key& out_key, const crypto::public_key &tx_public_key, const std::vector<crypto::public_key>& additional_tx_public_keys, size_t real_output_index, const std::vector<crypto::key_image> &pkis, crypto::key_image &ki);
+  uint32_t multisig_rounds_required(uint32_t participants, uint32_t threshold);
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -210,6 +210,7 @@ namespace cryptonote
     bool prepare_multisig(const std::vector<std::string>& args);
     bool make_multisig(const std::vector<std::string>& args);
     bool finalize_multisig(const std::vector<std::string> &args);
+    bool exchange_multisig_keys(const std::vector<std::string> &args);
     bool export_multisig(const std::vector<std::string>& args);
     bool import_multisig(const std::vector<std::string>& args);
     bool accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs);

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1187,6 +1187,20 @@ string WalletImpl::makeMultisig(const vector<string>& info, uint32_t threshold) 
     return string();
 }
 
+std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info) {
+    try {
+        clearStatus();
+        checkMultisigWalletNotReady(m_wallet);
+
+        return m_wallet->exchange_multisig_keys(epee::wipeable_string(m_password), info);
+    } catch (const exception& e) {
+        LOG_ERROR("Error on exchanging multisig keys: ") << e.what();
+        setStatusError(string(tr("Failed to make multisig: ")) + e.what());
+    }
+
+    return string();
+}
+
 bool WalletImpl::finalizeMultisig(const vector<string>& extraMultisigInfo) {
     try {
         clearStatus();

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -137,6 +137,7 @@ public:
     MultisigState multisig() const override;
     std::string getMultisigInfo() const override;
     std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) override;
+    std::string exchangeMultisigKeys(const std::vector<std::string> &info) override;
     bool finalizeMultisig(const std::vector<std::string>& extraMultisigInfo) override;
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -707,6 +707,12 @@ struct Wallet
      */
     virtual std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) = 0;
     /**
+     * @brief exchange_multisig_keys - provides additional key exchange round for arbitrary multisig schemes (like N-1/N, M/N)
+     * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
+     * @return new info string if more rounds required or an empty string if wallet creation is done
+     */
+    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info) = 0;
+    /**
      * @brief finalizeMultisig - finalizes N - 1 / N multisig wallets creation
      * @param extraMultisigInfo - wallet participants' extra multisig info obtained with makeMultisig call
      * @return true if success

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -121,6 +121,7 @@ using namespace cryptonote;
 #define FIRST_REFRESH_GRANULARITY     1024
 
 static const std::string MULTISIG_SIGNATURE_MAGIC = "SigMultisigPkV1";
+static const std::string MULTISIG_EXTRA_INFO_MAGIC = "MultisigxV1";
 
 namespace
 {
@@ -131,6 +132,42 @@ namespace
     dir = dir.remove_filename();
     dir /= ".shared-ringdb";
     return dir.string();
+  }
+
+  std::string pack_multisignature_keys(const std::string& prefix, const std::vector<crypto::public_key>& keys, const crypto::secret_key& signer_secret_key)
+  {
+    std::string data;
+    crypto::public_key signer;
+    CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(signer_secret_key, signer), "Failed to derive public spend key");
+    data += std::string((const char *)&signer, sizeof(crypto::public_key));
+
+    for (const auto &key: keys)
+    {
+      data += std::string((const char *)&key, sizeof(crypto::public_key));
+    }
+
+    data.resize(data.size() + sizeof(crypto::signature));
+
+    crypto::hash hash;
+    crypto::cn_fast_hash(data.data(), data.size() - sizeof(crypto::signature), hash);
+    crypto::signature &signature = *(crypto::signature*)&data[data.size() - sizeof(crypto::signature)];
+    crypto::generate_signature(hash, signer, signer_secret_key, signature);
+
+    return MULTISIG_EXTRA_INFO_MAGIC + tools::base58::encode(data);
+  }
+
+  std::vector<crypto::public_key> secret_keys_to_public_keys(const std::vector<crypto::secret_key>& keys)
+  {
+    std::vector<crypto::public_key> public_keys;
+    public_keys.reserve(keys.size());
+
+    std::transform(keys.begin(), keys.end(), std::back_inserter(public_keys), [] (const crypto::secret_key& k) -> crypto::public_key {
+      crypto::public_key p;
+      CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(k, p), "Failed to derive public spend key");
+      return p;
+    });
+
+    return public_keys;
   }
 }
 
@@ -758,6 +795,7 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended):
   m_callback(0),
   m_trusted_daemon(false),
   m_nettype(nettype),
+  m_multisig_rounds_passed(0),
   m_always_confirm_transfers(true),
   m_print_ring_members(false),
   m_store_tx_info(true),
@@ -2885,6 +2923,7 @@ bool wallet2::clear()
   m_address_book.clear();
   m_subaddresses.clear();
   m_subaddress_labels.clear();
+  m_multisig_rounds_passed = 0;
   return true;
 }
 
@@ -2899,6 +2938,7 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
 {
   std::string account_data;
   std::string multisig_signers;
+  std::string multisig_derivations;
   cryptonote::account_base account = m_account;
 
   crypto::chacha_key key;
@@ -2951,6 +2991,14 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
     CHECK_AND_ASSERT_MES(r, false, "failed to serialize wallet multisig signers");
     value.SetString(multisig_signers.c_str(), multisig_signers.length());
     json.AddMember("multisig_signers", value, json.GetAllocator());
+
+    r = ::serialization::dump_binary(m_multisig_derivations, multisig_derivations);
+    CHECK_AND_ASSERT_MES(r, false, "failed to serialize wallet multisig derivations");
+    value.SetString(multisig_derivations.c_str(), multisig_derivations.length());
+    json.AddMember("multisig_derivations", value, json.GetAllocator());
+
+    value2.SetUint(m_multisig_rounds_passed);
+    json.AddMember("multisig_rounds_passed", value2, json.GetAllocator());
   }
 
   value2.SetInt(m_always_confirm_transfers ? 1 :0);
@@ -3123,6 +3171,8 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     m_multisig = false;
     m_multisig_threshold = 0;
     m_multisig_signers.clear();
+    m_multisig_rounds_passed = 0;
+    m_multisig_derivations.clear();
     m_always_confirm_transfers = false;
     m_print_ring_members = false;
     m_default_mixin = 0;
@@ -3181,6 +3231,8 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     m_multisig = field_multisig;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, multisig_threshold, unsigned int, Uint, m_multisig, 0);
     m_multisig_threshold = field_multisig_threshold;
+    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, multisig_rounds_passed, unsigned int, Uint, false, 0);
+    m_multisig_rounds_passed = field_multisig_rounds_passed;
     if (m_multisig)
     {
       if (!json.HasMember("multisig_signers"))
@@ -3200,6 +3252,24 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
       {
         LOG_ERROR("Field multisig_signers found in JSON, but failed to parse");
         return false;
+      }
+
+      //previous version of multisig does not have this field
+      if (json.HasMember("multisig_derivations"))
+      {
+        if (!json["multisig_derivations"].IsString())
+        {
+          LOG_ERROR("Field multisig_derivations found in JSON, but not String");
+          return false;
+        }
+        const char *field_multisig_derivations = json["multisig_derivations"].GetString();
+        std::string multisig_derivations = std::string(field_multisig_derivations, field_multisig_derivations + json["multisig_derivations"].GetStringLength());
+        r = ::serialization::parse_binary(multisig_derivations, m_multisig_derivations);
+        if (!r)
+        {
+          LOG_ERROR("Field multisig_derivations found in JSON, but failed to parse");
+          return false;
+        }
       }
     }
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, always_confirm_transfers, int, Int, false, true);
@@ -3829,12 +3899,12 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   CHECK_AND_ASSERT_THROW_MES(!view_keys.empty(), "empty view keys");
   CHECK_AND_ASSERT_THROW_MES(view_keys.size() == spend_keys.size(), "Mismatched view/spend key sizes");
   CHECK_AND_ASSERT_THROW_MES(threshold > 1 && threshold <= spend_keys.size() + 1, "Invalid threshold");
-  CHECK_AND_ASSERT_THROW_MES(threshold == spend_keys.size() || threshold == spend_keys.size() + 1, "Unsupported threshold case");
 
   std::string extra_multisig_info;
-  crypto::hash hash;
-
-  clear();
+  std::vector<crypto::secret_key> multisig_keys;
+  rct::key spend_pkey = rct::identity();
+  rct::key spend_skey;
+  std::vector<crypto::public_key> multisig_signers;
 
   // decrypt keys
   epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
@@ -3847,43 +3917,78 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
     keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this, chacha_key]() { m_account.encrypt_keys(chacha_key); m_account.decrypt_viewkey(chacha_key); });
   }
 
-  MINFO("Creating spend key...");
-  std::vector<crypto::secret_key> multisig_keys;
-  rct::key spend_pkey, spend_skey;
+  // In common multisig scheme there are 4 types of key exchange rounds:
+  // 1. First round is exchange of view secret keys and public spend keys.
+  // 2. Middle round is exchange of derivations: Ki = b * Mj, where b - spend secret key,
+  //    M - public multisig key (in first round it equals to public spend key), K - new public multisig key.
+  // 3. Secret spend establishment round sets your secret multisig keys as follows: kl = H(Ml), where M - is *your* public multisig key,
+  //    k - secret multisig key used to sign transactions. k and M are sets of keys, of course.
+  //    And secret spend key as the sum of all participant's secret multisig keys
+  // 4. Last round establishes multisig wallet's public spend key. Participants exchange their public multisig keys
+  //    and calculate common spend public key as sum of all unique participants' public multisig keys.
+  // Note that N/N scheme has only first round. N-1/N has 2 rounds: first and last. Common M/N has all 4 rounds.
+
+  // IMPORTANT: wallet's public spend key is not equal to secret_spend_key * G!
+  // Wallet's public spend key is the sum of unique public multisig keys of all participants.
+  // secret_spend_key * G = public signer key
+
   if (threshold == spend_keys.size() + 1)
   {
+    // In N / N case we only need to do one round and calculate secret multisig keys and new secret spend key
+    MINFO("Creating spend key...");
+
+    // Calculates all multisig keys and spend key
     cryptonote::generate_multisig_N_N(get_account().get_keys(), spend_keys, multisig_keys, spend_skey, spend_pkey);
-  }
-  else if (threshold == spend_keys.size())
-  {
-    cryptonote::generate_multisig_N1_N(get_account().get_keys(), spend_keys, multisig_keys, spend_skey, spend_pkey);
 
-    // We need an extra step, so we package all the composite public keys
-    // we know about, and make a signed string out of them
-    std::string data;
-    crypto::public_key signer;
-    CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(rct::rct2sk(spend_skey), signer), "Failed to derive public spend key");
-    data += std::string((const char *)&signer, sizeof(crypto::public_key));
-
-    for (const auto &msk: multisig_keys)
-    {
-      rct::key pmsk = rct::scalarmultBase(rct::sk2rct(msk));
-      data += std::string((const char *)&pmsk, sizeof(crypto::public_key));
-    }
-
-    data.resize(data.size() + sizeof(crypto::signature));
-    crypto::cn_fast_hash(data.data(), data.size() - sizeof(signature), hash);
-    crypto::signature &signature = *(crypto::signature*)&data[data.size() - sizeof(crypto::signature)];
-    crypto::generate_signature(hash, signer, rct::rct2sk(spend_skey), signature);
-
-    extra_multisig_info = std::string("MultisigxV1") + tools::base58::encode(data);
+    // Our signer key is b * G, where b is secret spend key.
+    multisig_signers = spend_keys;
+    multisig_signers.push_back(get_multisig_signer_public_key(get_account().get_keys().m_spend_secret_key));
   }
   else
   {
-    CHECK_AND_ASSERT_THROW_MES(false, "Unsupported threshold case");
+    // We just got public spend keys of all participants and deriving multisig keys (set of Mi = b * Bi).
+    // note that derivations are public keys as DH exchange suppose it to be
+    auto derivations = cryptonote::generate_multisig_derivations(get_account().get_keys(), spend_keys);
+
+    spend_pkey = rct::identity();
+    multisig_signers = std::vector<crypto::public_key>(spend_keys.size() + 1, crypto::null_pkey);
+
+    if (threshold == spend_keys.size())
+    {
+      // N - 1 / N case
+
+      // We need an extra step, so we package all the composite public keys
+      // we know about, and make a signed string out of them
+      MINFO("Creating spend key...");
+
+      // Calculating set of our secret multisig keys as follows: mi = H(Mi),
+      // where mi - secret multisig key, Mi - others' participants public multisig key
+      multisig_keys = cryptonote::calculate_multisig_keys(derivations);
+
+      // calculating current participant's spend secret key as sum of all secret multisig keys for current participant.
+      // IMPORTANT: participant's secret spend key is not an entire wallet's secret spend!
+      //            Entire wallet's secret spend is sum of all unique secret multisig keys
+      //            among all of participants and is not held by anyone!
+      spend_skey = rct::sk2rct(cryptonote::calculate_multisig_signer_key(multisig_keys));
+
+      // Preparing data for the last round to calculate common public spend key. The data contains public multisig keys.
+      extra_multisig_info = pack_multisignature_keys(MULTISIG_EXTRA_INFO_MAGIC, secret_keys_to_public_keys(multisig_keys), rct::rct2sk(spend_skey));
+    }
+    else
+    {
+      // M / N case
+      MINFO("Preparing keys for next exchange round...");
+
+      // Preparing data for middle round - packing new public multisig keys to exchage with others.
+      extra_multisig_info = pack_multisignature_keys(MULTISIG_EXTRA_INFO_MAGIC, derivations, m_account.get_keys().m_spend_secret_key);
+      spend_skey = rct::sk2rct(m_account.get_keys().m_spend_secret_key);
+
+      // Need to store middle keys to be able to proceed in case of wallet shutdown.
+      m_multisig_derivations = derivations;
+    }
   }
 
-  // the multisig view key is shared by all, make one all can derive
+  clear();
   MINFO("Creating view key...");
   crypto::secret_key view_skey = cryptonote::generate_multisig_view_secret_key(get_account().get_keys().m_view_secret_key, view_keys);
 
@@ -3895,18 +4000,10 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   m_account_public_address = m_account.get_keys().m_account_address;
   m_watch_only = false;
   m_multisig = true;
-  m_multisig_threshold = threshold;
   m_key_device_type = hw::device::device_type::SOFTWARE;
-
-  if (threshold == spend_keys.size() + 1)
-  {
-    m_multisig_signers = spend_keys;
-    m_multisig_signers.push_back(get_multisig_signer_public_key());
-  }
-  else
-  {
-    m_multisig_signers = std::vector<crypto::public_key>(spend_keys.size() + 1, crypto::null_pkey);
-  }
+  m_multisig_threshold = threshold;
+  m_multisig_signers = multisig_signers;
+  ++m_multisig_rounds_passed;
 
   // re-encrypt keys
   keys_reencryptor = epee::misc_utils::auto_scope_leave_caller();
@@ -3921,13 +4018,147 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   return extra_multisig_info;
 }
 
-std::string wallet2::make_multisig(const epee::wipeable_string &password,
-  const std::vector<std::string> &info,
-  uint32_t threshold)
+std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &password,
+  const std::vector<std::string> &info)
+{
+  THROW_WALLET_EXCEPTION_IF(info.empty(),
+    error::wallet_internal_error, "Empty multisig info");
+
+  if (info[0].substr(0, MULTISIG_EXTRA_INFO_MAGIC.size()) != MULTISIG_EXTRA_INFO_MAGIC)
+  {
+    THROW_WALLET_EXCEPTION_IF(false,
+      error::wallet_internal_error, "Unsupported info string");
+  }
+
+  std::vector<crypto::public_key> signers;
+  std::unordered_set<crypto::public_key> pkeys;
+
+  THROW_WALLET_EXCEPTION_IF(!unpack_extra_multisig_info(info, signers, pkeys),
+    error::wallet_internal_error, "Bad extra multisig info");
+
+  return exchange_multisig_keys(password, pkeys, signers);
+}
+
+std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &password,
+  std::unordered_set<crypto::public_key> derivations,
+  std::vector<crypto::public_key> signers)
+{
+  CHECK_AND_ASSERT_THROW_MES(!derivations.empty(), "empty pkeys");
+  CHECK_AND_ASSERT_THROW_MES(!signers.empty(), "empty signers");
+
+  bool ready = false;
+  CHECK_AND_ASSERT_THROW_MES(multisig(&ready), "The wallet is not multisig");
+  CHECK_AND_ASSERT_THROW_MES(!ready, "Multisig wallet creation process has already been finished");
+
+  // keys are decrypted
+  epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
+  if (m_ask_password == AskPasswordToDecrypt && !m_unattended && !m_watch_only)
+  {
+    crypto::chacha_key chacha_key;
+    crypto::generate_chacha_key(password.data(), password.size(), chacha_key, m_kdf_rounds);
+    m_account.encrypt_viewkey(chacha_key);
+    m_account.decrypt_keys(chacha_key);
+    keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this, chacha_key]() { m_account.encrypt_keys(chacha_key); m_account.decrypt_viewkey(chacha_key); });
+  }
+
+  if (m_multisig_rounds_passed == multisig_rounds_required(m_multisig_signers.size(), m_multisig_threshold) - 1)
+  {
+    // the last round is passed and we have to calculate spend public key
+    // add ours if not included
+    crypto::public_key local_signer = get_multisig_signer_public_key();
+
+    if (std::find(signers.begin(), signers.end(), local_signer) == signers.end())
+    {
+        signers.push_back(local_signer);
+        for (const auto &msk: get_account().get_multisig_keys())
+        {
+            derivations.insert(rct::rct2pk(rct::scalarmultBase(rct::sk2rct(msk))));
+        }
+    }
+
+    CHECK_AND_ASSERT_THROW_MES(signers.size() == m_multisig_signers.size(), "Bad signers size");
+
+    // Summing all of unique public multisig keys to calculate common public spend key
+    crypto::public_key spend_public_key = cryptonote::generate_multisig_M_N_spend_public_key(std::vector<crypto::public_key>(derivations.begin(), derivations.end()));
+    m_account_public_address.m_spend_public_key = spend_public_key;
+    m_account.finalize_multisig(spend_public_key);
+
+    m_multisig_signers = signers;
+    std::sort(m_multisig_signers.begin(), m_multisig_signers.end(), [](const crypto::public_key &e0, const crypto::public_key &e1){ return memcmp(&e0, &e1, sizeof(e0)); });
+
+    ++m_multisig_rounds_passed;
+    m_multisig_derivations.clear();
+
+    // keys are encrypted again
+    keys_reencryptor = epee::misc_utils::auto_scope_leave_caller();
+
+    if (!m_wallet_file.empty())
+    {
+      bool r = store_keys(m_keys_file, password, false);
+      THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, m_keys_file);
+
+      if (boost::filesystem::exists(m_wallet_file + ".address.txt"))
+      {
+        r = file_io_utils::save_string_to_file(m_wallet_file + ".address.txt", m_account.get_public_address_str(m_nettype));
+        if(!r) MERROR("String with address text not saved");
+      }
+    }
+
+    m_subaddresses.clear();
+    m_subaddress_labels.clear();
+    add_subaddress_account(tr("Primary account"));
+
+    if (!m_wallet_file.empty())
+      store();
+
+    return {};
+  }
+
+  // Below are either middle or secret spend key establishment rounds
+
+  for (const auto& key: m_multisig_derivations)
+    derivations.erase(key);
+
+  // Deriving multisig keys (set of Mi = b * Bi) according to DH from other participants' multisig keys.
+  auto new_derivations = cryptonote::generate_multisig_derivations(get_account().get_keys(), std::vector<crypto::public_key>(derivations.begin(), derivations.end()));
+
+  std::string extra_multisig_info;
+  if (m_multisig_rounds_passed == multisig_rounds_required(m_multisig_signers.size(), m_multisig_threshold) - 2) // next round is last
+  {
+    // Next round is last therefore we are performing secret spend establishment round as described above.
+    MINFO("Creating spend key...");
+
+    // Calculating our secret multisig keys by hashing our public multisig keys.
+    auto multisig_keys = cryptonote::calculate_multisig_keys(std::vector<crypto::public_key>(new_derivations.begin(), new_derivations.end()));
+    // And summing it to get personal secret spend key
+    crypto::secret_key spend_skey = cryptonote::calculate_multisig_signer_key(multisig_keys);
+
+    m_account.make_multisig(m_account.get_keys().m_view_secret_key, spend_skey, rct::rct2pk(rct::identity()), multisig_keys);
+
+    // Packing public multisig keys to exchange with others and calculate common public spend key in the last round
+    extra_multisig_info = pack_multisignature_keys(MULTISIG_EXTRA_INFO_MAGIC, secret_keys_to_public_keys(multisig_keys), spend_skey);
+  }
+  else
+  {
+    // This is just middle round
+    MINFO("Preparing keys for next exchange round...");
+    extra_multisig_info = pack_multisignature_keys(MULTISIG_EXTRA_INFO_MAGIC, new_derivations, m_account.get_keys().m_spend_secret_key);
+    m_multisig_derivations = new_derivations;
+  }
+
+  ++m_multisig_rounds_passed;
+
+  create_keys_file(m_wallet_file, false, password, boost::filesystem::exists(m_wallet_file + ".address.txt"));
+  return extra_multisig_info;
+}
+
+void wallet2::unpack_multisig_info(const std::vector<std::string>& info,
+  std::vector<crypto::public_key> &public_keys,
+  std::vector<crypto::secret_key> &secret_keys) const
 {
   // parse all multisig info
-  std::vector<crypto::secret_key> secret_keys(info.size());
-  std::vector<crypto::public_key> public_keys(info.size());
+  public_keys.resize(info.size());
+  secret_keys.resize(info.size());
   for (size_t i = 0; i < info.size(); ++i)
   {
     THROW_WALLET_EXCEPTION_IF(!verify_multisig_info(info[i], secret_keys[i], public_keys[i]),
@@ -3971,75 +4202,51 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
           "Found local spend public key, but not local view secret key - something very weird");
     }
   }
+}
 
+std::string wallet2::make_multisig(const epee::wipeable_string &password,
+  const std::vector<std::string> &info,
+  uint32_t threshold)
+{
+  std::vector<crypto::secret_key> secret_keys(info.size());
+  std::vector<crypto::public_key> public_keys(info.size());
+  unpack_multisig_info(info, public_keys, secret_keys);
   return make_multisig(password, secret_keys, public_keys, threshold);
 }
 
 bool wallet2::finalize_multisig(const epee::wipeable_string &password, std::unordered_set<crypto::public_key> pkeys, std::vector<crypto::public_key> signers)
 {
-  CHECK_AND_ASSERT_THROW_MES(!pkeys.empty(), "empty pkeys");
+  exchange_multisig_keys(password, pkeys, signers);
+  return true;
+}
 
-  // keys are decrypted
-  epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
-  if (m_ask_password == AskPasswordToDecrypt && !m_unattended && !m_watch_only)
+bool wallet2::unpack_extra_multisig_info(const std::vector<std::string>& info,
+  std::vector<crypto::public_key> &signers,
+  std::unordered_set<crypto::public_key> &pkeys) const
+{
+  // parse all multisig info
+  signers.resize(info.size(), crypto::null_pkey);
+  for (size_t i = 0; i < info.size(); ++i)
   {
-    crypto::chacha_key chacha_key;
-    crypto::generate_chacha_key(password.data(), password.size(), chacha_key, m_kdf_rounds);
-    m_account.encrypt_viewkey(chacha_key);
-    m_account.decrypt_keys(chacha_key);
-    keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this, chacha_key]() { m_account.encrypt_keys(chacha_key); m_account.decrypt_viewkey(chacha_key); });
+      if (!verify_extra_multisig_info(info[i], pkeys, signers[i]))
+      {
+          return false;
+      }
   }
-
-  // add ours if not included
-  crypto::public_key local_signer;
-  CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(get_account().get_keys().m_spend_secret_key, local_signer),
-      "Failed to derive public spend key");
-  if (std::find(signers.begin(), signers.end(), local_signer) == signers.end())
-  {
-    signers.push_back(local_signer);
-    for (const auto &msk: get_account().get_multisig_keys())
-    {
-      pkeys.insert(rct::rct2pk(rct::scalarmultBase(rct::sk2rct(msk))));
-    }
-  }
-
-  CHECK_AND_ASSERT_THROW_MES(signers.size() == m_multisig_signers.size(), "Bad signers size");
-
-  crypto::public_key spend_public_key = cryptonote::generate_multisig_N1_N_spend_public_key(std::vector<crypto::public_key>(pkeys.begin(), pkeys.end()));
-  m_account_public_address.m_spend_public_key = spend_public_key;
-  m_account.finalize_multisig(spend_public_key);
-
-  m_multisig_signers = signers;
-  std::sort(m_multisig_signers.begin(), m_multisig_signers.end(), [](const crypto::public_key &e0, const crypto::public_key &e1){ return memcmp(&e0, &e1, sizeof(e0)); });
-
-  // keys are encrypted again
-  keys_reencryptor = epee::misc_utils::auto_scope_leave_caller();
-
-  create_keys_file(m_wallet_file, false, password, boost::filesystem::exists(m_wallet_file + ".address.txt"));
-
-  m_subaddresses.clear();
-  m_subaddress_labels.clear();
-  add_subaddress_account(tr("Primary account"));
-
-  if (!m_wallet_file.empty())
-    store();
 
   return true;
 }
 
 bool wallet2::finalize_multisig(const epee::wipeable_string &password, const std::vector<std::string> &info)
 {
-  // parse all multisig info
   std::unordered_set<crypto::public_key> public_keys;
-  std::vector<crypto::public_key> signers(info.size(), crypto::null_pkey);
-  for (size_t i = 0; i < info.size(); ++i)
+  std::vector<crypto::public_key> signers;
+  if (!unpack_extra_multisig_info(info, signers, public_keys))
   {
-    if (!verify_extra_multisig_info(info[i], public_keys, signers[i]))
-    {
-      MERROR("Bad multisig info");
-      return false;
-    }
+    MERROR("Bad multisig info");
+    return false;
   }
+
   return finalize_multisig(password, public_keys, signers);
 }
 
@@ -4102,14 +4309,13 @@ bool wallet2::verify_multisig_info(const std::string &data, crypto::secret_key &
 
 bool wallet2::verify_extra_multisig_info(const std::string &data, std::unordered_set<crypto::public_key> &pkeys, crypto::public_key &signer)
 {
-  const size_t header_len = strlen("MultisigxV1");
-  if (data.size() < header_len || data.substr(0, header_len) != "MultisigxV1")
+  if (data.size() < MULTISIG_EXTRA_INFO_MAGIC.size() || data.substr(0, MULTISIG_EXTRA_INFO_MAGIC.size()) != MULTISIG_EXTRA_INFO_MAGIC)
   {
     MERROR("Multisig info header check error");
     return false;
   }
   std::string decoded;
-  if (!tools::base58::decode(data.substr(header_len), decoded))
+  if (!tools::base58::decode(data.substr(MULTISIG_EXTRA_INFO_MAGIC.size()), decoded))
   {
     MERROR("Multisig info decoding error");
     return false;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -573,6 +573,14 @@ namespace tools
       const std::vector<crypto::secret_key> &view_keys,
       const std::vector<crypto::public_key> &spend_keys,
       uint32_t threshold);
+    std::string exchange_multisig_keys(const epee::wipeable_string &password,
+      const std::vector<std::string> &info);
+    /*!
+     * \brief Any but first round of keys exchange
+     */
+    std::string exchange_multisig_keys(const epee::wipeable_string &password,
+      std::unordered_set<crypto::public_key> pkeys,
+      std::vector<crypto::public_key> signers);
     /*!
      * \brief Finalizes creation of a multisig wallet
      */
@@ -1245,6 +1253,12 @@ namespace tools
     bool get_rct_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution);
 
     uint64_t get_segregation_fork_height() const;
+    void unpack_multisig_info(const std::vector<std::string>& info,
+      std::vector<crypto::public_key> &public_keys,
+      std::vector<crypto::secret_key> &secret_keys) const;
+    bool unpack_extra_multisig_info(const std::vector<std::string>& info,
+      std::vector<crypto::public_key> &signers,
+      std::unordered_set<crypto::public_key> &pkeys) const;
 
     void cache_tx_data(const cryptonote::transaction& tx, const crypto::hash &txid, tx_cache_data &tx_cache_data) const;
 
@@ -1295,6 +1309,9 @@ namespace tools
     bool m_multisig; /*!< if > 1 spend secret key will not match spend public key */
     uint32_t m_multisig_threshold;
     std::vector<crypto::public_key> m_multisig_signers;
+    //in case of general M/N multisig wallet we should perform N - M + 1 key exchange rounds and remember how many rounds are passed.
+    uint32_t m_multisig_rounds_passed;
+    std::vector<crypto::public_key> m_multisig_derivations;
     bool m_always_confirm_transfers;
     bool m_print_ring_members;
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3119,7 +3119,7 @@ namespace tools
       return false;
     }
 
-    if (req.multisig_info.size() < threshold - 1)
+    if (req.multisig_info.size() < 1 || req.multisig_info.size() > total)
     {
       er.code = WALLET_RPC_ERROR_CODE_THRESHOLD_NOT_REACHED;
       er.message = "Needs multisig info from more participants";
@@ -3143,6 +3143,55 @@ namespace tools
     }
     res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
 
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_exchange_multisig_keys(const wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::request& req, wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::response& res, epee::json_rpc::error& er)
+  {
+    if (!m_wallet) return not_open(er);
+    if (m_restricted)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_DENIED;
+      er.message = "Command unavailable in restricted mode.";
+      return false;
+    }
+    bool ready;
+    uint32_t threshold, total;
+    if (!m_wallet->multisig(&ready, &threshold, &total))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
+      er.message = "This wallet is not multisig";
+      return false;
+    }
+
+    if (ready)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_ALREADY_MULTISIG;
+      er.message = "This wallet is multisig, and already finalized";
+      return false;
+    }
+
+    if (req.multisig_info.size() < 1 || req.multisig_info.size() > total)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_THRESHOLD_NOT_REACHED;
+      er.message = "Needs multisig info from more participants";
+      return false;
+    }
+
+    try
+    {
+      res.multisig_info = m_wallet->exchange_multisig_keys(req.password, req.multisig_info);
+      if (res.multisig_info.empty())
+      {
+        res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
+      }
+    }
+    catch (const std::exception &e)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = std::string("Error calling exchange_multisig_info: ") + e.what();
+      return false;
+    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -141,6 +141,7 @@ namespace tools
         MAP_JON_RPC_WE("export_multisig_info", on_export_multisig,  wallet_rpc::COMMAND_RPC_EXPORT_MULTISIG)
         MAP_JON_RPC_WE("import_multisig_info", on_import_multisig,  wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG)
         MAP_JON_RPC_WE("finalize_multisig",  on_finalize_multisig,  wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG)
+        MAP_JON_RPC_WE("exchange_multisig_keys",  on_exchange_multisig_keys,  wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS)
         MAP_JON_RPC_WE("sign_multisig",      on_sign_multisig,      wallet_rpc::COMMAND_RPC_SIGN_MULTISIG)
         MAP_JON_RPC_WE("submit_multisig",    on_submit_multisig,    wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG)
         MAP_JON_RPC_WE("get_version",        on_get_version,        wallet_rpc::COMMAND_RPC_GET_VERSION)
@@ -218,6 +219,7 @@ namespace tools
       bool on_export_multisig(const wallet_rpc::COMMAND_RPC_EXPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_EXPORT_MULTISIG::response& res, epee::json_rpc::error& er);
       bool on_import_multisig(const wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::response& res, epee::json_rpc::error& er);
       bool on_finalize_multisig(const wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::response& res, epee::json_rpc::error& er);
+      bool on_exchange_multisig_keys(const wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::request& req, wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::response& res, epee::json_rpc::error& er);
       bool on_sign_multisig(const wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::response& res, epee::json_rpc::error& er);
       bool on_submit_multisig(const wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::response& res, epee::json_rpc::error& er);
       bool on_get_version(const wallet_rpc::COMMAND_RPC_GET_VERSION::request& req, wallet_rpc::COMMAND_RPC_GET_VERSION::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1990,6 +1990,31 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_EXCHANGE_MULTISIG_KEYS
+  {
+    struct request
+    {
+      std::string password;
+      std::vector<std::string> multisig_info;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(password)
+        KV_SERIALIZE(multisig_info)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string address;
+      std::string multisig_info;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(address)
+        KV_SERIALIZE(multisig_info)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_SIGN_MULTISIG
   {
     struct request

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -593,7 +593,7 @@ inline bool do_replay_file(const std::string& filename)
         std::vector<crypto::public_key> spend_public_keys; \
         for (const auto &k: all_multisig_keys) \
           spend_public_keys.push_back(k); \
-        crypto::public_key spend_pkey = cryptonote::generate_multisig_N1_N_spend_public_key(spend_public_keys); \
+        crypto::public_key spend_pkey = cryptonote::generate_multisig_M_N_spend_public_key(spend_public_keys); \
         for (size_t msidx = 0; msidx < total; ++msidx) \
           account[msidx].finalize_multisig(spend_pkey); \
       } \

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -544,6 +544,7 @@ inline bool do_replay_file(const std::string& filename)
   }
   return do_replay_events<t_test_class>(events);
 }
+
 //--------------------------------------------------------------------------
 #define GENERATE_ACCOUNT(account) \
     cryptonote::account_base account; \
@@ -556,47 +557,7 @@ inline bool do_replay_file(const std::string& filename)
     { \
       for (size_t msidx = 0; msidx < total; ++msidx) \
         account[msidx].generate(); \
-      std::unordered_set<crypto::public_key> all_multisig_keys; \
-      std::vector<std::vector<crypto::secret_key>> view_keys(total); \
-      std::vector<std::vector<crypto::public_key>> spend_keys(total); \
-      for (size_t msidx = 0; msidx < total; ++msidx) \
-      { \
-        for (size_t msidx_inner = 0; msidx_inner < total; ++msidx_inner) \
-        { \
-          if (msidx_inner != msidx) \
-          { \
-            crypto::secret_key vkh = cryptonote::get_multisig_blinded_secret_key(account[msidx_inner].get_keys().m_view_secret_key); \
-            view_keys[msidx].push_back(vkh); \
-            crypto::secret_key skh = cryptonote::get_multisig_blinded_secret_key(account[msidx_inner].get_keys().m_spend_secret_key); \
-            crypto::public_key pskh; \
-            crypto::secret_key_to_public_key(skh, pskh); \
-            spend_keys[msidx].push_back(pskh); \
-          } \
-        } \
-      } \
-      for (size_t msidx = 0; msidx < total; ++msidx) \
-      { \
-        std::vector<crypto::secret_key> multisig_keys; \
-        crypto::secret_key spend_skey; \
-        crypto::public_key spend_pkey; \
-        if (threshold == total) \
-          cryptonote::generate_multisig_N_N(account[msidx].get_keys(), spend_keys[msidx], multisig_keys, (rct::key&)spend_skey, (rct::key&)spend_pkey); \
-        else \
-          cryptonote::generate_multisig_N1_N(account[msidx].get_keys(), spend_keys[msidx], multisig_keys, (rct::key&)spend_skey, (rct::key&)spend_pkey); \
-        crypto::secret_key view_skey = cryptonote::generate_multisig_view_secret_key(account[msidx].get_keys().m_view_secret_key, view_keys[msidx]); \
-        account[msidx].make_multisig(view_skey, spend_skey, spend_pkey, multisig_keys); \
-        for (const auto &k: multisig_keys) \
-          all_multisig_keys.insert(rct::rct2pk(rct::scalarmultBase(rct::sk2rct(k)))); \
-      } \
-      if (threshold < total) \
-      { \
-        std::vector<crypto::public_key> spend_public_keys; \
-        for (const auto &k: all_multisig_keys) \
-          spend_public_keys.push_back(k); \
-        crypto::public_key spend_pkey = cryptonote::generate_multisig_M_N_spend_public_key(spend_public_keys); \
-        for (size_t msidx = 0; msidx < total; ++msidx) \
-          account[msidx].finalize_multisig(spend_pkey); \
-      } \
+      make_multisig_accounts(account, threshold); \
     } while(0)
 
 #define MAKE_ACCOUNT(VEC_EVENTS, account) \

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -223,6 +223,16 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_33_1__no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_33_1_2_no_threshold);
     GENERATE_AND_PLAY(gen_multisig_tx_invalid_33_1_3_no_threshold);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_24_1_2);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_24_1_2_many_inputs);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_25_1_2);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_25_1_2_many_inputs);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_48_1_234);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_48_1_234_many_inputs);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_24_1_no_signers);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_25_1_no_signers);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_48_1_no_signers);
+    GENERATE_AND_PLAY(gen_multisig_tx_valid_48_1_23_no_threshold);
 
     GENERATE_AND_PLAY(gen_bp_tx_valid_1);
     GENERATE_AND_PLAY(gen_bp_tx_invalid_1_1);

--- a/tests/core_tests/multisig.h
+++ b/tests/core_tests/multisig.h
@@ -161,6 +161,42 @@ struct gen_multisig_tx_valid_89_3_1245789: public gen_multisig_tx_validation_bas
 };
 template<> struct get_test_options<gen_multisig_tx_valid_89_3_1245789>: public get_test_options<gen_multisig_tx_validation_base> {};
 
+struct gen_multisig_tx_valid_24_1_2: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_24_1_2>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_24_1_2_many_inputs: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_24_1_2_many_inputs>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_25_1_2: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_25_1_2>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_25_1_2_many_inputs: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_25_1_2_many_inputs>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_48_1_234: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_48_1_234>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_48_1_234_many_inputs: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_48_1_234_many_inputs>: public get_test_options<gen_multisig_tx_validation_base> {};
+
 // invalid
 struct gen_multisig_tx_invalid_22_1__no_threshold: public gen_multisig_tx_validation_base
 {
@@ -197,3 +233,27 @@ struct gen_multisig_tx_invalid_45_5_23_no_threshold: public gen_multisig_tx_vali
   bool generate(std::vector<test_event_entry>& events) const;
 };
 template<> struct get_test_options<gen_multisig_tx_invalid_45_5_23_no_threshold>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_24_1_no_signers: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_24_1_no_signers>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_25_1_no_signers: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_25_1_no_signers>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_48_1_no_signers: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_48_1_no_signers>: public get_test_options<gen_multisig_tx_validation_base> {};
+
+struct gen_multisig_tx_valid_48_1_23_no_threshold: public gen_multisig_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_multisig_tx_valid_48_1_23_no_threshold>: public get_test_options<gen_multisig_tx_validation_base> {};


### PR DESCRIPTION
Extended multisignatures to schemes M/N.

I saved compatibility with previous API flow for multisig wallets creation. 2/4 wallets creation process looks as follows:

```
[wallet 5BUgPa]: prepare_multisig
Wallet password: 
MultisigV1XQAM98AQLYTAR83FDuGbn3Crvtgm9jRyKKEryVwcHC5j8sCaryT339hNBrbWXQUaEe4NUB7vv9BdPHTuZuUFvSoVbC273qbGrJGcAcDHbP91oXXd46xUVSzknRDQQ8L9ddjmZX789VveWRYUeyrP6Q5UVpEzmDn1NpfRA4NA21UxihEx
Send this multisig info to all other participants, then use make_multisig <threshold> <info1> [<info2>...] with others' multisig info
This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet's participants 

[wallet 5BUgPa]: make_multisig 2 MultisigV1A9TsWdMbPHtgvM6FDuYR7nPovfNdTPteSPFZwFgcNeR6PNsrmGjPvHbhiq7Ra1sMs9VrW5ev5MBX5aP1zTXmFLPcRcnj8i4zvoJ7qZS7YqyGdSgXfvwcoqS3bbtmASNmHivZNCyJkno5mdB1JNxD5wqUtNVUiQwRRfifTK6WFaNZjE2H MultisigV1hzHY9B7TuKaMF6cjjA53j4418G164HFzuVjtKGiam5YaVJm2rgTnXWZSHsQgPwW4abXpTS74SB8KbNs69DfzrsWB69ghrcRz3xuDUi4nnwEvxmAk8ECQQicbXiVfuWPyijdGUuiRHvnGBw6G3nXiWTYoKE5oLLgo7iGryFi68Vrp9MT2 MultisigV1SKvVDZ1ReJXMDbugtaJBiEEQ9hCVGD51we3b7w4pV5bPTCoigR7G2qoMQcaAgp87pXZCY9wDsHbRUHGwJYaGQ1NofLJJVP7they2rM348cpjEgAPVUoLxa52wjMP7pZQsfMeBCpZWKtiPL91J7R7uWes2DYH1gBRgpsHhFVjEeGrEDzx
Wallet password: 
Another step is needed
MultisigxV1jag57V1msEsWDDtYtTmaBCAR97maah4H2hxLeXfrXRWUEtNigxghaLA1ZjmjYiTyjYSXTucNMEeNvLBKtqrUME5ZNvtX3iiLLmJCzoXAMn2YhYDTUEpVi1bMN8fv3oxE9tQWNbghwVYazvjgBhXcRoNuh989GT84GEuDpjPcfSYDrosPeGj8KKH1AmsbQPCNoA7ppi6pSwjrzxJJW436KbKqHBwkAkhQVevWjj8Gmsbgg5ZQZcFRfFpMbJp8DXEtX32rKzEP
Send this multisig info to all other participants, then use exchage_multisig_keys <info1> [<info2>...] with others' multisig info

[wallet 51sLpF (out of sync)]: exchange_multisig_keys MultisigxV16oHHLiL2WsyEsmRj1fc37YJTmQs4bgmERBGRTKSoFxtR253qC31hnnTE7wy8xLFumwWmQzyAdjJjzR2cwfatJkpU6HX6WFSqE6DDsn5xyrPNiXifA6QCSfZxycnGA1roQ76p79BWRqr7yFzWUKu2uZYMDDYre85YEyZp5emiVz2JXeakQwARLCMk9neSSUsZFbPmPcMNmby9gQvScPgTXmKeBUKAjBK7njF6M1hGEkcKdPT2caiSYaX8V1mrZGpSxaESWDV9 MultisigxV1P5bu44mS6SqLWfh5f8AuNzDotbMT6iEf7LVaFfixJnyuM2VBNiwcJSbBbFifbgj7VidFZjzV1kpi64gRQk1aigGS6HX6WFSqE6DDsn5xyrPNiXifA6QCSfZxycnGA1roQ76pGSNmJhNYMSUNTdB2HviM6hFL2E9Uypy5eMjuQ9B4Wx4oBpXWmfjGbTk1qBUqPhyWwwU58jMqa9oQLSbv9TX8T82CYdFUEEgVVAvM1hoHjzpofLLxzPKFjyCofZ2UK3HsoLeq MultisigxV1BjP86fURDjY2L31oxTC64GDfDdPfqogahNdYLw2evHbo8PYmCtWxM8u7wSb6LY2VVrR4zW7vpq7QkGGkV2mYh19M79BWRqr7yFzWUKu2uZYMDDYre85YEyZp5emiVz2JXeakGSNmJhNYMSUNTdB2HviM6hFL2E9Uypy5eMjuQ9B4Wx4oE3351oRkZD86TH4z5SjThn2do9u6UXgDRExMNatSRcKVUCKFnmLLdCwdLYJATYMc2wFgq7rVG2LMdMX8jffrgVpC
Wallet password: 
Another step is needed
MultisigxV1AExg753mNvX17iyTbFX6Tq3sjpJ2YcPsgWi9jQkM2rMKctP8R5sBzZeCRDPXmCvHF54Gs7BKCj7W6AgPiwaLEJVF1r8MKR6yUmkeJMfexLhwun6VGqErFWFMV2SY1wXK5jNvFqLpiK3Ng6QjiWnAiqDccLajgFZvT5uLrXFgJm8JgrF5domBJYwSgZ89sfeC2RP45uQq6ksxGL3pYBThLwoWNieJS1A7P4MRqiiCYc2NqstSfzRVBeEZ3ezGhGNF89E2zL2YJos52A14AdFdF6PNUdK7UhMuGntMeBH8bgKAAuz1bfa57JDe4dwoC1rRTuhvL2Ewhq49PaQeBtntqHJuDnHwYme6cGkJGrEJoMqaX9tSajc1FkBgBop7hvkC6cq8BtMCjmZT
Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info

[wallet 51sLpF]: exchange_multisig_keys MultisigxV1PUq5CDZ9oWf3jUcWdx8aC32pWeCySeE7wJJH1aFaPVyAetYD2Bm9yh4PUSNuLtScvV2NKZzbQWQCgJq5saoLvCmVh5h5WtcM25Pc23k5ovZFjY8LnRjfT4DbkTCHv7kh2oPPRsW3Ax9XKFFEjRPh5DECjzCQMWwKXa9KneZmiQWB6kohV9nAHzG3ohYcHQq8E9NZR8UxsMDjRpmTxj6FrDPFCj2DXavpoe9reN94owQvP1dCc1XacHsVg7RKSKQMgUj8DNnS MultisigxV1dLf4xkCR7tD7C2cRhR1YATW5yJVFm2XiANVuMQjwsiM2etYD2Bm9yh4PUSNuLtScvV2NKZzbQWQCgJq5saoLvCmVd6syGgSUGA5hh8tkn8A6vpNhbwP5PjfBhfREypkSWuXjRsW3Ax9XKFFEjRPh5DECjzCQMWwKXa9KneZmiQWB6kohRuXSZGmcDNxYQoS5WSvC3P2qKQLTvLxULCDXUqbz6rJzA1st1tg4iRVdjdiWbyVPKRSBSU9oCx3wKKUkqhjqCGJR MultisigxV16FJqCGcFCnBTNTQmbY3CN7C5HqW62EMhXAh6Nax6rZ6UetYD2Bm9yh4PUSNuLtScvV2NKZzbQWQCgJq5saoLvCmVh5h5WtcM25Pc23k5ovZFjY8LnRjfT4DbkTCHv7kh2oPPd6syGgSUGA5hh8tkn8A6vpNhbwP5PjfBhfREypkSWuXj6tQM6LDnKbnJ8QkB9CePUK7q7wYM7x8JbJmj4D26Mko2DYAB5vbtmYjZxeapFTHuWYNgcgB4KAqoLFTb4M5Z9eGo
Wallet password: 
Multisig wallet has been successfully created. Current wallet type: 2/4
[wallet 526g4j]: address
0  526g4jUk2MxYjKFGrq655vAC9CBYLM66sWLn1VzXeAukE52fUbUkjsecpLLAzgBt7C9mTkutf29fnUEpPt39KUYZJ5votVx  Primary address 
```

For classic `N-1/N` wallets instead of `exchange_multisig_keys` you _may_ also use `finalize_multisig` command as you did before. Signing and submitting multisignature transactions procedure as well as partial key images exchange remain the same. In other words, only `exchange_multisig_keys` was added from API perspective.

Support for arbitrary scheme has been built also into:
- wallet api
- waller rpc
- `monero-gen-trusted-multisig` utility

Two members `m_multisig_rounds_passed` and `m_multisig_derivations` have been added in `wallet2` class to be able to continue creation procedure if the wallet has been closed between rounds.

On of the first transactions sent from 2/4 wallet on _stagenet_ is `244697a55e460e2188bb43b7a95ecf51298de1b6bc6a81f88d6d170e943ad0ef`, from 2/5 wallet - `fd3bb0a12e44cdc4aa7834032c9ac15c7b0528c0bf9644d851e4d99d47606368`. I may provide these wallets if needed :)

Tested with wallet api, wallet cli and wallet rpc on Ubuntu 17.10.
Core tests have also been added.