### PR TITLE
[Suggestion] Native Android Ledger comm (replacing PCSC dependency)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,10 @@ if(STATIC AND NOT IOS)
   endif()
 endif()
 
-find_package(PCSC)
+option(MONERUJO_PCSC "PCSC is handled by Monerujo" OFF)
+if(NOT MONERUJO_PCSC)
+  find_package(PCSC)
+endif()
 
 add_definition_if_library_exists(c memset_s "string.h" HAVE_MEMSET_S)
 add_definition_if_library_exists(c explicit_bzero "strings.h" HAVE_EXPLICIT_BZERO)

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -32,6 +32,13 @@ set(device_sources
   log.cpp
   )
 
+if(MONERUJO_PCSC)
+    set(PCSC_FOUND 1)
+    add_definitions(-DHAVE_PCSC)
+    add_definitions(-DHAVE_MONERUJO)
+    set(device_headers ${device_headers} monerujo_ledger.h)
+endif()
+
 if(PCSC_FOUND)
   set(device_sources ${device_sources} device_ledger.cpp)
 endif()

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <string>
 #include "device.hpp"
+#ifndef HAVE_MONERUJO
 #ifdef WIN32
 #include <winscard.h>
 #define MAX_ATR_SIZE            33
@@ -40,6 +41,10 @@
 #include <PCSC/winscard.h>
 #include <PCSC/wintypes.h>
 #endif
+#else
+#include "monerujo_ledger.h"
+#endif
+
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 

--- a/src/device/monerujo_ledger.h
+++ b/src/device/monerujo_ledger.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2018 m2049r
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef XMRWALLET_LEDGER_H
+#define XMRWALLET_LEDGER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SCARD_S_SUCCESS ((LONG)0x00000000) /**< No error was encountered. */
+#define SCARD_E_INSUFFICIENT_BUFFER    ((LONG)0x80100008) /**< The data buffer to receive returned data is too small for the returned data. */
+#define SCARD_E_NO_READERS_AVAILABLE ((LONG)0x8010002E) /**< Cannot find a smart card reader. */
+
+typedef long LONG;
+typedef unsigned long DWORD;
+typedef DWORD *LPDWORD;
+typedef unsigned char BYTE;
+typedef BYTE *LPBYTE;
+typedef const BYTE *LPCBYTE;
+
+typedef char CHAR;
+typedef CHAR *LPSTR;
+
+typedef LONG SCARDCONTEXT;
+typedef LONG SCARDHANDLE;
+
+/**
+ * @brief LedgerFind - find Ledger Device and return it's name
+ * @param buffer - buffer for name of found device
+ * @param len    - length of buffer
+ * @return  0 - success
+ *         -1 - no device connected / found
+ *         -2 - JVM not found
+ */
+int LedgerFind(char *buffer, size_t len);
+
+/**
+ * @brief LedgerExchange - exchange data with Ledger Device
+ * @param pbSendBuffer   - buffer for data to send
+ * @param cbSendLength   - length of send buffer
+ * @param pbRecvBuffer   - buffer for received data
+ * @param pcbRecvLength  - pointer to size of receive buffer
+ *                         gets set with length of received data on successful return
+ * @return SCARD_S_SUCCESS - success
+ *         SCARD_E_NO_READERS_AVAILABLE - no device connected / found
+ *         SCARD_E_INSUFFICIENT_BUFFER  - pbRecvBuffer is too small for the response
+ */
+LONG LedgerExchange(LPCBYTE pbSendBuffer, DWORD cbSendLength, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //XMRWALLET_LEDGER_H


### PR DESCRIPTION
This PR enables communication on Android to a Ledger Nano S without the need for rooting (i.e. no need for PCSC libraries). The Android app needs to provide 2 JNI functions (see ```src/device/monerujo_ledger.h```):

```
int LedgerFind(char *buffer, size_t len);
LONG LedgerExchange(LPCBYTE pbSendBuffer, DWORD cbSendLength, LPBYTE pbRecvBuffer, LPDWORD pcbRecvLength);
```

See [xmrwallet](https://github.com/m2049r/xmrwallet/blob/master/app/src/main/cpp/monerujo.cpp#L1393) for a reference implementation.

The functionality is enabled with ```-D MONERUJO_PCSC=ON``` in ```cmake```.

Not sure if it can/should be merged to the monero repo. I propose it is.