### PR TITLE
rctTypes: fix incorrect serialization

### DIFF
--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -313,10 +313,10 @@ namespace rct {
             return false;
           if (type == RCTTypeBulletproof)
           {
-            ar.tag("bp");
-            ar.begin_array();
             uint32_t nbp = bulletproofs.size();
             FIELD(nbp)
+            ar.tag("bp");
+            ar.begin_array();
             if (nbp > outputs)
               return false;
             PREPARE_CUSTOM_VECTOR_SERIALIZATION(nbp, bulletproofs);


### PR DESCRIPTION
I realized that the new BP format is being serialized incorrectly when using the updated https://github.com/moneroexamples/onion-monero-blockchain-explorer:
![screen shot 2018-09-12 at 20 45 57](https://user-images.githubusercontent.com/26077532/45423553-ae625c00-b6ce-11e8-9771-ab96662ca2d1.jpg)

With this patch:
![screen shot 2018-09-12 at 20 45 03](https://user-images.githubusercontent.com/26077532/45423566-b91cf100-b6ce-11e8-971f-368698da9a70.jpg)
