### PR TITLE
tests: fix MSYS2 gcc 7.3.0 warning -Wtype-limits

### DIFF
--- a/tests/unit_tests/keccak.cpp
+++ b/tests/unit_tests/keccak.cpp
@@ -37,7 +37,7 @@ extern "C" {
 #define TEST_KECCAK(sz, chunks) \
   std::string data; \
   data.resize(sz); \
-  for (size_t i = 0; i < sz; ++i) \
+  for (size_t i = 0; i < data.size(); ++i) \
     data[i] = i * 17; \
   uint8_t md0[32], md1[32]; \
   keccak((const uint8_t*)data.data(), data.size(), md0, 32); \


### PR DESCRIPTION
```c++
C:/msys32/home/buildbot/slave/monero-static-win32/build/tests/unit_tests/keccak.cpp: In member function 'virtual void keccak_0_and_0_Test::TestBody()':
C:/msys32/home/buildbot/slave/monero-static-win32/build/tests/unit_tests/keccak.cpp:40:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   for (size_t i = 0; i < sz; ++i) \
                      ~~^~~~~~~~~~~~
     data[i] = i * 17; \
     ~~~~~~~~~~~~~~~~~~~ 
   uint8_t md0[32], md1[32]; \
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   keccak((const uint8_t*)data.data(), data.size(), md0, 32); \
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   KECCAK_CTX ctx; \
   ~~~~~~~~~~~~~~~~~     
   keccak_init(&ctx); \
   ~~~~~~~~~~~~~~~~~~~~  
   size_t offset = 0; \
   ~~~~~~~~~~~~~~~~~~~~  
   for (size_t i = 0; i < sizeof(chunks) / sizeof(chunks[0]); ++i) \
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   { \
   ~~~                   
     ASSERT_TRUE(offset + chunks[i] <= data.size()); \
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     keccak_update(&ctx, (const uint8_t*)data.data() + offset, chunks[i]); \
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     offset += chunks[i]; \
     ~~~~~~~~~~~~~~~~~~~~~~
   } \
   ~~~                   
   ASSERT_TRUE(offset == data.size()); \
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   keccak_finish(&ctx, md1); \
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ASSERT_EQ(memcmp(md0, md1, 32), 0);
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
                         
 TEST(keccak, )
 ~~~~~~~~~~~~~~          
 {
 ~                       
 }
 ~                       
 
                         
 TEST(keccak, 0_and_0)
 ~~~~~~~~~~~~~~~~~~~~~   
 {
 ~                       
   static const size_t chunks[] = {0};
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   TEST_KECCAK(0, chunks);
   ~~~~~~~~~~~~~         
C:/msys32/home/buildbot/slave/monero-static-win32/build/tests/unit_tests/keccak.cpp:64:3: note: in expansion of macro 'TEST_KECCAK'
   TEST_KECCAK(0, chunks);
   ^~~~~~~~~~~
```