### PR TITLE
common: fix base58 gcc -Werror=implicit-fallthrough

### DIFF
--- a/src/common/base58.cpp
+++ b/src/common/base58.cpp
@@ -109,20 +109,8 @@ namespace tools
         assert(1 <= size && size <= sizeof(uint64_t));
 
         uint64_t res = 0;
-        switch (9 - size)
-        {
-        case 1:            res |= *data++; /* FALLTHRU */
-        case 2: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 3: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 4: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 5: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 6: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 7: res <<= 8; res |= *data++; /* FALLTHRU */
-        case 8: res <<= 8; res |= *data; break;
-        default: assert(false);
-        }
-
-        return res;
+        memcpy(reinterpret_cast<uint8_t*>(&res) + sizeof(uint64_t) - size, data, size);
+        return SWAP64BE(res);
       }
 
       void uint_64_to_8be(uint64_t num, size_t size, uint8_t* data)


### PR DESCRIPTION
Fixes build error, makes `uint_8be_to_64` code consistent with `uint_64_to_8be` implementation.

Build error logs: https://github.com/monero-project/monero/pull/4837#issuecomment-437998175