### PR TITLE
Linting for monero based on kovri

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,49 @@ See [LICENSE](LICENSE).
 
 If you want to help out, see [CONTRIBUTING](CONTRIBUTING.md) for a set of guidelines.
 
+## Guidelines
+- We aim for complete C++11/14 compliance; please use this to your advantage
+- Please use the standard library and dependency libraries whenever possible
+
+### Style
+1. Read [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html) (particularly for non-formatting style reference)
+   - If bash programming, read [Google's Shell Style Guide](https://github.com/google/styleguide/blob/gh-pages/shell.xml)
+2. For files containing only new work, run [clang-format](http://clang.llvm.org/docs/ClangFormat.html) with ```-style=file``` (which uses our provided [clang-format](https://github.com/monero-project/monero/tree/master/contrib/utils/clang-format))
+```bash
+$ cd monero/ && clang-format -i -style=file src/path/to/my/file
+```
+3. For files with mixed (existing + new) work, run [clang-format](http://clang.llvm.org/docs/ClangFormat.html) selectively over only lines directly related to the new work.
+   - See [vim](http://clang.llvm.org/docs/ClangFormat.html#vim-integration) and [emacs](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration) documentation for examples of configuring keybindings for `clang-format` plugins.
+4. Run [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint) (which uses our provided [CPPLINT.cfg](https://github.com/monero-project/monero/tree/master/contrib/utils/cpplint.cfg)) to catch any issues that were missed by clang-format
+```bash
+$ cd monero/ && cpplint src/path/to/my/file && [edit file manually to apply fixes]
+```
+
+#### Plugins
+
+- Vim integration
+  - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#vim-integration)
+  - [clang-format ubuntu 16.04 vim workaround](http://stackoverflow.com/questions/39490082/clang-format-not-working-under-gvim)
+  - [cpplint.vim](https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/cpp/cpplint.vim)
+- Emacs integration
+  - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration) + [clang-format.el](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el)
+  - [flycheck-google-cpplint.el](https://github.com/flycheck/flycheck-google-cpplint)
+
+#### Amendments to Google's proposed C++ style
+
+- Avoid prepended mixed-case ```k``` and MACRO_TYPE for all constants
+- Use Doxygen three-slash ```/// C++ comments``` when documenting for Doxygen
+- Try to document all your work for Doxygen as you progress
+- If anonymity is a concern, try to blend in with a present contributor's style
+
+#### Optional Checks
+1. [cppdep](https://github.com/rakhimov/cppdep)
+   for component dependency, physical insulation, and include checks.
+2. [cppcheck](https://github.com/danmar/cppcheck/) for static analysis
+   (complementary to Coverity).
+3. [lizard](https://github.com/terryyin/lizard) for code complexity checks.
+
+
 ## Scheduled software upgrades
 
 Monero uses a fixed-schedule software upgrade (hard fork) mechanism to implement new features. This means that users of Monero (end users and service providers) should run current versions and upgrade their software on a regular schedule. Software upgrades occur during the months of April and October. The required software for these upgrades will be available prior to the scheduled date. Please check the repository prior to this date for the proper Monero software version. Below is the historical schedule and the projected schedule for the next upgrade.

--- a/contrib/utils/clang-format
+++ b/contrib/utils/clang-format
@@ -1,0 +1,19 @@
+Language: Cpp
+BasedOnStyle: Google
+
+AlignAfterOpenBracket: AlwaysBreak
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: GNU
+ColumnLimit: 80
+CommentPragmas: '.*'
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 2

--- a/contrib/utils/clang-format
+++ b/contrib/utils/clang-format
@@ -10,8 +10,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: GNU
+BreakBeforeBraces: Allman
 ColumnLimit: 80
 CommentPragmas: '.*'
 DerivePointerAlignment: false

--- a/contrib/utils/cppling.cfg
+++ b/contrib/utils/cppling.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace/braces,-whitespace/newline,-whitespace/line_length


### PR DESCRIPTION
This PR is supposed to start a conversation around linting in monero. The addition is largely based on Kovri, which has great documentation regarding code style. I think it is good design practice to follow a coding standard, especially if so many different developers provide code. Of course the standard and deviations thereof can be discussed but in the end we should have something which allows us to get the codebase to one coding standard which everyone is (almost) happy with. 

Also, whether this text should be in CONTRIBUTING instead of in the README is up for discussion of course. 

I do not think linting the whole codebase is possible at the moment, ideally we will get to a point where we can enforce all new commits to automatically get checked with each PR to comply with the then established monero guidelines on every new commit message.