### PR TITLE
mlocker: fix dtor ordering problem

### DIFF
--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -84,8 +84,8 @@ namespace epee
 
   boost::mutex &mlocker::mutex()
   {
-    static boost::mutex vmutex;
-    return vmutex;
+    static boost::mutex *vmutex = new boost::mutex();
+    return *vmutex;
   }
   std::map<size_t, unsigned int> &mlocker::map()
   {


### PR DESCRIPTION
leak the mutex instead, it's a one off