### PR TITLE
Fix for usage of deprecated type, and bugfix

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2600,7 +2600,7 @@ bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_pr
     for (size_t n = 0; n < tx.vin.size(); ++n)
       rv.p.MGs[0].II[n] = rct::ki2rct(boost::get<txin_to_key>(tx.vin[n]).k_image);
   }
-  else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof || rct::RCTTypeBulletproof2)
+  else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof || rv.type == rct::RCTTypeBulletproof2)
   {
     CHECK_AND_ASSERT_MES(rv.p.MGs.size() == tx.vin.size(), false, "Bad MGs size");
     for (size_t n = 0; n < tx.vin.size(); ++n)

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -61,7 +61,7 @@ namespace cryptonote
   class txCompare
   {
   public:
-    bool operator()(const tx_by_fee_and_receive_time_entry& a, const tx_by_fee_and_receive_time_entry& b)
+    bool operator()(const tx_by_fee_and_receive_time_entry& a, const tx_by_fee_and_receive_time_entry& b) const
     {
       // sort by greatest first, not least
       if (a.first.first > b.first.first) return true;

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -99,7 +99,7 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
 {
 
   explicit binary_archive(stream_type &s) : base_type(s) {
-    stream_type::streampos pos = stream_.tellg();
+    stream_type::pos_type pos = stream_.tellg();
     stream_.seekg(0, std::ios_base::end);
     eof_pos_ = stream_.tellg();
     stream_.seekg(pos);


### PR DESCRIPTION
In serialization/binary_archive.h, the ios_base::streampos member type was used, which is deprecated (and removed in C++17). (see [cppreference.com](https://en.cppreference.com/w/cpp/io/ios_base)) The usage is changed to ios_base::pos_type, which is not deprecated.

In cryptonote_core/tx_pool.h, the function call overload of a comparison object was not marked 'const', which it should be for usage with STL containers. (I don't know why this compiled fine otherwise.)

Also, in cryptonote_core/blockchain.cpp, an enum value was used as a boolean condition. Since the enum value was nonzero, the condition was always true; I think the original code was a typo, and this fixes it.

Compiler: GCC 8.2.1