### PR TITLE
rpc: fix output distribution caching ignoring chain changes

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2118,6 +2118,8 @@ namespace cryptonote
 
     try
     {
+      // 0 is placeholder for the whole chain
+      const uint64_t req_to_height = req.to_height ? req.to_height : (m_core.get_current_blockchain_height() - 1);
       for (uint64_t amount: req.amounts)
       {
         static struct D
@@ -2130,7 +2132,7 @@ namespace cryptonote
         } d;
         boost::unique_lock<boost::mutex> lock(d.mutex);
 
-        if (d.cached && amount == 0 && d.cached_from == req.from_height && d.cached_to == req.to_height)
+        if (d.cached && amount == 0 && d.cached_from == req.from_height && d.cached_to == req_to_height)
         {
           res.distributions.push_back({amount, d.cached_start_height, req.binary, d.cached_distribution, d.cached_base});
           if (!req.cumulative)
@@ -2145,23 +2147,23 @@ namespace cryptonote
 
         std::vector<uint64_t> distribution;
         uint64_t start_height, base;
-        if (!m_core.get_output_distribution(amount, req.from_height, req.to_height, start_height, distribution, base))
+        if (!m_core.get_output_distribution(amount, req.from_height, req_to_height, start_height, distribution, base))
         {
           error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
           error_resp.message = "Failed to get rct distribution";
           return false;
         }
-        if (req.to_height > 0 && req.to_height >= req.from_height)
+        if (req_to_height > 0 && req_to_height >= req.from_height)
         {
           uint64_t offset = std::max(req.from_height, start_height);
-          if (offset <= req.to_height && req.to_height - offset + 1 < distribution.size())
-            distribution.resize(req.to_height - offset + 1);
+          if (offset <= req_to_height && req_to_height - offset + 1 < distribution.size())
+            distribution.resize(req_to_height - offset + 1);
         }
 
         if (amount == 0)
         {
           d.cached_from = req.from_height;
-          d.cached_to = req.to_height;
+          d.cached_to = req_to_height;
           d.cached_distribution = distribution;
           d.cached_start_height = start_height;
           d.cached_base = base;


### PR DESCRIPTION
0 is placeholder for whole chain, so we should compare chain
height changes rather than chain-height-or-zero. Even this isn't
totally foolproof if a blocks are popped and the same number
added again, but it is much better as it prevents the data from
slowly going out of sync.