### PR TITLE
wallet2: fix out_of_hashchain_bounds_error in refresh

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2720,7 +2720,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
           short_chain_history.clear();
           get_short_chain_history(short_chain_history);
           fast_refresh(stop_height, blocks_start_height, short_chain_history, true);
-          THROW_WALLET_EXCEPTION_IF(m_blockchain.size() != stop_height, error::wallet_internal_error, "Unexpected hashchain size");
+          THROW_WALLET_EXCEPTION_IF((m_blockchain.size() == stop_height || (m_blockchain.size() == 1 && stop_height == 0) ? false : true), error::wallet_internal_error, "Unexpected hashchain size");
           THROW_WALLET_EXCEPTION_IF(m_blockchain.offset() != 0, error::wallet_internal_error, "Unexpected hashchain offset");
           for (const auto &h: tip)
             m_blockchain.push_back(h);


### PR DESCRIPTION
15:43 < hahsun> Im on stagenet and I suddenly get this exception: 2018-11-04 14:42:52.416 [RPC0] ERROR wallet.wallet2 src/wallet/wallet2.cpp:2070 !m_blockchain.is_in_bounds(current_index). THROW EXCEPTION: error::out_of_hashchain_bounds_error
16:01 <+moneromooo> OK, possibly because the blckchain is always seeded with the genesis block hash...
16:02 <+moneromooo> So that case should be allowed, assuming it doesn't break the code around it.
16:05 <+moneromooo> OK if stop_height == size || (size==1 && stop_heigt ==0)
16:05 <+moneromooo> Throw if not that.
16:06 < hahsun> k