### PR TITLE
rpc: fix linking error of 6097472, get_output_distribution

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -27,11 +27,11 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(rpc_base_sources
-  rpc_args.cpp
-  rpc_handler.cpp)
+  rpc_args.cpp)
 
 set(rpc_sources
   core_rpc_server.cpp
+  rpc_handler.cpp
   instanciations)
 
 set(daemon_messages_sources
@@ -44,10 +44,10 @@ set(daemon_rpc_server_sources
 
 
 set(rpc_base_headers
-  rpc_args.h
-  rpc_handler.h)
+  rpc_args.h)
 
-set(rpc_headers)
+set(rpc_headers
+  rpc_handler.cpp)
 
 set(daemon_rpc_server_headers)
 


### PR DESCRIPTION
@fluffypony, build of 7e2483e yields the following error

```
Undefined symbols for architecture x86_64:
  "cryptonote::core::get_output_distribution(unsigned long long, unsigned long long, unsigned long long, unsigned long long&, std::__1::vector<unsigned long long, std::__1::allocator<unsigned long long> >&, unsigned long long&) const", referenced from:
      cryptonote::rpc::RpcHandler::get_output_distribution(cryptonote::core&, unsigned long long, unsigned long long, unsigned long long, bool) in rpc_handler.cpp.o
```

This PR fixes the compilation error. 
