### PR TITLE
mlocker: don't throw from lock/unlock

### DIFF
--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -113,6 +113,8 @@ namespace epee
 
   void mlocker::lock(void *ptr, size_t len)
   {
+    TRY_ENTRY();
+
     size_t page_size = get_page_size();
     if (page_size == 0)
       return;
@@ -123,10 +125,14 @@ namespace epee
     for (size_t page = first; page <= last; ++page)
       lock_page(page);
     ++num_locked_objects;
+
+    CATCH_ENTRY_L1("mlocker::lock", void());
   }
 
   void mlocker::unlock(void *ptr, size_t len)
   {
+    TRY_ENTRY();
+
     size_t page_size = get_page_size();
     if (page_size == 0)
       return;
@@ -136,6 +142,8 @@ namespace epee
     for (size_t page = first; page <= last; ++page)
       unlock_page(page);
     --num_locked_objects;
+
+    CATCH_ENTRY_L1("mlocker::lock", void());
   }
 
   size_t mlocker::get_num_locked_pages()


### PR DESCRIPTION
This prevents exceptions from showing up in various awkward
places such as dtors, since the only exception that can be
thrown is a lock failure, and nothing handles a lock failure
anyway.