### PR TITLE
ringct: make conversion functions return const refs

### DIFF
--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -517,14 +517,14 @@ namespace rct {
     //int[64] to uint long long
     xmr_amount b2d(bits amountb);
 
-    static inline const rct::key pk2rct(const crypto::public_key &pk) { return (const rct::key&)pk; }
-    static inline const rct::key sk2rct(const crypto::secret_key &sk) { return (const rct::key&)sk; }
-    static inline const rct::key ki2rct(const crypto::key_image &ki) { return (const rct::key&)ki; }
-    static inline const rct::key hash2rct(const crypto::hash &h) { return (const rct::key&)h; }
-    static inline const crypto::public_key rct2pk(const rct::key &k) { return (const crypto::public_key&)k; }
-    static inline const crypto::secret_key rct2sk(const rct::key &k) { return (const crypto::secret_key&)k; }
-    static inline const crypto::key_image rct2ki(const rct::key &k) { return (const crypto::key_image&)k; }
-    static inline const crypto::hash rct2hash(const rct::key &k) { return (const crypto::hash&)k; }
+    static inline const rct::key &pk2rct(const crypto::public_key &pk) { return (const rct::key&)pk; }
+    static inline const rct::key &sk2rct(const crypto::secret_key &sk) { return (const rct::key&)sk; }
+    static inline const rct::key &ki2rct(const crypto::key_image &ki) { return (const rct::key&)ki; }
+    static inline const rct::key &hash2rct(const crypto::hash &h) { return (const rct::key&)h; }
+    static inline const crypto::public_key &rct2pk(const rct::key &k) { return (const crypto::public_key&)k; }
+    static inline const crypto::secret_key &rct2sk(const rct::key &k) { return (const crypto::secret_key&)k; }
+    static inline const crypto::key_image &rct2ki(const rct::key &k) { return (const crypto::key_image&)k; }
+    static inline const crypto::hash &rct2hash(const rct::key &k) { return (const crypto::hash&)k; }
     static inline bool operator==(const rct::key &k0, const crypto::public_key &k1) { return !crypto_verify_32(k0.bytes, (const unsigned char*)&k1); }
     static inline bool operator!=(const rct::key &k0, const crypto::public_key &k1) { return crypto_verify_32(k0.bytes, (const unsigned char*)&k1); }
 }


### PR DESCRIPTION
This might avoid unnecessary copies.

Reported by stoffu