### PR TITLE
ringct: fix v1 ecdhInfo serialization

### DIFF
--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -45,8 +45,6 @@
 #include "ringct/rctTypes.h"
 #include "ringct/rctOps.h"
 
-BOOST_CLASS_VERSION(rct::ecdhTuple, 1)
-
 //namespace cryptonote {
 namespace boost
 {
@@ -249,19 +247,8 @@ namespace boost
   template <class Archive>
   inline void serialize(Archive &a, rct::ecdhTuple &x, const boost::serialization::version_type ver)
   {
-    if (ver < 1)
-    {
-      a & x.mask;
-      a & x.amount;
-      return;
-    }
-    crypto::hash8 &amount = (crypto::hash8&)x.amount;
-    if (!Archive::is_saving::value)
-    {
-      memset(&x.mask, 0, sizeof(x.mask));
-      memset(&x.amount, 0, sizeof(x.amount));
-    }
-    a & amount;
+    a & x.mask;
+    a & x.amount;
   }
 
   template <class Archive>


### PR DESCRIPTION
The change made for v2 broke v1, and we have no way to know which
version we're serializing here. However, since we don't actually
care about space savings in this case, we continue serialiazing
both mask and amount.