### PR TITLE
easylogging++: remove std::deque usage

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -1981,6 +1981,12 @@ void VRegistry::setCategories(const char* categories, bool clear) {
     m_categoriesString += ",";
   m_categoriesString += categories;
 
+  size_t n_fields = m_categories.size() + 1;
+  for (const char *ptr = categories; *ptr; ++ptr)
+    if (*ptr == ',')
+      ++n_fields;
+  m_categories.reserve(n_fields);
+
   bool isCat = true;
   bool isLevel = false;
   std::stringstream ss;
@@ -2042,7 +2048,7 @@ bool VRegistry::allowed(Level level, const char* category) {
   if (m_categories.empty() || category == nullptr) {
     return false;
   } else {
-    std::deque<std::pair<std::string, Level>>::const_reverse_iterator it = m_categories.rbegin();
+    std::vector<std::pair<std::string, Level>>::const_reverse_iterator it = m_categories.rbegin();
     for (; it != m_categories.rend(); ++it) {
       if (base::utils::Str::wildCardMatch(category, it->first.c_str())) {
         const int p = priority(it->second);

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -386,7 +386,6 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #include <string>
 #include <vector>
 #include <map>
-#include <deque>
 #include <utility>
 #include <functional>
 #include <algorithm>
@@ -2531,7 +2530,7 @@ class VRegistry : base::NoCopy, public base::threading::ThreadSafe {
   base::type::VerboseLevel m_level;
   base::type::EnumType* m_pFlags;
   std::map<std::string, base::type::VerboseLevel> m_modules;
-  std::deque<std::pair<std::string, Level>> m_categories;
+  std::vector<std::pair<std::string, Level>> m_categories;
   std::map<std::string, int> m_cached_allowed_categories;
   std::string m_categoriesString;
   std::string m_filenameCommonPrefix;


### PR DESCRIPTION
It's not actually needed for this use, and saves a STL header