### PR TITLE
WalletImpl: migrate to std::thread due to possible bug in boost 1.66

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -390,7 +390,7 @@ WalletImpl::WalletImpl(NetworkType nettype)
 
     m_refreshIntervalMillis = DEFAULT_REFRESH_INTERVAL_MILLIS;
 
-    m_refreshThread = boost::thread([this] () {
+    m_refreshThread = std::thread([this] () {
         this->refreshThreadFunc();
     });
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -35,8 +35,8 @@
 #include "wallet/wallet2.h"
 
 #include <string>
+#include <thread>
 #include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
 
 
@@ -232,7 +232,7 @@ private:
     // synchronizing  sync and async refresh
     boost::mutex        m_refreshMutex2;
     boost::condition_variable m_refreshCV;
-    boost::thread       m_refreshThread;
+    std::thread       m_refreshThread;
     // flag indicating wallet is recovering from seed
     // so it shouldn't be considered as new and pull blocks (slow-refresh)
     // instead of pulling hashes (fast-refresh)


### PR DESCRIPTION
on OSX 10.13 I experience regular crash in boost::thread 1.66 using wallet api. See minimal [example](https://github.com/mmitkevich/monero-multisig-api-example/blob/crash_on_exit/main.cpp)
```
#include <memory>
#include <iostream>
#include <string>
#include "src/wallet/api/wallet2_api.h"
#include "contrib/epee/include/misc_log_ex.h"

int main(int argc, char ** argv) {
    Monero::WalletManagerFactory::setLogLevel(Monero::WalletManagerFactory::LogLevel_Max);
    
    auto walletManager = std::unique_ptr<Monero::WalletManager>(Monero::WalletManagerFactory::getWalletManager());

    auto wallet = std::unique_ptr<Monero::Wallet>(walletManager->createWallet("test-wallet", "123", "en", Monero::NetworkType::MAINNET));
}
```

Here is relevant log and stacktrace
```
Mikhails-MacBook-Pro:monero-multisig-api-example mike$ lldb ./build/app-monero
...
018-07-19 12:47:20,256 DEBUG [device.ledger] [mike@unknown-host] [hw::ledger::device_ledger::device_ledger()] [/Users/mike/monero/src/device/device_ledger.cpp:225] Device 0 Created
2018-07-19 12:47:20,257 TRACE [WalletAPI] [bool Monero::WalletImpl::create(const std::string &, const std::string &, const std::string &)] [/Users/mike/monero/src/wallet/api/wallet.cpp:427] wallet_path: test-wallet
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1933] refreshThreadFunc: starting refresh thread
2018-07-19 12:47:20,257 TRACE [WalletAPI] [bool Monero::WalletImpl::create(const std::string &, const std::string &, const std::string &)] [/Users/mike/monero/src/wallet/api/wallet.cpp:429] keys_file_exists: true  wallet_file_exists: true
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1940] refreshThreadFunc: waiting for refresh...
2018-07-19 12:47:20,257 ERROR [WalletAPI] attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not riskoverwriting.
2018-07-19 12:47:20,257 INFO  [WalletAPI] ~WalletImpl
2018-07-19 12:47:20,257 DEBUG [WalletAPI] [mike@unknown-host] [virtual void Monero::WalletImpl::pauseRefresh()] [/Users/mike/monero/src/wallet/api/wallet.cpp:2015] pauseRefresh: refresh paused...
2018-07-19 12:47:20,257 INFO  [WalletAPI] closing wallet...
2018-07-19 12:47:20,257 INFO  [WalletAPI] Calling wallet::stop...
2018-07-19 12:47:20,257 INFO  [WalletAPI] wallet::stop done
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1950] refreshThreadFunc: refresh lock acquired...
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1951] refreshThreadFunc: m_refreshEnabled: 0
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1952] refreshThreadFunc: m_status: 0
2018-07-19 12:47:20,257 TRACE [WalletAPI] [void Monero::WalletImpl::refreshThreadFunc()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1958] refreshThreadFunc: refresh thread stopped
Process 10614 stopped
* thread #2, stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
    frame #0: 0x00000001029e9060 libboost_thread.dylib`boost::detail::(anonymous namespace)::tls_destructor(void*) + 128
libboost_thread.dylib`boost::detail::(anonymous namespace)::tls_destructor:
->  0x1029e9060 <+128>: movq   0x8(%rbx), %rax
    0x1029e9064 <+132>: movq   %rax, 0x198(%r12)
    0x1029e906c <+140>: movq   (%rbx), %rdi
    0x1029e906f <+143>: testq  %rdi, %rdi
Target 0: (app-monero) stopped.
(lldb) bt
* thread #2, stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
  * frame #0: 0x00000001029e9060 libboost_thread.dylib`boost::detail::(anonymous namespace)::tls_destructor(void*) + 128
    frame #1: 0x00000001029e6332 libboost_thread.dylib`boost::(anonymous namespace)::thread_proxy(void*) + 146
    frame #2: 0x00007fff66eb4661 libsystem_pthread.dylib`_pthread_body + 340
    frame #3: 0x00007fff66eb450d libsystem_pthread.dylib`_pthread_start + 377
    frame #4: 0x00007fff66eb3bf9 libsystem_pthread.dylib`thread_start + 13
(lldb)
```

After migration from `boost::thread` to `std::thread` crash has gone away.

My team members report that this crash often reproduces on ios and android platform when closing wallets.

Probably https://github.com/monero-project/monero-gui/issues/894  has same roots.

I could migrate `boost::mutex` to `std::mutex` in wallet api as well, If you decide to merge this PR.
