### PR TITLE
Add new command "export_transfers" to save transfers to csv

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -190,6 +190,7 @@ namespace cryptonote
     bool get_reserve_proof(const std::vector<std::string> &args);
     bool check_reserve_proof(const std::vector<std::string> &args);
     bool show_transfers(const std::vector<std::string> &args);
+    bool export_transfers(const std::vector<std::string> &args);
     bool unspent_outputs(const std::vector<std::string> &args);
     bool rescan_blockchain(const std::vector<std::string> &args);
     bool refresh_main(uint64_t start_height, ResetType reset, bool is_init = false);
@@ -240,6 +241,23 @@ namespace cryptonote
     bool print_ring_members(const std::vector<tools::wallet2::pending_tx>& ptx_vector, std::ostream& ostr);
     std::string get_prompt() const;
     bool print_seed(bool encrypted);
+
+    struct transfer_view
+    {
+      boost::variant<uint64_t, std::string> block;
+      uint64_t timestamp;
+      std::string direction;
+      bool confirmed;
+      uint64_t amount;
+      crypto::hash hash;
+      std::string payment_id;
+      uint64_t fee;
+      std::vector<std::pair<std::string, uint64_t>> outputs;
+      std::set<uint32_t> index;
+      std::string note;
+      std::string unlocked;
+    };
+    bool get_transfers(std::vector<std::string>& args_, std::vector<transfer_view>& transfers);
 
     /*!
      * \brief Prints the seed with a nice message


### PR DESCRIPTION
This pull request adds a new `export_transfers` command to the wallet cli that exports the transfers to a csv file.

Since `show_transfers` and `export_transfers` basically require the same data, I've added a new function `get_transfers` that returns a vector of `transfer_view` structs (new structure as well). That function does all the querying, calculations, sorting and can consume some of the common arguments.
Then, it's up to the caller function to display the data in the appropriate way (print or export as csv).

Notable difference between the csv file and the printed list of transfers:
- The csv file shows the "running balance" next the the transfer amount. This field is not affected by unconfirmed transfers (pending/failed/pool).
- To handle transfers with multiple outputs, the csv file displays a new line for any subsequent outputs after the first one,  showing only the destination address and amount sent:
```
x, <total amount>, xxxxx, xxxxxxxxxxxxxxxxx, <address1>, <amount 1>
 ,               ,      ,                  , <address2>, <amount 2>
```

Changes made to both:
- display the (shortened) destination address for incoming transfers, to easily match which address the funds were sent to. This will make it easier to match the transfer with the owner's accounts/addresses.
