### PR TITLE
[RELEASE] disable asm w/ x64 instructions set on i386

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -48,7 +48,7 @@ set(crypto_sources
   CryptonightR_JIT.c
   tree-hash.c)
 
-if(ARCH_ID STREQUAL "i386" OR ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64")
+if(ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64")
 list(APPEND crypto_sources CryptonightR_template.S)
 endif()
 

--- a/src/crypto/CryptonightR_JIT.c
+++ b/src/crypto/CryptonightR_JIT.c
@@ -12,7 +12,7 @@
 #include "CryptonightR_template.h"
 
 static const uint8_t prologue[] = {
-#if defined __i386 || defined __x86_64__
+#if defined __x86_64__
 	0x4C, 0x8B, 0xD7,	// mov r10, rdi
 	0x53,			// push rbx
 	0x55,			// push rbp
@@ -31,7 +31,7 @@ static const uint8_t prologue[] = {
 };
 
 static const uint8_t epilogue[] = {
-#if defined __i386 || defined __x86_64__
+#if defined __x86_64__
 	0x49, 0x8B, 0xE3,	// mov rsp, r11
 	0x41, 0x89, 0x1A,	// mov DWORD PTR [r10], ebx
 	0x41, 0x89, 0x72, 0x04,	// mov DWORD PTR [r10+4], esi
@@ -54,7 +54,7 @@ static const uint8_t epilogue[] = {
 
 int v4_generate_JIT_code(const struct V4_Instruction* code, v4_random_math_JIT_func buf, const size_t buf_size)
 {
-#if defined __i386 || defined __x86_64__
+#if defined __x86_64__
 	uint8_t* JIT_code = (uint8_t*) buf;
 	const uint8_t* JIT_code_end = JIT_code + buf_size;
 

--- a/src/crypto/CryptonightR_JIT.h
+++ b/src/crypto/CryptonightR_JIT.h
@@ -9,7 +9,7 @@
 // - Call the generated code instead of "v4_random_math(code, r)", omit the "code" parameter
 
 typedef void (*v4_random_math_JIT_func)(uint32_t* r)
-#if defined __i386 || defined __x86_64__
+#if defined __x86_64__
 __attribute__((sysv_abi))
 #endif
 ;


### PR DESCRIPTION
Related to #5206. This fixes compilation on i386 arch.
If the PR is accepted I'll make a PR to master