### PR TITLE
Fuzz: fix building fuzz tests on unix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ release-static-win32:
 
 fuzz:
 	mkdir -p $(builddir)/fuzz
-	cd $(builddir)/fuzz && cmake -D STATIC=ON -D SANITIZE=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-gcc -D CMAKE_CXX_COMPILER=afl-g++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" $(topdir) && $(MAKE)
+	cd $(builddir)/fuzz && cmake -D STATIC=ON -D SANITIZE=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-clang -D CMAKE_CXX_COMPILER=afl-clang++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" $(topdir) && $(MAKE)
 
 clean:
 	@echo "WARNING: Back-up your wallet if it exists within ./"$(deldirs)"!" ; \


### PR DESCRIPTION
Fixes pthread error:

```
/usr/bin/ld: CMakeFiles/parse-url_fuzz_tests.dir/parse_url.cpp.o: undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'          
/usr/lib/../lib/libpthread.so.0: error adding symbols: DSO missing from command line                                                              
collect2: error: ld returned 1 exit status                                                                                                        
make[3]: *** [tests/fuzz/CMakeFiles/parse-url_fuzz_tests.dir/build.make:111: tests/fuzz/parse-url_fuzz_tests] Error 1                             
make[3]: Leaving directory '/home/oneiric/monero/build/Linux/master/fuzz'                                                                         
make[2]: *** [CMakeFiles/Makefile2:4304: tests/fuzz/CMakeFiles/parse-url_fuzz_tests.dir/all] Error 2                                              
make[2]: *** Waiting for unfinished jobs....
```

and strange TLS error from afl-gcc:

```
/usr/bin/ld: ../../src/crypto/libcncrypto.a(slow-hash.c.o): TLS transition from R_X86_64_TLSGD to R_X86_64_GOTTPOFF against `hp_state' at 0x59f in section `.text' failed
/usr/bin/ld: final link failed: Nonrepresentable section on output                                                                                
collect2: error: ld returned 1 exit status                                                                                                        
make[3]: *** [tests/hash/CMakeFiles/hash-tests.dir/build.make:100: tests/hash/hash-tests] Error 1                                                 
make[3]: Leaving directory '/home/oneiric/monero/build/Linux/master/fuzz'                                                                         
make[2]: *** [CMakeFiles/Makefile2:4842: tests/hash/CMakeFiles/hash-tests.dir/all] Error 2                                                        
make[2]: *** Waiting for unfinished jobs....
```