### PR TITLE
tx_pool: store hex string instead of raw binary to tx_blob of get_tra…

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -766,7 +766,7 @@ namespace cryptonote
     m_blockchain.for_all_txpool_txes([&tx_infos, key_image_infos, include_sensitive_data](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *bd){
       tx_info txi;
       txi.id_hash = epee::string_tools::pod_to_hex(txid);
-      txi.tx_blob = *bd;
+      txi.tx_blob = epee::string_tools::buff_to_hex_nodelimer(*bd);
       transaction tx;
       if (!parse_and_validate_tx_from_blob(*bd, tx))
       {


### PR DESCRIPTION
…nsaction_pool RPC

Inspired by https://github.com/masari-project/masari/issues/93

The struct `tx_info` defined in core_rpc_server_commands_defs.h seems to assume all non-integral fields to be hex strings (such as `id_hash`), so it seems wrong to store the tx blob as raw into the `tx_blob` field.