### PR TITLE
mlocker: fix access to global lock map after dtor on exit

### DIFF
--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -89,8 +89,8 @@ namespace epee
   }
   std::map<size_t, unsigned int> &mlocker::map()
   {
-    static std::map<size_t, unsigned int> vmap;
-    return vmap;
+    static std::map<size_t, unsigned int> *vmap = new std::map<size_t, unsigned int>();
+    return *vmap;
   }
 
   size_t mlocker::get_page_size()


### PR DESCRIPTION
as the lock, it now leaks