### PR TITLE
tests: ringdb: use --data-dir arg

### DIFF
--- a/tests/unit_tests/ringdb.cpp
+++ b/tests/unit_tests/ringdb.cpp
@@ -76,13 +76,13 @@ public:
 private:
   std::string make_filename()
   {
-    boost::filesystem::path path = tools::get_default_data_dir();
-    path /= "fake";
+    boost::filesystem::path path =
+      boost::filesystem::temp_directory_path();
 #if defined(__MINGW32__) || defined(__MINGW__)
-    filename = tempnam(path.string().c_str(), "ringdb-test-");
+    filename = tempnam(path.string().c_str(), "monero-ringdb-test-");
     EXPECT_TRUE(filename != NULL);
 #else
-    path /= "ringdb-test-XXXXXX";
+    path /= "monero-ringdb-test-XXXXXX";
     filename = strdup(path.string().c_str());
     EXPECT_TRUE(mkdtemp(filename) != NULL);
 #endif


### PR DESCRIPTION
Fixes failing test during Arch package build (due to attempt to write to
~/.bitmonero/...). Also, now it is consistent with other tests.