### PR TITLE
device: device registry segfail fix on program termination

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -187,6 +187,7 @@ bool t_daemon::run(bool interactive)
     for(auto& rpc : mp_internals->rpcs)
       rpc->stop();
     mp_internals->core.get().get_miner().stop();
+    hw::deinit_device_registry();
     MGINFO("Node stopped.");
     return true;
   }

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -216,11 +216,14 @@ namespace hw {
 
     public:
       device_registry();
+      virtual ~device_registry();
       bool register_device(const std::string & device_name, device * hw_device);
       device& get_device(const std::string & device_descriptor);
+      void deinit();
     };
 
+    std::shared_ptr<device_registry> get_device_registry();
+    void deinit_device_registry();
     device& get_device(const std::string & device_descriptor);
-    bool register_device(const std::string & device_name, device * hw_device);
 }
 

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -195,7 +195,6 @@ namespace hw {
 
     device_ledger::~device_ledger() {
       this->release();
-      MDEBUG( "Device "<<this->id <<" Destroyed");
     }
 
     /* ======================================================================= */

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3360,6 +3360,13 @@ public:
 
   bool run()
   {
+    const bool res = body();
+    hw::deinit_device_registry();
+    return res;
+  }
+
+  bool body()
+  {
     std::unique_ptr<tools::wallet2> wal;
     try
     {


### PR DESCRIPTION
- logging in the destructor can cause segfault when a program terminates

Crashlog provided by @iDunk5400  (thanks!):

```
Thread 1 "core_tests" received signal SIGSEGV, Segmentation fault.
0x0000555555ca7fed in el::base::Writer::construct(int, char const*, ...) ()
(gdb) bt
#0  0x0000555555ca7fed in el::base::Writer::construct(int, char const*, ...) ()
#1  0x0000555555aa88c8 in hw::ledger::device_ledger::~device_ledger() ()
#2  0x0000555555aa8af9 in hw::ledger::device_ledger::~device_ledger() [clone .localalias.315] ()
#3  0x0000555555aa0a5f in std::unique_ptr<hw::device_registry, std::default_delete<hw::device_registry> >::~unique_ptr() ()
#4  0x00007ffff554aff8 in __run_exit_handlers (status=0, listp=0x7ffff58d55f8 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true) at exit.c:82
#5  0x00007ffff554b045 in __GI_exit (status=<optimized out>) at exit.c:104
#6  0x00007ffff5531837 in __libc_start_main (main=0x5555557a23b8 <main>, argc=2, argv=0x7fffffffe398, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>,
    stack_end=0x7fffffffe388) at ../csu/libc-start.c:325
#7  0x00005555557ee209 in _start ()
(gdb)
```

Ledger device destructor uses `MDEBUG` to log a message. This causes a segfault when the program terminates. The probable cause is the shared logging state is already destroyed. 

I've added new macros:
- `MCHECK_LOGGING()` resolves to true if the logging system is still initialized
- `MSAFELOG(x)` executes the `x` only if the logging system is still initialized

However, there still can be race conditions. Maybe there is a more clever way to solve this. If the proposed solution does not work we just remove logging from the destructor. 

It would be nice to avoid this problem completelly so program does not crash even if logging is added to a method that is called by the destructor. 