### PR TITLE
wallet2: import_multisig forward refresh exception

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10878,7 +10878,12 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
 
     refresh(false);
   }
-  catch (...) {}
+  catch (...)
+  {
+    m_multisig_rescan_info = NULL;
+    m_multisig_rescan_k = NULL;
+    throw;
+  }
   m_multisig_rescan_info = NULL;
   m_multisig_rescan_k = NULL;
 


### PR DESCRIPTION
Calling code needs to know if the operation has been finished successfully.
This PR fixes issue https://github.com/monero-project/monero/issues/4359