### PR TITLE
hw_device: support for multiple devices added [for review]

### DIFF
--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -197,10 +197,14 @@ DISABLE_VS_WARNINGS(4244 4345)
   //-----------------------------------------------------------------
   void account_base::create_from_device(const std::string &device_name)
   {
-
     hw::device &hwdev =  hw::get_device(device_name);
-    m_keys.set_device(hwdev);
     hwdev.set_name(device_name);
+    create_from_device(hwdev);
+  }
+
+  void account_base::create_from_device(hw::device &hwdev)
+  {
+    m_keys.set_device(hwdev);
     MCDEBUG("ledger", "device type: "<<typeid(hwdev).name());
     hwdev.init();
     hwdev.connect();

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -77,7 +77,8 @@ namespace cryptonote
   public:
     account_base();
     crypto::secret_key generate(const crypto::secret_key& recovery_key = crypto::secret_key(), bool recover = false, bool two_random = false);
-    void create_from_device(const std::string &device_name) ;
+    void create_from_device(const std::string &device_name);
+    void create_from_device(hw::device &hwdev);
     void create_from_keys(const cryptonote::account_public_address& address, const crypto::secret_key& spendkey, const crypto::secret_key& viewkey);
     void create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey);
     bool make_multisig(const crypto::secret_key &view_secret_key, const crypto::secret_key &spend_secret_key, const crypto::public_key &spend_public_key, const std::vector<crypto::secret_key> &multisig_keys);

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -39,32 +39,60 @@ namespace hw {
     
     /* ======================================================================= */
     /*  SETUP                                                                  */
-    /* ======================================================================= */   
-    device& get_device(const std::string device_descriptor) {
-        
-        struct s_devices {
-            std::map<std::string, std::unique_ptr<device>> registry;
-            s_devices() : registry() {
-                hw::core::register_all(registry);
-                #ifdef HAVE_PCSC
-                hw::ledger::register_all(registry); 
-                #endif
-           };
-        };
-        
-        static const s_devices devices;
+    /* ======================================================================= */
 
-        auto device = devices.registry.find(device_descriptor);
-        if (device == devices.registry.end()) {
-            MERROR("device not found in registry: '" << device_descriptor << "'\n" <<
-                      "known devices:");
-            
-            for( const auto& sm_pair : devices.registry ) {
+    static std::unique_ptr<device_registry> registry;
+
+    device_registry::device_registry(){
+        hw::core::register_all(registry);
+        #ifdef HAVE_PCSC
+        hw::ledger::register_all(registry);
+        #endif
+    }
+
+    bool device_registry::register_device(const std::string & device_name, device * hw_device){
+        auto search = registry.find(device_name);
+        if (search != registry.end()){
+            return false;
+        }
+
+        registry.insert(std::make_pair(device_name, std::unique_ptr<device>(hw_device)));
+        return true;
+    }
+
+    device& device_registry::get_device(const std::string & device_descriptor){
+        // Device descriptor can contain further specs after first :
+        auto delim = device_descriptor.find(':');
+        auto device_descriptor_lookup = device_descriptor;
+        if (delim != std::string::npos) {
+            device_descriptor_lookup = device_descriptor.substr(0, delim);
+        }
+
+        auto device = registry.find(device_descriptor_lookup);
+        if (device == registry.end()) {
+            MERROR("Device not found in registry: '" << device_descriptor << "'. Known devices: ");
+            for( const auto& sm_pair : registry ) {
                 MERROR(" - " << sm_pair.first);
             }
-            throw std::runtime_error("device not found: "+ device_descriptor);
+            throw std::runtime_error("device not found: " + device_descriptor);
         }
         return *device->second;
+    }
+
+    device& get_device(const std::string & device_descriptor) {
+        if (!registry){
+            registry.reset(new device_registry());
+        }
+
+        return registry->get_device(device_descriptor);
+    }
+
+    bool register_device(const std::string & device_name, device * hw_device){
+        if (!registry){
+            registry.reset(new device_registry());
+        }
+
+        return registry->register_device(device_name, hw_device);
     }
 
 }

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -202,6 +202,17 @@ namespace hw {
         ~reset_mode() { hwref.set_mode(hw::device::NONE);}
     };
 
-    device& get_device(const std::string device_descriptor) ;
+    class device_registry {
+    private:
+      std::map<std::string, std::unique_ptr<device>> registry;
+
+    public:
+      device_registry();
+      bool register_device(const std::string & device_name, device * hw_device);
+      device& get_device(const std::string & device_descriptor);
+    };
+
+    device& get_device(const std::string & device_descriptor);
+    bool register_device(const std::string & device_name, device * hw_device);
 }
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2523,6 +2523,10 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::import_key_images, this, _1),
                            tr("import_key_images <file>"),
                            tr("Import a signed key images list and verify their spent status."));
+  m_cmd_binder.set_handler("hw_reconnect",
+                           boost::bind(&simple_wallet::hw_reconnect, this, _1),
+                           tr("hw_reconnect"),
+                           tr("Attempts to reconnect HW wallet."));
   m_cmd_binder.set_handler("export_outputs",
                            boost::bind(&simple_wallet::export_outputs, this, _1),
                            tr("export_outputs <file>"),
@@ -2650,6 +2654,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "subaddress-lookahead = " << lookahead.first << ":" << lookahead.second;
     success_msg_writer() << "segregation-height = " << m_wallet->segregation_height();
     success_msg_writer() << "ignore-fractional-outputs = " << m_wallet->ignore_fractional_outputs();
+    success_msg_writer() << "device_name = " << m_wallet->device_name();
     return true;
   }
   else
@@ -3295,7 +3300,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     {
       m_wallet_file = m_generate_from_device;
       // create wallet
-      auto r = new_wallet(vm, "Ledger");
+      auto r = new_wallet(vm);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
       // if no block_height is specified, assume its a new account and start it "now"
@@ -3703,8 +3708,8 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
 }
 
 //----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
-                               const std::string &device_name) {
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm)
+{
   auto rc = tools::wallet2::make_new(vm, false, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
@@ -3723,10 +3728,11 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   if (m_restore_height)
     m_wallet->set_refresh_from_block_height(m_restore_height);
 
+  auto device_desc = tools::wallet2::device_name_option(vm);
   try
   {
     bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
-    m_wallet->restore(m_wallet_file, std::move(rc.second).password(), device_name, create_address_file);
+    m_wallet->restore(m_wallet_file, std::move(rc.second).password(), device_desc.empty() ? "Ledger" : device_desc, create_address_file);
     message_writer(console_color_white, true) << tr("Generated new wallet on hw device: ")
       << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
   }
@@ -7739,6 +7745,31 @@ bool simple_wallet::import_key_images(const std::vector<std::string> &args)
   catch (const std::exception &e)
   {
     fail_msg_writer() << "Failed to import key images: " << e.what();
+    return true;
+  }
+
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::hw_reconnect(const std::vector<std::string> &args)
+{
+  if (!m_wallet->key_on_device())
+  {
+    fail_msg_writer() << tr("command only supported by HW wallet");
+    return true;
+  }
+
+  LOCK_IDLE_SCOPE();
+  try
+  {
+    bool r = m_wallet->reconnect_device();
+    if (!r){
+      fail_msg_writer() << tr("Failed to reconnect device");
+    }
+  }
+  catch (const std::exception &e)
+  {
+    fail_msg_writer() << tr("Failed to reconnect device: ") << tr(e.what());
     return true;
   }
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -98,7 +98,7 @@ namespace cryptonote
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
         const epee::wipeable_string &multisig_keys, const std::string &old_language);
-    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm);
     bool open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
 
@@ -201,6 +201,7 @@ namespace cryptonote
     bool verify(const std::vector<std::string> &args);
     bool export_key_images(const std::vector<std::string> &args);
     bool import_key_images(const std::vector<std::string> &args);
+    bool hw_reconnect(const std::vector<std::string> &args);
     bool export_outputs(const std::vector<std::string> &args);
     bool import_outputs(const std::vector<std::string> &args);
     bool show_transfer(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -172,6 +172,7 @@ namespace tools
 
     static bool has_testnet_option(const boost::program_options::variables_map& vm);
     static bool has_stagenet_option(const boost::program_options::variables_map& vm);
+    static std::string device_name_option(const boost::program_options::variables_map& vm);
     static void init_options(boost::program_options::options_description& desc_params);
 
     //! Uses stdin and stdout. Returns a wallet2 if no errors.
@@ -709,6 +710,7 @@ namespace tools
     bool has_unknown_key_images() const;
     bool get_multisig_seed(epee::wipeable_string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
     bool key_on_device() const { return m_key_on_device; }
+    bool reconnect_device();
 
     // locked & unlocked balance of given or current subaddress account
     uint64_t balance(uint32_t subaddr_index_major) const;
@@ -938,6 +940,8 @@ namespace tools
     void ignore_fractional_outputs(bool value) { m_ignore_fractional_outputs = value; }
     bool confirm_non_default_ring_size() const { return m_confirm_non_default_ring_size; }
     void confirm_non_default_ring_size(bool always) { m_confirm_non_default_ring_size = always; }
+    const std::string & device_name() const { return m_device_name; }
+    void device_name(const std::string & device_name) { m_device_name = device_name; }
 
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const;
     void set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys);
@@ -1319,6 +1323,7 @@ namespace tools
     NodeRPCProxy m_node_rpc_proxy;
     std::unordered_set<crypto::hash> m_scanned_pool_txs[2];
     size_t m_subaddress_lookahead_major, m_subaddress_lookahead_minor;
+    std::string m_device_name;
 
     // Light wallet
     bool m_light_wallet; /* sends view key to daemon for scanning */


### PR DESCRIPTION
- Device name is a new wallet property
- Full device name is now a bit more structured so we can address particular device vendor + device path. Example: `Ledger`, `Trezor:udp`, `Trezor:udp:127.0.0.1:21324`, `Trezor:bridge:usb01`. The part before `:` identifies HW device implementation, the optional part after `:` is device path to look for.
- Device registry changed a bit so devices can be registered also in runtime - required for Trezor to break circular dependencies (Trezor is in separate cmake module as it has more dependencies which would cause circular deps)
- New --hw-device parameter added to the wallet, can name the hardware device
- Device reconnect  command added to wallet2 and simplewallet