### PR TITLE
device: proper handling of user input

### DIFF
--- a/src/device/device_io.hpp
+++ b/src/device/device_io.hpp
@@ -50,7 +50,7 @@ namespace hw {
       virtual void disconnect() = 0;
       virtual bool connected() const = 0;
 
-      virtual int  exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len) = 0;
+      virtual int  exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len, bool user_input) = 0;
     };
   };
 };

--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -148,7 +148,7 @@ namespace hw {
       return this->usb_device != NULL;
     }
 
-    int device_io_hid::exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len)  {
+    int device_io_hid::exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len, bool user_input)  {
       unsigned char buffer[400];
       unsigned char padding_buffer[MAX_BLOCK+1];
       unsigned int  result;
@@ -177,7 +177,11 @@ namespace hw {
 
       //get first response
       memset(buffer, 0, sizeof(buffer));
-      hid_ret = hid_read_timeout(this->usb_device, buffer, MAX_BLOCK, this->timeout);
+      if (!user_input) {
+        hid_ret = hid_read_timeout(this->usb_device, buffer, MAX_BLOCK, this->timeout);
+      } else {
+        hid_ret = hid_read(this->usb_device, buffer, MAX_BLOCK);
+      }
       ASSERT_X(hid_ret>=0, "Unable to read hidapi response. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
       result = (unsigned int)hid_ret;
       io_hid_log(1, buffer, result); 

--- a/src/device/device_io_hid.hpp
+++ b/src/device/device_io_hid.hpp
@@ -100,7 +100,7 @@ namespace hw {
       void connect(void *params);
       void connect(unsigned int vid, unsigned  int pid, boost::optional<int> interface_number, boost::optional<unsigned short> usage_page);
       bool connected() const;
-      int  exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len);
+      int  exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len, bool user_input);
       void disconnect();
       void release();
     };

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -95,6 +95,7 @@ namespace hw {
         void logCMD(void);
         void logRESP(void);
         unsigned int exchange(unsigned int ok=0x9000, unsigned int mask=0xFFFF);
+        unsigned int exchange_wait_on_input(unsigned int ok=0x9000, unsigned int mask=0xFFFF);
         void reset_buffer(void);
         int  set_command_header(unsigned char ins, unsigned char p1 = 0x00, unsigned char p2 = 0x00);
         int  set_command_header_noopt(unsigned char ins, unsigned char p1 = 0x00, unsigned char p2 = 0x00);


### PR DESCRIPTION
(1) If the user denies something on the Ledger, a proper error message is now shown.
(2) Ledger doesn't time out anymore while waiting on user input.
(3) Lower the timeout to 2 seconds, this is enough for normal Ledger <-> System communication.

ping @xiphon, you were unhappy about my change to remove all the timeouts. Is this better?