### PR TITLE
epee: fix missing return in once_a_time::get_time()

### DIFF
--- a/contrib/epee/include/math_helper.h
+++ b/contrib/epee/include/math_helper.h
@@ -243,6 +243,7 @@ namespace math_helper
       present = present << 32;
       present |= fileTime.dwLowDateTime;
       present /= 10;  // mic-sec
+      return present;
 #else
       struct timeval tv;
       gettimeofday(&tv, NULL);


### PR DESCRIPTION
Affects Windows platform. Due to undefined behavior some of these might get called too often or not at all.
```
    epee::math_helper::once_a_time_seconds<P2P_DEFAULT_HANDSHAKE_INTERVAL> m_peer_handshake_idle_maker_interval;
    epee::math_helper::once_a_time_seconds<1> m_connections_maker_interval;
    epee::math_helper::once_a_time_seconds<60*30, false> m_peerlist_store_interval;
    epee::math_helper::once_a_time_seconds<60> m_gray_peerlist_housekeeping_interval;
    epee::math_helper::once_a_time_seconds<3600, false> m_incoming_connections_interval;
```