### PR TITLE
Fix build of monero-gui by adding device_trezor to wallet_merged

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -120,7 +120,8 @@ if (BUILD_GUI_DEPS)
             ringct
             ringct_basic
             checkpoints
-            version)
+            version
+            device_trezor)
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt


### PR DESCRIPTION
This fixes problem with building monero-gui, see [issue](https://github.com/monero-project/monero-gui/issues/1726). Symbols from device_trezor were missing in wallet_merged.