### PR TITLE
Updating Monero GUI repo link in README.i18n.md

### DIFF
--- a/README.i18n.md
+++ b/README.i18n.md
@@ -3,7 +3,7 @@ Monero daemon internationalization
 
 The Monero command line tools can be translated in various languages. If you wish to contribute and need help/support, contact the [Monero Localization Workgroup on Taiga](https://taiga.getmonero.org/project/erciccione-monero-localization/) or come chat on `#monero-translations` (Freenode/IRC, riot/matrix, MatterMost)
 
-In order to use the same translation workflow as the [Monero Core GUI](https://github.com/monero-project/monero-core), they use Qt Linguist translation files.  However, to avoid the dependencies on Qt this normally implies, they use a custom loader to read those files at runtime.
+In order to use the same translation workflow as the [Monero Core GUI](https://github.com/monero-project/monero-gui), they use Qt Linguist translation files.  However, to avoid the dependencies on Qt this normally implies, they use a custom loader to read those files at runtime.
 
 ### Tools for translators
 


### PR DESCRIPTION
Just noticed this inconsistency. Not sure when the repo was renamed from monero-core to monero-gui.

As a side note, I think some improvements to terminology consistency(Monero GUI/Monero Core GUI/Monero Core) could help with general understanding in the community. Unsure if a sort of wiki for this already exists or not.