### PR TITLE
SHALL -> MUST

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,26 +88,26 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 ### Preliminaries
 
-- The project SHALL use the git distributed revision control system.
-- The project SHALL be hosted on github.com or equivalent, herein called the "Platform".
-- The project SHALL use the Platform issue tracker.
+- The project MUST use the git distributed revision control system.
+- The project MUST be hosted on github.com or equivalent, herein called the "Platform".
+- The project MUST use the Platform issue tracker.
   - Non-GitHub example:
     - "Platform" could be a vanilla git repo and Trac hosted on the same machine/network.
     - The Platform issue tracker would be Trac.
 - The project SHOULD have clearly documented guidelines for code style.
 - A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
 - A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
-- Contributors SHALL NOT have commit access to the repository unless they are also Maintainers.
-- Maintainers SHALL have commit access to the repository.
-- Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract.
+- Contributors MUST NOT have commit access to the repository unless they are also Maintainers.
+- Maintainers MUST have commit access to the repository.
+- Everyone, without distinction or discrimination, MUST have an equal right to become a Contributor under the terms of this contract.
 
 ### Licensing and ownership
 
-- The project SHALL use a share-alike license, such as BSD-3, the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
-- All contributions to the project source code ("patches") SHALL use the same license as the project.
-- All patches are owned by their authors. There SHALL NOT be any copyright assignment process.
-- The copyrights in the project SHALL be owned collectively by all its Contributors.
-- Each Contributor SHALL be responsible for identifying themselves in the project Contributor list.
+- The project MUST use a share-alike license, such as BSD-3, the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
+- All contributions to the project source code ("patches") MUST use the same license as the project.
+- All patches are owned by their authors. There MUST NOT be any copyright assignment process.
+- The copyrights in the project MUST be owned collectively by all its Contributors.
+- Each Contributor MUST be responsible for identifying themselves in the project Contributor list.
 
 ### Patch requirements
 
@@ -116,27 +116,27 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 - A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
 - A patch MUST adhere to the code style guidelines of the project if these are defined.
 - A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
-- A patch SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
+- A patch MUST NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
 - A patch MUST compile cleanly and pass project self-tests on at least the principle target platform.
 - A patch commit message SHOULD consist of a single short (less than 50 character) line summarizing the change, optionally followed by a blank line and then a more thorough description.
 - A "Correct Patch" is one that satisfies the above requirements.
 
 ### Development process
 
-- Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
+- Change on the project MUST be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
 - To request changes, a user SHOULD log an issue on the project Platform issue tracker.
 - The user or Contributor SHOULD write the issue by describing the problem they face or observe.
 - The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
-- Users SHALL NOT log feature requests, ideas, or suggestions unrelated to Monero code or Monero's dependency code or Monero's potential/future dependency code or research which successfully implements Monero.
-- Users SHALL NOT log any solutions to problems (verifiable or hypothetical) of which are not explicitly documented and/or not provable and/or cannot be reasonably proven.
-- Thus, the release history of the project SHALL be a list of meaningful issues logged and solved.
-- To work on an issue, a Contributor SHALL fork the project repository and then work on their forked repository.
-- To submit a patch, a Contributor SHALL create a Platform pull request back to the project.
-- A Contributor SHALL NOT commit changes directly to the project.
+- Users MUST NOT log feature requests, ideas, or suggestions unrelated to Monero code or Monero's dependency code or Monero's potential/future dependency code or research which successfully implements Monero.
+- Users MUST NOT log any solutions to problems (verifiable or hypothetical) of which are not explicitly documented and/or not provable and/or cannot be reasonably proven.
+- Thus, the release history of the project MUST be a list of meaningful issues logged and solved.
+- To work on an issue, a Contributor MUST fork the project repository and then work on their forked repository.
+- To submit a patch, a Contributor MUST create a Platform pull request back to the project.
+- A Contributor MUST NOT commit changes directly to the project.
 - To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
-- To accept or reject a patch, a Maintainer SHALL use the Platform interface.
+- To accept or reject a patch, a Maintainer MUST use the Platform interface.
 - Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 30 days) or unless urgent as defined by the Monero Maintainers Team.
-- Maintainers SHALL NOT make value judgments on correct patches unless the Maintainer (as may happen in rare circumstances) is a core code developer.
+- Maintainers MUST NOT make value judgments on correct patches unless the Maintainer (as may happen in rare circumstances) is a core code developer.
 - Maintainers MUST NOT merge pull requests in less than 168 hours (1 week) unless deemed urgent by at least 2 people from the Monero Maintainer Team.
 - The Contributor MAY tag an issue as "Ready" after making a pull request for the issue.
 - The user who created an issue SHOULD close the issue after checking the patch is successful.
@@ -146,27 +146,27 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 ### Creating stable releases
 
-- The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
-- The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
-- To make a stable release someone SHALL fork the repository by copying it and thus become maintainer of this repository.
+- The project MUST have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+- The project MUST NOT use topic branches for any reason. Personal forks MAY use topic branches.
+- To make a stable release someone MUST fork the repository by copying it and thus become maintainer of this repository.
 - Forking a project for stabilization MAY be done unilaterally and without agreement of project maintainers.
-- A patch to a stabilization project declared "stable" SHALL be accompanied by a reproducible test case.
+- A patch to a stabilization project declared "stable" MUST be accompanied by a reproducible test case.
 
 ### Evolution of public contracts
 
-- All Public Contracts (APIs or protocols) SHALL be documented.
+- All Public Contracts (APIs or protocols) MUST be documented.
 - All Public Contracts SHOULD have space for extensibility and experimentation.
 - A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
 - A patch that introduces new features to a Public Contract SHOULD do so using new names.
 - Old names SHOULD be deprecated in a systematic fashion by marking new names as "experimental" until they are stable, then marking the old names as "deprecated".
 - When sufficient time has passed, old deprecated names SHOULD be marked "legacy" and eventually removed.
-- Old names SHALL NOT be reused by new features.
+- Old names MUST NOT be reused by new features.
 - When old names are removed, their implementations MUST provoke an exception (assertion) if used by applications.
 
 ### Project administration
 
-- The project founders SHALL act as Administrators to manage the set of project Maintainers.
-- The Administrators SHALL ensure their own succession over time by promoting the most effective Maintainers.
-- A new Contributor who makes a correct patch SHALL be invited to become a Maintainer.
+- The project founders MUST act as Administrators to manage the set of project Maintainers.
+- The Administrators MUST ensure their own succession over time by promoting the most effective Maintainers.
+- A new Contributor who makes a correct patch MUST be invited to become a Maintainer.
 - Administrators MAY remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
 - Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.


### PR DESCRIPTION
The [spec](https://tools.ietf.org/html/rfc2119) states that these keywords are aliased to each other (in order to alleviate issues arising from the misinterpretation of using "shall"). Consistency helps readers (especially new/unfamiliar ones). 👀 References:

- https://www.faa.gov/about/initiatives/plain_language/articles/mandatory/ 
- https://ell.stackexchange.com/a/171990/2487