### PR TITLE
wallet api: don't truncate address in subaddress_account

### DIFF
--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -62,7 +62,7 @@ void SubaddressAccountImpl::refresh()
   {
     m_rows.push_back(new SubaddressAccountRow(
       i,
-      m_wallet->m_wallet->get_subaddress_as_str({i,0}).substr(0,6),
+      m_wallet->m_wallet->get_subaddress_as_str({i,0}),
       m_wallet->m_wallet->get_subaddress_label({i,0}),
       cryptonote::print_money(m_wallet->m_wallet->balance(i)),
       cryptonote::print_money(m_wallet->m_wallet->unlocked_balance(i))


### PR DESCRIPTION
Same behaviour as subaddress.cpp now.