### PR TITLE
boost_serialize: ECDH info serialization fix

### DIFF
--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -45,7 +45,7 @@
 #include "ringct/rctTypes.h"
 #include "ringct/rctOps.h"
 
-BOOST_CLASS_VERSION(rct::ecdhTuple, 1)
+BOOST_CLASS_VERSION(rct::ecdhTuple, 2)
 
 //namespace cryptonote {
 namespace boost
@@ -249,19 +249,22 @@ namespace boost
   template <class Archive>
   inline void serialize(Archive &a, rct::ecdhTuple &x, const boost::serialization::version_type ver)
   {
-    if (ver < 1)
+    if (ver < 1 || ver == 2)
     {
       a & x.mask;
       a & x.amount;
       return;
     }
-    crypto::hash8 &amount = (crypto::hash8&)x.amount;
-    if (!Archive::is_saving::value)
+    else if (ver < 2)
     {
-      memset(&x.mask, 0, sizeof(x.mask));
-      memset(&x.amount, 0, sizeof(x.amount));
+      crypto::hash8 &amount = (crypto::hash8 &) x.amount;
+      if (!Archive::is_saving::value)
+      {
+        memset(&x.mask, 0, sizeof(x.mask));
+        memset(&x.amount, 0, sizeof(x.amount));
+      }
+      a & amount;
     }
-    a & amount;
   }
 
   template <class Archive>


### PR DESCRIPTION
I've noticed problems with the serialization of transactions of older types. 
Problem: ECDH tuple serialization version should be determined by the transaction rct type, not by the ECDH tuple version number on its own ignoring the transaction version.

For instance, Bulletproof1 transaction should be serialized with full ECDH tuple as it does not have a deterministic mask, but Bulletproof2 transaction could make use of a more compact ECDH serialization. 

Currently, the ECDH tuple version set to 1 breaks serialization of an older transaction as the transaction hash differs after deserialization because of irreversibly incomplete ECDH data.

However, this space saving is maybe not worth the added complexity as it does not go into the blockchain. In my PR I've changed the version to 2 (which is the same as 0) so the PR does not break existing serialized structures. If breaking stuff is not of a concern, the PR can be simplified so the compact serialization is removed altogether. 

On the other hand, if the compact boost serialization is of concern, a separate serialization method for ECDH tuple, taking tx rct type into consideration has to be implemented.