### PR TITLE
add FORCE_USE_HEAP to prevent segfaults on aarch64

### DIFF
--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -46,6 +46,7 @@
 #define AES_KEY_SIZE    32
 #define INIT_SIZE_BLK   8
 #define INIT_SIZE_BYTE (INIT_SIZE_BLK * AES_BLOCK_SIZE)
+// #define FORCE_USE_HEAP        //added for ARM aarch64, uncomment if you want your ARM aarch64 device to synchronize outside checkpoints area
 
 extern void aesb_single_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);
 extern void aesb_pseudo_round(const uint8_t *in, uint8_t *out, const uint8_t *expandedKey);


### PR DESCRIPTION
added FORCE_USE_HEAP (line 49) to prevent segfaults on aarch64 platforms. Uncomment if compiling for aarch64 boards (rock64, OrangePI One Plus, RaspberryPi 3+...) and allow full blockchain sync & operation as a monerod node on ARM platforms. Uncomment if you compile for ARM aarch64. Could be done better, such as a CMAKE arg, but offers a quick fix that works. Readme instructions for building on ARM systems will need to be updated accordingly.  