### PR TITLE
Fixed missing return value in once_a_time class on windows

### DIFF
--- a/contrib/epee/include/math_helper.h
+++ b/contrib/epee/include/math_helper.h
@@ -243,6 +243,7 @@ namespace math_helper
       present = present << 32;
       present |= fileTime.dwLowDateTime;
       present /= 10;  // mic-sec
+      return present;
 #else
       struct timeval tv;
       gettimeofday(&tv, NULL);


### PR DESCRIPTION
Fixed missing return value in once_a_time class on windows