### PR TITLE
Windows: tell cmake it's not crosscompiling in MSYS2

### DIFF
--- a/cmake/32-bit-toolchain.cmake
+++ b/cmake/32-bit-toolchain.cmake
@@ -46,3 +46,7 @@ set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY) # Find includes in target
 
 set (MINGW_FLAG "-m32")
 set (USE_LTO_DEFAULT false)
+
+if (CMAKE_HOST_WIN32)
+  set (CMAKE_CROSSCOMPILING false)
+endif()

--- a/cmake/64-bit-toolchain.cmake
+++ b/cmake/64-bit-toolchain.cmake
@@ -46,3 +46,7 @@ set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY) # Find includes in target
 
 set (MINGW_FLAG "-m64")
 set (USE_LTO_DEFAULT false)
+
+if (CMAKE_HOST_WIN32)
+  set (CMAKE_CROSSCOMPILING false)
+endif()


### PR DESCRIPTION
This fixes a cmake error in MSYS2 introduced by #4294