### PR TITLE
README.md: increase swap size on Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Tested on a Raspberry Pi Zero with a clean install of minimal Raspbian Stretch (
 ```	
 	sudo /etc/init.d/dphys-swapfile stop  
 	sudo nano /etc/dphys-swapfile  
-	CONF_SWAPSIZE=1024  
+	CONF_SWAPSIZE=2048
 	sudo /etc/init.d/dphys-swapfile start  
 ```
 * If using an external hard disk without an external power supply, ensure it gets enough power to avoid hardware issues when syncing, by adding the line "max_usb_current=1" to /boot/config.txt
@@ -270,7 +270,7 @@ If you are using the older Raspbian Jessie image, compiling Monero is a bit more
 ```	
 	sudo /etc/init.d/dphys-swapfile stop  
 	sudo nano /etc/dphys-swapfile  
-	CONF_SWAPSIZE=1024  
+	CONF_SWAPSIZE=2048  
 	sudo /etc/init.d/dphys-swapfile start  
 ```
 


### PR DESCRIPTION
Increased swap size on raspberry pi compiling guide, since it might crash if the raspberry has any service runing in the background