### PR TITLE
WalletAPI: mulitsigSignData bug fixed

### DIFF
--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -200,7 +200,11 @@ std::string PendingTransactionImpl::multisigSignData() {
             throw std::runtime_error("wallet is not multisig");
         }
 
-        auto cipher = m_wallet.m_wallet->save_multisig_tx(m_pending_tx);
+        tools::wallet2::multisig_tx_set txSet;
+        txSet.m_ptx = m_pending_tx;
+        txSet.m_signers = m_signers;
+        auto cipher = m_wallet.m_wallet->save_multisig_tx(txSet);
+
         return epee::string_tools::buff_to_hex_nodelimer(cipher);
     } catch (const std::exception& e) {
         m_status = Status_Error;


### PR DESCRIPTION
Previously `Wallet::multisigSignData` method could not properly serialize transaction with more than 2 signatures. In other words transaction signature with 3 or more signatures required didn't work with wallet api.

This happened because of using wrong `wallet2::save_multisig_tx` method overload.
