### PR TITLE
[Wallet API] query_device() defaults to SOFTWARE

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3611,6 +3611,7 @@ bool wallet2::query_device(hw::device::device_type& device_type, const std::stri
   if (json.Parse(account_data.c_str()).HasParseError() || !json.IsObject())
     crypto::chacha8(keys_file_data.account_data.data(), keys_file_data.account_data.size(), key, keys_file_data.iv, &account_data[0]);
 
+  device_type = hw::device::device_type::SOFTWARE;
   // The contents should be JSON if the wallet follows the new format.
   if (json.Parse(account_data.c_str()).HasParseError())
   {


### PR DESCRIPTION
Same as #4574 but this is to master