### PR TITLE
rpc: allow to pass RPC login via RPC_LOGIN env var

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -239,11 +239,14 @@ int main(int argc, char const * argv[])
           return 1;
         }
 
+        const char *env_rpc_login = nullptr;
+        const bool has_rpc_arg = command_line::has_arg(vm, arg.rpc_login);
+        const bool use_rpc_env = !has_rpc_arg && (env_rpc_login = getenv("RPC_LOGIN")) != nullptr && strlen(env_rpc_login) > 0;
         boost::optional<tools::login> login{};
-        if (command_line::has_arg(vm, arg.rpc_login))
+        if (has_rpc_arg || use_rpc_env)
         {
           login = tools::login::parse(
-            command_line::get_arg(vm, arg.rpc_login), false, [](bool verify) {
+            has_rpc_arg ? command_line::get_arg(vm, arg.rpc_login) : std::string(env_rpc_login), false, [](bool verify) {
 #ifdef HAVE_READLINE
         rdln::suspend_readline pause_readline;
 #endif

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -82,11 +82,17 @@ namespace cryptonote
       }
     }
 
-    if (command_line::has_arg(vm, arg.rpc_login))
+    const char *env_rpc_login = nullptr;
+    const bool has_rpc_arg = command_line::has_arg(vm, arg.rpc_login);
+    const bool use_rpc_env = !has_rpc_arg && (env_rpc_login = getenv("RPC_LOGIN")) != nullptr && strlen(env_rpc_login) > 0;
+    boost::optional<tools::login> login{};
+    if (has_rpc_arg || use_rpc_env)
     {
-      config.login = tools::login::parse(command_line::get_arg(vm, arg.rpc_login), true, [](bool verify) {
-        return tools::password_container::prompt(verify, "RPC server password");
-      });
+      config.login = tools::login::parse(
+          has_rpc_arg ? command_line::get_arg(vm, arg.rpc_login) : std::string(env_rpc_login), true, [](bool verify) {
+            return tools::password_container::prompt(verify, "RPC server password");
+          });
+
       if (!config.login)
         return boost::none;
 


### PR DESCRIPTION
- passing by parameter is insecure as it is shown in the process list
- using environment variable for passing the password is more secure with this respect

Thanks for considering.