### PR TITLE
Dockerfile: use single build dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN set -ex \
 WORKDIR /src
 COPY . .
 
+ENV USE_SINGLE_BUILDDIR=1
 ARG NPROC
 RUN set -ex && \
     rm -rf build && \
@@ -128,7 +129,7 @@ RUN set -ex && \
     apt-get --no-install-recommends --yes install ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt
-COPY --from=builder /src/build/Linux/master/release/* /usr/local/bin/
+COPY --from=builder /src/build/release/bin /usr/local/bin/
 
 # Contains the blockchain
 VOLUME /root/.bitmonero

--- a/utils/build_scripts/android32.Dockerfile
+++ b/utils/build_scripts/android32.Dockerfile
@@ -138,4 +138,5 @@ RUN cd /src \
     && CMAKE_INCLUDE_PATH="${PREFIX}/include" \
        CMAKE_LIBRARY_PATH="${PREFIX}/lib" \
        ANDROID_STANDALONE_TOOLCHAIN_PATH=${TOOLCHAIN_DIR} \
+       USE_SINGLE_BUILDDIR=1 \
        PATH=${HOST_PATH} make release-static-android -j${NPROC}


### PR DESCRIPTION
Otherwise it only works with branch master (and it's currently missing `bin` dir)