### PR TITLE
spawn: close all file descriptors before execve

### DIFF
--- a/src/common/spawn.cpp
+++ b/src/common/spawn.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #include "misc_log_ex.h"
+#include "util.h"
 #include "spawn.h"
 
 namespace tools
@@ -101,6 +102,8 @@ int spawn(const char *filename, const std::vector<std::string>& args, bool wait)
   // child
   if (pid == 0)
   {
+    tools::closefrom(3);
+    close(0);
     char *envp[] = {NULL};
     execve(filename, argv, envp);
     MERROR("Failed to execve: " << strerror(errno));

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -28,6 +28,7 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include <unistd.h>
 #include <cstdio>
 
 #ifdef __GLIBC__
@@ -966,5 +967,24 @@ std::string get_nix_version_display_string()
     return buf;
   }
 #endif
+
+  void closefrom(int fd)
+  {
+#if defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__ || defined __DragonFly__
+    ::closefrom(fd);
+#else
+#if defined __GLIBC__
+    const int sc_open_max =  sysconf(_SC_OPEN_MAX);
+    const int MAX_FDS = std::min(65536, sc_open_max);
+#else
+    const int MAX_FDS = 65536;
+#endif
+    while (fd < MAX_FDS)
+    {
+      close(fd);
+      ++fd;
+    }
+#endif
+  }
 
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -238,4 +238,6 @@ namespace tools
 #ifdef _WIN32
   std::string input_line_win();
 #endif
+
+  void closefrom(int fd);
 }


### PR DESCRIPTION
No need to give whatever we're calling access to what we use