### PR TITLE
simplewallet: Show new address after going multisig

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1165,6 +1165,7 @@ bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &
         uint32_t threshold, total;
         m_wallet->multisig(NULL, &threshold, &total);
         success_msg_writer() << tr("Multisig wallet has been successfully created. Current wallet type: ") << threshold << "/" << total;
+        success_msg_writer() << tr("Multisig address: ") << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
       }
     }
     catch (const std::exception &e)


### PR DESCRIPTION
Make the new `exchange_multisig_keys` command in `simplewallet` show the newly established multisig address at the end, like `make_multisig` already does.