### PR TITLE
Wallet: use unique_ptr for WalletImpl members

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -376,15 +376,15 @@ WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     , m_rebuildWalletCache(false)
     , m_is_connected(false)
 {
-    m_wallet = new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds, true);
-    m_history = new TransactionHistoryImpl(this);
-    m_wallet2Callback = new Wallet2CallbackImpl(this);
+    m_wallet = std::make_unique<tools::wallet2>(static_cast<cryptonote::network_type>(nettype), kdf_rounds, true);
+    m_history = std::make_unique<TransactionHistoryImpl>(this);
+    m_wallet2Callback = std::make_unique<Wallet2CallbackImpl>(this);
     m_wallet->callback(m_wallet2Callback);
     m_refreshThreadDone = false;
     m_refreshEnabled = false;
-    m_addressBook = new AddressBookImpl(this);
-    m_subaddress = new SubaddressImpl(this);
-    m_subaddressAccount = new SubaddressAccountImpl(this);
+    m_addressBook = std::make_unique<AddressBookImpl>(this);
+    m_subaddress = std::make_unique<SubaddressImpl>(this);
+    m_subaddressAccount = std::make_unique<SubaddressAccountImpl>(this);
 
 
     m_refreshIntervalMillis = DEFAULT_REFRESH_INTERVAL_MILLIS;
@@ -405,12 +405,6 @@ WalletImpl::~WalletImpl()
     close(false); // do not store wallet as part of the closing activities
     // Stop refresh thread
     stopRefresh();
-    delete m_wallet2Callback;
-    delete m_history;
-    delete m_addressBook;
-    delete m_subaddress;
-    delete m_subaddressAccount;
-    delete m_wallet;
     LOG_PRINT_L1(__FUNCTION__ << " finished");
 }
 
@@ -1551,22 +1545,22 @@ void WalletImpl::disposeTransaction(PendingTransaction *t)
 
 TransactionHistory *WalletImpl::history()
 {
-    return m_history;
+    return m_history.get();
 }
 
 AddressBook *WalletImpl::addressBook()
 {
-    return m_addressBook;
+    return m_addressBook.get();
 }
 
 Subaddress *WalletImpl::subaddress()
 {
-    return m_subaddress;
+    return m_subaddress.get();
 }
 
 SubaddressAccount *WalletImpl::subaddressAccount()
 {
-    return m_subaddressAccount;
+    return m_subaddressAccount.get();
 }
 
 void WalletImpl::setListener(WalletListener *l)

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -215,16 +215,16 @@ private:
     friend class SubaddressImpl;
     friend class SubaddressAccountImpl;
 
-    tools::wallet2 * m_wallet;
+    std::unique_ptr<tools::wallet2> m_wallet;
     mutable boost::mutex m_statusMutex;
     mutable int m_status;
     mutable std::string m_errorString;
     std::string m_password;
-    TransactionHistoryImpl * m_history;
-    Wallet2CallbackImpl * m_wallet2Callback;
-    AddressBookImpl *  m_addressBook;
-    SubaddressImpl *  m_subaddress;
-    SubaddressAccountImpl *  m_subaddressAccount;
+    std::unique_ptr<TransactionHistoryImpl> m_history;
+    std::unique_ptr<Wallet2CallbackImpl> m_wallet2Callback;
+    std::unique_ptr<AddressBookImpl>  m_addressBook;
+    std::unique_ptr<SubaddressImpl>  m_subaddress;
+    std::unique_ptr<SubaddressAccountImpl>  m_subaddressAccount;
 
     // multi-threaded refresh stuff
     std::atomic<bool> m_refreshEnabled;


### PR DESCRIPTION
Use unique_ptr to manage WalletImpl internals, rather than raw pointers.