### PR TITLE
tests: fix MSYS2 warning 'MONERO_DEFAULT_LOG_CATEGORY redefined'

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -32,7 +32,9 @@
 
 #include "easylogging++.h"
 
+#undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
+
 #define MAX_LOG_FILE_SIZE 104850000 // 100 MB - 7600 bytes
 #define MAX_LOG_FILES 50
 


### PR DESCRIPTION
```c++
In file included from C:/msys32/home/buildbot/slave/monero-static-win32/build/src/common/util.h:45:0,
                 from C:/msys32/home/buildbot/slave/monero-static-win32/build/src/crypto/crypto.h:42,
                 from C:/msys32/home/buildbot/slave/monero-static-win32/build/tests/unit_tests/http.cpp:63:
C:/msys32/home/buildbot/slave/monero-static-win32/build/contrib/epee/include/misc_log_ex.h:35:0: warning: "MONERO_DEFAULT_LOG_CATEGORY" redefined
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
 
In file included from C:/msys32/home/buildbot/slave/monero-static-win32/build/tests/unit_tests/http.cpp:30:0:
C:/msys32/home/buildbot/slave/monero-static-win32/build/contrib/epee/include/net/http_auth.h:40:0: note: this is the location of the previous definition
 #define MONERO_DEFAULT_LOG_CATEGORY "net.http"
```