### PR TITLE
simplewallet: Simplify LOCK_IDLE_SCOPE macro

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -95,13 +95,8 @@ typedef cryptonote::simple_wallet sw;
   m_auto_refresh_enabled.store(false, std::memory_order_relaxed); \
   /* stop any background refresh, and take over */ \
   m_wallet->stop(); \
-  m_idle_mutex.lock(); \
-  while (m_auto_refresh_refreshing) \
-    m_idle_cond.notify_one(); \
-  m_idle_mutex.unlock(); \
-/*  if (auto_refresh_run)*/ \
-    /*m_auto_refresh_thread.join();*/ \
   boost::unique_lock<boost::mutex> lock(m_idle_mutex); \
+  m_idle_cond.notify_all(); \
   epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ \
     m_auto_refresh_enabled.store(auto_refresh_enabled, std::memory_order_relaxed); \
   })


### PR DESCRIPTION
After I thoroughly studied C++/Boost thread sync support and its use in `simplewallet` I noticed that the `LOCK_IDLE_SCOPE` macro does not contain any outright bug, but is nevertheless needlessly complex and does things that have no effect, and I propose to simplify it from 10 lines of code down to 3.

Two threads within `simplewallet` must be in sync when accessing / changing the `wallet2` object: The main thread and the idle thread that does autorefresh. Sync is done through locks on the `m_idle_mutex` mutex: The thread that manages to put a lock on that mutex can be sure to have exclusive access to the wallet until the lock is lifted.

The main thread uses the `LOCK_IDLE_SCOPE` macro to lock and relies on the destructor of the `boost::unique_lock` object at the end of the method in question to unlock.

---------

Locks on that mutex alone are sufficient already to sync the access of the two threads to the `wallet2` resource. It's unnecessary, as was done until now, to temporarily set the `m_auto_refresh_enabled` option to `false` as a second, additional measure: The idle thread can't do anything anyway if it does not currently hold a lock on the mutex.

**EDIT**: Turned out to be only half the truth. The mutex alone is alright to sync access to the wallet, but if you want to reliably interrupt any auto-refresh that happens to run at the time you want to lock, fiddling with `m_auto_refresh_enabled` is indeed needed in addition.

----------

It makes sense to call `m_idle_cond.notify_one` within `LOCK_IDLE_SCOPE`: You want to stop the up-to-90-seconds wait of the idle thread between auto refreshes and make it refresh right away after the wallet state changed. But there is no need to put a lock on the mutex and use a loop for doing so.

I am aware that syncing threads the wrong way can lead to subtle and rarely occuring bugs because of the dependence on timing, so I tested carefully. I made the refresh thread doing a refresh 3 times every second instead of once every 90 seconds attempting to provoke a sync breakdown, without success.

--------

The `wallet` class that the GUI wallet uses to access its `wallet2` object also works with mutexes, but such a complicated logic like until now in `LOCK_IDLE_SCOPE` is nowhere in sight.

**EDIT**: After having gone through this all here I have the suspicion that the absence of "complicated" logic in the `wallet` class is not an argument pro simplicity, but a sign that not all is well yet there concerning sync.

-------