### PR TITLE
[WalletAPI] Allow query if Wallet is on hardware

### DIFF
--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -78,7 +78,6 @@ namespace hw {
            return false;
     }
 
-
     class device {
     protected:
         std::string  name;
@@ -96,6 +95,12 @@ namespace hw {
             TRANSACTION_CREATE_FAKE,
             TRANSACTION_PARSE
         };
+        enum device_type
+        {
+          SOFTWARE = 0,
+          LEDGER = 1
+        };
+
 
         /* ======================================================================= */
         /*                              SETUP/TEARDOWN                             */
@@ -109,7 +114,9 @@ namespace hw {
         virtual bool connect(void) = 0;
         virtual bool disconnect(void) = 0;
 
-        virtual bool  set_mode(device_mode mode) = 0;
+        virtual bool set_mode(device_mode mode) = 0;
+
+        virtual device_type get_type() const = 0;
 
 
         /* ======================================================================= */

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -61,6 +61,8 @@ namespace hw {
  
             bool set_mode(device_mode mode) override;
 
+            device_type get_type() const {return device_type::SOFTWARE;};
+
             /* ======================================================================= */
             /*  LOCKER                                                                 */
             /* ======================================================================= */ 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -142,7 +142,9 @@ namespace hw {
         bool connect(void) override;
         bool disconnect() override;
 
-        bool  set_mode(device_mode mode) override;
+        bool set_mode(device_mode mode) override;
+
+        device_type get_type() const {return device_type::LEDGER;};
 
         /* ======================================================================= */
         /*  LOCKER                                                                 */

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -639,6 +639,11 @@ bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &p
     return true;
 }
 
+Wallet::Device WalletImpl::getDeviceType() const
+{
+    return static_cast<Wallet::Device>(m_wallet->get_device_type());
+}
+
 bool WalletImpl::open(const std::string &path, const std::string &password)
 {
     clearStatus();

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -79,6 +79,7 @@ public:
     bool recoverFromDevice(const std::string &path,
                            const std::string &password,
                            const std::string &device_name);
+    Device getDeviceType() const;
     bool close(bool store = true);
     std::string seed() const override;
     std::string getSeedLanguage() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -373,6 +373,10 @@ struct WalletListener
  */
 struct Wallet
 {
+    enum Device {
+        Device_Software = 0,
+        Device_Ledger = 1
+    };
 
     enum Status {
         Status_Ok,
@@ -911,6 +915,12 @@ struct Wallet
     virtual bool unlockKeysFile() = 0;
     //! returns true if the keys file is locked
     virtual bool isKeysFileLocked() = 0;
+
+    /*!
+     * \brief Queries backing device for wallet keys
+     * \return Device they are on
+     */
+    virtual Device getDeviceType() const = 0;
 };
 
 /**
@@ -1095,6 +1105,18 @@ struct WalletManager
      * In this case, Wallet::unlockKeysFile() and Wallet::lockKeysFile() need to be called before and after the call to this function, respectively.
      */
     virtual bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const = 0;
+
+    /*!
+     * \brief determine the key storage for the specified wallet file
+     * \param device_type     (OUT) wallet backend as enumerated in Wallet::Device
+     * \param keys_file_name  Keys file to verify password for
+     * \param password        Password to verify
+     * \return                true if password correct, else false
+     *
+     * for verification only - determines key storage hardware
+     *
+     */
+    virtual bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const = 0;
 
     /*!
      * \brief findWallets - searches for the wallet files by given path name recursively

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -167,6 +167,14 @@ bool WalletManagerImpl::verifyWalletPassword(const std::string &keys_file_name, 
 	    return tools::wallet2::verify_password(keys_file_name, password, no_spend_key, hw::get_device("default"), kdf_rounds);
 }
 
+bool WalletManagerImpl::queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds) const
+{
+    hw::device::device_type type;
+    bool r = tools::wallet2::query_device(type, keys_file_name, password, kdf_rounds);
+    device_type = static_cast<Wallet::Device>(type);
+    return r;
+}
+
 std::vector<std::string> WalletManagerImpl::findWallets(const std::string &path)
 {
     std::vector<std::string> result;

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -76,6 +76,7 @@ public:
     virtual bool closeWallet(Wallet *wallet, bool store = true) override;
     bool walletExists(const std::string &path) override;
     bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const override;
+    bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const;
     std::vector<std::string> findWallets(const std::string &path) override;
     std::string errorString() const override;
     void setDaemonAddress(const std::string &address) override;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -189,6 +189,7 @@ namespace tools
     static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev, uint64_t kdf_rounds);
+    static bool query_device(hw::device::device_type& device_type, const std::string& keys_file_name, const epee::wipeable_string& password, uint64_t kdf_rounds = 1);
 
     wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, uint64_t kdf_rounds = 1, bool unattended = false);
     ~wallet2();
@@ -709,7 +710,8 @@ namespace tools
     bool has_multisig_partial_key_images() const;
     bool has_unknown_key_images() const;
     bool get_multisig_seed(epee::wipeable_string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
-    bool key_on_device() const { return m_key_on_device; }
+    bool key_on_device() const { return get_device_type() != hw::device::device_type::SOFTWARE; }
+    hw::device::device_type get_device_type() const { return m_key_device_type; }
     bool reconnect_device();
 
     // locked & unlocked balance of given or current subaddress account
@@ -1284,7 +1286,7 @@ namespace tools
 
     bool m_trusted_daemon;
     i_wallet2_callback* m_callback;
-    bool m_key_on_device;
+    hw::device::device_type m_key_device_type;
     cryptonote::network_type m_nettype;
     uint64_t m_kdf_rounds;
     std::string seed_language; /*!< Language of the mnemonics (seed). */


### PR DESCRIPTION
Provides ```WalletManager::queryWalletHardware()``` in the wallet API to query if (and how) the wallet is hardware-backed. This also implicitly verifies the wallet password without the need for the hardware to be connected. (```WalletManager::verifyWalletPassword()``` does not work on hardware-backed wallets without the hardware device being connected, so in order to check if a wallet is hardware-backed, the hardware needs to be connected...) These two methods share a lot of code, but I am still at a loss of how to refactor it well. Enumeration of the Hardware Devices might also be in order, but as current code assumes Ledger or not (boolean) I did not.

This PR also provides ```key_on_device``` to the Wallet API to enable handling of open wallets appropriately.