### PR TITLE
Fixed a typo

### DIFF
--- a/cmake/CheckLinkerFlag.cmake
+++ b/cmake/CheckLinkerFlag.cmake
@@ -39,7 +39,7 @@ macro(CHECK_LINKER_FLAG flag VARIABLE)
       endif()
       set(${VARIABLE} "" CACHE INTERNAL "Have linker flag ${flag}")
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
-        "Determining if the ${flag} linker flag is suppored "
+        "Determining if the ${flag} linker flag is supported "
         "failed with the following output:\n"
         "${OUTPUT}\n\n")
     endif()


### PR DESCRIPTION
This is the only such occurrence after running `grep -rnw . -ie ".*suppor[^t].*"`.