### PR TITLE
Fix: Missing override to get_type(), clang 6

### DIFF
--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -61,7 +61,7 @@ namespace hw {
  
             bool set_mode(device_mode mode) override;
 
-            device_type get_type() const {return device_type::SOFTWARE;};
+            device_type get_type() const override {return device_type::SOFTWARE;};
 
             /* ======================================================================= */
             /*  LOCKER                                                                 */


### PR DESCRIPTION
Monero does not compile using clang 6.0.1 on Arch Linux, due to:

```
In file included from /home/mwo/monero/src/device/device.cpp:31:
/home/mwo/monero/src/device/device_default.hpp:64:25: error: 'get_type' overrides a member
      function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
            device_type get_type() const {return device_type::SOFTWARE;};
                        ^
/home/mwo/monero/src/device/device.hpp:120:29: note: overridden virtual function is here
        virtual device_type get_type() const = 0;
```

The PR adds the missing override so that compilation with clang works.
 