### PR TITLE
epee: add SSL support

### DIFF
--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -47,8 +47,10 @@
 #include <memory>
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 
 #include "net/net_utils_base.h"
+#include "net/net_ssl.h"
 #include "syncobj.h"
 
 namespace epee
@@ -95,16 +97,56 @@ class connection_basic { // not-templated base class for rapid developmet of som
     /// Strand to ensure the connection's handlers are not called concurrently.
     boost::asio::io_service::strand strand_;
     /// Socket for the connection.
-    boost::asio::ip::tcp::socket socket_;
+    ssl_context_t &m_ssl_context;
+    ssl_support_t m_ssl_support;
+    boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket_;
 
 	public:
 		// first counter is the ++/-- count of current sockets, the other socket_number is only-increasing ++ number generator
-		connection_basic(boost::asio::ip::tcp::socket&& socket, boost::shared_ptr<socket_stats> stats);
+		connection_basic(boost::asio::ip::tcp::socket&& socket, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context);
+		connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context);
 
 		virtual ~connection_basic() noexcept(false);
 
                 //! \return `socket_stats` object passed in construction (ptr never changes).
 		socket_stats& get_stats() noexcept { return *m_stats; /* verified in constructor */ }
+		connection_basic(boost::asio::io_service& io_service, std::atomic<long> &ref_sock_count, std::atomic<long> &sock_number, ssl_support_t ssl, ssl_context_t &ssl_context);
+
+		boost::asio::ip::tcp::socket& socket() { return socket_.next_layer(); }
+		ssl_support_t get_ssl_support() const { return m_ssl_support; }
+		void disable_ssl() { m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_disabled; }
+
+		bool handshake(boost::asio::ssl::stream_base::handshake_type type)
+		{
+			return ssl_handshake(socket_, type, m_ssl_context);
+		}
+
+		template<typename MutableBufferSequence, typename ReadHandler>
+		void async_read_some(const MutableBufferSequence &buffers, ReadHandler &&handler)
+		{
+			if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+				socket_.async_read_some(buffers, std::forward<ReadHandler>(handler));
+			else
+				socket().async_read_some(buffers, std::forward<ReadHandler>(handler));
+		}
+
+		template<typename ConstBufferSequence, typename WriteHandler>
+		void async_write_some(const ConstBufferSequence &buffers, WriteHandler &&handler)
+		{
+			if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+				socket_.async_write_some(buffers, std::forward<WriteHandler>(handler));
+			else
+				socket().async_write_some(buffers, std::forward<WriteHandler>(handler));
+		}
+
+		template<typename ConstBufferSequence, typename WriteHandler>
+		void async_write(const ConstBufferSequence &buffers, WriteHandler &&handler)
+		{
+			if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+				boost::asio::async_write(socket_, buffers, std::forward<WriteHandler>(handler));
+			else
+				boost::asio::async_write(socket(), buffers, std::forward<WriteHandler>(handler));
+		}
 
 		// various handlers to be called from connection class:
 		void do_send_handler_write(const void * ptr , size_t cb);

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -58,7 +58,10 @@ namespace epee
 
     bool init(std::function<void(size_t, uint8_t*)> rng, const std::string& bind_port = "0", const std::string& bind_ip = "0.0.0.0",
       std::vector<std::string> access_control_origins = std::vector<std::string>(),
-      boost::optional<net_utils::http::login> user = boost::none)
+      boost::optional<net_utils::http::login> user = boost::none,
+      epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
+      const std::pair<std::string, std::string> &private_key_and_certificate_path = {},
+      const std::list<std::string> &allowed_certificates = std::list<std::string>(), bool allow_any_cert = false)
     {
 
       //set self as callback handler
@@ -75,7 +78,7 @@ namespace epee
       m_net_server.get_config_object().m_user = std::move(user);
 
       MGINFO("Binding on " << bind_ip << ":" << bind_port);
-      bool res = m_net_server.init_server(bind_port, bind_ip);
+      bool res = m_net_server.init_server(bind_port, bind_ip, ssl_support, private_key_and_certificate_path, allowed_certificates, allow_any_cert);
       if(!res)
       {
         LOG_ERROR("Failed to bind server");

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+
+
+#ifndef _NET_SSL_H
+#define _NET_SSL_H
+
+#include <stdint.h>
+#include <string>
+#include <list>
+#include <boost/utility/string_ref.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl.hpp>
+
+namespace epee
+{
+namespace net_utils
+{
+	enum class ssl_support_t: uint8_t {
+		e_ssl_support_disabled,
+		e_ssl_support_enabled,
+		e_ssl_support_autodetect,
+	};
+  
+	struct ssl_context_t
+	{
+		boost::asio::ssl::context context;
+		std::list<std::string> allowed_certificates;
+		bool allow_any_cert;
+	};
+
+        // https://security.stackexchange.com/questions/34780/checking-client-hello-for-https-classification
+	constexpr size_t get_ssl_magic_size() { return 9; }
+	bool is_ssl(const unsigned char *data, size_t len);
+	ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &private_key_and_certificate_path, std::list<std::string> allowed_certificates, bool allow_any_cert);
+	void use_ssl_certificate(ssl_context_t &ssl_context, const std::pair<std::string, std::string> &private_key_and_certificate_path);
+	bool create_ssl_certificate(std::string &pkey_buffer, std::string &cert_buffer);
+	bool is_certificate_allowed(boost::asio::ssl::verify_context &ctx, const std::list<std::string> &allowed_certificates);
+	bool ssl_handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const epee::net_utils::ssl_context_t &ssl_context);
+        bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
+}
+}
+
+#endif //_NET_SSL_H

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -241,6 +241,7 @@ namespace net_utils
     const network_address m_remote_address;
     const bool     m_is_income;
     const time_t   m_started;
+    const time_t   m_ssl;
     time_t   m_last_recv;
     time_t   m_last_send;
     uint64_t m_recv_cnt;
@@ -251,13 +252,14 @@ namespace net_utils
     double m_max_speed_up;
 
     connection_context_base(boost::uuids::uuid connection_id,
-                            const network_address &remote_address, bool is_income,
+                            const network_address &remote_address, bool is_income, bool ssl,
                             time_t last_recv = 0, time_t last_send = 0,
                             uint64_t recv_cnt = 0, uint64_t send_cnt = 0):
                                             m_connection_id(connection_id),
                                             m_remote_address(remote_address),
                                             m_is_income(is_income),
                                             m_started(time(NULL)),
+                                            m_ssl(ssl),
                                             m_last_recv(last_recv),
                                             m_last_send(last_send),
                                             m_recv_cnt(recv_cnt),
@@ -272,6 +274,7 @@ namespace net_utils
                                m_remote_address(),
                                m_is_income(false),
                                m_started(time(NULL)),
+                               m_ssl(false),
                                m_last_recv(0),
                                m_last_send(0),
                                m_recv_cnt(0),
@@ -284,17 +287,17 @@ namespace net_utils
 
     connection_context_base& operator=(const connection_context_base& a)
     {
-      set_details(a.m_connection_id, a.m_remote_address, a.m_is_income);
+      set_details(a.m_connection_id, a.m_remote_address, a.m_is_income, a.m_ssl);
       return *this;
     }
     
   private:
     template<class t_protocol_handler>
     friend class connection;
-    void set_details(boost::uuids::uuid connection_id, const network_address &remote_address, bool is_income)
+    void set_details(boost::uuids::uuid connection_id, const network_address &remote_address, bool is_income, bool ssl)
     {
       this->~connection_context_base();
-      new(this) connection_context_base(connection_id, remote_address, is_income);
+      new(this) connection_context_base(connection_id, remote_address, is_income, ssl);
     }
 
 	};

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -27,7 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 add_library(epee STATIC hex.cpp http_auth.cpp mlog.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp memwipe.c
-    connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp)
+    connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp)
 if (USE_READLINE AND GNU_READLINE_FOUND)
   add_library(epee_readline STATIC readline_buffer.cpp)
 endif()

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -48,7 +48,7 @@
 #include "net/network_throttle-detail.hpp"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "net.p2p"
+#define MONERO_DEFAULT_LOG_CATEGORY "net.conn"
 
 // ################################################################################################
 // local (TU local) headers
@@ -113,14 +113,41 @@ connection_basic_pimpl::connection_basic_pimpl(const std::string &name) : m_thro
 int connection_basic_pimpl::m_default_tos;
 
 // methods:
-connection_basic::connection_basic(boost::asio::ip::tcp::socket&& socket, boost::shared_ptr<socket_stats> stats)
+connection_basic::connection_basic(boost::asio::ip::tcp::socket&& sock, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context)
 	:
 	m_stats(std::move(stats)),
 	mI( new connection_basic_pimpl("peer") ),
-	strand_(socket.get_io_service()),
-	socket_(std::move(socket)),
+	strand_(sock.get_io_service()),
+	socket_(sock.get_io_service(), ssl_context.context),
+	m_want_close_connection(false),
+	m_was_shutdown(false),
+	m_ssl_support(ssl_support),
+	m_ssl_context(ssl_context)
+{
+	// add nullptr checks if removed
+	CHECK_AND_ASSERT_THROW_MES(bool(m_stats), "stats shared_ptr cannot be null");
+
+        socket_.next_layer() = std::move(sock);
+
+	++(m_stats->sock_count); // increase the global counter
+	mI->m_peer_number = m_stats->sock_number.fetch_add(1); // use, and increase the generated number
+
+	std::string remote_addr_str = "?";
+	try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;
+
+	_note("Spawned connection #"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_stats->sock_count);
+}
+
+connection_basic::connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context)
+	:
+	m_stats(std::move(stats)),
+	mI( new connection_basic_pimpl("peer") ),
+	strand_(io_service),
+	socket_(io_service, ssl_context.context),
 	m_want_close_connection(false), 
-	m_was_shutdown(false)
+	m_was_shutdown(false),
+	m_ssl_support(ssl_support),
+	m_ssl_context(ssl_context)
 {
 	// add nullptr checks if removed
 	CHECK_AND_ASSERT_THROW_MES(bool(m_stats), "stats shared_ptr cannot be null");
@@ -129,17 +156,18 @@ connection_basic::connection_basic(boost::asio::ip::tcp::socket&& socket, boost:
 	mI->m_peer_number = m_stats->sock_number.fetch_add(1); // use, and increase the generated number
 
 	std::string remote_addr_str = "?";
-	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
+	try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;
 
-	_note("Spawned connection p2p#"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_stats->sock_count);
+	_note("Spawned connection #"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_stats->sock_count);
 }
 
 connection_basic::~connection_basic() noexcept(false) {
 	--(m_stats->sock_count);
 
 	std::string remote_addr_str = "?";
-	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
-	_note("Destructing connection p2p#"<<mI->m_peer_number << " to " << remote_addr_str);
+	try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;
+	_note("Destructing connection #"<<mI->m_peer_number << " to " << remote_addr_str);
+try { throw 0; } catch(...){}
 }
 
 void connection_basic::set_rate_up_limit(uint64_t limit) {

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -1,0 +1,319 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <string.h>
+#include <boost/asio/ssl.hpp>
+#include <openssl/ssl.h>
+#include <openssl/pem.h>
+#include "misc_log_ex.h"
+#include "net/net_ssl.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "net.ssl"
+
+// openssl genrsa -out /tmp/KEY 4096
+// openssl req -new -key /tmp/KEY -out /tmp/REQ
+// openssl x509 -req -days 999999 -sha256 -in /tmp/REQ -signkey /tmp/KEY -out /tmp/CERT
+
+namespace
+{
+  struct openssl_bio_free
+  {
+    void operator()(BIO* ptr) const noexcept
+    {
+      if (ptr)
+        BIO_free(ptr);
+    }
+  };
+  using openssl_bio = std::unique_ptr<BIO, openssl_bio_free>;
+
+  struct openssl_pkey_free
+  {
+    void operator()(EVP_PKEY* ptr) const noexcept
+    {
+      if (ptr)
+        EVP_PKEY_free(ptr);
+    }
+  };
+  using openssl_pkey = std::unique_ptr<EVP_PKEY, openssl_pkey_free>;
+
+}
+
+namespace epee
+{
+namespace net_utils
+{
+
+// https://stackoverflow.com/questions/256405/programmatically-create-x509-certificate-using-openssl
+bool create_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
+{
+  MGINFO("Generating SSL certificate");
+  pkey = EVP_PKEY_new();
+  openssl_pkey pkey_deleter{pkey};
+  if (!pkey)
+  {
+    MERROR("Failed to create new private key");
+    return false;
+  }
+  RSA *rsa = RSA_generate_key(4096, RSA_F4, NULL, NULL);
+  if (!rsa)
+  {
+    MERROR("Error generating RSA private key");
+    return false;
+  }
+  if (EVP_PKEY_assign_RSA(pkey, rsa) <= 0)
+  {
+    RSA_free(rsa);
+    MERROR("Error assigning RSA private key");
+    return false;
+  }
+
+  cert = X509_new();
+  if (!cert)
+  {
+    MERROR("Failed to create new X509 certificate");
+    return false;
+  }
+  ASN1_INTEGER_set(X509_get_serialNumber(cert), 1);
+  X509_gmtime_adj(X509_get_notBefore(cert), 0);
+  X509_gmtime_adj(X509_get_notAfter(cert), 3600 * 24 * 182); // half a year
+  if (!X509_set_pubkey(cert, pkey))
+  {
+    MERROR("Error setting pubkey on certificate");
+    X509_free(cert);
+    return false;
+  }
+  X509_NAME *name = X509_get_subject_name(cert);
+  X509_set_issuer_name(cert, name);
+
+  if (X509_sign(cert, pkey, EVP_sha256()) == 0)
+  {
+    MERROR("Error signing certificate");
+    X509_free(cert);
+    return false;
+  }
+  return true;
+}
+
+bool create_ssl_certificate(std::string &pkey_buffer, std::string &cert_buffer)
+{
+  EVP_PKEY *pkey;
+  X509 *cert;
+  if (!create_ssl_certificate(pkey, cert))
+    return false;
+  BIO *bio_pkey = BIO_new(BIO_s_mem()), *bio_cert = BIO_new(BIO_s_mem());
+  openssl_bio bio_pkey_deleter{bio_pkey};
+  bool success = PEM_write_bio_PrivateKey(bio_pkey, pkey, NULL, NULL, 0, NULL, NULL) && PEM_write_bio_X509(bio_cert, cert);
+  X509_free(cert);
+  if (!success)
+  {
+    MERROR("Failed to write cert and/or pkey: " << ERR_get_error());
+    return false;
+  }
+  BUF_MEM *buf = NULL;
+  BIO_get_mem_ptr(bio_pkey, &buf);
+  if (!buf || !buf->data || !buf->length)
+  {
+    MERROR("Failed to write pkey: " << ERR_get_error());
+    return false;
+  }
+  pkey_buffer = std::string(buf->data, buf->length);
+  buf = NULL;
+  BIO_get_mem_ptr(bio_cert, &buf);
+  if (!buf || !buf->data || !buf->length)
+  {
+    MERROR("Failed to write cert: " << ERR_get_error());
+    return false;
+  }
+  cert_buffer = std::string(buf->data, buf->length);
+  return success;
+}
+
+ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &private_key_and_certificate_path, std::list<std::string> allowed_certificates, bool allow_any_cert)
+{
+  ssl_context_t ssl_context({boost::asio::ssl::context(boost::asio::ssl::context::sslv23), std::move(allowed_certificates)});
+
+  // disable sslv2
+  ssl_context.context.set_options(boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2);
+  ssl_context.context.set_default_verify_paths();
+
+  // set options on the SSL context for added security
+  SSL_CTX *ctx = ssl_context.context.native_handle();
+  CHECK_AND_ASSERT_THROW_MES(ctx, "Failed to get SSL context");
+  SSL_CTX_clear_options(ctx, SSL_OP_LEGACY_SERVER_CONNECT); // SSL_CTX_SET_OPTIONS(3)
+  SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF); // https://stackoverflow.com/questions/22378442
+#ifdef SSL_OP_NO_TICKET
+  SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET); // https://stackoverflow.com/questions/22378442
+#endif
+#ifdef SSL_OP_NO_RENEGOTIATION
+  SSL_CTX_set_options(ctx, SSL_OP_NO_RENEGOTIATION);
+#endif
+#ifdef SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
+  SSL_CTX_set_options(ctx, SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+#endif
+#ifdef SSL_OP_NO_COMPRESSION
+  SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
+#endif
+  SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1); // https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices
+
+  CHECK_AND_ASSERT_THROW_MES(private_key_and_certificate_path.first.empty() == private_key_and_certificate_path.second.empty(), "private key and certificate must be either both given or both empty");
+  if (private_key_and_certificate_path.second.empty())
+  {
+    std::string pkey, cert;
+    CHECK_AND_ASSERT_THROW_MES(create_ssl_certificate(pkey, cert), "Failed to create certificate");
+    ssl_context.context.use_private_key(boost::asio::buffer(pkey), boost::asio::ssl::context::pem);
+    ssl_context.context.use_certificate(boost::asio::buffer(cert), boost::asio::ssl::context::pem);
+  }
+  else
+  {
+    ssl_context.context.use_private_key_file(private_key_and_certificate_path.first, boost::asio::ssl::context::pem);
+    ssl_context.context.use_certificate_file(private_key_and_certificate_path.second, boost::asio::ssl::context::pem);
+  }
+  ssl_context.allow_any_cert = allow_any_cert;
+
+  return ssl_context;
+}
+
+void use_ssl_certificate(ssl_context_t &ssl_context, const std::pair<std::string, std::string> &private_key_and_certificate_path)
+{
+  ssl_context.context.use_private_key_file(private_key_and_certificate_path.first, boost::asio::ssl::context::pem);
+  ssl_context.context.use_certificate_file(private_key_and_certificate_path.second, boost::asio::ssl::context::pem);
+}
+
+bool is_ssl(const unsigned char *data, size_t len)
+{
+  if (len < get_ssl_magic_size())
+    return false;
+
+  // https://security.stackexchange.com/questions/34780/checking-client-hello-for-https-classification
+  MDEBUG("SSL detection buffer, " << len << " bytes: "
+    << (unsigned)(unsigned char)data[0] << " " << (unsigned)(unsigned char)data[1] << " "
+    << (unsigned)(unsigned char)data[2] << " " << (unsigned)(unsigned char)data[3] << " "
+    << (unsigned)(unsigned char)data[4] << " " << (unsigned)(unsigned char)data[5] << " "
+    << (unsigned)(unsigned char)data[6] << " " << (unsigned)(unsigned char)data[7] << " "
+    << (unsigned)(unsigned char)data[8]);
+  if (data[0] == 0x16) // record
+  if (data[1] == 3) // major version
+  if (data[5] == 1) // ClientHello
+  if (data[6] == 0 && data[3]*256 + data[4] == data[7]*256 + data[8] + 4) // length check
+    return true;
+  return false;
+}
+
+bool is_certificate_allowed(boost::asio::ssl::verify_context &ctx, const std::list<std::string> &allowed_certificates)
+{
+  X509_STORE_CTX *sctx = ctx.native_handle();
+  if (!sctx)
+  {
+    MERROR("Error getting verify_context handle");
+    return false;
+  }
+  X509 *cert =X509_STORE_CTX_get_current_cert(sctx);
+  if (!cert)
+  {
+    MERROR("No certificate found in verify_context");
+    return false;
+  }
+
+  BIO *bio_cert = BIO_new(BIO_s_mem());
+  openssl_bio bio_cert_deleter{bio_cert};
+  bool success = PEM_write_bio_X509(bio_cert, cert);
+  if (!success)
+  {
+    MERROR("Failed to print certificate");
+    return false;
+  }
+  BUF_MEM *buf = NULL;
+  BIO_get_mem_ptr(bio_cert, &buf);
+  if (!buf || !buf->data || !buf->length)
+  {
+    MERROR("Failed to write certificate: " << ERR_get_error());
+    return false;
+  }
+  std::string certificate(std::string(buf->data, buf->length));
+  return std::find(allowed_certificates.begin(), allowed_certificates.end(), certificate) != allowed_certificates.end();
+}
+
+bool ssl_handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const epee::net_utils::ssl_context_t &ssl_context)
+{
+  bool verified = false;
+  socket.next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
+  socket.set_verify_mode(boost::asio::ssl::verify_peer);
+  socket.set_verify_callback([&](bool preverified, boost::asio::ssl::verify_context &ctx)
+  {
+    if (!preverified)
+    {
+      const int err = X509_STORE_CTX_get_error(ctx.native_handle());
+      const int depth = X509_STORE_CTX_get_error_depth(ctx.native_handle());
+      if (err != X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT || depth != 0)
+      {
+        MERROR("Invalid SSL certificate, error " << err << " at depth " << depth << ", connection dropped");
+        return false;
+      }
+    }
+    if (!ssl_context.allow_any_cert && !ssl_context.allowed_certificates.empty() && !is_certificate_allowed(ctx, ssl_context.allowed_certificates))
+    {
+      MERROR("Certificate is not in the allowed list, connection droppped");
+      return false;
+    }
+    verified = true;
+    return true;
+  });
+
+  boost::system::error_code ec;
+  socket.handshake(type, ec);
+  if (ec)
+  {
+    MERROR("handshake failed, connection dropped");
+    return false;
+  }
+  if (!ssl_context.allow_any_cert && !verified)
+  {
+    MERROR("Peer did not provide a certificate in the allowed list, connection dropped");
+    return false;
+  }
+  MDEBUG("SSL handshake success");
+  return true;
+}
+
+bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s)
+{
+  if (s == "enabled")
+    ssl = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+  else if (s == "disabled")
+    ssl = epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+  else if (s == "autodetect")
+    ssl = epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+  else
+    return false;
+  return true;
+}
+
+} // namespace
+} // namespace
+

--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -179,8 +179,8 @@ namespace tools
 
       lock.unlock();
 
-      bool ssl = u_c.schema == "https";
-      uint16_t port = u_c.port ? u_c.port : ssl ? 443 : 80;
+      epee::net_utils::ssl_support_t ssl = u_c.schema == "https" ? epee::net_utils::ssl_support_t::e_ssl_support_enabled : epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+      uint16_t port = u_c.port ? u_c.port : ssl == epee::net_utils::ssl_support_t::e_ssl_support_enabled ? 443 : 80;
       MDEBUG("Connecting to " << u_c.host << ":" << port);
       client.set_server(u_c.host, std::to_string(port), boost::none, ssl);
       if (!client.connect(std::chrono::seconds(30)))

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -48,6 +48,7 @@ namespace cryptonote
     bool incoming;
     bool localhost;
     bool local_ip;
+    bool ssl;
 
     std::string address;
     std::string host;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -268,6 +268,7 @@ namespace cryptonote
       cnx.current_upload = cntxt.m_current_speed_up / 1024;
 
       cnx.connection_id = epee::string_tools::pod_to_hex(cntxt.m_connection_id);
+      cnx.ssl = cntxt.m_ssl;
 
       cnx.height = cntxt.m_remote_blockchain_height;
       cnx.pruning_seed = cntxt.m_pruning_seed;

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -510,6 +510,7 @@ bool t_rpc_command_executor::print_connections() {
   }
 
   tools::msg_writer() << std::setw(30) << std::left << "Remote Host"
+      << std::setw(6) << "SSL"
       << std::setw(20) << "Peer id"
       << std::setw(20) << "Support Flags"      
       << std::setw(30) << "Recv/Sent (inactive,sec)"
@@ -529,6 +530,7 @@ bool t_rpc_command_executor::print_connections() {
     tools::msg_writer() 
      //<< std::setw(30) << std::left << in_out
      << std::setw(30) << std::left << address
+     << std::setw(6) << (info.ssl ? "yes" : "no")
      << std::setw(20) << epee::string_tools::pad_string(info.peer_id, 16, '0', true)
      << std::setw(20) << info.support_flags
      << std::setw(30) << std::to_string(info.recv_count) + "("  + std::to_string(info.recv_idle_time) + ")/" + std::to_string(info.send_count) + "(" + std::to_string(info.send_idle_time) + ")"

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -162,7 +162,7 @@ namespace trezor {
         m_session(boost::none),
         m_device_info(boost::none)
     {
-      m_http_client.set_server(m_bridge_host, boost::none, false);
+      m_http_client.set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     }
 
     virtual ~BridgeTransport() = default;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -129,7 +129,7 @@ namespace nodetool
     typedef epee::net_utils::boosted_tcp_server<epee::levin::async_protocol_handler<p2p_connection_context>> net_server;
 
     struct network_zone;
-    using connect_func = boost::optional<p2p_connection_context>(network_zone&, epee::net_utils::network_address const&);
+    using connect_func = boost::optional<p2p_connection_context>(network_zone&, epee::net_utils::network_address const&, epee::net_utils::ssl_support_t);
 
     struct config
     {
@@ -437,8 +437,8 @@ namespace nodetool
     //keep connections to initiate some interactions
 
 
-    static boost::optional<p2p_connection_context> public_connect(network_zone&, epee::net_utils::network_address const&);
-    static boost::optional<p2p_connection_context> socks_connect(network_zone&, epee::net_utils::network_address const&);
+    static boost::optional<p2p_connection_context> public_connect(network_zone&, epee::net_utils::network_address const&, epee::net_utils::ssl_support_t);
+    static boost::optional<p2p_connection_context> socks_connect(network_zone&, epee::net_utils::network_address const&, epee::net_utils::ssl_support_t);
 
 
     /* A `std::map` provides constant iterators and key/value pointers even with
@@ -463,6 +463,8 @@ namespace nodetool
 
     boost::uuids::uuid m_network_id;
     cryptonote::network_type m_nettype;
+
+    epee::net_utils::ssl_support_t m_ssl_support;
   };
 
     const int64_t default_limit_up = P2P_DEFAULT_LIMIT_RATE_UP;      // kB/s

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -56,6 +56,11 @@ namespace cryptonote
     static const command_line::arg_descriptor<std::string, false, true, 2> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
+    static const command_line::arg_descriptor<std::string> arg_rpc_ssl;
+    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key;
+    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate;
+    static const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_certificates;
+    static const command_line::arg_descriptor<bool> arg_rpc_ssl_allow_any_cert;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_login;
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8402,7 +8402,8 @@ bool simple_wallet::status(const std::vector<std::string> &args)
 {
   uint64_t local_height = m_wallet->get_blockchain_current_height();
   uint32_t version = 0;
-  if (!m_wallet->check_connection(&version))
+  bool ssl = false;
+  if (!m_wallet->check_connection(&version, &ssl))
   {
     success_msg_writer() << "Refreshed " << local_height << "/?, no daemon connected";
     return true;
@@ -8414,7 +8415,7 @@ bool simple_wallet::status(const std::vector<std::string> &args)
   {
     bool synced = local_height == bc_height;
     success_msg_writer() << "Refreshed " << local_height << "/" << bc_height << ", " << (synced ? "synced" : "syncing")
-        << ", daemon RPC v" << get_version_string(version);
+        << ", daemon RPC v" << get_version_string(version) << ", " << (ssl ? "SSL" : "no SSL");
   }
   else
   {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1924,7 +1924,7 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
 
 bool WalletImpl::connectToDaemon()
 {
-    bool result = m_wallet->check_connection(NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    bool result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
     if (!result) {
         setStatusError("Error connecting to daemon at " + m_wallet->get_daemon_address());
     } else {
@@ -1937,7 +1937,7 @@ bool WalletImpl::connectToDaemon()
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
     uint32_t version = 0;
-    m_is_connected = m_wallet->check_connection(&version, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    m_is_connected = m_wallet->check_connection(&version, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
     if (!m_is_connected)
         return Wallet::ConnectionStatus_Disconnected;
     // Version check is not implemented in light wallets nodes/wallets

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -237,6 +237,11 @@ struct options {
   const command_line::arg_descriptor<std::string> password_file = {"password-file", tools::wallet2::tr("Wallet password file"), "", true};
   const command_line::arg_descriptor<int> daemon_port = {"daemon-port", tools::wallet2::tr("Use daemon instance at port <arg> instead of 18081"), 0};
   const command_line::arg_descriptor<std::string> daemon_login = {"daemon-login", tools::wallet2::tr("Specify username[:password] for daemon RPC client"), "", true};
+  const command_line::arg_descriptor<std::string> daemon_ssl = {"daemon-ssl", tools::wallet2::tr("Enable SSL on daemon RPC connections: enabled|disabled|autodetect"), "autodetect"};
+  const command_line::arg_descriptor<std::string> daemon_ssl_private_key = {"daemon-ssl-private-key", tools::wallet2::tr("Path to a PEM format private key"), ""};
+  const command_line::arg_descriptor<std::string> daemon_ssl_certificate = {"daemon-ssl-certificate", tools::wallet2::tr("Path to a PEM format certificate"), ""};
+  const command_line::arg_descriptor<std::vector<std::string>> daemon_ssl_allowed_certificates = {"daemon-ssl-allowed-certificates", tools::wallet2::tr("List of paths to PEM format certificates of allowed RPC servers")};
+  const command_line::arg_descriptor<bool> daemon_ssl_allow_any_cert = {"daemon-ssl-allow-any-cert", tools::wallet2::tr("Allow any SSL certificate from the daemon"), false};
   const command_line::arg_descriptor<bool> testnet = {"testnet", tools::wallet2::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
   const command_line::arg_descriptor<bool> stagenet = {"stagenet", tools::wallet2::tr("For stagenet. Daemon must also be launched with --stagenet flag"), false};
   const command_line::arg_descriptor<std::string, false, true, 2> shared_ringdb_dir = {
@@ -308,6 +313,14 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   auto daemon_port = command_line::get_arg(vm, opts.daemon_port);
   auto device_name = command_line::get_arg(vm, opts.hw_device);
   auto device_derivation_path = command_line::get_arg(vm, opts.hw_device_derivation_path);
+  auto daemon_ssl_private_key = command_line::get_arg(vm, opts.daemon_ssl_private_key);
+  auto daemon_ssl_certificate = command_line::get_arg(vm, opts.daemon_ssl_certificate);
+  auto daemon_ssl_allowed_certificates = command_line::get_arg(vm, opts.daemon_ssl_allowed_certificates);
+  auto daemon_ssl_allow_any_cert = command_line::get_arg(vm, opts.daemon_ssl_allow_any_cert);
+  auto daemon_ssl = command_line::get_arg(vm, opts.daemon_ssl);
+  epee::net_utils::ssl_support_t ssl_support;
+  THROW_WALLET_EXCEPTION_IF(!epee::net_utils::ssl_support_from_string(ssl_support, daemon_ssl), tools::error::wallet_internal_error,
+      tools::wallet2::tr("Invalid argument for ") + std::string(opts.daemon_ssl.name));
 
   THROW_WALLET_EXCEPTION_IF(!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port,
       tools::error::wallet_internal_error, tools::wallet2::tr("can't specify daemon host or port more than once"));
@@ -358,8 +371,20 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
     catch (const std::exception &e) { }
   }
 
+  std::list<std::string> ssl_allowed_certificates;
+  for (const std::string &path: daemon_ssl_allowed_certificates)
+  {
+      ssl_allowed_certificates.push_back({});
+      if (!epee::file_io_utils::load_file_to_string(path, ssl_allowed_certificates.back()))
+      {
+        MERROR("Failed to load certificate: " << path);
+        ssl_allowed_certificates.back() = std::string();
+      }
+  }
+
   std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, kdf_rounds, unattended));
-  wallet->init(std::move(daemon_address), std::move(login), 0, false, *trusted_daemon);
+  wallet->init(std::move(daemon_address), std::move(login), 0, *trusted_daemon, ssl_support, std::make_pair(daemon_ssl_private_key, daemon_ssl_certificate), ssl_allowed_certificates, daemon_ssl_allow_any_cert);
+
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());
   wallet->get_message_store().set_options(vm);
@@ -1015,6 +1040,11 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.password_file);
   command_line::add_arg(desc_params, opts.daemon_port);
   command_line::add_arg(desc_params, opts.daemon_login);
+  command_line::add_arg(desc_params, opts.daemon_ssl);
+  command_line::add_arg(desc_params, opts.daemon_ssl_private_key);
+  command_line::add_arg(desc_params, opts.daemon_ssl_certificate);
+  command_line::add_arg(desc_params, opts.daemon_ssl_allowed_certificates);
+  command_line::add_arg(desc_params, opts.daemon_ssl_allow_any_cert);
   command_line::add_arg(desc_params, opts.testnet);
   command_line::add_arg(desc_params, opts.stagenet);
   command_line::add_arg(desc_params, opts.shared_ringdb_dir);
@@ -1066,7 +1096,7 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 }
 
 //----------------------------------------------------------------------------------------------------
-bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_weight_limit, bool ssl, bool trusted_daemon)
+bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_support_t ssl_support, const std::pair<std::string, std::string> &private_key_and_certificate_path, const std::list<std::string> &allowed_certificates, bool allow_any_cert)
 {
   m_checkpoints.init_default_checkpoints(m_nettype);
   if(m_http_client.is_connected())
@@ -1076,8 +1106,7 @@ bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
   m_trusted_daemon = trusted_daemon;
-  // When switching from light wallet to full wallet, we need to reset the height we got from lw node.
-  return m_http_client.set_server(get_daemon_address(), get_daemon_login(), ssl);
+  return m_http_client.set_server(get_daemon_address(), get_daemon_login(), ssl_support, private_key_and_certificate_path, allowed_certificates, allow_any_cert);
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_deterministic() const
@@ -4848,7 +4877,7 @@ bool wallet2::prepare_file_names(const std::string& file_path)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::check_connection(uint32_t *version, uint32_t timeout)
+bool wallet2::check_connection(uint32_t *version, bool *ssl, uint32_t timeout)
 {
   THROW_WALLET_EXCEPTION_IF(!m_is_initialized, error::wallet_not_initialized);
 
@@ -4856,14 +4885,19 @@ bool wallet2::check_connection(uint32_t *version, uint32_t timeout)
 
   // TODO: Add light wallet version check.
   if(m_light_wallet) {
-      version = 0;
+      if (version)
+        *version = 0;
+      if (ssl)
+        *ssl = m_light_wallet_connected; // light wallet is always SSL
       return m_light_wallet_connected;
   }
 
-  if(!m_http_client.is_connected())
+  if(!m_http_client.is_connected(ssl))
   {
     m_node_rpc_proxy.invalidate();
     if (!m_http_client.connect(std::chrono::milliseconds(timeout)))
+      return false;
+    if(!m_http_client.is_connected(ssl))
       return false;
   }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -676,7 +676,11 @@ namespace tools
 
     bool deinit();
     bool init(std::string daemon_address = "http://localhost:8080",
-      boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_weight_limit = 0, bool ssl = false, bool trusted_daemon = false);
+      boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_weight_limit = 0,
+      bool trusted_daemon = true,
+      epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
+      const std::pair<std::string, std::string> &private_key_and_certificate_path = {},
+      const std::list<std::string> &allowed_certificates = {}, bool allow_any_cert = false);
 
     void stop() { m_run.store(false, std::memory_order_relaxed); m_message_store.stop(); }
 
@@ -800,7 +804,7 @@ namespace tools
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);
     std::vector<pending_tx> create_unmixable_sweep_transactions();
     void discard_unmixable_outputs();
-    bool check_connection(uint32_t *version = NULL, uint32_t timeout = 200000);
+    bool check_connection(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 200000);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0, const boost::optional<uint32_t>& subaddr_account = boost::none, const std::set<uint32_t>& subaddr_indices = {}) const;
     void get_payments(std::list<std::pair<crypto::hash,wallet2::payment_details>>& payments, uint64_t min_height, uint64_t max_height = (uint64_t)-1, const boost::optional<uint32_t>& subaddr_account = boost::none, const std::set<uint32_t>& subaddr_indices = {}) const;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -63,6 +63,10 @@ namespace
   const command_line::arg_descriptor<bool> arg_restricted = {"restricted-rpc", "Restricts to view-only commands", false};
   const command_line::arg_descriptor<std::string> arg_wallet_dir = {"wallet-dir", "Directory for newly created wallets"};
   const command_line::arg_descriptor<bool> arg_prompt_for_password = {"prompt-for-password", "Prompts for password when not provided", false};
+  const command_line::arg_descriptor<std::string> arg_rpc_ssl = {"rpc-ssl", tools::wallet2::tr("Enable SSL on wallet RPC connections: enabled|disabled|autodetect"), "autodetect"};
+  const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key = {"rpc-ssl-private-key", tools::wallet2::tr("Path to a PEM format private key"), ""};
+  const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate = {"rpc-ssl-certificate", tools::wallet2::tr("Path to a PEM format certificate"), ""};
+  const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_certificates = {"rpc-ssl-allowed-certificates", tools::wallet2::tr("List of paths to PEM format certificates of allowed RPC servers (all allowed if empty)")};
 
   constexpr const char default_rpc_username[] = "monero";
 
@@ -233,10 +237,32 @@ namespace tools
       assert(bool(http_login));
     } // end auth enabled
 
+    auto rpc_ssl_private_key = command_line::get_arg(vm, arg_rpc_ssl_private_key);
+    auto rpc_ssl_certificate = command_line::get_arg(vm, arg_rpc_ssl_certificate);
+    auto rpc_ssl_allowed_certificates = command_line::get_arg(vm, arg_rpc_ssl_allowed_certificates);
+    auto rpc_ssl = command_line::get_arg(vm, arg_rpc_ssl);
+    epee::net_utils::ssl_support_t rpc_ssl_support;
+    if (!epee::net_utils::ssl_support_from_string(rpc_ssl_support, rpc_ssl))
+    {
+      MERROR("Invalid argument for " << std::string(arg_rpc_ssl.name));
+      return false;
+    }
+    std::list<std::string> allowed_certificates;
+    for (const std::string &path: rpc_ssl_allowed_certificates)
+    {
+        allowed_certificates.push_back({});
+        if (!epee::file_io_utils::load_file_to_string(path, allowed_certificates.back()))
+        {
+          MERROR("Failed to load certificate: " << path);
+          allowed_certificates.back() = std::string();
+        }
+    }
+
     m_net_server.set_threads_prefix("RPC");
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::init(
-      rng, std::move(bind_port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login)
+      rng, std::move(bind_port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login),
+      rpc_ssl_support, std::make_pair(rpc_ssl_private_key, rpc_ssl_certificate), allowed_certificates
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3937,6 +3963,10 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_from_json);
   command_line::add_arg(desc_params, arg_wallet_dir);
   command_line::add_arg(desc_params, arg_prompt_for_password);
+  command_line::add_arg(desc_params, arg_rpc_ssl);
+  command_line::add_arg(desc_params, arg_rpc_ssl_private_key);
+  command_line::add_arg(desc_params, arg_rpc_ssl_certificate);
+  command_line::add_arg(desc_params, arg_rpc_ssl_allowed_certificates);
 
   daemonizer::init_options(hidden_options, desc_params);
   desc_params.add(hidden_options);


### PR DESCRIPTION
P2P and RPC connections now have optional tranparent SSL.

An optional private key and certificate file can be passed,
using the --{p2p,rpc,daemon}-ssl-private-key and
--{p2p,rpc,daemon}-ssl-certificate options. Those have as
argument a path to a PEM format private private key and
certificate, respectively.
If not given, a temporary self signed certificate will be used.

SSL can be enabled or disabled using --{p2p,rpc}-ssl, which
accepts autodetect (default), disabled or enabled.

Access can be restricted to particular certificates using the
--{p2p,rpc}-ssl-allowed-certificates, which takes a list of
paths to PEM encoded certificates. This can allow a wallet to
connect to only the daemon they think they're connected to,
by forcing SSL and listing the paths to the known good
certificates.

To generate long term certificates:

openssl genrsa -out /tmp/KEY 4096
openssl req -new -key /tmp/KEY -out /tmp/REQ
openssl x509 -req -days 999999 -sha256 -in /tmp/REQ -signkey /tmp/KEY -out /tmp/CERT

/tmp/KEY is the private key, and /tmp/CERT is the certificate,
both in PEM format. /tmp/REQ can be removed. Adjust the last
command to set expiration date, etc, as needed. It doesn't
make a whole lot of sense for monero anyway, since most servers
will run with one time temporary self signed certificates anyway.

SSL support is transparent, so all communication is done on the
existing ports, with SSL autodetection. This means you can start
using an SSL daemon now, but you should not enforce SSL yet or
nothing will talk to you.