### PR TITLE
singleton: fix missing *this return value in operator=

### DIFF
--- a/src/mnemonics/singleton.h
+++ b/src/mnemonics/singleton.h
@@ -50,8 +50,8 @@ namespace Language
   class Singleton
   {
     Singleton() {}
-    Singleton(Singleton &s) {}
-    Singleton& operator=(const Singleton&) {}
+    Singleton(Singleton &s) = delete;
+    Singleton& operator=(const Singleton&) = delete;
   public:
     static T* instance()
     {


### PR DESCRIPTION
while there, disable both operator= and copy ctor, since they
are not supposed to be around for a singleton