### PR TITLE
Optimize e2i function [who-biz]

### DIFF
--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1409,7 +1409,7 @@ static void (*const extra_hashes[4])(const void *, size_t, char *) = {
   hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein
 };
 
-static size_t e2i(const uint8_t* a, size_t count) { return (SWAP64LE(*((uint64_t*)a)) / AES_BLOCK_SIZE) & (count - 1); }
+static size_t e2i(const uint8_t* a) { return (SWAP64LE(*((uint64_t*)a)) & (MEMORY - 1)); }
 
 static void mul(const uint8_t* a, const uint8_t* b, uint8_t* res) {
   uint64_t a0, b0;
@@ -1525,16 +1525,16 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int 
      * next address  <-+
      */
     /* Iteration 1 */
-    j = e2i(a, MEMORY / AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
+    j = e2i(a);
     copy_block(c1, &long_state[j]);
     aesb_single_round(c1, c1, a);
     VARIANT2_PORTABLE_SHUFFLE_ADD(long_state, j);
     copy_block(&long_state[j], c1);
     xor_blocks(&long_state[j], b);
-    assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE) * AES_BLOCK_SIZE);
+    assert(j == e2i(a));
     VARIANT1_1(&long_state[j]);
     /* Iteration 2 */
-    j = e2i(c1, MEMORY / AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
+    j = e2i(c1);
     copy_block(c2, &long_state[j]);
     VARIANT2_PORTABLE_INTEGER_MATH(c2, c1);
     mul(c1, c2, d);
@@ -1546,7 +1546,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int 
     xor_blocks(c1, c2);
     VARIANT1_2(c2 + 8);
     copy_block(&long_state[j], c2);
-    assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE) * AES_BLOCK_SIZE);
+    assert(j == e2i(a));
     if (variant >= 2) {
       copy_block(b + AES_BLOCK_SIZE, b);
     }


### PR DESCRIPTION
This function appears to do a lot of extra math that is unnecessary.  The modifications in this PR have been fully tested on 64-bit linux.  All tests applicable to slow-hash passed. 

Below is an explanation of my logic: 

Substituting in constants for the variables in the e2i function we get: 

`e2i(a,count) = (a /16) & (count - 1)`  

Each time we apply this function, we use the same values to calculate the `count` parameter. In all of these instances we have:

`count = (MEMORY / AES_BLOCK_SIZE)`

Substituting constants for those variables again, we see that:

`count = 2097152/16 = 131072`

Since this is a power of two, we know that:

` a & (count - 1) == a mod (count)`

So, we now know we can use modular arithmetic properties on the e2i function, and the equation will still behave properly.  This is made a lot more useful by the fact that we have:

`j == e2i(a,count) * 16` for all applicable instances of `j`.  

Modular arithmetic properties allow us to distribute that 16 across `b = a mod n` by multiplying such that the following holds true:

`(16)b = (16)a mod 16(n)` == `b = a mod n`

So, since we already have 16 as a multiplier, all we have to do is multiply `count` by 16, and we can eliminate the count parameter altogether, as well as the divisor in a.  As it happens:

`131072 * 16 == 1 << 21 == MEMORY`

We are therefore left with no `count` parameter in the e2i function, as only `a` is variable to begin with... and we can eliminate the modulus operator with a bitwise AND since it is still a power of two. 

`e2i(a) = a % MEMORY` or `e2i(a) = a & (MEMORY - 1)`