### PR TITLE
wallet_rpc_server: remove unused fields in relay_tx RPC

### DIFF
--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -768,15 +768,9 @@ namespace wallet_rpc
     struct response
     {
       std::string tx_hash;
-      std::string tx_key;
-      uint64_t fee;
-      std::string tx_blob;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
-        KV_SERIALIZE(tx_key)
-        KV_SERIALIZE(fee)
-        KV_SERIALIZE(tx_blob)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
This removes the unused fields `tx_key`, `fee` & `tx_blob`.

Those are not close to be added in wallet_rpc_server.cpp (which only return tx_hash on line 1262), and at least `fee` is misleading as defaulting to `0` when the `relay_tx` method is used.