### PR TITLE
build: fix Ubuntu 16.04 (GCC 5.4.0) compilation

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11069,7 +11069,8 @@ std::string wallet2::export_outputs_to_str() const
 
   std::stringstream oss;
   boost::archive::portable_binary_oarchive ar(oss);
-  ar << export_outputs();
+  const auto& outputs = export_outputs();
+  ar << outputs;
 
   std::string magic(OUTPUT_EXPORT_FILE_MAGIC, strlen(OUTPUT_EXPORT_FILE_MAGIC));
   const cryptonote::account_public_address &keys = get_account().get_keys().m_account_address;


### PR DESCRIPTION
@iDunk5400 reported in #monero-dev
> Current master on Ubuntu 16.04 (GCC 5.4.0)  https://paste.fedoraproject.org/paste/LbcCnZn31BNLwhHXQU0fqQ/raw