### PR TITLE
console_handler: add a global log when exiting via EOF

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -352,8 +352,11 @@ eof:
 
           std::string command;
           bool get_line_ret = m_stdin_reader.get_line(command);
-          if (!m_running || m_stdin_reader.eos())
+          if (!m_running)
+            break;
+          if (m_stdin_reader.eos())
           {
+            MGINFO("EOF on stdin, exiting");
             break;
           }
           if (!get_line_ret)


### PR DESCRIPTION
It's a common confusion point for users which run monerod
without stdin and with --detach