### PR TITLE
Sync short hash chain bug fixed

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2265,11 +2265,10 @@ void wallet2::pull_and_parse_next_blocks(uint64_t start_height, uint64_t &blocks
     THROW_WALLET_EXCEPTION_IF(prev_blocks.size() != prev_parsed_blocks.size(), error::wallet_internal_error, "size mismatch");
 
     // prepend the last 3 blocks, should be enough to guard against a block or two's reorg
-    std::vector<parsed_block>::const_reverse_iterator i = prev_parsed_blocks.rbegin();
-    for (size_t n = 0; n < std::min((size_t)3, prev_parsed_blocks.size()); ++n)
+    auto s = std::next(prev_parsed_blocks.rbegin(), std::min((size_t)3, prev_parsed_blocks.size())).base();
+    for (; s != prev_parsed_blocks.end(); ++s)
     {
-      short_chain_history.push_front(i->hash);
-      ++i;
+      short_chain_history.push_front(s->hash);
     }
 
     // pull the new blocks


### PR DESCRIPTION
I started figuring out anomaly big count of log messages during wallet sync:
```
2018-12-14 11:51:10.720	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 07df8c064d0eb589ef9b68ff380816a1d69d4b1a9a9e5cfb2d9c740c7bf0091d
2018-12-14 11:51:10.720	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 8e8577f8b4bade8a6c2201e8af8603774c9d3c3b6a0fcfda2c45409a5f3b2af4
2018-12-14 11:51:10.720	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 7a9e78b73a31b5d03ee30def977a95b4dc386e9e6cdc2e904477a2fcaec99236
2018-12-14 11:51:11.496	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 8239ee8bd1e9a32468a99260f6d69c6f6a92515ee9f8b4920a87fb4d18727c0c
2018-12-14 11:51:11.496	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 6c29ae20ff3f8087a40fa2fa71cf11dcebbdfa08f2dd3b78863ffbb1b8fe05a4
2018-12-14 11:51:11.496	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: b5b76e9a7bd7b850e3a6ea94e0b9472ef7fc25f008162d311d99fe936914aa40
2018-12-14 11:51:12.202	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: ae28feda31da052a1d7dac4bbe83312fcec46b06f72ea887fed5e9960189eb1b
2018-12-14 11:51:12.202	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: f2e9ff59b8b724b3717c8f61a10fb79096a4809551a1b64583f31e8c3150890f
2018-12-14 11:51:12.202	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: ed68ab2b60acb38d548594274c5781309b1e8595132e9b95b2816a86f39d1b4f
2018-12-14 11:51:13.045	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 7c43ae61d87df867d5b888a8f74811c8de7e95e3f765df0db3708d3e56441e9f
2018-12-14 11:51:13.045	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: c268cb15ee28d295441ff31c34ee87e6f476451e418434ceb0e7e99856f759ea
2018-12-14 11:51:13.045	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 64e5c17902442a4885bae17014b4e18839f8f241ef48b2f0813023cfbe8075c8
2018-12-14 11:51:13.873	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 730505c7c64f84888401fcdf74189520d0c57d7696b9f83c8b50104024b6605c
2018-12-14 11:51:13.873	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: f13e9fde8034cf0d0e65d3426528ee4f59fd35b987714d00e8975c968fb76a66
2018-12-14 11:51:13.873	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 07af0a3863412d5bf6dd455ce5f3dac6c8ebfa10ea38857543759f7496e7652c
2018-12-14 11:51:14.532	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: e9a5cba9a1f6869d3988a8170aa57f6ed5ada6b973228f577033d5f1b52bfb85
2018-12-14 11:51:14.532	    7fc455397780	DEBUG	wallet.wallet2	src/wallet/wallet2.cpp:2200	Block is already in blockchain: 6be702a80d5f5db096a1c5f302708e17c9ac478cda4138ef8e53366ac7dfa601
```

It turns out this is not overlapping blocks between blocks bulks from daemon. For example, the first 3 blocks correspond to heights (on `stagenet`): `102691`, `102692`, `102693`.

This happens when wallet tries to update short hash chain. For example, if in `prev_parsed_blocks` wallet had block hashes with heights: `104`, `103`, `102`, `101`, `100`, etc, in next chain we'd get: `102`, `103`, `104`, `101`, `100`.

Node seeks for hashes intersection from `0`-index hash from hash chain. In this case daemon's sync response would start from block `102`, not `104` and wallet will write such a messages in log file.
