### PR TITLE
device: remove Ledger timeout

### DIFF
--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -56,17 +56,16 @@ namespace hw {
       return std::string("NULL path");
     }
 
-    device_io_hid::device_io_hid(unsigned short c, unsigned char t, unsigned int ps, unsigned int to) : 
+    device_io_hid::device_io_hid(unsigned short c, unsigned char t, unsigned int ps) : 
       channel(c), 
       tag(t), 
       packet_size(ps), 
-      timeout(to),
       usb_vid(0),
       usb_pid(0),
       usb_device(NULL) {
     }
 
-    device_io_hid::device_io_hid() : device_io_hid(DEFAULT_CHANNEL, DEFAULT_TAG, DEFAULT_PACKET_SIZE, DEFAULT_TIMEOUT) {
+    device_io_hid::device_io_hid() : device_io_hid(DEFAULT_CHANNEL, DEFAULT_TAG, DEFAULT_PACKET_SIZE) {
     }
 
     void device_io_hid::io_hid_log(int read, unsigned char* buffer, int block_len) {
@@ -177,7 +176,7 @@ namespace hw {
 
       //get first response
       memset(buffer, 0, sizeof(buffer));
-      hid_ret = hid_read_timeout(this->usb_device, buffer, MAX_BLOCK, this->timeout);
+      hid_ret = hid_read(this->usb_device, buffer, MAX_BLOCK);
       ASSERT_X(hid_ret>=0, "Unable to read hidapi response. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
       result = (unsigned int)hid_ret;
       io_hid_log(1, buffer, result); 
@@ -188,7 +187,7 @@ namespace hw {
         if (result != 0) {
           break;
         }
-        hid_ret = hid_read_timeout(this->usb_device, buffer + offset, MAX_BLOCK, this->timeout);
+        hid_ret = hid_read(this->usb_device, buffer + offset, MAX_BLOCK);
         ASSERT_X(hid_ret>=0, "Unable to receive hidapi response. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
         result = (unsigned int)hid_ret;
         io_hid_log(1, buffer + offset, result);

--- a/src/device/device_io_hid.hpp
+++ b/src/device/device_io_hid.hpp
@@ -67,7 +67,6 @@ namespace hw {
       unsigned short channel;
       unsigned char  tag;
       unsigned int   packet_size; 
-      unsigned int   timeout;
 
       unsigned int   usb_vid;
       unsigned int   usb_pid;
@@ -90,9 +89,8 @@ namespace hw {
       static const unsigned short DEFAULT_CHANNEL     = 0x0001;
       static const unsigned char  DEFAULT_TAG         = 0x01;
       static const unsigned int   DEFAULT_PACKET_SIZE = 64;
-      static const unsigned int   DEFAULT_TIMEOUT     = 120000;
 
-      device_io_hid(unsigned short channel, unsigned char tag, unsigned int packet_zize, unsigned int timeout);
+      device_io_hid(unsigned short channel, unsigned char tag, unsigned int packet_zize);
       device_io_hid();
       ~device_io_hid() {};
 

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -176,7 +176,7 @@ namespace hw {
     #define INS_GET_RESPONSE                    0xc0
 
 
-    device_ledger::device_ledger(): hw_device(0x0101, 0x05, 64, 120000) {
+    device_ledger::device_ledger(): hw_device(0x0101, 0x05, 64) {
       this->id = device_id++;
       this->reset_buffer();      
       this->mode = NONE;


### PR DESCRIPTION
Fixes #4734 and improves #4512 (no more timeout after two minutes in the fee menu).

I’ve tested this and it works but maybe there is a reason why there’s a timeout in the first place.