### PR TITLE
device/trezor: store tx_prefix_hash in tx key aux

### DIFF
--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -877,6 +877,9 @@ namespace tx {
     valueS.SetString(m_ct.enc_salt2.c_str(), m_ct.enc_salt2.size());
     json.AddMember("salt2", valueS, json.GetAllocator());
 
+    valueS.SetString(m_ct.tx_prefix_hash.c_str(), m_ct.tx_prefix_hash.size());
+    json.AddMember("tx_prefix_hash", valueS, json.GetAllocator());
+
     valueS.SetString(m_ct.enc_keys.c_str(), m_ct.enc_keys.size());
     json.AddMember("enc_keys", valueS, json.GetAllocator());
 


### PR DESCRIPTION
tx_prefix_hash is required in the key derivation for decryption of the tx keys