### PR TITLE
Updated electrum-words/create_checksum_index to support variable word list length

### DIFF
--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -215,7 +215,7 @@ namespace
     }
     boost::crc_32_type result;
     result.process_bytes(trimmed_words.data(), trimmed_words.length());
-    return result.checksum() % crypto::ElectrumWords::seed_length;
+    return result.checksum() % word_list.size();
   }
 
   /*!


### PR DESCRIPTION
To support 13-word (and any other size for the future) mnemonics by avoiding out of bounds memory access in callers like bytes_to_words, etc.