### PR TITLE
rpc: fix wrongly formatted JSON for pruned tx

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -212,23 +212,15 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  static cryptonote::blobdata get_pruned_tx_blob(cryptonote::transaction &tx)
-  {
-    std::stringstream ss;
-    binary_archive<true> ba(ss);
-    bool r = tx.serialize_base(ba);
-    CHECK_AND_ASSERT_MES(r, cryptonote::blobdata(), "Failed to serialize rct signatures base");
-    return ss.str();
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  static cryptonote::blobdata get_pruned_tx_json(cryptonote::transaction &tx)
-  {
-    std::stringstream ss;
-    json_archive<true> ar(ss);
-    bool r = tx.serialize_base(ar);
-    CHECK_AND_ASSERT_MES(r, cryptonote::blobdata(), "Failed to serialize rct signatures base");
-    return ss.str();
-  }
+  class pruned_transaction {
+    transaction& tx;
+  public:
+    pruned_transaction(transaction& tx) : tx(tx) {}
+    BEGIN_SERIALIZE_OBJECT()
+      bool r = tx.serialize_base(ar);
+      if (!r) return false;
+    END_SERIALIZE()
+  };
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_blocks(const COMMAND_RPC_GET_BLOCKS_FAST::request& req, COMMAND_RPC_GET_BLOCKS_FAST::response& res)
   {
@@ -564,10 +556,11 @@ namespace cryptonote
 
       crypto::hash tx_hash = *vhi++;
       e.tx_hash = *txhi++;
-      blobdata blob = req.prune ? get_pruned_tx_blob(tx) : t_serializable_object_to_blob(tx);
+      pruned_transaction pruned_tx{tx};
+      blobdata blob = req.prune ? t_serializable_object_to_blob(pruned_tx) : t_serializable_object_to_blob(tx);
       e.as_hex = string_tools::buff_to_hex_nodelimer(blob);
       if (req.decode_as_json)
-        e.as_json = req.prune ? get_pruned_tx_json(tx) : obj_to_json_str(tx);
+        e.as_json = req.prune ? obj_to_json_str(pruned_tx) : obj_to_json_str(tx);
       e.in_pool = pool_tx_hashes.find(tx_hash) != pool_tx_hashes.end();
       if (e.in_pool)
       {


### PR DESCRIPTION
Fix for #4399.
Also unifies code for serializing pruned tx to binary/json into one.

Example query:

    $ curl -H 'Content-Type: application/json' -X POST http://127.0.0.1:18081/get_transactions -d '{"txs_hashes":["eaf5e7be5d346aadb4855bcf701d3758c8f298a4d7dfbf74ab73de2242381003"],"decode_as_json":true,"prune":true}'

Invalid JSON string returned by the current master (note the missing curly brackets at the front and the back):

    "as_hex": "02000102000787d127c2fc54f9de7bf2cc289ff82fffc509fbf922c675477a4493922aa6fbafb4ca404511a54f89e5c486e4466dbcd10ca751f0bd02000280f421bb61df58295fcd9b54ef90f73e0eb17bec935fb0e26878925685cdca01000264f3083552ce5dca50c8f4337a22d9b6348fea5028831909ae71f8422a9d527021010acac7df0cdf5b9961be7b5ecef7efa949c209e40f933dbf32fc531cd4c7ecea018090dfc04ad6d480da4434e8ab5f685454991307d1ab38139c88182113a04955f416cc0f0b40f068d3be0c46dc363db5c6f5376610d14af492984e339c0c3dcb4e832b120c38bd9546db683ce6fa6fc0304fb98dcdd6c20d8234b7be9facfd195235ff690f33d47503ca40605820e637444425a647b7d6a0b1f801218190228d930b27ec00e172abc96eb0bbe52efd0f115ccd63748570fd13ec7e7bafdc3ed6cc752003eac931b4540487b71dc314b875ba6f311748ee4aa663f5c47fa05d11514c5c6d39",
    "as_json": ", \"version\": 2, \"unlock_time\": 0, \"vin\": [ {\"key\": {\"amount\": 0, \"key_offsets\": [ 649351, 1392194, 2027385, 665202, 785439, 156415, 572667], \"k_image\": \"c675477a4493922aa6fbafb4ca404511a54f89e5c486e4466dbcd10ca751f0bd\"}}], \"vout\": [ {\"amount\": 0, \"target\": {\"key\": \"80f421bb61df58295fcd9b54ef90f73e0eb17bec935fb0e26878925685cdca01\"}}, {\"amount\": 0, \"target\": {\"key\": \"64f3083552ce5dca50c8f4337a22d9b6348fea5028831909ae71f8422a9d5270\"}}], \"extra\": [ 1, 10, 202, 199, 223, 12, 223, 91, 153, 97, 190, 123, 94, 206, 247, 239, 169, 73, 194, 9, 228, 15, 147, 61, 191, 50, 252, 83, 28, 212, 199, 236, 234], \"rct_signatures\": {\"type\": 1, \"txnFee\": 20000000000, \"ecdhInfo\": [ {\"mask\": \"d6d480da4434e8ab5f685454991307d1ab38139c88182113a04955f416cc0f0b\", \"amount\": \"40f068d3be0c46dc363db5c6f5376610d14af492984e339c0c3dcb4e832b120c\"}, {\"mask\": \"38bd9546db683ce6fa6fc0304fb98dcdd6c20d8234b7be9facfd195235ff690f\", \"amount\": \"33d47503ca40605820e637444425a647b7d6a0b1f801218190228d930b27ec00\"}], \"outPk\": [ \"e172abc96eb0bbe52efd0f115ccd63748570fd13ec7e7bafdc3ed6cc752003ea\", \"c931b4540487b71dc314b875ba6f311748ee4aa663f5c47fa05d11514c5c6d39\"]}",

Correction by this PR:

    "as_hex": "02000102000787d127c2fc54f9de7bf2cc289ff82fffc509fbf922c675477a4493922aa6fbafb4ca404511a54f89e5c486e4466dbcd10ca751f0bd02000280f421bb61df58295fcd9b54ef90f73e0eb17bec935fb0e26878925685cdca01000264f3083552ce5dca50c8f4337a22d9b6348fea5028831909ae71f8422a9d527021010acac7df0cdf5b9961be7b5ecef7efa949c209e40f933dbf32fc531cd4c7ecea018090dfc04ad6d480da4434e8ab5f685454991307d1ab38139c88182113a04955f416cc0f0b40f068d3be0c46dc363db5c6f5376610d14af492984e339c0c3dcb4e832b120c38bd9546db683ce6fa6fc0304fb98dcdd6c20d8234b7be9facfd195235ff690f33d47503ca40605820e637444425a647b7d6a0b1f801218190228d930b27ec00e172abc96eb0bbe52efd0f115ccd63748570fd13ec7e7bafdc3ed6cc752003eac931b4540487b71dc314b875ba6f311748ee4aa663f5c47fa05d11514c5c6d39",
    "as_json": "{\n  \"version\": 2, \n  \"unlock_time\": 0, \n  \"vin\": [ {\n      \"key\": {\n        \"amount\": 0, \n        \"key_offsets\": [ 649351, 1392194, 2027385, 665202, 785439, 156415, 572667\n        ], \n        \"k_image\": \"c675477a4493922aa6fbafb4ca404511a54f89e5c486e4466dbcd10ca751f0bd\"\n      }\n    }\n  ], \n  \"vout\": [ {\n      \"amount\": 0, \n      \"target\": {\n        \"key\": \"80f421bb61df58295fcd9b54ef90f73e0eb17bec935fb0e26878925685cdca01\"\n      }\n    }, {\n      \"amount\": 0, \n      \"target\": {\n        \"key\": \"64f3083552ce5dca50c8f4337a22d9b6348fea5028831909ae71f8422a9d5270\"\n      }\n    }\n  ], \n  \"extra\": [ 1, 10, 202, 199, 223, 12, 223, 91, 153, 97, 190, 123, 94, 206, 247, 239, 169, 73, 194, 9, 228, 15, 147, 61, 191, 50, 252, 83, 28, 212, 199, 236, 234\n  ], \n  \"rct_signatures\": {\n    \"type\": 1, \n    \"txnFee\": 20000000000, \n    \"ecdhInfo\": [ {\n        \"mask\": \"d6d480da4434e8ab5f685454991307d1ab38139c88182113a04955f416cc0f0b\", \n        \"amount\": \"40f068d3be0c46dc363db5c6f5376610d14af492984e339c0c3dcb4e832b120c\"\n      }, {\n        \"mask\": \"38bd9546db683ce6fa6fc0304fb98dcdd6c20d8234b7be9facfd195235ff690f\", \n        \"amount\": \"33d47503ca40605820e637444425a647b7d6a0b1f801218190228d930b27ec00\"\n      }], \n    \"outPk\": [ \"e172abc96eb0bbe52efd0f115ccd63748570fd13ec7e7bafdc3ed6cc752003ea\", \"c931b4540487b71dc314b875ba6f311748ee4aa663f5c47fa05d11514c5c6d39\"]\n  }\n}",

Note that the binary serialization part (which was slightly refactored in this PR) is also functioning properly as the same hex string is returned.
