### PR TITLE
util: remove unused <ustat.h>

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -38,7 +38,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
-#include <ustat.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>


### PR DESCRIPTION
It's obsolete and removed from at least Arch Linux 8.2

Reported by moneroexamples