### PR TITLE
Translate all contexts but simple_wallet for Japanese, translate 23% of simple_wallet for Japanese

### DIFF
--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -34,12 +34,12 @@
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="97"/>
         <source>Failed to write transaction(s) to file</source>
-        <translation>ファイルに取引を書き出せなかった</translation>
+        <translation>取引をファイルに書き込めませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
-        <translation>デーモン忙しいです。後でもう一度試してください。</translation>
+        <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
@@ -72,53 +72,53 @@
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>これは閲覧専用ウォレットです</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>取引を署名できませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
-        <translation type="unfinished"></translation>
+        <translation>請求したお釣りはもうお金に送ったアドレス送りません</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
-        <translation type="unfinished"></translation>
+        <translation>請求したお釣りはお釣りのアドレスに送ったペイメントより大きいです</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
-        <translation type="unfinished"></translation>
+        <translation>お釣りは複数のアドレスに送ります</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s を %s に送ってます</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
-        <translation type="unfinished"></translation>
+        <translation>目的地なし</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s のお釣り %s に</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
-        <translation type="unfinished"></translation>
+        <translation>お釣りありません</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
-        <translation type="unfinished"></translation>
+        <translation>取引は %lu ロードした、 %s に、%s のの手数料、 %s 、 %s 、最小リングサイズ %lu 。%s</translation>
     </message>
 </context>
 <context>
@@ -126,219 +126,219 @@
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation type="unfinished"></translation>
+        <translation>ペイメントIDのフォーマットは不正です。16文字または64文字の16進数の文字列が必要で： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
         <source>Failed to add short payment id: </source>
-        <translation type="unfinished"></translation>
+        <translation>短いペイメントIDの追加に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
         <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
         <source>RPC error: </source>
-        <translation type="unfinished"></translation>
+        <translation>RPCエラー： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
         <source>not enough outputs for specified ring size</source>
-        <translation type="unfinished"></translation>
+        <translation>指定したリングサイズのアウトプットが不十分です</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>found outputs to use</source>
-        <translation type="unfinished"></translation>
+        <translation>使うためにアウトプットを見つかれました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Please sweep unmixable outputs.</source>
-        <translation type="unfinished"></translation>
+        <translation>ミックス不能なアウトプットをスイープしてください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
         <source>failed to get random outputs to mix</source>
-        <translation type="unfinished"></translation>
+        <translation>ランダムなアウトプットをミックスすることに失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
-        <translation type="unfinished"></translation>
+        <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="474"/>
         <source>failed to parse address</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="486"/>
         <source>failed to parse secret spend key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="496"/>
         <source>No view key supplied, cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキーをもらいませんでしたのでキャンセルしました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="503"/>
         <source>failed to parse secret view key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="513"/>
         <source>failed to verify secret spend key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="518"/>
         <source>spend key does not match address</source>
-        <translation type="unfinished"></translation>
+        <translation>スペンドキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="524"/>
         <source>failed to verify secret view key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="529"/>
         <source>view key does not match address</source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="548"/>
         <source>failed to generate new wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="773"/>
         <source>Failed to send import wallet request</source>
-        <translation type="unfinished"></translation>
+        <translation>インポートウォレットリクエストの送信に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="919"/>
         <source>Failed to load unsigned transactions</source>
-        <translation type="unfinished"></translation>
+        <translation>未署名の取引を読み込めませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="940"/>
         <source>Failed to load transaction from file</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="958"/>
         <source>Wallet is view only</source>
-        <translation type="unfinished"></translation>
+        <translation>閲覧専用ウォレットです</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="967"/>
         <source>failed to save file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="986"/>
         <source>Key images can only be imported with a trusted daemon</source>
-        <translation type="unfinished"></translation>
+        <translation>信頼できるデーモンしかでキーイメージをインポートしません</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="999"/>
         <source>Failed to import key images: </source>
-        <translation type="unfinished"></translation>
+        <translation>キーイメージをインポートできませんでした： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
         <source>Failed to get subaddress label: </source>
-        <translation type="unfinished"></translation>
+        <translation>サブアドレスラベルを取得できませんでした： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
         <source>Failed to set subaddress label: </source>
-        <translation type="unfinished"></translation>
+        <translation>サブアドレスラベルをセットできませんでした： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
         <source>failed to get random outputs to mix: %s</source>
-        <translation type="unfinished"></translation>
+        <translation>ランダムなアウトプットをミックスすることに失敗しました： %s</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
-        <translation type="unfinished"></translation>
+        <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
         <source>output amount</source>
-        <translation type="unfinished"></translation>
+        <translation>アウトプットの金額</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>transaction was not constructed</source>
-        <translation type="unfinished"></translation>
+        <translation>取引を作りませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished"></translation>
+        <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
         <source>one of destinations is zero</source>
-        <translation type="unfinished"></translation>
+        <translation>宛先の1つはゼロです</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
         <source>failed to find a suitable way to split transactions</source>
-        <translation type="unfinished"></translation>
+        <translation>取引を分割する適切な方法を見つけることができませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
         <source>unknown transfer error: </source>
-        <translation type="unfinished"></translation>
+        <translation>不明な転送エラー： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>internal error: </source>
-        <translation type="unfinished"></translation>
+        <translation>内部エラー： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
         <source>unexpected error: </source>
-        <translation type="unfinished"></translation>
+        <translation>予期せぬエラー： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
         <source>unknown error</source>
-        <translation type="unfinished"></translation>
+        <translation>不明なエラー</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
@@ -348,18 +348,18 @@
         <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
         <source>Failed to parse txid</source>
-        <translation type="unfinished"></translation>
+        <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <source>no tx keys found for this txid</source>
-        <translation type="unfinished"></translation>
+        <translation>このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
         <source>Failed to parse tx key</source>
-        <translation type="unfinished"></translation>
+        <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
@@ -367,17 +367,17 @@
         <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>Failed to parse address</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>Address must not be a subaddress</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
-        <translation type="unfinished"></translation>
+        <translation>信頼できるデーモンしかで再スキャンしません</translation>
     </message>
 </context>
 <context>
@@ -385,17 +385,17 @@
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
-        <translation>アドレスを解析できませんでした</translation>
+        <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
-        <translation>キーを解析できませんでした</translation>
+        <translation>キーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
-        <translation>キーを検証できませんでした</translation>
+        <translation>キーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="271"/>
@@ -421,48 +421,48 @@
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="40"/>
         <source>Specify IP to bind RPC server</source>
-        <translation type="unfinished"></translation>
+        <translation>RPCサーバに接続するIPを指定してください</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="41"/>
         <source>Specify username[:password] required for RPC server</source>
-        <translation type="unfinished"></translation>
+        <translation>RPCサーバを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="42"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
-        <translation type="unfinished"></translation>
+        <translation>rpc-bind-ipの価はループバック(ローカル)IPじゃないことを確認してください</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="43"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
-        <translation type="unfinished"></translation>
+        <translation>クロスオリジンリソース共同をできるためにコンマ区切りリストを指定してください</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="70"/>
         <source>Invalid IP address given for --</source>
-        <translation type="unfinished"></translation>
+        <translation>このRPCサーバーのIPはだめです --</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="78"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
-        <translation type="unfinished"></translation>
+        <translation> は暗号化されていない外部接続をできますがSSHトンネルやSSLプロキシの方がいいです。これでオーバーライド --</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Username specified with --</source>
-        <translation type="unfinished"></translation>
+        <translation>このRPCサーバのユーザー名につて --</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> cannot be empty</source>
-        <translation type="unfinished"></translation>
+        <translation> 入力する必要があります</translation>
     </message>
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source> requires RPC server password --</source>
-        <translation type="unfinished"></translation>
+        <translation> のRPCサーバのパスワードありません --</translation>
     </message>
 </context>
 <context>
@@ -480,7 +480,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
         <source>invalid password</source>
-        <translation type="unfinished"></translation>
+        <translation>不正なパスワード</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
@@ -524,18 +524,18 @@
         <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
         <source>0 or 1</source>
-        <translation type="unfinished"></translation>
+        <translation>０や１</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
         <source>0, 1, 2, 3, or 4</source>
-        <translation type="unfinished"></translation>
+        <translation>０、１、２、３、や ４</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
         <source>unsigned integer</source>
-        <translation type="unfinished"></translation>
+        <translation>符号無しの整数</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
@@ -595,7 +595,7 @@
         <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
         <source>failed to generate new wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
@@ -622,7 +622,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>failed to load wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットをロードできませんでした： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
@@ -670,7 +670,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
         <source>transaction </source>
-        <translation type="unfinished"></translation>
+        <translation>取引 </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
@@ -751,7 +751,8 @@
         <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
         <source>
 Transaction </source>
-        <translation type="unfinished"></translation>
+        <translation>
+取引 </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
@@ -790,7 +791,7 @@ Transaction </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
         <source>.</source>
-        <translation type="unfinished"></translation>
+        <translation>。</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
@@ -850,7 +851,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
         <source>failed to parse key image</source>
-        <translation type="unfinished"></translation>
+        <translation>キーイメージの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
@@ -900,7 +901,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
         <source>sending %s to %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s を %s に送ってます</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
@@ -910,12 +911,12 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
         <source>with no destinations</source>
-        <translation type="unfinished"></translation>
+        <translation>目的地なし</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
+        <translation>取引は %lu ロードした、 %s に、%s のの手数料、 %s 、 %s 、最小リングサイズ %lu 、%s。これは大丈夫ですか？&#x3000;はい&#x3000;(Y)&#x3000;いいえ (N)： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
@@ -930,12 +931,12 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
         <source>Failed to sign transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>取引を署名できませんでした</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
         <source>Failed to sign transaction: </source>
-        <translation type="unfinished"></translation>
+        <translation>取引を署名できませんでした： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
@@ -945,13 +946,13 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
         <source>Failed to load transaction from file</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
         <source>RPC error: </source>
-        <translation type="unfinished"></translation>
+        <translation>RPCエラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
@@ -984,7 +985,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
         <source>invalid unit</source>
-        <translation type="unfinished"></translation>
+        <translation>不正なユニット</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
@@ -995,7 +996,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
         <source>invalid value</source>
-        <translation type="unfinished"></translation>
+        <translation>不正な金額</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
@@ -1005,7 +1006,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
         <source>(Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
+        <translation>(はい (Y)&#x3000;いいえ (N)): </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
@@ -1027,12 +1028,12 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
         <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
         <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
+        <translation>これは大丈夫ですか？ (はい (Y)&#x3000;いいえ (N)): </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
         <source>Daemon is local, assuming trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
@@ -1047,14 +1048,14 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>internal error: </source>
-        <translation type="unfinished"></translation>
+        <translation>内部エラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
         <source>unexpected error: </source>
-        <translation type="unfinished"></translation>
+        <translation>予期せぬエラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
@@ -1067,7 +1068,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
         <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
         <source>unknown error</source>
-        <translation type="unfinished"></translation>
+        <translation>不明なエラー</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
@@ -1082,14 +1083,14 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>unlocked balance: </source>
-        <translation type="unfinished"></translation>
+        <translation>ロック解除された残高： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>amount</source>
-        <translation type="unfinished"></translation>
+        <translation>金額</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
@@ -1099,17 +1100,17 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>Unknown command: </source>
-        <translation type="unfinished"></translation>
+        <translation>未知のコマンド： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
         <source>Command usage: </source>
-        <translation type="unfinished"></translation>
+        <translation>コマンドの使用： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
         <source>Command description: </source>
-        <translation type="unfinished"></translation>
+        <translation>コマンドの記述： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
@@ -1237,14 +1238,14 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
         <source> multisig address: </source>
-        <translation type="unfinished"></translation>
+        <translation> マルチサインアドレス： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>This wallet is not multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
@@ -1320,7 +1321,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
         <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
         <source>This is not a multisig wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
@@ -1335,7 +1336,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
         <source>Multisig error: </source>
-        <translation type="unfinished"></translation>
+        <translation>マルチサインエラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
@@ -2085,12 +2086,12 @@ Otherwise, you prove the reserve of the smallest possible amount above &lt;amoun
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
         <source>Error: expected M/N, but got: </source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
@@ -2105,12 +2106,12 @@ Otherwise, you prove the reserve of the smallest possible amount above &lt;amoun
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
         <source>failed to parse secret view key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
         <source>failed to verify secret view key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
@@ -2157,7 +2158,7 @@ your wallet again (your wallet keys are NOT at risk in any case).
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
         <source>failed to generate new mutlisig wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいマルチシッグウォレットの生成に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
@@ -2199,13 +2200,13 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
         <source>txid </source>
-        <translation type="unfinished"></translation>
+        <translation>txid </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
         <source>idx </source>
-        <translation type="unfinished"></translation>
+        <translation>idx </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
@@ -2220,12 +2221,12 @@ your wallet again (your wallet keys are NOT at risk in any case).
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
         <source>] </source>
-        <translation type="unfinished"></translation>
+        <translation>] </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
         <source>Tag: </source>
-        <translation type="unfinished"></translation>
+        <translation>タグ： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
@@ -2240,30 +2241,30 @@ your wallet again (your wallet keys are NOT at risk in any case).
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <source>Address</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレス</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
         <source>Balance</source>
-        <translation type="unfinished"></translation>
+        <translation>残高</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
         <source>Unlocked balance</source>
-        <translation type="unfinished"></translation>
+        <translation>ロック解除された残高</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <source>Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation>アウトプット</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
         <source>Label</source>
-        <translation type="unfinished"></translation>
+        <translation>ラベル</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
@@ -2294,7 +2295,7 @@ your wallet again (your wallet keys are NOT at risk in any case).
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>tx id</source>
-        <translation type="unfinished"></translation>
+        <translation>tx id</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
@@ -2325,12 +2326,12 @@ your wallet again (your wallet keys are NOT at risk in any case).
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>payment</source>
-        <translation type="unfinished"></translation>
+        <translation>ペイメント</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
         <source>transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>取引</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
@@ -2395,14 +2396,16 @@ Originating block heights: </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
         <source>
 |</source>
-        <translation type="unfinished"></translation>
+        <translation>
+|</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>|
 </source>
-        <translation type="unfinished"></translation>
+        <translation>|
+</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
@@ -2454,7 +2457,7 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
         <source>, txid </source>
-        <translation type="unfinished"></translation>
+        <translation>、txid </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
@@ -2482,7 +2485,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
         <source>This is a watch only wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>これは閲覧専用ウォレットです</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
@@ -2565,12 +2568,12 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
         <source>Generating new wallet...</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいウォレットを生じてます...</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
         <source>Electrum-style word list failed verification</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
@@ -2584,7 +2587,7 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
         <source>No data supplied, cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>データをもらいませんでしたのでキャンセルしました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
@@ -2600,26 +2603,26 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>failed to parse address</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>failed to parse view key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>failed to verify view key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
         <source>view key does not match standard address</source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
@@ -2635,19 +2638,19 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
         <source>failed to parse spend key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
         <source>failed to verify spend key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
         <source>spend key does not match standard address</source>
-        <translation type="unfinished"></translation>
+        <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
@@ -2673,7 +2676,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
         <source>View key: </source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
@@ -2701,13 +2704,13 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
         <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
@@ -2717,7 +2720,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
         <source>Balance: </source>
-        <translation type="unfinished"></translation>
+        <translation>残高： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
@@ -2727,28 +2730,28 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
         <source>key image</source>
-        <translation type="unfinished"></translation>
+        <translation>キーイメージ</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
         <source>unlocked</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>ringct</source>
-        <translation type="unfinished"></translation>
+        <translation>ringct</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>T</source>
-        <translation type="unfinished"></translation>
+        <translation>T</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
         <source>F</source>
-        <translation type="unfinished"></translation>
+        <translation>F</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
@@ -2758,12 +2761,12 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>RingCT</source>
-        <translation type="unfinished"></translation>
+        <translation>RingCT</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
@@ -2778,7 +2781,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
         <source>the same transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>同じ取引</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
@@ -2841,24 +2844,24 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
         <source>Index: </source>
-        <translation type="unfinished"></translation>
+        <translation>インデックス： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
         <source>Address: </source>
-        <translation type="unfinished"></translation>
+        <translation>アドレス： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
         <source>Payment ID: </source>
-        <translation type="unfinished"></translation>
+        <translation>ペイメントID： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
         <source>Description: </source>
-        <translation type="unfinished"></translation>
+        <translation>記述： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
@@ -2886,7 +2889,7 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
         <source>failed to read file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルの読み込みに失敗しました </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
@@ -2933,7 +2936,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
         <source>Address must not be a subaddress</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
@@ -2963,7 +2966,7 @@ Warning: Some input keys being spent are from </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source> (no daemon)</source>
-        <translation type="unfinished"></translation>
+        <translation> (デーモンありません）</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
@@ -2983,7 +2986,7 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
         <source>failed to parse index: </source>
-        <translation type="unfinished"></translation>
+        <translation>インデックスの解析に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
@@ -3013,7 +3016,7 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
         <source>, unlocked balance: </source>
-        <translation type="unfinished"></translation>
+        <translation>、ロック解除された残高： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
@@ -3028,12 +3031,12 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
         <source>Accounts with tag: </source>
-        <translation type="unfinished"></translation>
+        <translation>タグを持ってるアカウント： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
         <source>Tag&apos;s description: </source>
-        <translation type="unfinished"></translation>
+        <translation>タグの記述： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
@@ -3043,22 +3046,22 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
         <source> %c%8u %6s %21s %21s %21s</source>
-        <translation type="unfinished"></translation>
+        <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
         <source>----------------------------------------------------------------------------------</source>
-        <translation type="unfinished"></translation>
+        <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
         <source>%15s %21s %21s</source>
-        <translation type="unfinished"></translation>
+        <translation>%15s %21s %21s</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
         <source>Primary address</source>
-        <translation type="unfinished"></translation>
+        <translation>プライマリアドレス</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
@@ -3099,7 +3102,7 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>Subaddress: </source>
-        <translation type="unfinished"></translation>
+        <translation>サブアドレス： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
@@ -3109,52 +3112,52 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
         <source>no description found</source>
-        <translation type="unfinished"></translation>
+        <translation>記述を見つかれませんでした</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
         <source>description found: </source>
-        <translation type="unfinished"></translation>
+        <translation>記述を見つかれました： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
         <source>Filename: </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル名： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>Watch only</source>
-        <translation type="unfinished"></translation>
+        <translation>閲覧専用</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
         <source>%u/%u multisig%s</source>
-        <translation type="unfinished"></translation>
+        <translation>%u/%u マルチサイン%s</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation>ノーマル</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
         <source>Type: </source>
-        <translation type="unfinished"></translation>
+        <translation>タイプ： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
         <source>Testnet: </source>
-        <translation type="unfinished"></translation>
+        <translation>テストネット： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>はい</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>いいえ</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
@@ -3191,7 +3194,7 @@ Grand total:
         <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
         <source>failed to save file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
@@ -3249,12 +3252,12 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
         <source>%s change to %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s のお釣り %s に</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
         <source>no change</source>
-        <translation type="unfinished"></translation>
+        <translation>お釣りありません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
@@ -3279,12 +3282,12 @@ Grand total:
         <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>failed to parse txid</source>
-        <translation type="unfinished"></translation>
+        <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
         <source>Tx key: </source>
-        <translation type="unfinished"></translation>
+        <translation>txキー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
@@ -3319,26 +3322,26 @@ Grand total:
         <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
         <source>failed to parse tx key</source>
-        <translation type="unfinished"></translation>
+        <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
         <source>error: </source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>received</source>
-        <translation type="unfinished"></translation>
+        <translation>貰いました</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
         <source>in txid</source>
-        <translation type="unfinished"></translation>
+        <translation>txidに</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
@@ -3388,7 +3391,7 @@ Grand total:
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
         <source>failed</source>
-        <translation type="unfinished"></translation>
+        <translation>失敗</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
@@ -3404,17 +3407,18 @@ Grand total:
         <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>
 Amount: </source>
-        <translation type="unfinished"></translation>
+        <translation>
+金額： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
         <source>, number of keys: </source>
-        <translation type="unfinished"></translation>
+        <translation>、キーの数： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
         <source> </source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
@@ -3468,45 +3472,47 @@ Outputs per *: </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
         <source>  |</source>
-        <translation type="unfinished"></translation>
+        <translation>  |</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>  +</source>
-        <translation type="unfinished"></translation>
+        <translation>  +</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
         <source>+--&gt; block height
 </source>
-        <translation type="unfinished"></translation>
+        <translation>+--&gt; ブロック高
+</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>   ^</source>
-        <translation type="unfinished"></translation>
+        <translation>   ^</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
         <source>^
 </source>
-        <translation type="unfinished"></translation>
+        <translation>^
+</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
         <source>  </source>
-        <translation type="unfinished"></translation>
+        <translation>  </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
         <source>wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレット</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
         <source>Random payment ID: </source>
-        <translation type="unfinished"></translation>
+        <translation>ランダムなペイメントID： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
@@ -3519,83 +3525,83 @@ Outputs per *: </source>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
-        <translation type="unfinished"></translation>
+        <translation>ベースファイル名（必要があれば－１、－２、とかのサフィックスを追加します）</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
-        <translation type="unfinished"></translation>
+        <translation>M/Nってのフォーマットで同じ時に閾値と参加者をください</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>マルチサインウォレットを分ける人はいくついますか</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>有効な取引を署名するために必要な人いくついますか</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>テストネットのマルチサインウォレットを作る</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
         <source>Generating %u %u/%u multisig wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>%u %u/%u マルチサインウォレットを生じてます</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
         <source>Error verifying multisig extra info</source>
-        <translation type="unfinished"></translation>
+        <translation>マルチサインの追加情報を検証中にエラーありました</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
         <source>Error finalizing multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>マルチサイン締結中にエラーありました</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスのためにマルチサインウォレットを生じなかった </translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
-        <translation type="unfinished"></translation>
+        <translation>マルチサインウォレットを樹立中にエラーありました： </translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
-        <translation type="unfinished"></translation>
+        <translation>このプログラムはマルチサインウォレットのセットを生じます&#x3000;－&#x3000;みんながみんなを信用する場合にだけこの単純なスキームを使ってください</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
         <source>Error: expected N/M, but got: </source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： --scheme あるいは--threshold と --participants を上げられる</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでも N＝＝%u と M＝＝%d を貰いました</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
         <source>Error: --filename-base is required</source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： --filename-baseを使う必要だがあります</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
         <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： 不正なスキーム： N/N や N-1/N`のことをできます</translation>
     </message>
 </context>
 <context>
@@ -3603,98 +3609,98 @@ Outputs per *: </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいウォレットを生じろ &lt;arg&gt; をこっちにセーブしてください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
         <source>Generate incoming-only wallet from view key</source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキーで閲覧専用ウォレットを生じろください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
         <source>Generate deterministic wallet from spend key</source>
-        <translation type="unfinished"></translation>
+        <translation>スペンドキーで決定論的なウォレットを生じろください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="118"/>
         <source>Generate wallet from private keys</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なキーでウォレットを生じろください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
         <source>Generate a master wallet from multisig wallet keys</source>
-        <translation type="unfinished"></translation>
+        <translation>マルチシガーウォレットキーでマスターウォレットを生じろください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
         <source>Language for mnemonic</source>
-        <translation type="unfinished"></translation>
+        <translation>ニーモニックのための言語</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットの回収や作成のためにElectrumなニーモニックシードを指定してください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumなニーモニックシードでウォレットを復元してください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumなニーモニックシードでマルチシガーウォレットを復元してください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
         <source>Generate non-deterministic view and spend keys</source>
-        <translation type="unfinished"></translation>
+        <translation>非決定論的のビューとスペンドキーを生じろください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
         <source>Enable commands which rely on a trusted daemon</source>
-        <translation type="unfinished"></translation>
+        <translation>必要な信用できるデーモンのコマンドをエネーブルしてください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
-        <translation type="unfinished"></translation>
+        <translation>別のRPCバージョンを使用してるデーモンとの通信を許可してください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
         <source>Restore from specific blockchain height</source>
-        <translation type="unfinished"></translation>
+        <translation>特定ブロックチェイン高で復元してください</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
-        <translation type="unfinished"></translation>
+        <translation>新しい取引をネットワークに中継しません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
         <source>possibly lost connection to daemon</source>
-        <translation type="unfinished"></translation>
+        <translation>デモンの接続が切れましたかもしりません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
         <source>Error: </source>
-        <translation type="unfinished"></translation>
+        <translation>エラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
-        <translation type="unfinished"></translation>
+        <translation>これはMoneroのコマンドラインウォレットです。別のMoneroデモンと接続する必要があります。</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
         <source>Failed to initialize wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットを初期化できませんでした</translation>
     </message>
 </context>
 <context>
@@ -3702,151 +3708,151 @@ daemon to work correctly.</source>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="113"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;host&gt;:&lt;port&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="114"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
-        <translation type="unfinished"></translation>
+        <translation>localhostの代わりにホスト &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="116"/>
         <source>Wallet password file</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのパスワードファイル</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="117"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
-        <translation type="unfinished"></translation>
+        <translation>１８０８１の代わりにポート &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="119"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
-        <translation type="unfinished"></translation>
+        <translation>テストネットのためにデーモンは --testnet のフラグで開始する必要があります</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="120"/>
         <source>Restricts to view-only commands</source>
-        <translation type="unfinished"></translation>
+        <translation>閲覧専用コマンドに限ります</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="168"/>
         <source>can&apos;t specify daemon host or port more than once</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンのホストやポートを複数回指定することはできません</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="204"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
-        <translation type="unfinished"></translation>
+        <translation>--password と --passwordfile を1つしか指定しません</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="217"/>
         <source>the password file specified could not be read</source>
-        <translation type="unfinished"></translation>
+        <translation>指定されたパスワードファイルを読み取れません</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Failed to load file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルのロードに失敗しました </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="115"/>
         <source>Wallet password (escape/quote as needed)</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのパスワード(随時にエスケープ文字を使ってください)</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="118"/>
         <source>Specify username[:password] for daemon RPC client</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンのRPCクライアントを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="224"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
-        <translation type="unfinished"></translation>
+        <translation>パスワードを指定しませんでした。パスワードプロンプトを見るために--prompt-for-password を使ってください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Failed to parse JSON</source>
-        <translation type="unfinished"></translation>
+        <translation>JSONを解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Version %u too new, we can only grok up to %u</source>
-        <translation type="unfinished"></translation>
+        <translation>バージョン %u 新しすぎるです。%u までグロークできます</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>failed to parse view key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <location filename="../src/wallet/wallet2.cpp" line="339"/>
         <location filename="../src/wallet/wallet2.cpp" line="380"/>
         <source>failed to verify view key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>failed to parse spend key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="290"/>
         <location filename="../src/wallet/wallet2.cpp" line="349"/>
         <location filename="../src/wallet/wallet2.cpp" line="405"/>
         <source>failed to verify spend key secret key</source>
-        <translation type="unfinished"></translation>
+        <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="302"/>
         <source>Electrum-style word list failed verification</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="319"/>
         <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumな単語表と秘密なビューキーと秘密なスペンドキーの少なくとも1つを指定する必要があります</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="323"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
-        <translation type="unfinished"></translation>
+        <translation>Electrumな単語表と秘密なキーを指定しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="333"/>
         <source>invalid address</source>
-        <translation type="unfinished"></translation>
+        <translation>不正なアドレス</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="342"/>
         <source>view key does not match standard address</source>
-        <translation type="unfinished"></translation>
+        <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="352"/>
         <source>spend key does not match standard address</source>
-        <translation type="unfinished"></translation>
+        <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="360"/>
         <source>Cannot generate deprecated wallets from JSON</source>
-        <translation type="unfinished"></translation>
+        <translation>JSONで非推奨のウォレットを生成することはできません</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="392"/>
         <source>failed to parse address: </source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスの解析に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="398"/>
         <source>Address must be specified in order to create watch-only wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>閲覧専用ウォレットを作るためにアドレスを指定する必要があります</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="413"/>
         <source>failed to generate new wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="2813"/>
@@ -3858,17 +3864,17 @@ daemon to work correctly.</source>
         <location filename="../src/wallet/wallet2.cpp" line="3599"/>
         <location filename="../src/wallet/wallet2.cpp" line="3955"/>
         <source>Primary account</source>
-        <translation type="unfinished"></translation>
+        <translation>プライマリア カウント</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="7914"/>
         <source>No funds received in this tx.</source>
-        <translation type="unfinished"></translation>
+        <translation>この取引から資金貰いませんでした。</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="8607"/>
         <source>failed to read file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルの読み込みに失敗しました </translation>
     </message>
 </context>
 <context>
@@ -3876,125 +3882,125 @@ daemon to work correctly.</source>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
         <source>Daemon is local, assuming trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
         <source>Failed to create directory </source>
-        <translation type="unfinished"></translation>
+        <translation>ディレクトリの作成に失敗しました </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
         <source>Failed to create directory %s: %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s %s ディレクトリの作成に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Cannot specify --</source>
-        <translation type="unfinished"></translation>
+        <translation>これを指定しません： --</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source> and --</source>
-        <translation type="unfinished"></translation>
+        <translation> と --</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>Failed to create file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルの作成に失敗しました </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
         <source>. Check permissions or remove file</source>
-        <translation type="unfinished"></translation>
+        <translation>。 パーミッションを確認するか、ファイルを削除してください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
         <source>Error writing to file </source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルへの書き込みエラー </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>RPC username/password is stored in file </source>
-        <translation type="unfinished"></translation>
+        <translation>RPCユーザー名/パスワードはファイルに保存しました </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
         <source>Tag %s is unregistered.</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ %s を登録してません。</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
-        <translation type="unfinished"></translation>
+        <translation>これはMoneroのコマンドラインウォレットです。別のMoneroデモンと接続する必要があります。</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
-        <translation type="unfinished"></translation>
+        <translation>--wallet-file と --generate-from-json を1つしか指定しません</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
-        <translation type="unfinished"></translation>
+        <translation>--wallet-file や --generate-from-json や --wallet-dir を指定する必要があります</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
         <source>Loading wallet...</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットをロードしてます...</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
         <source>Saving wallet...</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットを保存してます...</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
         <source>Successfully saved</source>
-        <translation type="unfinished"></translation>
+        <translation>保存しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
         <source>Successfully loaded</source>
-        <translation type="unfinished"></translation>
+        <translation>ロードしました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
         <source>Wallet initialization failed: </source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットを初期化できませんでした: </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
         <source>Failed to initialize wallet RPC server</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのRPCサーバを初期化できませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
         <source>Starting wallet RPC server</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのRPCサーバを開始してます</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
         <source>Failed to run wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットを起動することできませんでした： </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
         <source>Stopped wallet RPC server</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのRPCサーバを停止しました</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
         <source>Failed to save wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットを保存することできませんでした： </translation>
     </message>
 </context>
 <context>
@@ -4004,63 +4010,63 @@ daemon to work correctly.</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
         <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
         <source>Wallet options</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットのオプション</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
-        <translation type="unfinished"></translation>
+        <translation>JSONフォーマットファイルでウォレットを生じてください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>ウォレットの &lt;arg&gt; を使てください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="104"/>
         <source>Max number of threads to use for a parallel job</source>
-        <translation type="unfinished"></translation>
+        <translation>並列ジョブのために最大スレッドの数</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="105"/>
         <source>Specify log file</source>
-        <translation type="unfinished"></translation>
+        <translation>ログファイルを指定してください</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="106"/>
         <source>Config file</source>
-        <translation type="unfinished"></translation>
+        <translation>設定ファイル</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="115"/>
         <source>General options</source>
-        <translation type="unfinished"></translation>
+        <translation>ジェネラルオプション</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="138"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
-        <translation type="unfinished"></translation>
+        <translation>これはMoneroのコマンドラインウォレットです。別のMoneroデモンと接続する必要があります。</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="161"/>
         <source>Can&apos;t find config file </source>
-        <translation type="unfinished"></translation>
+        <translation>設定ファイルを見つかりませんでした </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="195"/>
         <source>Logging to: </source>
-        <translation type="unfinished"></translation>
+        <translation>こっちにログをしてます: </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="197"/>
         <source>Logging to %s</source>
-        <translation type="unfinished"></translation>
+        <translation>%s にログをしてます</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="140"/>
         <source>Usage:</source>
-        <translation type="unfinished"></translation>
+        <translation>使用：</translation>
     </message>
 </context>
 </TS>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -1,0 +1,4066 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja" sourcelanguage="en">
+<context>
+    <name>Monero::AddressBookImpl</name>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
+        <source>Invalid destination address</source>
+        <translation>不正な宛先アドレス</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="63"/>
+        <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
+        <translation>不正なペイメントIDありっます。インテグレーテットアドレスにだけ短いペイメントIDを使えます</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="70"/>
+        <source>Invalid payment ID</source>
+        <translation>不正なペイメントID</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/address_book.cpp" line="77"/>
+        <source>Integrated address and long payment ID can&apos;t be used at the same time</source>
+        <translation>同じ時にインテグレーテットアドレスと長いペイメントIDを使えません</translation>
+    </message>
+</context>
+<context>
+    <name>Monero::PendingTransactionImpl</name>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="90"/>
+        <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="97"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
+        <source>no connection to daemon. Please make sure daemon is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
+        <source>transaction %s was rejected by daemon with status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
+        <source>. Reason: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
+        <source>Unknown exception: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
+        <source>Unhandled exception</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Monero::UnsignedTransactionImpl</name>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
+        <source>This is a watch only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
+        <source>Failed to sign transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
+        <source>Claimed change does not go to a paid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
+        <source>Claimed change is larger than payment to the change address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
+        <source>Change goes to more than one address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
+        <source>sending %s to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
+        <source>with no destinations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
+        <source>%s change to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
+        <source>no change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Monero::WalletImpl</name>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1111"/>
+        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <source>Failed to add short payment id: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1154"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1258"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1157"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1261"/>
+        <source>no connection to daemon. Please make sure daemon is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1264"/>
+        <source>RPC error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1301"/>
+        <source>not enough outputs for specified ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>found outputs to use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
+        <source>Please sweep unmixable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1267"/>
+        <source>failed to get random outputs to mix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1170"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1274"/>
+        <source>not enough money to transfer, available only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="474"/>
+        <source>failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="486"/>
+        <source>failed to parse secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="496"/>
+        <source>No view key supplied, cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="503"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="513"/>
+        <source>failed to verify secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="518"/>
+        <source>spend key does not match address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="524"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="529"/>
+        <source>view key does not match address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="548"/>
+        <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="773"/>
+        <source>Failed to send import wallet request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="919"/>
+        <source>Failed to load unsigned transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="940"/>
+        <source>Failed to load transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="958"/>
+        <source>Wallet is view only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="967"/>
+        <source>failed to save file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="986"/>
+        <source>Key images can only be imported with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="999"/>
+        <source>Failed to import key images: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1032"/>
+        <source>Failed to get subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1046"/>
+        <source>Failed to set subaddress label: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1163"/>
+        <source>failed to get random outputs to mix: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1283"/>
+        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1292"/>
+        <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1199"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1303"/>
+        <source>output amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1205"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
+        <source>transaction was not constructed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1209"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
+        <source>transaction %s was rejected by daemon with status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1216"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1319"/>
+        <source>one of destinations is zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1322"/>
+        <source>failed to find a suitable way to split transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1222"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1325"/>
+        <source>unknown transfer error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1225"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
+        <source>internal error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1228"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1331"/>
+        <source>unexpected error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1231"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1334"/>
+        <source>unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1412"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1441"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1494"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1525"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1556"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1579"/>
+        <source>Failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1450"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
+        <source>Failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1502"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1533"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1849"/>
+        <source>Rescan spent can only be used with a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wallet</name>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="246"/>
+        <source>Failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="253"/>
+        <source>Failed to parse key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="261"/>
+        <source>failed to verify key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="271"/>
+        <source>key does not match address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>command_line</name>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="57"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/common/command_line.cpp" line="71"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>cryptonote::rpc_args</name>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="40"/>
+        <source>Specify IP to bind RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="41"/>
+        <source>Specify username[:password] required for RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="42"/>
+        <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="43"/>
+        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="70"/>
+        <source>Invalid IP address given for --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="78"/>
+        <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <source>Username specified with --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
+        <source> requires RPC server password --</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>cryptonote::simple_wallet</name>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="479"/>
+        <source>Commands: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <source>failed to read wallet password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2699"/>
+        <source>invalid password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1905"/>
+        <source>set seed: needs an argument. available options: language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1933"/>
+        <source>set: unrecognized argument(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
+        <source>wallet file path not valid: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1987"/>
+        <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="662"/>
+        <source>usage: payment_id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1891"/>
+        <source>needs an argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1927"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1931"/>
+        <source>0 or 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1920"/>
+        <source>0, 1, 2, 3, or 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1928"/>
+        <source>unsigned integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2041"/>
+        <source>NOTE: the following 25 words can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2092"/>
+        <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2121"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
+        <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2635"/>
+        <source>wallet failed to connect to daemon: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2643"/>
+        <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2662"/>
+        <source>List of available languages for your wallet&apos;s seed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2671"/>
+        <source>Enter the number corresponding to the language of your choice: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2737"/>
+        <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2809"/>
+        <source>Generated new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2858"/>
+        <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2887"/>
+        <source>Opened watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2891"/>
+        <source>Opened wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
+        <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
+        <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
+        <source>failed to load wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2941"/>
+        <source>Use the &quot;help&quot; command to see the list of available commands.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <source>Wallet data saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3072"/>
+        <source>Mining started in daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3074"/>
+        <source>mining has NOT been started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
+        <source>Mining stopped in daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
+        <source>mining has NOT been stopped: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
+        <source>Blockchain saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3165"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3197"/>
+        <source>transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
+        <source>spent </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3198"/>
+        <source>unsupported transaction format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3219"/>
+        <source>Starting refresh...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
+        <source>Refresh done, blocks received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3758"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
+        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <source>bad locked_blocks parameter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4462"/>
+        <source>a single transaction cannot use more than one payment id: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4470"/>
+        <source>failed to set up payment id, though it was decoded correctly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3835"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4096"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4527"/>
+        <source>transaction cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3900"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3905"/>
+        <source>Failed to check for backlog: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <source>
+Transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
+        <source>Spending from address index %d
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3953"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4309"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3955"/>
+        <source>Sending %s.  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3958"/>
+        <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3964"/>
+        <source>The transaction fee is %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3967"/>
+        <source>, of which %s is dust from change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
+        <source>.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3968"/>
+        <source>A total of %s from dust change will be sent to dust address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3973"/>
+        <source>.
+This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4011"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4352"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4549"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4003"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4111"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4356"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
+        <source>Unsigned transaction(s) successfully written to file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4066"/>
+        <source>No unmixable outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4149"/>
+        <source>No address given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4424"/>
+        <source>failed to parse Payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4440"/>
+        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4447"/>
+        <source>failed to parse key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
+        <source>No outputs found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4504"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4586"/>
+        <source>missing threshold amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <source>invalid amount threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4601"/>
+        <source>donations are not enabled on the testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4702"/>
+        <source>Claimed change does not go to a paid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Claimed change is larger than payment to the change address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4738"/>
+        <source>sending %s to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4748"/>
+        <source> dummy output(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>with no destinations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4763"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4797"/>
+        <source>usage: sign_transfer [export]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4809"/>
+        <source>Failed to sign transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4815"/>
+        <source>Failed to sign transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4836"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4852"/>
+        <source>Failed to load transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3551"/>
+        <source>RPC error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="522"/>
+        <source>wallet is watch-only and has no spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
+        <source>Your original password was incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="650"/>
+        <source>Error with wallet rewrite: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
+        <source>priority must be 0, 1, 2, 3, or 4 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1316"/>
+        <source>priority must be 0, 1, 2, 3, or 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
+        <source>invalid unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1422"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1484"/>
+        <source>invalid count: must be an unsigned integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1440"/>
+        <source>invalid value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1942"/>
+        <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2013"/>
+        <source>(Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2536"/>
+        <source>bad m_restore_height parameter: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2514"/>
+        <source>date format must be YYYY-MM-DD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2527"/>
+        <source>Restore height is: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3980"/>
+        <source>Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <source>Daemon is local, assuming trusted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
+        <source>Password for new watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source>internal error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3556"/>
+        <source>unexpected error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1119"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4865"/>
+        <source>unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <source>refresh failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <source>Blocks received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <source>unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="219"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
+        <source>Unknown command: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="500"/>
+        <source>Command usage: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="503"/>
+        <source>Command description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="551"/>
+        <source>wallet is multisig but not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
+        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="584"/>
+        <source>Failed to retrieve seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
+        <source>wallet is multisig and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="674"/>
+        <source>Cannot connect to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="679"/>
+        <source>Current fee is %s monero per kB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <source>Error: failed to estimate backlog array size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="700"/>
+        <source>Error: bad estimated backlog array size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="712"/>
+        <source> (current)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="715"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="717"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="720"/>
+        <source>No backlog at priority </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="729"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="762"/>
+        <source>This wallet is already multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="767"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="773"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <source>Your password is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="753"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="754"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="786"/>
+        <source>usage: make_multisig &lt;threshold&gt; &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="794"/>
+        <source>Invalid threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <source>Another step is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="809"/>
+        <source>Send this multisig info to all other participants, then use finalize_multisig &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="815"/>
+        <source>Error creating multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="822"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="825"/>
+        <source> multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="836"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="880"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>This wallet is not multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="841"/>
+        <source>This wallet is already finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <source>usage: finalize_multisig &lt;multisiginfo1&gt; [&lt;multisiginfo2&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="862"/>
+        <source>Failed to finalize multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
+        <source>Failed to finalize multisig: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1136"/>
+        <source>This multisig wallet is not yet finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
+        <source>usage: export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="913"/>
+        <source>Error exporting multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="917"/>
+        <source>Multisig info exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="937"/>
+        <source>usage: import_multisig_info &lt;filename1&gt; [&lt;filename2&gt;...] - one for each other participant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="965"/>
+        <source>Multisig info imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="969"/>
+        <source>Failed to import multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="980"/>
+        <source>Failed to update spent status after importing multisig info: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="985"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1131"/>
+        <source>This is not a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1011"/>
+        <source>usage: sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1024"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1030"/>
+        <source>Multisig error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1035"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1058"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source>usage: submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1094"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1155"/>
+        <source>Failed to load multisig transaction from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1160"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6750"/>
+        <source>Transaction successfully submitted, transaction </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6751"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <source>usage: export_raw_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1176"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1180"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1277"/>
+        <source>could not change default ring size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1518"/>
+        <source>Invalid height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1564"/>
+        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1565"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
+        <source>Stop mining in the daemon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <source>set_daemon &lt;host&gt;[:&lt;port&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1572"/>
+        <source>Set another daemon to connect to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1575"/>
+        <source>Save the current blockchain data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1582"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1585"/>
+        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1586"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1589"/>
+        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1590"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1593"/>
+        <source>Show the blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
+        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1597"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1600"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1604"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1609"/>
+        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1610"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
+        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1614"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1617"/>
+        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1618"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1621"/>
+        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1625"/>
+        <source>sign_transfer &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1626"/>
+        <source>Sign a transaction from a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1629"/>
+        <source>Submit a signed transaction from a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1633"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1636"/>
+        <source>account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt; 
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
+        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1653"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1656"/>
+        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1660"/>
+        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <source>Save the wallet data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1667"/>
+        <source>Save a watch-only keys file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1670"/>
+        <source>Display the private view key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Display the private spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1676"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <source>set &lt;option&gt; [&lt;value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1680"/>
+        <source>Available options:
+ seed language
+   Set the wallet&apos;s seed language.
+ always-confirm-transfers &lt;1|0&gt;
+   Whether to confirm unsplit txes.
+ print-ring-members &lt;1|0&gt;
+   Whether to print detailed information about ring members during confirmation.
+ store-tx-info &lt;1|0&gt;
+   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
+ default-ring-size &lt;n&gt;
+   Set the default ring size (default and minimum is 5).
+ auto-refresh &lt;1|0&gt;
+   Whether to automatically synchronize new blocks from the daemon.
+ refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
+   Set the wallet&apos;s refresh behaviour.
+ priority [0|1|2|3|4]
+   Set the fee to default/unimportant/normal/elevated/priority.
+ confirm-missing-payment-id &lt;1|0&gt;
+ ask-password &lt;1|0&gt;
+ unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
+   Set the default monero (sub-)unit.
+ min-outputs-count [n]
+   Try to keep at least that many outputs of value at least min-outputs-value.
+ min-outputs-value [n]
+   Try to keep at least min-outputs-count outputs of at least that value.
+ merge-destinations &lt;1|0&gt;
+   Whether to merge multiple payments to the same destination address.
+ confirm-backlog &lt;1|0&gt;
+   Whether to warn if there is transaction backlog.
+ confirm-backlog-threshold [n]
+   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
+ refresh-from-block-height [n]
+   Set the height before which to ignore blocks.
+ auto-low-priority &lt;1|0&gt;
+   Whether to automatically use the low priority fee level when it&apos;s safe to do so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1717"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
+        <source>get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1724"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1727"/>
+        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1728"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1731"/>
+        <source>get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1735"/>
+        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1736"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1739"/>
+        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1740"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1747"/>
+        <source>get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1748"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
+        <source>check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1754"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1757"/>
+        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1761"/>
+        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1762"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1765"/>
+        <source>Rescan the blockchain from scratch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1768"/>
+        <source>set_tx_note &lt;txid&gt; [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1769"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1772"/>
+        <source>get_tx_note &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>set_description [free text note]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1777"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1780"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1783"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1786"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1789"/>
+        <source>sign &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1790"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1793"/>
+        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1794"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>export_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1798"/>
+        <source>Export a signed set of key images to a &lt;file&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1801"/>
+        <source>import_key_images &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1802"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1805"/>
+        <source>export_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1806"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1809"/>
+        <source>import_outputs &lt;file&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1810"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
+        <source>show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1814"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1823"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1825"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>make_multisig &lt;threshold&gt; &lt;string1&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1831"/>
+        <source>finalize_multisig &lt;string&gt; [&lt;string&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1835"/>
+        <source>export_multisig_info &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1836"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1839"/>
+        <source>import_multisig_info &lt;filename&gt; [&lt;filename&gt;...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1840"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1843"/>
+        <source>sign_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
+        <source>submit_multisig &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1848"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1851"/>
+        <source>export_raw_multisig_tx &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1855"/>
+        <source>help [&lt;command&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1856"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1917"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1930"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2012"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2068"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2084"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2090"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>Enter seed encryption passphrase, empty if none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2259"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2337"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2342"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2347"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2350"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2379"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2388"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2408"/>
+        <source>Secret spend key (%u of %u):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2432"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2550"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2551"/>
+        <source>Still apply restore height?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2582"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2850"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2853"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <source>missing daemon URL argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3186"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3318"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
+        <source>usage: balance [detail]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
+        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>global index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>tx id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3423"/>
+        <source>No incoming transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3427"/>
+        <source>No incoming available transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3431"/>
+        <source>No incoming unavailable transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3442"/>
+        <source>expected at least one payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3451"/>
+        <source>unlock time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3463"/>
+        <source>No payments with id </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3853"/>
+        <source>failed to get blockchain height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5259"/>
+        <source>failed to connect to the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3590"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
+        <source>
+Input %llu/%llu: amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3616"/>
+        <source>failed to get output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3624"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
+        <source>
+Originating block heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <source>
+|</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3643"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
+        <source>|
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3660"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3662"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4184"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3724"/>
+        <source>wrong number of arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4479"/>
+        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3872"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>, txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6745"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4081"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4519"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4630"/>
+        <source>Donating </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
+        <source>This is a watch only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <source>usage: show_transfer &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6673"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6708"/>
+        <source>Transaction ID not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="214"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="267"/>
+        <source>failed to parse refresh type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="608"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="613"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1226"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1245"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <source>could not change default priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1919"/>
+        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
+        <source>monero, millinero, micronero, nanonero, piconero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>
+        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
+        <source>Wallet and key files found, loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1998"/>
+        <source>Key file found but not wallet file. Regenerating...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2004"/>
+        <source>Key file not found. Failed to open wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2023"/>
+        <source>Generating new wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2141"/>
+        <source>Electrum-style word list failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2248"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2357"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2413"/>
+        <source>No data supplied, cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
+        <source>failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
+        <source>failed to parse view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2210"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
+        <source>failed to verify view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2393"/>
+        <source>view key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2238"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2480"/>
+        <source>account creation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
+        <source>failed to parse spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2439"/>
+        <source>failed to verify spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
+        <source>spend key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <source>failed to open account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4962"/>
+        <source>wallet is null</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2680"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2685"/>
+        <source>invalid language choice entered. Please try again.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2753"/>
+        <source>View key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2935"/>
+        <source>You may want to remove the file &quot;%s&quot; and try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2963"/>
+        <source>failed to deinitialize wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6410"/>
+        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3152"/>
+        <source>blockchain can&apos;t be saved: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3538"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3243"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3542"/>
+        <source>no connection to daemon. Please make sure daemon is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3253"/>
+        <source>refresh error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <source>Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
+        <source>pubkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3399"/>
+        <source>key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
+        <source>unlocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>ringct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3409"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3410"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
+        <source>RingCT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3411"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
+        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>failed to get spent status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
+        <source>the same transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3661"/>
+        <source>blocks that are temporally very close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3778"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Good signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <source>Bad signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6046"/>
+        <source>usage: integrated_address [payment ID]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Standard address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6087"/>
+        <source>failed to parse payment ID or address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6098"/>
+        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <source>failed to parse payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6146"/>
+        <source>failed to parse index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <source>Address book is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6160"/>
+        <source>Index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6287"/>
+        <source>Address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <source>Payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6286"/>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <source>usage: set_tx_note [txid] free text note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6201"/>
+        <source>usage: get_tx_note [txid]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6304"/>
+        <source>usage: sign &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6309"/>
+        <source>wallet is watch-only and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6501"/>
+        <source>failed to read file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5066"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5278"/>
+        <source>failed to load signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
+        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <source>wallet is watch-only and cannot generate the proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5161"/>
+        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
+        <source>usage: get_reserve_proof (all|&lt;amount&gt;) [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
+        <source>The reserve proof can be generated only by a full wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5253"/>
+        <source>usage: check_reserve_proof &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5271"/>
+        <source>Address must not be a subaddress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5289"/>
+        <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5353"/>
+        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5490"/>
+        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
+        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
+        <source>There is no unspent output in the specified address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
+        <source> (no daemon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5701"/>
+        <source> (out of sync)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5758"/>
+        <source>(Untitled account)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5789"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6013"/>
+        <source>failed to parse index: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <source>specify an index between 0 and </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5873"/>
+        <source>usage:
+  account
+  account new &lt;label text with white spaces allowed&gt;
+  account switch &lt;index&gt;
+  account label &lt;index&gt; &lt;label text with white spaces allowed&gt;
+  account tag &lt;tag_name&gt; &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account untag &lt;account_index_1&gt; [&lt;account_index_2&gt; ...]
+  account tag_description &lt;tag_name&gt; &lt;description&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>
+Grand total:
+  Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <source>, unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5909"/>
+        <source>Untagged accounts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5915"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5918"/>
+        <source>Accounts with tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
+        <source>Tag&apos;s description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5921"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5927"/>
+        <source> %c%8u %6s %21s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <source>----------------------------------------------------------------------------------</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <source>%15s %21s %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>Primary address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5961"/>
+        <source>(used)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>(Untitled address)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6022"/>
+        <source>&lt;index_min&gt; is already out of bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6027"/>
+        <source>&lt;index_max&gt; exceeds the bound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6035"/>
+        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6065"/>
+        <source>Integrated addresses can only be created for account 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6077"/>
+        <source>Integrated address: %s, payment ID: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
+        <source>Subaddress: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6242"/>
+        <source>usage: get_description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
+        <source>no description found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6250"/>
+        <source>description found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6285"/>
+        <source>Filename: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <source>Watch only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6292"/>
+        <source>%u/%u multisig%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Testnet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6296"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6314"/>
+        <source>This wallet is multisig and cannot sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6335"/>
+        <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <source>Bad signature from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <source>Good signature from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <source>usage: export_key_images &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <source>wallet is watch-only and cannot export key images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6473"/>
+        <source>failed to save file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6402"/>
+        <source>Signed key images exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6416"/>
+        <source>usage: import_key_images &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6447"/>
+        <source>usage: export_outputs &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6484"/>
+        <source>Outputs exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6492"/>
+        <source>usage: import_outputs &lt;filename&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3819"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <source>amount is wrong: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <source>expected number from 0 to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4079"/>
+        <source>Sweeping </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4559"/>
+        <source>Money successfully sent, transaction: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4716"/>
+        <source>Change goes to more than one address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>%s change to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4760"/>
+        <source>no change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4826"/>
+        <source>Transaction successfully signed to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4876"/>
+        <source>usage: get_tx_key &lt;txid&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5050"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6208"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <source>failed to parse txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4898"/>
+        <source>Tx key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
+        <source>no tx keys found for this txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4912"/>
+        <source>usage: get_tx_proof &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5239"/>
+        <source>signature file saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5241"/>
+        <source>failed to save signature file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4953"/>
+        <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4985"/>
+        <source>failed to parse tx key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5031"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5109"/>
+        <source>error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
+        <source>received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5080"/>
+        <source>in txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5099"/>
+        <source>received nothing in txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5010"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5083"/>
+        <source>WARNING: this transaction is not yet included in the blockchain!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <source>This transaction has %u confirmations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
+        <source>WARNING: failed to determine number of confirmations!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
+        <source>bad min_height parameter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5413"/>
+        <source>bad max_height parameter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <source>in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <source>out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <source>pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
+        <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
+        <source>
+Amount: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5592"/>
+        <source>, number of keys: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5597"/>
+        <source> </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <source>
+Min block height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
+        <source>
+Max block height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
+        <source>
+Min amount found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
+        <source>
+Max amount found: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5606"/>
+        <source>
+Total count: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5646"/>
+        <source>
+Bin size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5647"/>
+        <source>
+Outputs per *: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
+        <source>count
+  ^
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5651"/>
+        <source>  |</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
+        <source>  +</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
+        <source>+--&gt; block height
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <source>   ^</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <source>^
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5655"/>
+        <source>  </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5696"/>
+        <source>wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6057"/>
+        <source>Random payment ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <source>Matching integrated address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>genms</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
+        <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
+        <source>Give threshold and participants at once as M/N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
+        <source>How many participants will share parts of the multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
+        <source>How many signers are required to sign a valid transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
+        <source>Create testnet multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="81"/>
+        <source>Generating %u %u/%u multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="138"/>
+        <source>Error verifying multisig extra info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="146"/>
+        <source>Error finalizing multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
+        <source>Generated multisig wallets for address </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
+        <source>Error creating multisig wallets: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="176"/>
+        <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="194"/>
+        <source>Error: expected N/M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="202"/>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="211"/>
+        <source>Error: either --scheme or both of --threshold and --participants may be given</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="218"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="227"/>
+        <source>Error: --filename-base is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="233"/>
+        <source>Error: unsupported scheme: only N/N and N-1/N are supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>sw</name>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="115"/>
+        <source>Generate new wallet and save it to &lt;arg&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="116"/>
+        <source>Generate incoming-only wallet from view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="117"/>
+        <source>Generate deterministic wallet from spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="118"/>
+        <source>Generate wallet from private keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="119"/>
+        <source>Generate a master wallet from multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="121"/>
+        <source>Language for mnemonic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="122"/>
+        <source>Specify Electrum seed for wallet recovery/creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="123"/>
+        <source>Recover wallet using Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="124"/>
+        <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <source>Generate non-deterministic view and spend keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <source>Enable commands which rely on a trusted daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <source>Allow communicating with a daemon that uses a different RPC version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <source>Restore from specific blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <source>The newly created transaction will not be relayed to the monero network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="180"/>
+        <source>possibly lost connection to daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="197"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6801"/>
+        <source>Failed to initialize wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>tools::wallet2</name>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="113"/>
+        <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="114"/>
+        <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="116"/>
+        <source>Wallet password file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="117"/>
+        <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="119"/>
+        <source>For testnet. Daemon must also be launched with --testnet flag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="120"/>
+        <source>Restricts to view-only commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="168"/>
+        <source>can&apos;t specify daemon host or port more than once</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <source>can&apos;t specify more than one of --password and --password-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="217"/>
+        <source>the password file specified could not be read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <source>Failed to load file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="115"/>
+        <source>Wallet password (escape/quote as needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="118"/>
+        <source>Specify username[:password] for daemon RPC client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <source>no password specified; use --prompt-for-password to prompt for a password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Failed to parse JSON</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <source>Version %u too new, we can only grok up to %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>failed to parse view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
+        <location filename="../src/wallet/wallet2.cpp" line="339"/>
+        <location filename="../src/wallet/wallet2.cpp" line="380"/>
+        <source>failed to verify view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="285"/>
+        <source>failed to parse spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="290"/>
+        <location filename="../src/wallet/wallet2.cpp" line="349"/>
+        <location filename="../src/wallet/wallet2.cpp" line="405"/>
+        <source>failed to verify spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="302"/>
+        <source>Electrum-style word list failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="319"/>
+        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <source>Both Electrum-style word list and private key(s) specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="333"/>
+        <source>invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="342"/>
+        <source>view key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="352"/>
+        <source>spend key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="360"/>
+        <source>Cannot generate deprecated wallets from JSON</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="392"/>
+        <source>failed to parse address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source>Address must be specified in order to create watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="413"/>
+        <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="2813"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2873"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2952"/>
+        <location filename="../src/wallet/wallet2.cpp" line="2998"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3089"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3189"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3599"/>
+        <location filename="../src/wallet/wallet2.cpp" line="3955"/>
+        <source>Primary account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="7914"/>
+        <source>No funds received in this tx.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="8607"/>
+        <source>failed to read file </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>tools::wallet_rpc_server</name>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="160"/>
+        <source>Daemon is local, assuming trusted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="175"/>
+        <source>Failed to create directory </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="177"/>
+        <source>Failed to create directory %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
+        <source>Cannot specify --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
+        <source> and --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
+        <source>Failed to create file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="207"/>
+        <source>. Check permissions or remove file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="217"/>
+        <source>Error writing to file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
+        <source>RPC username/password is stored in file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="443"/>
+        <source>Tag %s is unregistered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2435"/>
+        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2870"/>
+        <source>This is the RPC monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2893"/>
+        <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2905"/>
+        <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2909"/>
+        <source>Loading wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2942"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2975"/>
+        <source>Saving wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2944"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2977"/>
+        <source>Successfully saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2947"/>
+        <source>Successfully loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2951"/>
+        <source>Wallet initialization failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2958"/>
+        <source>Failed to initialize wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2962"/>
+        <source>Starting wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2969"/>
+        <source>Failed to run wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2972"/>
+        <source>Stopped wallet RPC server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2981"/>
+        <source>Failed to save wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wallet_args</name>
+    <message>
+        <location filename="../src/gen_multisig/gen_multisig.cpp" line="166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6760"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="2856"/>
+        <source>Wallet options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
+        <source>Generate wallet from JSON format file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
+        <source>Use wallet &lt;arg&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="104"/>
+        <source>Max number of threads to use for a parallel job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="105"/>
+        <source>Specify log file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="106"/>
+        <source>Config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="115"/>
+        <source>General options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="138"/>
+        <source>This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="161"/>
+        <source>Can&apos;t find config file </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="195"/>
+        <source>Logging to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="197"/>
+        <source>Logging to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_args.cpp" line="140"/>
+        <source>Usage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -29,42 +29,42 @@
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="90"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルは既に存在するのでファイルに取引を書き出せなかった。上書きしないにエグジットしてます。ファイル：</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="97"/>
         <source>Failed to write transaction(s) to file</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルに取引を書き出せなかった</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="115"/>
         <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモン忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="118"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
+        <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="122"/>
         <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished"></translation>
+        <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="127"/>
         <source>. Reason: </source>
-        <translation type="unfinished"></translation>
+        <translation>。 理由： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="129"/>
         <source>Unknown exception: </source>
-        <translation type="unfinished"></translation>
+        <translation>未知の例外： </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="132"/>
         <source>Unhandled exception</source>
-        <translation type="unfinished"></translation>
+        <translation>未処理の例外</translation>
     </message>
 </context>
 <context>
@@ -385,22 +385,22 @@
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="246"/>
         <source>Failed to parse address</source>
-        <translation type="unfinished"></translation>
+        <translation>アドレスを解析できませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="253"/>
         <source>Failed to parse key</source>
-        <translation type="unfinished"></translation>
+        <translation>キーを解析できませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="261"/>
         <source>failed to verify key</source>
-        <translation type="unfinished"></translation>
+        <translation>キーを検証できませんでした</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="271"/>
         <source>key does not match address</source>
-        <translation type="unfinished"></translation>
+        <translation>キーがアドレスと一致しませんでした</translation>
     </message>
 </context>
 <context>
@@ -408,12 +408,12 @@
     <message>
         <location filename="../src/common/command_line.cpp" line="57"/>
         <source>yes</source>
-        <translation type="unfinished"></translation>
+        <translation>はい</translation>
     </message>
     <message>
         <location filename="../src/common/command_line.cpp" line="71"/>
         <source>no</source>
-        <translation type="unfinished"></translation>
+        <translation>いいえ</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Translate all contexts but simple_wallet for Japanese, translate 23% of simple_wallet for Japanese. Depending on how things are determined in monero-dev channel (e.g. suggested that 0.13 branch only be bug fix commits post 0.13 release), I will push the remaining translations to the relevant branch.