### PR TITLE
simplewallet: fixed deadlock if a user hits CTRL+C twice

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7050,12 +7050,6 @@ bool simple_wallet::run()
 void simple_wallet::stop()
 {
   m_cmd_binder.stop_handling();
-
-  m_idle_run.store(false, std::memory_order_relaxed);
-  m_wallet->stop();
-  // make the background refresh thread quit
-  boost::unique_lock<boost::mutex> lock(m_idle_mutex);
-  m_idle_cond.notify_one();
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector<std::string>()*/)


### PR DESCRIPTION
Affects any platform that uses fork/clone to implement threads.

The bug occurs due to the signal handler being set before we start background refresh thread, so signal handling will be inherited by the background refresh thread as well.

SIGINT handler will be executed in arbitrary thread's context.
Deadlock occurs if a user hits CTRL+C twice.

Locks:
1. Global mutex in SIGINT handler
https://github.com/monero-project/monero/blob/master/src/common/util.h#L213
2. Condition variable mutex 
https://github.com/monero-project/monero/blob/master/src/simplewallet/simplewallet.cpp#L7000
https://github.com/monero-project/monero/blob/master/src/simplewallet/simplewallet.cpp#L7057