### PR TITLE
Add Socks Proxy (for Tor/i2pd/Kovri) Support to Wallets

### DIFF
--- a/ANONYMITY_NETWORKS.md
+++ b/ANONYMITY_NETWORKS.md
@@ -19,6 +19,11 @@ network. The transaction will not be broadcast unless an anonymity connection
 is made or until `monerod` is shutdown and restarted with only public
 connections enabled.
 
+Anonymity networks can also be used with `monero-wallet-cli` and
+`monero-wallet-rpc` - the wallets will connect to a daemon through a proxy. The
+daemon must provide a hidden service for the RPC itself, which is separate from
+the hidden service for P2P connections.
+
 
 ## P2P Commands
 
@@ -73,6 +78,35 @@ address "cmeua5767mz2q5jsaelk2rxhf67agrwuetaso5dzbenyzwlbkg2q.b32.i2p:5000" and
 forwarded to `monerod` localhost port 30000.
 These addresses will be shared with outgoing peers, over the same network type,
 otherwise the peer will not be notified of the peer address by the proxy.
+
+### Wallet RPC
+
+An anonymity network can be configured to forward incoming connections to a
+`monerod` RPC port - which is independent from the configuration for incoming
+P2P anonymity connections. The anonymity network (Tor/i2p) is
+[configured in the same manner](#configuration), except the localhost port
+must be the RPC port (typically 18081 for mainnet) instead of the p2p port:
+
+> HiddenServiceDir /var/lib/tor/data/monero
+> HiddenServicePort 18081 127.0.0.1:18081
+
+Then the wallet will be configured to use a Tor/i2p address:
+> `--proxy 127.0.0.1:9050`
+> `--daemon-address rveahdfho7wo4b2m.onion`
+
+The proxy must match the address type - a Tor proxy will not work properly with
+i2p addresses, etc.
+
+i2p and onion addresses provide the information necessary to authenticate and
+encrypt the connection from end-to-end. If desired, SSL can also be applied to
+the connection with `--daemon-address https://rveahdfho7wo4b2m.onion` which
+requires a server certificate that is signed by a "root" certificate on the
+machine running the wallet. Alternatively, `--daemon-cert-file` can be used to
+specify a certificate to authenticate the server.
+
+Proxies can also be used to connect to "clearnet" (ipv4 addresses or ICANN
+domains), but `--daemon-cert-file` _must_ be used for authentication and
+encryption.
 
 ### Network Types
 

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -58,11 +58,6 @@
 #define DEFAULT_TIMEOUT_MS_REMOTE 300000 // 5 minutes
 #define TIMEOUT_EXTRA_MS_PER_BYTE 0.2
 
-#if BOOST_VERSION >= 107000
-#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
-#else
-#define GET_IO_SERVICE(s) ((s).get_io_service())
-#endif
 
 PRAGMA_WARNING_PUSH
 namespace epee

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -327,10 +327,17 @@ namespace net_utils
 				m_net_client.set_ssl(m_ssl_support, m_ssl_private_key_and_certificate_path, m_ssl_allowed_certificates, m_ssl_allowed_fingerprints, m_ssl_allow_any_cert);
 			}
 
+			template<typename F>
+			void set_connector(F connector)
+			{
+				CRITICAL_REGION_LOCAL(m_lock);
+				m_net_client.set_connector(std::move(connector));
+			}
+
       bool connect(std::chrono::milliseconds timeout)
       {
         CRITICAL_REGION_LOCAL(m_lock);
-        return m_net_client.connect(m_host_buff, m_port, timeout, "0.0.0.0");
+        return m_net_client.connect(m_host_buff, m_port, timeout);
       }
 			//---------------------------------------------------------------------------
 			bool disconnect()

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -44,6 +44,12 @@
 #define MAKE_IP( a1, a2, a3, a4 )	(a1|(a2<<8)|(a3<<16)|(a4<<24))
 #endif
 
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s).get_io_service())
+#endif
+
 namespace net
 {
 	class tor_address;

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -26,8 +26,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(epee STATIC hex.cpp http_auth.cpp mlog.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp memwipe.c
+add_library(epee STATIC hex.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp memwipe.c
     connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp)
+
 if (USE_READLINE AND GNU_READLINE_FOUND)
   add_library(epee_readline STATIC readline_buffer.cpp)
 endif()

--- a/contrib/epee/src/net_helper.cpp
+++ b/contrib/epee/src/net_helper.cpp
@@ -1,0 +1,54 @@
+#include "net/net_helper.h"
+
+namespace epee
+{
+namespace net_utils
+{
+	boost::unique_future<boost::asio::ip::tcp::socket>
+	direct_connect::operator()(const std::string& addr, const std::string& port, boost::asio::steady_timer& timeout) const
+	{
+		// Get a list of endpoints corresponding to the server name.
+		//////////////////////////////////////////////////////////////////////////
+		boost::asio::ip::tcp::resolver resolver(GET_IO_SERVICE(timeout));
+		boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), addr, port, boost::asio::ip::tcp::resolver::query::canonical_name);
+		boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
+		boost::asio::ip::tcp::resolver::iterator end;
+		if(iterator == end) // Documentation states that successful call is guaranteed to be non-empty
+			throw boost::system::system_error{boost::asio::error::fault, "Failed to resolve " + addr};
+
+		//////////////////////////////////////////////////////////////////////////
+
+		struct new_connection
+		{
+			boost::promise<boost::asio::ip::tcp::socket> result_;
+			boost::asio::ip::tcp::socket socket_;
+
+			explicit new_connection(boost::asio::io_service& io_service)
+			  : result_(), socket_(io_service)
+			{}
+		};
+
+		const auto shared = std::make_shared<new_connection>(GET_IO_SERVICE(timeout));
+		timeout.async_wait([shared] (boost::system::error_code error)
+		{
+			if (error != boost::system::errc::operation_canceled && shared && shared->socket_.is_open())
+			{
+				shared->socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+				shared->socket_.close();
+			}
+		});
+		shared->socket_.async_connect(*iterator, [shared] (boost::system::error_code error)
+		{
+			if (shared)
+			{
+				if (error)
+					shared->result_.set_exception(boost::system::system_error{error});
+				else
+					shared->result_.set_value(std::move(shared->socket_));
+			}
+		});
+		return shared->result_.get_future();
+	}
+}
+}
+

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -26,8 +26,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(net_sources error.cpp parse.cpp socks.cpp tor_address.cpp i2p_address.cpp)
-set(net_headers error.h parse.h socks.h tor_address.h i2p_address.h)
+set(net_sources error.cpp i2p_address.cpp parse.cpp socks.cpp socks_connect.cpp tor_address.cpp)
+set(net_headers error.h i2p_address.h parse.h socks.h socks_connect.h tor_address.h)
 
 monero_add_library(net ${net_sources} ${net_headers})
 target_link_libraries(net common epee ${Boost_ASIO_LIBRARY})

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Monero Project
+// Copyright (c) 2018-2019, The Monero Project
 //
 // All rights reserved.
 //
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/io_service.hpp>
+#include <boost/asio/strand.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/utility/string_ref.hpp>
@@ -92,6 +93,7 @@ namespace socks
     class client
     {
         boost::asio::ip::tcp::socket proxy_;
+        boost::asio::io_service::strand strand_;
         std::uint16_t buffer_size_;
         std::uint8_t buffer_[1024];
         socks::version ver_;
@@ -168,6 +170,8 @@ namespace socks
 
             \note Must use one of the `self->set_*_command` calls before using
                 this function.
+            \note Only `async_close` can be invoked on `self` until the `done`
+                callback is invoked.
 
             \param self ownership of object is given to function.
             \param proxy_address of the socks server.
@@ -182,11 +186,21 @@ namespace socks
 
             \note Must use one of the `self->set_*_command` calls before using
                 the function.
+            \note Only `async_close` can be invoked on `self` until the `done`
+                callback is invoked.
 
             \param self ownership of object is given to function.
             \return False if `self->buffer().empty()` (no command set).
         */
         static bool send(std::shared_ptr<client> self);
+
+        /*! Callback for closing socket. Thread-safe with `*send` functions;
+            never blocks (uses strands). */
+        struct async_close
+        {
+            std::shared_ptr<client> self_;
+            void operator()(boost::system::error_code error = boost::system::error_code{});
+        };
     };
 
     template<typename Handler>

--- a/src/net/socks_connect.cpp
+++ b/src/net/socks_connect.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2019, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "socks_connect.h"
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+#include <cstdint>
+#include <memory>
+#include <system_error>
+
+#include "net/error.h"
+#include "net/net_utils_base.h"
+#include "net/socks.h"
+#include "string_tools.h"
+
+namespace net
+{
+namespace socks
+{
+    boost::unique_future<boost::asio::ip::tcp::socket>
+    connector::operator()(const std::string& remote_host, const std::string& remote_port, boost::asio::steady_timer& timeout) const
+    {
+        struct future_socket
+        {
+            boost::promise<boost::asio::ip::tcp::socket> result_;
+
+            void operator()(boost::system::error_code error, boost::asio::ip::tcp::socket&& socket)
+            {
+                if (error)
+                    result_.set_exception(boost::system::system_error{error});
+                else
+                    result_.set_value(std::move(socket));
+            }
+        };
+
+        boost::unique_future<boost::asio::ip::tcp::socket> out{};
+        {
+            std::uint16_t port = 0;
+            if (!epee::string_tools::get_xtype_from_string(port, remote_port))
+                throw std::system_error{net::error::invalid_port, "Remote port for socks proxy"};
+
+            bool is_set = false;
+            std::uint32_t ip_address = 0;
+            boost::promise<boost::asio::ip::tcp::socket> result{};
+            out = result.get_future();
+            const auto proxy = net::socks::make_connect_client(
+                boost::asio::ip::tcp::socket{GET_IO_SERVICE(timeout)}, net::socks::version::v4a, future_socket{std::move(result)}
+            );
+
+            if (epee::string_tools::get_ip_int32_from_string(ip_address, remote_host))
+                is_set = proxy->set_connect_command(epee::net_utils::ipv4_network_address{ip_address, port});
+            else
+                is_set = proxy->set_connect_command(remote_host, port);
+
+            if (!is_set || !net::socks::client::connect_and_send(proxy, proxy_address))
+                throw std::system_error{net::error::invalid_host, "Address for socks proxy"};
+
+            timeout.async_wait(net::socks::client::async_close{std::move(proxy)});
+        }
+
+        return out;
+    }
+} // socks
+} // net

--- a/src/net/socks_connect.h
+++ b/src/net/socks_connect.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/thread/future.hpp>
+#include <string>
+
+namespace net
+{
+namespace socks
+{
+    //! Primarily for use with `epee::net_utils::http_client`.
+    struct connector
+    {
+        boost::asio::ip::tcp::endpoint proxy_address;
+
+        /*! Creates a new socket, asynchronously connects to `proxy_address`,
+            and requests a connection to `remote_host` on `remote_port`. Sets
+            socket as closed if `timeout` is reached.
+
+            \return The socket if successful, and exception in the future with
+                error otherwise. */
+        boost::unique_future<boost::asio::ip::tcp::socket>
+            operator()(const std::string& remote_host, const std::string& remote_port, boost::asio::steady_timer& timeout) const;
+    };
+} // socks
+} // net

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(wallet
     cryptonote_core
     mnemonics
     device_trezor
+    net
     ${LMDB_LIBRARY}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2173,8 +2173,7 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
 
 bool WalletImpl::doInit(const string &daemon_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    // claim RPC so there's no in-memory encryption for now
-    if (!m_wallet->init(daemon_address, m_daemon_login, upper_transaction_size_limit, ssl))
+    if (!m_wallet->init(daemon_address, m_daemon_login, tcp::endpoint{}, upper_transaction_size_limit))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -680,7 +680,9 @@ namespace tools
 
     bool deinit();
     bool init(std::string daemon_address = "http://localhost:8080",
-      boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_weight_limit = 0,
+      boost::optional<epee::net_utils::http::login> daemon_login = boost::none,
+      boost::asio::ip::tcp::endpoint proxy = {},
+      uint64_t upper_transaction_weight_limit = 0,
       bool trusted_daemon = true,
       epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
       const std::pair<std::string, std::string> &private_key_and_certificate_path = {},

--- a/tests/fuzz/cold-outputs.cpp
+++ b/tests/fuzz/cold-outputs.cpp
@@ -53,7 +53,7 @@ int ColdOutputsFuzzer::init()
 
   try
   {
-    wallet.init("", boost::none, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+    wallet.init("", boost::none, boost::asio::ip::tcp::endpoint{}, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     wallet.set_subaddress_lookahead(1, 1);
     wallet.generate("", "", spendkey, true, false);
   }

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -54,7 +54,7 @@ int ColdTransactionFuzzer::init()
 
   try
   {
-    wallet.init("", boost::none, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+    wallet.init("", boost::none, boost::asio::ip::tcp::endpoint{}, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     wallet.set_subaddress_lookahead(1, 1);
     wallet.generate("", "", spendkey, true, false);
   }

--- a/tests/fuzz/signature.cpp
+++ b/tests/fuzz/signature.cpp
@@ -54,7 +54,7 @@ int SignatureFuzzer::init()
 
   try
   {
-    wallet.init("", boost::none, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+    wallet.init("", boost::none, boost::asio::ip::tcp::endpoint{}, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     wallet.set_subaddress_lookahead(1, 1);
     wallet.generate("", "", spendkey, true, false);
 

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -71,7 +71,7 @@ static void make_wallet(unsigned int idx, tools::wallet2 &wallet)
 
   try
   {
-    wallet.init("", boost::none, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+    wallet.init("", boost::none, boost::asio::ip::tcp::endpoint{}, 0, true, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     wallet.set_subaddress_lookahead(1, 1);
     wallet.generate("", "", spendkey, true, false);
     ASSERT_TRUE(test_addresses[idx].address == wallet.get_account().get_public_address_str(cryptonote::TESTNET));


### PR DESCRIPTION
Allows wallets to connect to daemon over tor/i2pd/kovri. If proxy usage is enabled, the daemon address must be onion/i2p based or use `--daemon-cert-file`. The idea is to prevent root CA shadiness over these networks in addition to the authenticated/unencrypted problems. A root CA can be combined with an onion/i2p address (the former can definitely be signed by a few CAs) by using `--daemon-address https://xyz.onion`. Additionally, `--daemon-address https://...` and `--daemon-cert-file` will work with ipv4 or ICANN hostnames.

Will have to coordinate with @moneromooo-monero for the SSL changes. The first commit (for p2p tor/socks) will be rebased away once its merged.