### PR TITLE
Update License to exclude government use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -16,6 +16,9 @@ and/or other materials provided with the distribution.
 may be used to endorse or promote products derived from this software without
 specific prior written permission.
 
+4. Any state or government entity is strictly prohibited from copy or use of the source
+code even through third persons directly or indirectly.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE


### PR DESCRIPTION
Government entities are considering ban of anonymous cryptocurrencies. It is possible by author to restrict use of the source code based on civil law. This should be seriously considered due to multiple legal reasons. We should not be prohibited to use anonymous cryptocurrencies. If governments are thinking about ban of anonymous cryptocurrencies, they should be legally deprived of option to use anonymous coins first. "Nevertheless, it would be worthwhile to consider introducing a ban. If authorities then bump into the prohibited activities, they have a legal basis for prosecution, insofar not yet available. Possibly, imposing a ban could also have a deterrent effect." Source: http://www.europarl.europa.eu/cmsdata/150761/TAX3%20Study%20on%20cryptocurrencies%20and%20blockchain.pdf