### PR TITLE
Dockerfile: init and update submodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ COPY . .
 ENV USE_SINGLE_BUILDDIR=1
 ARG NPROC
 RUN set -ex && \
+    git submodule init && git submodule update && \
     rm -rf build && \
     if [ -z "$NPROC" ] ; \
     then make -j$(nproc) release-static ; \


### PR DESCRIPTION
The Docker image is failing to build, as the submodules are not being
explicitly initialized and updated.

Fixes: https://github.com/monero-project/monero/issues/4582

Signed-off-by: Tyler Baker <tyler@foundries.io>