### PR TITLE
Remove unused hash in export_key_images

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10699,9 +10699,6 @@ std::pair<size_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> 
   {
     const transfer_details &td = m_transfers[n];
 
-    crypto::hash hash;
-    crypto::cn_fast_hash(&td.m_key_image, sizeof(td.m_key_image), hash);
-
     // get ephemeral public key
     const cryptonote::tx_out &out = td.m_tx.vout[td.m_internal_output_index];
     THROW_WALLET_EXCEPTION_IF(out.target.type() != typeid(txout_to_key), error::wallet_internal_error,


### PR DESCRIPTION
It looks like the intention was to hash it for `crypto::generate_ring_signature` but it just uses the key-image wholesale as the hash `(const crypto::hash &)td.m_key_image)` instead.