### PR TITLE
util: win32: enable VT processing

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -948,7 +948,7 @@ std::string get_nix_version_display_string()
 
     FlushConsoleInputBuffer(hConIn);
     GetConsoleMode(hConIn, &oldMode);
-    SetConsoleMode(hConIn, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+    SetConsoleMode(hConIn, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 
     wchar_t buffer[1024];
     DWORD read;


### PR DESCRIPTION
Parse the console for VT100 and similar control characters on Win32
systems.

Fixes: https://github.com/monero-project/monero/issues/1934

Signed-off-by: Tyler Baker <tyler@foundries.io>