### PR TITLE
cryptonote_core: fix build error gcc 5.4.0 'sign-compare'

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1716,7 +1716,7 @@ namespace cryptonote
     for (size_t n = 0; n < sizeof(seconds)/sizeof(seconds[0]); ++n)
     {
       unsigned int b = 0;
-      for (time_t ts: timestamps) b += ts >= now - seconds[n];
+      for (time_t ts: timestamps) b += ts >= now - static_cast<time_t>(seconds[n]);
       const double p = probability(b, seconds[n] / DIFFICULTY_TARGET_V2);
       MDEBUG("blocks in the last " << seconds[n] / 60 << " minutes: " << b << " (probability " << p << ")");
       if (p < threshold)


### PR DESCRIPTION
Because it's proving hard to get it without the reformatting.