### PR TITLE
simplewallet: make sure wallet config is stored right after creation

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -91,13 +91,13 @@ namespace cryptonote
     //! \return Prompts user for password and verifies against local file. Logs on error and returns `none`
     boost::optional<tools::password_container> get_and_verify_password() const;
 
-    bool new_wallet(const boost::program_options::variables_map& vm, const crypto::secret_key& recovery_key,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const crypto::secret_key& recovery_key,
         bool recover, bool two_random, const std::string &old_language);
-    bool new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
-    bool new_wallet(const boost::program_options::variables_map& vm,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
         const std::string &multisig_keys, const std::string &old_language);
-    bool new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
     bool open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
 


### PR DESCRIPTION
Currently, when simplewallet resotres a wallet, the refresh height setting is changed after the creation (call to `new_wallet` or `restore`), and it doesn't get saved unless the user explicitly updates the wallet settings via the `set` command.
An example:

```
~/monero$ ./monero-wallet-cli --stagenet --restore-deterministic-wallet --generate-new-wallet wallets/temp-1
This is the command line monero wallet. It needs to connect to a monero
daemon to work correctly.
WARNING: Do not reuse your Monero keys on an another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.

Monero 'Lithium Luna' (v0.12.3.0-release)
Logging to ./monero-wallet-cli.log
Specify Electrum seed: ashtray testing metro bovine cabin using wipeout lectures vaults directed fruit festival ivory village wade hedgehog tequila segments request comb enigma oven react runway festival
Enter seed encryption passphrase, empty if none: 
Enter a new password for the wallet: 
Confirm password: 
Generated new wallet: 5A7Gv4ywGavExAC6BVnXCPGR6J3wimLSFbq2wfMLqokK67cx8bhQnJZg27G6yACiFS8rTogBMhx62D3HEDJ2Ka2JEHVW29N
View key: fc01c8d7accd8d3f48b4c21cccb60515c1ad2b9a62e5be7014aa8d4a91c6e603
**********************************************************************
Your wallet has been generated!
To start synchronizing with the daemon, use the "refresh" command.
Use the "help" command to see the list of available commands.
Use "help <command>" to see a command's documentation.
Always use the "exit" command when closing monero-wallet-cli to save 
your current session's state. Otherwise, you might need to synchronize 
your wallet again (your wallet keys are NOT at risk in any case).


NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.

ashtray testing metro bovine cabin using wipeout lectures
vaults directed fruit festival ivory village wade hedgehog
tequila segments request comb enigma oven react runway festival
**********************************************************************
Restore from specific blockchain height (optional, default 0),
or alternatively from specific date (YYYY-MM-DD): 120000
Starting refresh...
...
Balance: 13.035463850000, unlocked balance: 13.035463850000
Background refresh thread started
[wallet 5A7Gv4]: set
...
refresh-from-block-height = 120000
...
[wallet 5A7Gv4]: exit

~/monero$ ./monero-wallet-cli --stagenet --wallet-file wallets/temp-1
This is the command line monero wallet. It needs to connect to a monero
daemon to work correctly.
WARNING: Do not reuse your Monero keys on an another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.

Monero 'Lithium Luna' (v0.12.3.0-release)
Logging to ./monero-wallet-cli.log
Wallet password: 
Opened wallet: 5A7Gv4ywGavExAC6BVnXCPGR6J3wimLSFbq2wfMLqokK67cx8bhQnJZg27G6yACiFS8rTogBMhx62D3HEDJ2Ka2JEHVW29N
...
Balance: 13.035463850000, unlocked balance: 13.035463850000
Background refresh thread started
[wallet 5A7Gv4]: set
...
refresh-from-block-height = 0
...
```

This patch ensures that `wallet2::rewrite` is called after all the additional wallet setting changes (potentially more than just the refresh height).
