### PR TITLE
Fixes make debug compilation on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,7 +769,7 @@ else()
   endif()
 
   if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -DGTEST_HAS_TR1_TUPLE=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default -DGTEST_HAS_TR1_TUPLE=0")
   endif()
 
   set(DEBUG_FLAGS "-g3")


### PR DESCRIPTION
This PR fixes #4444 

Not sure why was the `-fvisibility=hidden` required for Apple builds but at the moment it prevents me from successfully building with shared lib mode on Mac (as described in the issue).

Needs #4443 merged to successfully compile with `make debug`.
