### PR TITLE
Fix crash in view wallets decrypting the null spendkey

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -867,7 +867,7 @@ wallet_keys_unlocker::wallet_keys_unlocker(wallet2 &w, const boost::optional<too
   w(w),
   locked(password != boost::none)
 {
-  if (!locked || w.is_unattended() || w.ask_password() != tools::wallet2::AskPasswordToDecrypt)
+  if (!locked || w.is_unattended() || w.ask_password() != tools::wallet2::AskPasswordToDecrypt || w.watch_only())
   {
     locked = false;
     return;


### PR DESCRIPTION
When trying to construct a transaction in a view-only wallet, wallet_keys_unlocker will decrypt the null spend key into account key's m_spend_secret_key that then gets passed to construct_tx_with_tx_key(). This then tries to generate a transaction using the decrypted null secret key and crashes in debug and fails in release mode.