### PR TITLE
daemon: stop miner before we bring the whole thing down

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -247,6 +247,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------
   void core::stop()
   {
+    m_miner.stop();
     m_blockchain_storage.cancel();
 
     tools::download_async_handle handle;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -198,7 +198,6 @@ bool t_daemon::run(bool interactive)
 
     for(auto& rpc : mp_internals->rpcs)
       rpc->stop();
-    mp_internals->core.get().get_miner().stop();
     MGINFO("Node stopped.");
     return true;
   }
@@ -220,7 +219,6 @@ void t_daemon::stop()
   {
     throw std::runtime_error{"Can't stop stopped daemon"};
   }
-  mp_internals->core.get().get_miner().stop();
   mp_internals->p2p.stop();
   for(auto& rpc : mp_internals->rpcs)
     rpc->stop();


### PR DESCRIPTION
This avoids the miner erroring out trying to submit blocks
to a core that's already shut down (and avoids pegging
the CPU while we're busy shutting down).