### PR TITLE
simplewallet: don't skip asking for password when watch-only

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -104,7 +104,7 @@ typedef cryptonote::simple_wallet sw;
 #define SCOPED_WALLET_UNLOCK() \
   LOCK_IDLE_SCOPE(); \
   boost::optional<tools::password_container> pwd_container = boost::none; \
-  if (m_wallet->ask_password() && !m_wallet->watch_only() && !(pwd_container = get_and_verify_password())) { return true; } \
+  if (m_wallet->ask_password() && !(pwd_container = get_and_verify_password())) { return true; } \
   tools::wallet_keys_unlocker unlocker(*m_wallet, pwd_container);
 
 enum TransferType {


### PR DESCRIPTION
Currently, the wallet skips asking for password when it's watch-only, which seems wrong since it still has some amount of secret information such as the view key.