### PR TITLE
db_lmdb: make mdb_block_info format conversion more future proof

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -268,7 +268,7 @@ inline void lmdb_db_open(MDB_txn* txn, const char* name, int flags, MDB_dbi& dbi
 namespace cryptonote
 {
 
-typedef struct mdb_block_info_old
+typedef struct mdb_block_info_1
 {
   uint64_t bi_height;
   uint64_t bi_timestamp;
@@ -276,7 +276,7 @@ typedef struct mdb_block_info_old
   uint64_t bi_weight; // a size_t really but we need 32-bit compat
   difficulty_type bi_diff;
   crypto::hash bi_hash;
-} mdb_block_info_old;
+} mdb_block_info_1;
 
 typedef struct mdb_block_info_2
 {
@@ -4126,7 +4126,7 @@ void BlockchainLMDB::migrate_0_1()
       break;
     }
     MDB_dbi diffs, hashes, sizes, timestamps;
-    mdb_block_info_old bi;
+    mdb_block_info_1 bi;
     MDB_val_set(nv, bi);
 
     lmdb_db_open(txn, "block_diffs", 0, diffs, "Failed to open db handle for block_diffs");
@@ -4753,8 +4753,8 @@ void BlockchainLMDB::migrate_2_3()
       }
       else if (result)
         throw0(DB_ERROR(lmdb_error("Failed to get a record from block_info: ", result).c_str()));
-      const mdb_block_info_old *bi_old = (const mdb_block_info_old*)v.mv_data;
-      mdb_block_info bi;
+      const mdb_block_info_1 *bi_old = (const mdb_block_info_1*)v.mv_data;
+      mdb_block_info_2 bi;
       bi.bi_height = bi_old->bi_height;
       bi.bi_timestamp = bi_old->bi_timestamp;
       bi.bi_coins = bi_old->bi_coins;


### PR DESCRIPTION
If mdb_block_info changes again, the v2 to v3 conversion would
convert to an incorrect format.