### PR TITLE
Clarification of boolean options in config file

### DIFF
--- a/contrib/snap/monerod.conf
+++ b/contrib/snap/monerod.conf
@@ -1,8 +1,9 @@
 # Configuration for monerod
 # Syntax: any command line option may be specified as 'clioptionname=value'.
+#         Boolean options such as 'no-igd' are specified as 'no-igd=1'.
 # See 'monerod --help' for all available options.
 
-# Overrided by snap:
+# Overridden by snap:
 # data-dir=/var/lib/monero
 # log-file=/var/log/monero/monero.log
 

--- a/utils/conf/monerod.conf
+++ b/utils/conf/monerod.conf
@@ -1,5 +1,6 @@
 # Configuration for monerod
 # Syntax: any command line option may be specified as 'clioptionname=value'.
+#         Boolean options such as 'no-igd' are specified as 'no-igd=1'.
 # See 'monerod --help' for all available options.
 
 data-dir=/var/lib/monero


### PR DESCRIPTION
I recently ran into this confusing startup error:

> Error parsing config file: the options configuration file contains an invalid line 'no-igd'

Updating the example configuration files to reflect that boolean options require a value (whereas they do not on the commandline).