### PR TITLE
Use io_service::work in epee tcp server

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -330,7 +330,16 @@ namespace net_utils
     const boost::shared_ptr<typename connection<t_protocol_handler>::shared_state> m_state;
 
     /// The io_service used to perform asynchronous operations.
-    std::unique_ptr<boost::asio::io_service> m_io_service_local_instance;
+    struct worker
+    {
+      worker()
+        : io_service(), work(io_service)
+      {}
+
+      boost::asio::io_service io_service;
+      boost::asio::io_service::work work;
+    };
+    std::unique_ptr<worker> m_io_service_local_instance;
     boost::asio::io_service& io_service_;    
 
     /// Acceptor used to listen for incoming connections.

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -809,8 +809,8 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   template<class t_protocol_handler>
   boosted_tcp_server<t_protocol_handler>::boosted_tcp_server( t_connection_type connection_type ) :
     m_state(boost::make_shared<typename connection<t_protocol_handler>::shared_state>()),
-    m_io_service_local_instance(new boost::asio::io_service()),
-    io_service_(*m_io_service_local_instance.get()),
+    m_io_service_local_instance(new worker()),
+    io_service_(m_io_service_local_instance->io_service),
     acceptor_(io_service_),
     default_remote(),
     m_stop_signal_sent(false), m_port(0), 
@@ -919,9 +919,8 @@ POP_WARNINGS
     {
       try
       {
-        size_t cnt = io_service_.run();
-        if (cnt == 0)
-          misc_utils::sleep_no_w(1);
+        io_service_.run();
+        return true;
       }
       catch(const std::exception& ex)
       {


### PR DESCRIPTION
The [Boost ASIO documentation](https://www.boost.org/doc/libs/1_69_0/doc/html/boost_asio/reference/io_service.html) indicates that `io_service::restart` (formerly `io_service::reset`) must be called if a call to `io_service::run` returns. And the reset call is not thread-safe - meaning all `io_service::run` calls would have to be exited. Failing to do this results in the various `io_service` run variations not working properly (they don't execute any "work"). This _may_ be the reason why `monerod` occasionally stops processing data, although the conditions would have to be "just" right.

The fix is to use `io_service::work` so that `io_service::run` never returns until `io_service::stop` is called. Thrown exceptions do not require a call to `io_service::reset`.