### PR TITLE
device: destroy device objects on exit

### DIFF
--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -220,7 +220,7 @@ namespace hw {
       device& get_device(const std::string & device_descriptor);
     };
 
+    std::shared_ptr<device_registry> get_device_registry();
     device& get_device(const std::string & device_descriptor);
-    bool register_device(const std::string & device_name, device * hw_device);
 }
 

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -195,7 +195,6 @@ namespace hw {
 
     device_ledger::~device_ledger() {
       this->release();
-      MDEBUG( "Device "<<this->id <<" Destroyed");
     }
 
     /* ======================================================================= */


### PR DESCRIPTION
- device registry destruction with atexit(). This leads to destruction of the registered devices before program termination so registered devices are destructed in the defined order. Without this the device registry destructor was called in an undefined order (problem similar to so called static initialization fiasco) which leads to undefined behaviour of device destructors (e.g., logging system crashes as it has been already deinitialized before the devices). Code provided by @moneromooo-monero

- logging has been removed from the ledger destructor. Registered devices are in the disconnected state after being inserted to the device registry so it should be safe to destroy these "templates" safely (as wallet should properly disconnect the devices).

Originally #4496.

PR did not exist before tagging, so I've created this one. 