### PR TITLE
WalletAPI: rescanBlockchain, rescanBlockchainAsync

### DIFF
--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -114,6 +114,8 @@ public:
     bool synchronized() const override;
     bool refresh() override;
     void refreshAsync() override;
+    bool rescanBlockchain() override;
+    void rescanBlockchainAsync() override;    
     void setAutoRefreshInterval(int millis) override;
     int autoRefreshInterval() const override;
     void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) override;
@@ -232,6 +234,7 @@ private:
     std::atomic<bool> m_refreshEnabled;
     std::atomic<bool> m_refreshThreadDone;
     std::atomic<int>  m_refreshIntervalMillis;
+    std::atomic<bool> m_refreshShouldRescan;
     // synchronizing  refresh loop;
     boost::mutex        m_refreshMutex;
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -644,6 +644,17 @@ struct Wallet
     virtual void refreshAsync() = 0;
 
     /**
+     * @brief rescanBlockchain - rescans the wallet, updating transactions from daemon
+     * @return - true if refreshed successfully;
+     */
+    virtual bool rescanBlockchain() = 0;
+
+    /**
+     * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesys
+     */
+    virtual void rescanBlockchainAsync() = 0;
+
+    /**
      * @brief setAutoRefreshInterval - setup interval for automatic refresh.
      * @param seconds - interval in millis. if zero or less than zero - automatic refresh disabled;
      */


### PR DESCRIPTION
Changeset: `rescan_bc` command implemented in WalletAPI as `Wallet::rescanBlockchain()` and `Wallet::rescanBlockchainAsync()` methods.

Rationale: This functionality was required by mobile wallet team.

Notes: `WalletListener::refreshed()` callback is called only after `Wallet::rescanBlockchain()` is finished (It could be requested in background thread even while earlier `Wallet::refreshAsync()` is going on). This is implemented as a cycle in `doRefresh()` until `m_refreshShouldRescan==false`