### PR TITLE
wallet2: save ring in the ringdb once a tx is created

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7258,6 +7258,20 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       outs.push_back(v);
     }
   }
+
+  // save those outs in the ringdb for reuse
+  for (size_t i = 0; i < selected_transfers.size(); ++i)
+  {
+    const size_t idx = selected_transfers[i];
+    THROW_WALLET_EXCEPTION_IF(idx >= m_transfers.size(), error::wallet_internal_error, "selected_transfers entry out of range");
+    const transfer_details &td = m_transfers[idx];
+    std::vector<uint64_t> ring;
+    ring.reserve(outs[i].size());
+    for (const auto &e: outs[i])
+      ring.push_back(std::get<0>(e));
+    if (!set_ring(td.m_key_image, ring, false))
+      MERROR("Failed to set ring for " << td.m_key_image);
+  }
 }
 
 template<typename T>


### PR DESCRIPTION
Even if it is never relayed, it ensures a daemon supplying
fake outs on demand will never be asked for a set with the
real input being the only intersecting member (only a problem
with people who trust their privacy to some stranger's node,
but it seems to be a massively common thing, even in Monero)