### PR TITLE
device_ledger: remove full_name variable

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -322,7 +322,7 @@ namespace hw {
     }
 
     const std::string device_ledger::get_name() const {
-      if (this->full_name.empty() || !this->connected()) {
+      if (!this->connected()) {
         return std::string("<disconnected:").append(this->name).append(">");
       }
       return this->name;

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -85,7 +85,6 @@ namespace hw {
 
         //IO
         hw::io::device_io_hid hw_device;
-        std::string   full_name;        
         unsigned int  length_send;
         unsigned char buffer_send[BUFFER_SEND_SIZE];
         unsigned int  length_recv;


### PR DESCRIPTION
This variable was never set, resulting in the device name always showing as "disconnected".