### PR TITLE
wallet2: resume processing when tx extra is partially broken

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1362,8 +1362,8 @@ void wallet2::cache_tx_data(const cryptonote::transaction& tx, const crypto::has
   {
     // Extra may only be partially parsed, it's OK if tx_extra_fields contains public key
     LOG_PRINT_L0("Transaction extra has unsupported format: " << txid);
-    tx_cache_data.tx_extra_fields.clear();
-    return;
+    if (tx_cache_data.tx_extra_fields.empty())
+      return;
   }
 
   // Don't try to extract tx public key if tx has no ouputs


### PR DESCRIPTION
Motivated by https://monero.stackexchange.com/questions/10483

Some exchanges appear to have customized the wallet software
in an inappropriate way, making the tx extra field partially
unreadable. PR #3716 changed the wallet behavior disallowing
such partially valid tx extra.

An example tx reported by the user is
e87c675a85f34ecac58a8846613d25062f1813e1023c552b705afad32b972c38
where the normal tx pubkey appears again with the aditional
tx pubkeys tag `04` which is inappropriate.