### PR TITLE
blockchain: cache next block difficulty after adding a block

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3653,6 +3653,7 @@ leave:
 
   // appears to be a NOP *and* is called elsewhere.  wat?
   m_tx_pool.on_blockchain_inc(new_height, id);
+  get_difficulty_for_next_block(); // just to cache it
 
   return true;
 }


### PR DESCRIPTION
It's not 100% certain it'll be needed, but it avoids getinfo
needing the blockchain lock and potentially blocking