### PR TITLE
daemon: add --public-node mode, RPC port propagation over P2P

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -40,7 +40,8 @@ namespace cryptonote
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
-        m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0), m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_anchor(false) {}
+        m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
+        m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_anchor(false) {}
 
     enum state
     {
@@ -60,6 +61,7 @@ namespace cryptonote
     epee::copyable_atomic m_callback_request_count; //in debug purpose: problem with double callback rise
     crypto::hash m_last_known_hash;
     uint32_t m_pruning_seed;
+    uint16_t m_rpc_port;
     bool m_anchor;
     //size_t m_score;  TODO: add score calculations
   };

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -53,6 +53,7 @@ namespace cryptonote
     std::string host;
     std::string ip;
     std::string port;
+    uint16_t rpc_port;
 
     std::string peer_id;
 
@@ -88,6 +89,7 @@ namespace cryptonote
       KV_SERIALIZE(host)
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
+      KV_SERIALIZE(rpc_port)
       KV_SERIALIZE(peer_id)
       KV_SERIALIZE(recv_count)
       KV_SERIALIZE(recv_idle_time)

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -231,6 +231,7 @@ namespace cryptonote
         cnx.ip = cnx.host;
         cnx.port = std::to_string(cntxt.m_remote_address.as<epee::net_utils::ipv4_network_address>().port());
       }
+      cnx.rpc_port = cntxt.m_rpc_port;
 
       std::stringstream peer_id_str;
       peer_id_str << std::hex << std::setw(16) << peer_id;

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -96,6 +96,12 @@ namespace daemon_args
   , 0
   };
 
+  const command_line::arg_descriptor<bool> arg_public_node = {
+    "public-node"
+  , "Allow other users to use the node as a remote (restricted RPC mode, view-only commands) and advertise it over P2P"
+  , false
+  };
+
   const command_line::arg_descriptor<std::string> arg_zmq_rpc_bind_ip   = {
     "zmq-rpc-bind-ip"
       , "IP for ZMQ RPC server to listen on"

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -96,9 +96,11 @@ void t_daemon::init_options(boost::program_options::options_description & option
 }
 
 t_daemon::t_daemon(
-    boost::program_options::variables_map const & vm
+    boost::program_options::variables_map const & vm,
+    uint16_t public_rpc_port
   )
-  : mp_internals{new t_internals{vm}}
+  : mp_internals{new t_internals{vm}},
+  public_rpc_port(public_rpc_port)
 {
   zmq_rpc_bind_port = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_port);
   zmq_rpc_bind_address = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_ip);
@@ -186,6 +188,12 @@ bool t_daemon::run(bool interactive)
     MINFO(std::string("ZMQ server started at ") + zmq_rpc_bind_address
           + ":" + zmq_rpc_bind_port + ".");
 
+    if (public_rpc_port > 0)
+    {
+      MGINFO("Public RPC port " << public_rpc_port << " will be advertised to other peers over P2P");
+      mp_internals->p2p.get().set_rpc_port(public_rpc_port);
+    }
+    
     mp_internals->p2p.run(); // blocks until p2p goes down
 
     if (rpc_commands)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -43,11 +43,13 @@ private:
   void stop_p2p();
 private:
   std::unique_ptr<t_internals> mp_internals;
+  uint16_t public_rpc_port;
   std::string zmq_rpc_bind_address;
   std::string zmq_rpc_bind_port;
 public:
   t_daemon(
-      boost::program_options::variables_map const & vm
+      boost::program_options::variables_map const & vm,
+      uint16_t public_rpc_port = 0
     );
   t_daemon(t_daemon && other);
   t_daemon & operator=(t_daemon && other);

--- a/src/daemon/executor.cpp
+++ b/src/daemon/executor.cpp
@@ -59,21 +59,21 @@ namespace daemonize
     )
   {
     LOG_PRINT_L0("Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ") Daemonised");
-    return t_daemon{vm};
+    return t_daemon{vm, public_rpc_port};
   }
 
   bool t_executor::run_non_interactive(
       boost::program_options::variables_map const & vm
     )
   {
-    return t_daemon{vm}.run(false);
+    return t_daemon{vm, public_rpc_port}.run(false);
   }
 
   bool t_executor::run_interactive(
       boost::program_options::variables_map const & vm
     )
   {
-    return t_daemon{vm}.run(true);
+    return t_daemon{vm, public_rpc_port}.run(true);
   }
 }
 

--- a/src/daemon/executor.h
+++ b/src/daemon/executor.h
@@ -45,6 +45,10 @@ namespace daemonize
 
     static std::string const NAME;
 
+    t_executor(uint16_t public_rpc_port = 0) : public_rpc_port(public_rpc_port)
+    {
+    }
+
     static void init_options(
         boost::program_options::options_description & configurable_options
       );
@@ -62,5 +66,8 @@ namespace daemonize
     bool run_interactive(
         boost::program_options::variables_map const & vm
       );
+
+  private:
+    uint16_t public_rpc_port;
   };
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -61,8 +61,9 @@ namespace {
     peer_id_str >> id_str;
     epee::string_tools::xtype_to_string(peer.port, port_str);
     std::string addr_str = ip_str + ":" + port_str;
+    std::string rpc_port = peer.rpc_port ? std::to_string(peer.rpc_port) : "-";
     std::string pruning_seed = epee::string_tools::to_string_hex(peer.pruning_seed);
-    tools::msg_writer() << boost::format("%-10s %-25s %-25s %-4s %s") % prefix % id_str % addr_str % pruning_seed % elapsed;
+    tools::msg_writer() << boost::format("%-10s %-25s %-25s %-5s %-4s %s") % prefix % id_str % addr_str % rpc_port % pruning_seed % elapsed;
   }
 
   void print_block_header(cryptonote::block_header_response const & header)

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -210,6 +210,7 @@ namespace nodetool
     node_server(t_payload_net_handler& payload_handler)
       : m_payload_handler(payload_handler),
         m_external_port(0),
+        m_rpc_port(0),
         m_allow_local_ip(false),
         m_hide_my_port(false),
         m_no_igd(false),
@@ -399,6 +400,12 @@ namespace nodetool
       m_save_graph = save_graph;
       epee::net_utils::connection_basic::set_save_graph(save_graph);
     }
+
+    void set_rpc_port(uint16_t rpc_port)
+    {
+      m_rpc_port = rpc_port;
+    }
+
   private:
     std::string m_config_folder;
 
@@ -406,6 +413,7 @@ namespace nodetool
     bool m_first_connection_maker_call;
     uint32_t m_listening_port;
     uint32_t m_external_port;
+    uint16_t m_rpc_port;
     bool m_allow_local_ip;
     bool m_hide_my_port;
     bool m_no_igd;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -864,7 +864,8 @@ namespace nodetool
         }
 
         pi = context.peer_id = rsp.node_data.peer_id;
-        m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address, context.m_pruning_seed);
+        context.m_rpc_port = rsp.node_data.rpc_port;
+        m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address, context.m_pruning_seed, context.m_rpc_port);
 
         // move
         for (auto const& zone : m_network_zones)
@@ -930,7 +931,7 @@ namespace nodetool
         add_host_fail(context.m_remote_address);
       }
       if(!context.m_is_income)
-        m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.set_peer_just_seen(context.peer_id, context.m_remote_address, context.m_pruning_seed);
+        m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.set_peer_just_seen(context.peer_id, context.m_remote_address, context.m_pruning_seed, context.m_rpc_port);
       m_payload_handler.process_payload_sync_data(rsp.payload_data, context, false);
     });
 
@@ -1094,6 +1095,7 @@ namespace nodetool
     time(&last_seen);
     pe_local.last_seen = static_cast<int64_t>(last_seen);
     pe_local.pruning_seed = con->m_pruning_seed;
+    pe_local.rpc_port = con->m_rpc_port;
     zone.m_peerlist.append_with_peer_white(pe_local);
     //update last seen and push it to peerlist manager
 
@@ -1648,6 +1650,7 @@ namespace nodetool
       node_data.my_port = m_external_port ? m_external_port : m_listening_port;
     else
       node_data.my_port = 0;
+    node_data.rpc_port = zone.m_can_pingback ? m_rpc_port : 0;
     node_data.network_id = m_network_id;
     return true;
   }
@@ -2003,6 +2006,7 @@ namespace nodetool
     //associate peer_id with this connection
     context.peer_id = arg.node_data.peer_id;
     context.m_in_timedsync = false;
+    context.m_rpc_port = arg.node_data.rpc_port;
 
     if(arg.node_data.peer_id != zone.m_config.m_peer_id && arg.node_data.my_port && zone.m_can_pingback)
     {
@@ -2022,6 +2026,7 @@ namespace nodetool
         pe.last_seen = static_cast<int64_t>(last_seen);
         pe.id = peer_id_l;
         pe.pruning_seed = context.m_pruning_seed;
+        pe.rpc_port = context.m_rpc_port;
         this->m_network_zones.at(context.m_remote_address.get_zone()).m_peerlist.append_with_peer_white(pe);
         LOG_DEBUG_CC(context, "PING SUCCESS " << context.m_remote_address.host_str() << ":" << port_l);
       });
@@ -2322,7 +2327,7 @@ namespace nodetool
       }
       else
       {
-        zone.second.m_peerlist.set_peer_just_seen(pe.id, pe.adr, pe.pruning_seed);
+        zone.second.m_peerlist.set_peer_just_seen(pe.id, pe.adr, pe.pruning_seed, pe.rpc_port);
         LOG_PRINT_L2("PEER PROMOTED TO WHITE PEER LIST IP address: " << pe.adr.host_str() << " Peer ID: " << peerid_type(pe.id));
       }
     }

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -111,7 +111,7 @@ namespace nodetool
     bool append_with_peer_white(const peerlist_entry& pr);
     bool append_with_peer_gray(const peerlist_entry& pr);
     bool append_with_peer_anchor(const anchor_peerlist_entry& ple);
-    bool set_peer_just_seen(peerid_type peer, const epee::net_utils::network_address& addr, uint32_t pruning_seed);
+    bool set_peer_just_seen(peerid_type peer, const epee::net_utils::network_address& addr, uint32_t pruning_seed, uint16_t rpc_port);
     bool set_peer_unreachable(const peerlist_entry& pr);
     bool is_host_allowed(const epee::net_utils::network_address &address);
     bool get_random_gray_peer(peerlist_entry& pe);
@@ -295,7 +295,7 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::set_peer_just_seen(peerid_type peer, const epee::net_utils::network_address& addr, uint32_t pruning_seed)
+  bool peerlist_manager::set_peer_just_seen(peerid_type peer, const epee::net_utils::network_address& addr, uint32_t pruning_seed, uint16_t rpc_port)
   {
     TRY_ENTRY();
     CRITICAL_REGION_LOCAL(m_peerlist_lock);
@@ -305,6 +305,7 @@ namespace nodetool
     ple.id = peer;
     ple.last_seen = time(NULL);
     ple.pruning_seed = pruning_seed;
+    ple.rpc_port = rpc_port;
     return append_with_peer_white(ple);
     CATCH_ENTRY_L0("peerlist_manager::set_peer_just_seen()", false);
   }

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -41,6 +41,8 @@
 #include "common/pruning.h"
 #endif
 
+BOOST_CLASS_VERSION(nodetool::peerlist_entry, 2)
+
 namespace boost
 {
   namespace serialization
@@ -152,6 +154,13 @@ namespace boost
         pl.pruning_seed = tools::make_pruning_seed(1+pl.adr.as<epee::net_utils::ipv4_network_address>().ip() % (1<<CRYPTONOTE_PRUNING_LOG_STRIPES), CRYPTONOTE_PRUNING_LOG_STRIPES);
       }
 #endif
+      if (ver < 2)
+      {
+        if (!typename Archive::is_saving())
+          pl.rpc_port = 0;
+        return;
+      }
+      a & pl.rpc_port;
     }
 
     template <class Archive, class ver_type>

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -75,12 +75,14 @@ namespace nodetool
     peerid_type id;
     int64_t last_seen;
     uint32_t pruning_seed;
+    uint16_t rpc_port;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(adr)
       KV_SERIALIZE(id)
       KV_SERIALIZE(last_seen)
       KV_SERIALIZE_OPT(pruning_seed, (uint32_t)0)
+      KV_SERIALIZE_OPT(rpc_port, (uint16_t)0)
     END_KV_SERIALIZE_MAP()
   };
   typedef peerlist_entry_base<epee::net_utils::network_address> peerlist_entry;
@@ -126,7 +128,11 @@ namespace nodetool
     ss << std::setfill ('0') << std::setw (8) << std::hex << std::noshowbase;
     for(const peerlist_entry& pe: pl)
     {
-      ss << pe.id << "\t" << pe.adr.str() << " \tpruning seed " << pe.pruning_seed << " \tlast_seen: " << epee::misc_utils::get_time_interval_string(now_time - pe.last_seen) << std::endl;
+      ss << pe.id << "\t" << pe.adr.str() 
+        << " \trpc port " << (pe.rpc_port > 0 ? std::to_string(pe.rpc_port) : "-")
+        << " \tpruning seed " << pe.pruning_seed 
+        << " \tlast_seen: " << epee::misc_utils::get_time_interval_string(now_time - pe.last_seen) 
+        << std::endl;
     }
     return ss.str();
   }
@@ -157,6 +163,7 @@ namespace nodetool
     uuid network_id;                   
     uint64_t local_time;
     uint32_t my_port;
+    uint16_t rpc_port;
     peerid_type peer_id;
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -164,6 +171,7 @@ namespace nodetool
       KV_SERIALIZE(peer_id)
       KV_SERIALIZE(local_time)
       KV_SERIALIZE(my_port)
+      KV_SERIALIZE_OPT(rpc_port, (uint16_t)(0))
     END_KV_SERIALIZE_MAP()
   };
   
@@ -209,7 +217,7 @@ namespace nodetool
             {
               const epee::net_utils::network_address  &na = p.adr;
               const epee::net_utils::ipv4_network_address &ipv4 = na.as<const epee::net_utils::ipv4_network_address>();
-              local_peerlist.push_back(peerlist_entry_base<network_address_old>({{ipv4.ip(), ipv4.port()}, p.id, p.last_seen, p.pruning_seed}));
+              local_peerlist.push_back(peerlist_entry_base<network_address_old>({{ipv4.ip(), ipv4.port()}, p.id, p.last_seen, p.pruning_seed, p.rpc_port}));
             }
             else
               MDEBUG("Not including in legacy peer list: " << p.adr.str());
@@ -224,7 +232,7 @@ namespace nodetool
             std::vector<peerlist_entry_base<network_address_old>> local_peerlist;
             epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(local_peerlist, stg, hparent_section, "local_peerlist");
             for (const auto &p: local_peerlist)
-              ((response&)this_ref).local_peerlist_new.push_back(peerlist_entry({epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen, p.pruning_seed}));
+              ((response&)this_ref).local_peerlist_new.push_back(peerlist_entry({epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen, p.pruning_seed, p.rpc_port}));
           }
         }
       END_KV_SERIALIZE_MAP()
@@ -466,7 +474,3 @@ namespace nodetool
   }
 
 }
-
-BOOST_CLASS_VERSION(nodetool::peerlist_entry, 1)
-
-

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -910,9 +910,9 @@ namespace cryptonote
     {
       if (entry.adr.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
         res.white_list.emplace_back(entry.id, entry.adr.as<epee::net_utils::ipv4_network_address>().ip(),
-            entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen, entry.pruning_seed);
+            entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen, entry.pruning_seed, entry.rpc_port);
       else
-        res.white_list.emplace_back(entry.id, entry.adr.str(), entry.last_seen, entry.pruning_seed);
+        res.white_list.emplace_back(entry.id, entry.adr.str(), entry.last_seen, entry.pruning_seed, entry.rpc_port);
     }
 
     res.gray_list.reserve(gray_list.size());
@@ -920,9 +920,9 @@ namespace cryptonote
     {
       if (entry.adr.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
         res.gray_list.emplace_back(entry.id, entry.adr.as<epee::net_utils::ipv4_network_address>().ip(),
-            entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen, entry.pruning_seed);
+            entry.adr.as<epee::net_utils::ipv4_network_address>().port(), entry.last_seen, entry.pruning_seed, entry.rpc_port);
       else
-        res.gray_list.emplace_back(entry.id, entry.adr.str(), entry.last_seen, entry.pruning_seed);
+        res.gray_list.emplace_back(entry.id, entry.adr.str(), entry.last_seen, entry.pruning_seed, entry.rpc_port);
     }
 
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -53,6 +53,7 @@ namespace cryptonote
   {
   public:
 
+    static const command_line::arg_descriptor<bool> arg_public_node;
     static const command_line::arg_descriptor<std::string, false, true, 2> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -84,7 +84,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 2
-#define CORE_RPC_VERSION_MINOR 3
+#define CORE_RPC_VERSION_MINOR 4
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1318,16 +1318,17 @@ namespace cryptonote
     std::string host;
     uint32_t ip;
     uint16_t port;
+    uint16_t rpc_port;
     uint64_t last_seen;
     uint32_t pruning_seed;
 
     peer() = default;
 
-    peer(uint64_t id, const std::string &host, uint64_t last_seen, uint32_t pruning_seed)
-      : id(id), host(host), ip(0), port(0), last_seen(last_seen), pruning_seed(pruning_seed)
+    peer(uint64_t id, const std::string &host, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port)
+      : id(id), host(host), ip(0), port(0), rpc_port(rpc_port), last_seen(last_seen), pruning_seed(pruning_seed)
     {}
-    peer(uint64_t id, uint32_t ip, uint16_t port, uint64_t last_seen, uint32_t pruning_seed)
-      : id(id), host(std::to_string(ip)), ip(ip), port(port), last_seen(last_seen), pruning_seed(pruning_seed)
+    peer(uint64_t id, uint32_t ip, uint16_t port, uint64_t last_seen, uint32_t pruning_seed, uint16_t rpc_port)
+      : id(id), host(std::to_string(ip)), ip(ip), port(port), rpc_port(rpc_port), last_seen(last_seen), pruning_seed(pruning_seed)
     {}
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -1335,6 +1336,7 @@ namespace cryptonote
       KV_SERIALIZE(host)
       KV_SERIALIZE(ip)
       KV_SERIALIZE(port)
+      KV_SERIALIZE_OPT(rpc_port, (uint16_t)0)
       KV_SERIALIZE(last_seen)
       KV_SERIALIZE_OPT(pruning_seed, (uint32_t)0)
     END_KV_SERIALIZE_MAP()

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -78,6 +78,7 @@ namespace rpc
     uint64_t id;
     uint32_t ip;
     uint16_t port;
+    uint16_t rpc_port;
     uint64_t last_seen;
     uint32_t pruning_seed;
   };

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -570,6 +570,7 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::connection_info& in
 
   INSERT_INTO_JSON_OBJECT(val, doc, ip, info.ip);
   INSERT_INTO_JSON_OBJECT(val, doc, port, info.port);
+  INSERT_INTO_JSON_OBJECT(val, doc, rpc_port, info.rpc_port);
 
   INSERT_INTO_JSON_OBJECT(val, doc, peer_id, info.peer_id);
 
@@ -604,6 +605,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::connection_info& inf
 
   GET_FROM_JSON_OBJECT(val, info.ip, ip);
   GET_FROM_JSON_OBJECT(val, info.port, port);
+  GET_FROM_JSON_OBJECT(val, info.rpc_port, rpc_port);
 
   GET_FROM_JSON_OBJECT(val, info.peer_id, peer_id);
 
@@ -733,6 +735,7 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::peer& peer, ra
   INSERT_INTO_JSON_OBJECT(val, doc, id, peer.id);
   INSERT_INTO_JSON_OBJECT(val, doc, ip, peer.ip);
   INSERT_INTO_JSON_OBJECT(val, doc, port, peer.port);
+  INSERT_INTO_JSON_OBJECT(val, doc, rpc_port, peer.rpc_port);
   INSERT_INTO_JSON_OBJECT(val, doc, last_seen, peer.last_seen);
   INSERT_INTO_JSON_OBJECT(val, doc, pruning_seed, peer.pruning_seed);
 }
@@ -748,6 +751,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::peer& peer)
   GET_FROM_JSON_OBJECT(val, peer.id, id);
   GET_FROM_JSON_OBJECT(val, peer.ip, ip);
   GET_FROM_JSON_OBJECT(val, peer.port, port);
+  GET_FROM_JSON_OBJECT(val, peer.rpc_port, rpc_port);
   GET_FROM_JSON_OBJECT(val, peer.last_seen, last_seen);
   GET_FROM_JSON_OBJECT(val, peer.pruning_seed, pruning_seed);
 }


### PR DESCRIPTION
Command line switch `--public-node`
1. Requires restricted RPC mode
2. Advertise node's restricted RPC port to other peers over P2P network
3. Print a warning at startup if restricted RPC server is listening on local or loopback address
4. Store remote peer's RPC port in peer list only if the peer's destination address is reachable

The following commands will include remote peers' RPC ports (if any):
1. `print_pl` daemon command
2. `get_peer_list`, `get_connections`, `sync_info` RPC calls

```diff
monerod --public-node
- ERROR, restricted RPC mode is required

monerod --public-node --restricted-rpc
+ OK, default RPC port will be advertised over P2P network

monerod --public-node --rpc-restricted-bind-port 1234
+ OK, RPC port 1234 will be advertised over P2P network

monerod --public-node --restricted-rpc --rpc-restricted-bind-port 1234
+ OK, RPC port 1234 will be advertised over P2P network
```