### PR TITLE
mlocker: remove early page size log

### DIFF
--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -47,7 +47,6 @@ static size_t query_page_size()
     MERROR("Failed to determine page size");
     return 0;
   }
-  MINFO("Page size: " << ret);
   return ret;
 #else
 #warning Missing query_page_size implementation


### PR DESCRIPTION
It comes before the logger is initialized, so gets displayed
even though it should not be by default, and apparenly comes
too early for (some versions of) Android, where it crashes.