### PR TITLE
device/trezor: HF10 protocol upgrade

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -39,6 +39,7 @@ set(crypto_sources
   hash-extra-jh.c
   hash-extra-skein.c
   hash.c
+  hmac-keccak.c
   jh.c
   keccak.c
   oaes_lib.c
@@ -64,6 +65,7 @@ set(crypto_private_headers
   groestl_tables.h
   hash-ops.h
   hash.h
+  hmac-keccak.h
   initializer.h
   jh.h
   keccak.h

--- a/src/crypto/hmac-keccak.c
+++ b/src/crypto/hmac-keccak.c
@@ -1,0 +1,81 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "hmac-keccak.h"
+#include "memwipe.h"
+
+#define KECCAK_BLOCKLEN 136
+#define HASH_SIZE 32
+
+void hmac_keccak_init(hmac_keccak_state *S, const uint8_t *_key, size_t keylen) {
+  const uint8_t *key = _key;
+  uint8_t keyhash[HASH_SIZE];
+  uint8_t pad[KECCAK_BLOCKLEN];
+  uint64_t i;
+
+  if (keylen > KECCAK_BLOCKLEN) {
+    keccak(key, keylen, keyhash, HASH_SIZE);
+    key = keyhash;
+    keylen = HASH_SIZE;
+  }
+
+  keccak_init(&S->inner);
+  memset(pad, 0x36, KECCAK_BLOCKLEN);
+  for (i = 0; i < keylen; ++i) {
+    pad[i] ^= key[i];
+  }
+  keccak_update(&S->inner, pad, KECCAK_BLOCKLEN);
+
+  keccak_init(&S->outer);
+  memset(pad, 0x5c, KECCAK_BLOCKLEN);
+  for (i = 0; i < keylen; ++i) {
+    pad[i] ^= key[i];
+  }
+  keccak_update(&S->outer, pad, KECCAK_BLOCKLEN);
+
+  memwipe(keyhash, HASH_SIZE);
+}
+
+void hmac_keccak_update(hmac_keccak_state *S, const uint8_t *data, size_t datalen) {
+  keccak_update(&S->inner, data, datalen);
+}
+
+void hmac_keccak_finish(hmac_keccak_state *S, uint8_t *digest) {
+  uint8_t ihash[HASH_SIZE];
+  keccak_finish(&S->inner, ihash);
+  keccak_update(&S->outer, ihash, HASH_SIZE);
+  keccak_finish(&S->outer, digest);
+  memwipe(ihash, HASH_SIZE);
+}
+
+void hmac_keccak_hash(uint8_t *out, const uint8_t *key, size_t keylen, const uint8_t *in, size_t inlen) {
+  hmac_keccak_state S;
+  hmac_keccak_init(&S, key, keylen);
+  hmac_keccak_update(&S, in, inlen);
+  hmac_keccak_finish(&S, out);
+}

--- a/src/crypto/hmac-keccak.h
+++ b/src/crypto/hmac-keccak.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef HMAC_KECCAK_H
+#define HMAC_KECCAK_H
+
+#include "keccak.h"
+
+// HMAC RFC 2104 with Keccak-256 base hash function
+//
+// B = KECCAK_BLOCKLEN = 136 B
+// L = HASH_SIZE = 32 B
+//
+// Note this is not HMAC-SHA3 as SHA3 and Keccak differs in
+// the padding constant.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  KECCAK_CTX inner;
+  KECCAK_CTX outer;
+} hmac_keccak_state;
+
+void hmac_keccak_init(hmac_keccak_state *S, const uint8_t *_key, size_t keylen);
+void hmac_keccak_update(hmac_keccak_state *S, const uint8_t *data, size_t datalen);
+void hmac_keccak_finish(hmac_keccak_state *S, uint8_t *digest);
+void hmac_keccak_hash(uint8_t *out, const uint8_t *key, size_t keylen, const uint8_t *in, size_t inlen);
+
+#ifdef __cplusplus
+}
+#endif
+#endif //HMAC_KECCAK_H

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -282,6 +282,11 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool generate_key_image_helper_precomp(const account_keys& ack, const crypto::public_key& out_key, const crypto::key_derivation& recv_derivation, size_t real_output_index, const subaddress_index& received_index, keypair& in_ephemeral, crypto::key_image& ki, hw::device &hwdev)
   {
+    if (hwdev.compute_key_image(ack, out_key, recv_derivation, real_output_index, received_index, in_ephemeral, ki))
+    {
+      return true;
+    }
+
     if (ack.m_spend_secret_key == crypto::null_skey)
     {
       // for watch-only wallet, simply copy the known output pubkey

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -70,6 +70,7 @@ namespace cryptonote
     struct account_keys;
     struct subaddress_index;
     struct tx_destination_entry;
+    struct keypair;
 }
 
 namespace hw {
@@ -81,11 +82,18 @@ namespace hw {
            return false;
     }
 
+    class device_progress {
+    public:
+      virtual double progress() const { return 0; }
+      virtual bool indeterminate() const { return false; }
+    };
+
     class i_device_callback {
     public:
-        virtual void on_button_request() {}
-        virtual void on_pin_request(epee::wipeable_string & pin) {}
-        virtual void on_passphrase_request(bool on_device, epee::wipeable_string & passphrase) {}
+        virtual void on_button_request(uint64_t code=0) {}
+        virtual boost::optional<epee::wipeable_string> on_pin_request() { return boost::none; }
+        virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool on_device) { return boost::none; }
+        virtual void on_progress(const device_progress& event) {}
         virtual ~i_device_callback() = default;
     };
 
@@ -140,6 +148,9 @@ namespace hw {
         virtual device_protocol_t device_protocol() const { return PROTOCOL_DEFAULT; };
         virtual void set_callback(i_device_callback * callback) {};
         virtual void set_derivation_path(const std::string &derivation_path) {};
+
+        virtual void set_pin(const epee::wipeable_string & pin) {}
+        virtual void set_passphrase(const epee::wipeable_string & passphrase) {}
 
         /* ======================================================================= */
         /*  LOCKER                                                                 */
@@ -229,7 +240,9 @@ namespace hw {
 
         virtual bool  has_ki_cold_sync(void) const { return false; }
         virtual bool  has_tx_cold_sign(void) const { return false; }
-
+        virtual bool  has_ki_live_refresh(void) const { return true; }
+        virtual bool  compute_key_image(const cryptonote::account_keys& ack, const crypto::public_key& out_key, const crypto::key_derivation& recv_derivation, size_t real_output_index, const cryptonote::subaddress_index& received_index, cryptonote::keypair& in_ephemeral, crypto::key_image& ki) { return false; }
+        virtual void  computing_key_images(bool started) {};
         virtual void  set_network_type(cryptonote::network_type network_type) { }
 
     protected:

--- a/src/device/device_cold.hpp
+++ b/src/device/device_cold.hpp
@@ -31,6 +31,7 @@
 #define MONERO_DEVICE_COLD_H
 
 #include "wallet/wallet2.h"
+#include <boost/optional/optional.hpp>
 #include <boost/function.hpp>
 
 
@@ -44,12 +45,61 @@ namespace hw {
   public:
     std::vector<std::string> tx_device_aux;  // device generated aux data
     std::vector<cryptonote::address_parse_info> tx_recipients;  // as entered by user
+    boost::optional<int> bp_version;  // BP version to use
+    boost::optional<unsigned> client_version;  // Signing client version to use (testing)
   };
 
   class device_cold {
   public:
 
     using exported_key_image = std::vector<std::pair<crypto::key_image, crypto::signature>>;
+
+    class op_progress : public hw::device_progress {
+    public:
+      op_progress():m_progress(0), m_indeterminate(false) {};
+      explicit op_progress(double progress, bool indeterminate=false): m_progress(progress), m_indeterminate(indeterminate){}
+
+      double progress() const override { return m_progress; }
+      bool indeterminate() const override { return m_indeterminate; }
+    protected:
+      double m_progress;
+      bool m_indeterminate;
+    };
+
+    class tx_progress : public op_progress {
+    public:
+      tx_progress():
+        m_cur_tx(0), m_max_tx(1),
+        m_cur_step(0), m_max_step(1),
+        m_cur_substep(0), m_max_substep(1){};
+
+      tx_progress(size_t cur_tx, size_t max_tx, size_t cur_step, size_t max_step, size_t cur_substep, size_t max_substep):
+        m_cur_tx(cur_tx), m_max_tx(max_tx),
+        m_cur_step(cur_tx), m_max_step(max_tx),
+        m_cur_substep(cur_tx), m_max_substep(max_tx){}
+
+      double progress() const override {
+        return std::max(1.0, (double)m_cur_tx / m_max_tx
+          + (double)m_cur_step / (m_max_tx * m_max_step)
+          + (double)m_cur_substep / (m_max_tx * m_max_step * m_max_substep));
+      }
+      bool indeterminate() const override { return false; }
+
+    protected:
+      size_t m_cur_tx;
+      size_t m_max_tx;
+      size_t m_cur_step;
+      size_t m_max_step;
+      size_t m_cur_substep;
+      size_t m_max_substep;
+    };
+
+    typedef struct {
+      std::string salt1;
+      std::string salt2;
+      std::string tx_enc_keys;
+      std::string tx_prefix_hash;
+    } tx_key_data_t;
 
     /**
      * Key image sync with the cold protocol.
@@ -65,6 +115,52 @@ namespace hw {
                  const ::tools::wallet2::unsigned_tx_set & unsigned_tx,
                  ::tools::wallet2::signed_tx_set & signed_tx,
                  tx_aux_data & aux_data) =0;
+
+    /**
+     * Get tx key support check.
+     */
+    virtual bool is_get_tx_key_supported() const { return false; }
+
+    /**
+     * Loads TX aux data required for tx key.
+     */
+    virtual void load_tx_key_data(tx_key_data_t & res, const std::string & tx_aux_data) =0;
+
+    /**
+     * Decrypts TX keys.
+     */
+    virtual void get_tx_key(
+        std::vector<::crypto::secret_key> & tx_keys,
+        const tx_key_data_t & tx_aux_data,
+        const ::crypto::secret_key & view_key_priv) =0;
+
+    /**
+     * Live refresh support check
+     */
+    virtual bool is_live_refresh_supported() const { return false; };
+
+    /**
+     * Starts live refresh process with the device
+     */
+    virtual void live_refresh_start() =0;
+
+    /**
+     * One live refresh step
+     */
+    virtual void live_refresh(
+        const ::crypto::secret_key & view_key_priv,
+        const crypto::public_key& out_key,
+        const crypto::key_derivation& recv_derivation,
+        size_t real_output_index,
+        const cryptonote::subaddress_index& received_index,
+        cryptonote::keypair& in_ephemeral,
+        crypto::key_image& ki
+    ) =0;
+
+    /**
+     * Live refresh process termination
+     */
+    virtual void live_refresh_finish() =0;
   };
 }
 

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -57,7 +57,9 @@ namespace trezor {
     }
 
     device_trezor::device_trezor() {
-
+      m_live_refresh_in_progress = false;
+      m_live_refresh_enabled = true;
+      m_live_refresh_thread_running = false;
     }
 
     device_trezor::~device_trezor() {
@@ -66,6 +68,89 @@ namespace trezor {
         release();
       } catch(std::exception const& e){
         MWARNING("Could not disconnect and release: " << e.what());
+      }
+    }
+
+    bool device_trezor::init()
+    {
+      m_live_refresh_in_progress = false;
+      bool r = device_trezor_base::init();
+      if (r && !m_live_refresh_thread)
+      {
+        m_live_refresh_thread_running = true;
+        m_live_refresh_thread.reset(new boost::thread(boost::bind(&device_trezor::live_refresh_thread_main, this)));
+      }
+      return r;
+    }
+
+    bool device_trezor::release()
+    {
+      m_live_refresh_in_progress = false;
+      m_live_refresh_thread_running = false;
+      if (m_live_refresh_thread)
+      {
+        m_live_refresh_thread->join();
+        m_live_refresh_thread = nullptr;
+      }
+      return device_trezor_base::release();
+    }
+
+    bool device_trezor::disconnect()
+    {
+      m_live_refresh_in_progress = false;
+      return device_trezor_base::disconnect();
+    }
+
+    void device_trezor::device_state_reset_unsafe()
+    {
+      require_connected();
+      if (m_live_refresh_in_progress)
+      {
+        try
+        {
+          live_refresh_finish_unsafe();
+        }
+        catch(const std::exception & e)
+        {
+          MERROR("Live refresh could not be terminated: " << e.what());
+        }
+      }
+
+      m_live_refresh_in_progress = false;
+      device_trezor_base::device_state_reset_unsafe();
+    }
+
+    void device_trezor::live_refresh_thread_main()
+    {
+      while(m_live_refresh_thread_running)
+      {
+        boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
+        if (!m_live_refresh_in_progress)
+        {
+          continue;
+        }
+
+        TREZOR_AUTO_LOCK_DEVICE();
+        if (!m_transport || !m_live_refresh_in_progress)
+        {
+          continue;
+        }
+
+        auto current_time = std::chrono::steady_clock::now();
+        if (current_time - m_last_live_refresh_time <= std::chrono::seconds(20))
+        {
+          continue;
+        }
+
+        MTRACE("Closing live refresh process due to inactivity");
+        try
+        {
+          live_refresh_finish();
+        }
+        catch(const std::exception &e)
+        {
+          MWARNING("Live refresh auto-finish failed: " << e.what());
+        }
       }
     }
 
@@ -126,7 +211,7 @@ namespace trezor {
     std::shared_ptr<messages::monero::MoneroAddress> device_trezor::get_address(
         const boost::optional<std::vector<uint32_t>> & path,
         const boost::optional<cryptonote::network_type> & network_type){
-      AUTO_LOCK_CMD();
+      TREZOR_AUTO_LOCK_CMD();
       require_connected();
       device_state_reset_unsafe();
       require_initialized();
@@ -142,7 +227,7 @@ namespace trezor {
     std::shared_ptr<messages::monero::MoneroWatchKey> device_trezor::get_view_key(
         const boost::optional<std::vector<uint32_t>> & path,
         const boost::optional<cryptonote::network_type> & network_type){
-      AUTO_LOCK_CMD();
+      TREZOR_AUTO_LOCK_CMD();
       require_connected();
       device_state_reset_unsafe();
       require_initialized();
@@ -155,11 +240,43 @@ namespace trezor {
       return response;
     }
 
+    bool device_trezor::is_get_tx_key_supported() const
+    {
+      require_initialized();
+      return get_version() > pack_version(2, 0, 10);
+    }
+
+    void device_trezor::load_tx_key_data(::hw::device_cold::tx_key_data_t & res, const std::string & tx_aux_data)
+    {
+      protocol::tx::load_tx_key_data(res, tx_aux_data);
+    }
+
+    void device_trezor::get_tx_key(
+        std::vector<::crypto::secret_key> & tx_keys,
+        const ::hw::device_cold::tx_key_data_t & tx_aux_data,
+        const ::crypto::secret_key & view_key_priv)
+    {
+      TREZOR_AUTO_LOCK_CMD();
+      require_connected();
+      device_state_reset_unsafe();
+      require_initialized();
+
+      auto req = protocol::tx::get_tx_key(tx_aux_data);
+      this->set_msg_addr<messages::monero::MoneroGetTxKeyRequest>(req.get());
+
+      auto response = this->client_exchange<messages::monero::MoneroGetTxKeyAck>(req);
+      MTRACE("Get TX key response received");
+
+      protocol::tx::get_tx_key_ack(tx_keys, tx_aux_data.tx_prefix_hash, view_key_priv, response);
+    }
+
     void device_trezor::ki_sync(wallet_shim * wallet,
                                 const std::vector<tools::wallet2::transfer_details> & transfers,
                                 hw::device_cold::exported_key_image & ski)
     {
-      AUTO_LOCK_CMD();
+#define EVENT_PROGRESS(P) do { if (m_callback) {(m_callback)->on_progress(device_cold::op_progress(P)); } }while(0)
+
+      TREZOR_AUTO_LOCK_CMD();
       require_connected();
       device_state_reset_unsafe();
       require_initialized();
@@ -171,6 +288,7 @@ namespace trezor {
       protocol::ki::key_image_data(wallet, transfers, mtds);
       protocol::ki::generate_commitment(mtds, transfers, req);
 
+      EVENT_PROGRESS(0.);
       this->set_msg_addr<messages::monero::MoneroKeyImageExportInitRequest>(req.get());
       auto ack1 = this->client_exchange<messages::monero::MoneroKeyImageExportInitAck>(req);
 
@@ -194,27 +312,160 @@ namespace trezor {
         }
 
         MTRACE("Batch " << cur << " / " << num_batches << " batches processed");
+        EVENT_PROGRESS((double)cur * batch_size / mtds.size());
       }
+      EVENT_PROGRESS(1.);
 
       auto final_req = std::make_shared<messages::monero::MoneroKeyImageSyncFinalRequest>();
       auto final_ack = this->client_exchange<messages::monero::MoneroKeyImageSyncFinalAck>(final_req);
       ski.reserve(kis.size());
 
       for(auto & sub : kis){
-        char buff[32*3];
-        protocol::crypto::chacha::decrypt(sub.blob().data(), sub.blob().size(),
-                                          reinterpret_cast<const uint8_t *>(final_ack->enc_key().data()),
-                                          reinterpret_cast<const uint8_t *>(sub.iv().data()), buff);
-
         ::crypto::signature sig{};
         ::crypto::key_image ki;
-        memcpy(ki.data, buff, 32);
-        memcpy(sig.c.data, buff + 32, 32);
-        memcpy(sig.r.data, buff + 64, 32);
+        char buff[sizeof(ki.data)*3];
+
+        size_t buff_len = sizeof(buff);
+
+        protocol::crypto::chacha::decrypt(sub.blob().data(), sub.blob().size(),
+                                          reinterpret_cast<const uint8_t *>(final_ack->enc_key().data()),
+                                          reinterpret_cast<const uint8_t *>(sub.iv().data()), buff, &buff_len);
+        CHECK_AND_ASSERT_THROW_MES(buff_len == sizeof(buff), "Plaintext size invalid");
+
+        memcpy(ki.data, buff, sizeof(ki.data));
+        memcpy(sig.c.data, buff + sizeof(ki.data), sizeof(ki.data));
+        memcpy(sig.r.data, buff + 2*sizeof(ki.data), sizeof(ki.data));
         ski.push_back(std::make_pair(ki, sig));
+      }
+#undef EVENT_PROGRESS
+    }
+
+    bool device_trezor::is_live_refresh_supported() const
+    {
+      require_initialized();
+      return get_version() > pack_version(2, 0, 10);
+    }
+
+    bool device_trezor::is_live_refresh_enabled() const
+    {
+      return is_live_refresh_supported() && (mode == NONE || mode == TRANSACTION_PARSE) && m_live_refresh_enabled;
+    }
+
+    bool device_trezor::has_ki_live_refresh() const
+    {
+      try{
+        return is_live_refresh_enabled();
+      } catch(const std::exception & e){
+        MERROR("Could not detect if live refresh is enabled: " << e.what());
+      }
+      return false;
+    }
+
+    void device_trezor::live_refresh_start()
+    {
+      TREZOR_AUTO_LOCK_CMD();
+      require_connected();
+      live_refresh_start_unsafe();
+    }
+
+    void device_trezor::live_refresh_start_unsafe()
+    {
+      device_state_reset_unsafe();
+      require_initialized();
+
+      auto req = std::make_shared<messages::monero::MoneroLiveRefreshStartRequest>();
+      this->set_msg_addr<messages::monero::MoneroLiveRefreshStartRequest>(req.get());
+      this->client_exchange<messages::monero::MoneroLiveRefreshStartAck>(req);
+      m_live_refresh_in_progress = true;
+      m_last_live_refresh_time = std::chrono::steady_clock::now();
+    }
+
+    void device_trezor::live_refresh(
+        const ::crypto::secret_key & view_key_priv,
+        const crypto::public_key& out_key,
+        const crypto::key_derivation& recv_derivation,
+        size_t real_output_index,
+        const cryptonote::subaddress_index& received_index,
+        cryptonote::keypair& in_ephemeral,
+        crypto::key_image& ki
+    )
+    {
+      TREZOR_AUTO_LOCK_CMD();
+      require_connected();
+
+      if (!m_live_refresh_in_progress)
+      {
+        live_refresh_start_unsafe();
+      }
+
+      m_last_live_refresh_time = std::chrono::steady_clock::now();
+
+      auto req = std::make_shared<messages::monero::MoneroLiveRefreshStepRequest>();
+      req->set_out_key(out_key.data, 32);
+      req->set_recv_deriv(recv_derivation.data, 32);
+      req->set_real_out_idx(real_output_index);
+      req->set_sub_addr_major(received_index.major);
+      req->set_sub_addr_minor(received_index.minor);
+
+      auto ack = this->client_exchange<messages::monero::MoneroLiveRefreshStepAck>(req);
+      protocol::ki::live_refresh_ack(view_key_priv, out_key, ack, in_ephemeral, ki);
+    }
+
+    void device_trezor::live_refresh_finish_unsafe()
+    {
+      auto req = std::make_shared<messages::monero::MoneroLiveRefreshFinalRequest>();
+      this->client_exchange<messages::monero::MoneroLiveRefreshFinalAck>(req);
+      m_live_refresh_in_progress = false;
+    }
+
+    void device_trezor::live_refresh_finish()
+    {
+      TREZOR_AUTO_LOCK_CMD();
+      require_connected();
+      if (m_live_refresh_in_progress)
+      {
+        live_refresh_finish_unsafe();
       }
     }
 
+    void device_trezor::computing_key_images(bool started)
+    {
+      try
+      {
+        if (!is_live_refresh_enabled())
+        {
+          return;
+        }
+
+        // React only on termination as the process can auto-start itself.
+        if (!started && m_live_refresh_in_progress)
+        {
+          live_refresh_finish();
+        }
+      }
+      catch(const std::exception & e)
+      {
+        MWARNING("KI computation state change failed, started: " << started << ", e: " << e.what());
+      }
+    }
+
+    bool device_trezor::compute_key_image(
+        const ::cryptonote::account_keys& ack,
+        const ::crypto::public_key& out_key,
+        const ::crypto::key_derivation& recv_derivation,
+        size_t real_output_index,
+        const ::cryptonote::subaddress_index& received_index,
+        ::cryptonote::keypair& in_ephemeral,
+        ::crypto::key_image& ki)
+    {
+      if (!is_live_refresh_enabled())
+      {
+        return false;
+      }
+
+      live_refresh(ack.m_view_secret_key, out_key, recv_derivation, real_output_index, received_index, in_ephemeral, ki);
+      return true;
+    }
 
     void device_trezor::tx_sign(wallet_shim * wallet,
                                 const tools::wallet2::unsigned_tx_set & unsigned_tx,
@@ -222,7 +473,15 @@ namespace trezor {
                                 hw::tx_aux_data & aux_data)
     {
       CHECK_AND_ASSERT_THROW_MES(unsigned_tx.transfers.first == 0, "Unsuported non zero offset");
-      size_t num_tx = unsigned_tx.txes.size();
+
+      TREZOR_AUTO_LOCK_CMD();
+      require_connected();
+      device_state_reset_unsafe();
+      require_initialized();
+      transaction_versions_check(unsigned_tx, aux_data);
+
+      const size_t num_tx = unsigned_tx.txes.size();
+      m_num_transations_to_sign = num_tx;
       signed_tx.key_images.clear();
       signed_tx.key_images.resize(unsigned_tx.transfers.second.size());
 
@@ -267,6 +526,10 @@ namespace trezor {
         cpend.key_images = key_images;
 
         // KI sync
+        for(size_t cidx=0, trans_max=unsigned_tx.transfers.second.size(); cidx < trans_max; ++cidx){
+          signed_tx.key_images[cidx] = unsigned_tx.transfers.second[cidx].m_key_image;
+        }
+
         size_t num_sources = cdata.tx_data.sources.size();
         CHECK_AND_ASSERT_THROW_MES(num_sources == cdata.source_permutation.size(), "Invalid permutation size");
         CHECK_AND_ASSERT_THROW_MES(num_sources == cdata.tx.vin.size(), "Invalid tx.vin size");
@@ -276,11 +539,18 @@ namespace trezor {
           CHECK_AND_ASSERT_THROW_MES(src_idx < cdata.tx.vin.size(), "Invalid idx_mapped");
 
           size_t idx_map_src = cdata.tx_data.selected_transfers[idx_mapped];
-          auto vini = boost::get<cryptonote::txin_to_key>(cdata.tx.vin[src_idx]);
+          CHECK_AND_ASSERT_THROW_MES(idx_map_src >= unsigned_tx.transfers.first, "Invalid offset");
 
+          idx_map_src -= unsigned_tx.transfers.first;
           CHECK_AND_ASSERT_THROW_MES(idx_map_src < signed_tx.key_images.size(), "Invalid key image index");
+
+          const auto vini = boost::get<cryptonote::txin_to_key>(cdata.tx.vin[src_idx]);
           signed_tx.key_images[idx_map_src] = vini.k_image;
         }
+      }
+
+      if (m_callback){
+        m_callback->on_progress(device_cold::tx_progress(m_num_transations_to_sign, m_num_transations_to_sign, 1, 1, 1, 1));
       }
     }
 
@@ -290,10 +560,16 @@ namespace trezor {
                    hw::tx_aux_data & aux_data,
                    std::shared_ptr<protocol::tx::Signer> & signer)
     {
-      AUTO_LOCK_CMD();
+#define EVENT_PROGRESS(S, SUB, SUBMAX) do { if (m_callback) { \
+      (m_callback)->on_progress(device_cold::tx_progress(idx, m_num_transations_to_sign, S, 10, SUB, SUBMAX)); \
+} }while(0)
+
       require_connected();
-      device_state_reset_unsafe();
+      if (idx > 0)
+        device_state_reset_unsafe();
+
       require_initialized();
+      EVENT_PROGRESS(0, 1, 1);
 
       CHECK_AND_ASSERT_THROW_MES(idx < unsigned_tx.txes.size(), "Invalid transaction index");
       signer = std::make_shared<protocol::tx::Signer>(wallet, &unsigned_tx, idx, &aux_data);
@@ -305,6 +581,7 @@ namespace trezor {
       auto init_msg = signer->step_init();
       this->set_msg_addr(init_msg.get());
       transaction_pre_check(init_msg);
+      EVENT_PROGRESS(1, 1, 1);
 
       auto response = this->client_exchange<messages::monero::MoneroTransactionInitAck>(init_msg);
       signer->step_init_ack(response);
@@ -314,6 +591,7 @@ namespace trezor {
         auto src = signer->step_set_input(cur_src);
         auto ack = this->client_exchange<messages::monero::MoneroTransactionSetInputAck>(src);
         signer->step_set_input_ack(ack);
+        EVENT_PROGRESS(2, cur_src, num_sources);
       }
 
       // Step: sort
@@ -322,44 +600,82 @@ namespace trezor {
         auto perm_ack = this->client_exchange<messages::monero::MoneroTransactionInputsPermutationAck>(perm_req);
         signer->step_permutation_ack(perm_ack);
       }
+      EVENT_PROGRESS(3, 1, 1);
 
       // Step: input_vini
-      if (!signer->in_memory()){
-        for(size_t cur_src = 0; cur_src < num_sources; ++cur_src){
-          auto src = signer->step_set_vini_input(cur_src);
-          auto ack = this->client_exchange<messages::monero::MoneroTransactionInputViniAck>(src);
-          signer->step_set_vini_input_ack(ack);
-        }
+      for(size_t cur_src = 0; cur_src < num_sources; ++cur_src){
+        auto src = signer->step_set_vini_input(cur_src);
+        auto ack = this->client_exchange<messages::monero::MoneroTransactionInputViniAck>(src);
+        signer->step_set_vini_input_ack(ack);
+        EVENT_PROGRESS(4, cur_src, num_sources);
       }
 
       // Step: all inputs set
       auto all_inputs_set = signer->step_all_inputs_set();
       auto ack_all_inputs = this->client_exchange<messages::monero::MoneroTransactionAllInputsSetAck>(all_inputs_set);
       signer->step_all_inputs_set_ack(ack_all_inputs);
+      EVENT_PROGRESS(5, 1, 1);
 
       // Step: outputs
       for(size_t cur_dst = 0; cur_dst < num_outputs; ++cur_dst){
         auto src = signer->step_set_output(cur_dst);
         auto ack = this->client_exchange<messages::monero::MoneroTransactionSetOutputAck>(src);
         signer->step_set_output_ack(ack);
+
+        // If BP is offloaded to host, another step with computed BP may be needed.
+        auto offloaded_bp = signer->step_rsig(cur_dst);
+        if (offloaded_bp){
+          auto bp_ack = this->client_exchange<messages::monero::MoneroTransactionSetOutputAck>(offloaded_bp);
+          signer->step_set_rsig_ack(ack);
+        }
+
+        EVENT_PROGRESS(6, cur_dst, num_outputs);
       }
 
       // Step: all outs set
       auto all_out_set = signer->step_all_outs_set();
       auto ack_all_out_set = this->client_exchange<messages::monero::MoneroTransactionAllOutSetAck>(all_out_set);
       signer->step_all_outs_set_ack(ack_all_out_set, *this);
+      EVENT_PROGRESS(7, 1, 1);
 
       // Step: sign each input
       for(size_t cur_src = 0; cur_src < num_sources; ++cur_src){
         auto src = signer->step_sign_input(cur_src);
         auto ack_sign = this->client_exchange<messages::monero::MoneroTransactionSignInputAck>(src);
         signer->step_sign_input_ack(ack_sign);
+        EVENT_PROGRESS(8, cur_src, num_sources);
       }
 
       // Step: final
       auto final_msg = signer->step_final();
       auto ack_final = this->client_exchange<messages::monero::MoneroTransactionFinalAck>(final_msg);
       signer->step_final_ack(ack_final);
+      EVENT_PROGRESS(9, 1, 1);
+#undef EVENT_PROGRESS
+    }
+
+    void device_trezor::transaction_versions_check(const ::tools::wallet2::unsigned_tx_set & unsigned_tx, hw::tx_aux_data & aux_data)
+    {
+      auto trezor_version = get_version();
+      unsigned client_version = 1;  // default client version for tx
+
+      if (trezor_version <= pack_version(2, 0, 10)){
+        client_version = 0;
+      }
+
+      if (aux_data.client_version){
+        auto wanted_client_version = aux_data.client_version.get();
+        if (wanted_client_version > client_version){
+          throw exc::TrezorException("Trezor firmware 2.0.10 and lower does not support current transaction sign protocol. Please update.");
+        } else {
+          client_version = wanted_client_version;
+        }
+      }
+      aux_data.client_version = client_version;
+
+      if (client_version == 0 && aux_data.bp_version && aux_data.bp_version.get() != 1){
+        throw exc::TrezorException("Trezor firmware 2.0.10 and lower does not support current transaction sign protocol (BPv2+). Please update.");
+      }
     }
 
     void device_trezor::transaction_pre_check(std::shared_ptr<messages::monero::MoneroTransactionInitRequest> init_msg)
@@ -396,7 +712,7 @@ namespace trezor {
 
       const bool nonce_required = tdata.tsx_data.has_payment_id() && tdata.tsx_data.payment_id().size() > 0;
       const bool has_nonce = cryptonote::find_tx_extra_field_by_type(tx_extra_fields, nonce);
-      CHECK_AND_ASSERT_THROW_MES(has_nonce == nonce_required, "Transaction nonce presence inconsistent");
+      CHECK_AND_ASSERT_THROW_MES(has_nonce || !nonce_required, "Transaction nonce not present");
 
       if (nonce_required){
         const std::string & payment_id = tdata.tsx_data.payment_id();

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2049,7 +2049,7 @@ bool simple_wallet::cold_sign_tx(const std::vector<tools::wallet2::pending_tx>& 
   m_wallet->cold_tx_aux_import(exported_txs.ptx, tx_aux);
 
   // import key images
-  return m_wallet->import_key_images(exported_txs.key_images);
+  return m_wallet->import_key_images(exported_txs, 0, true);
 }
 
 bool simple_wallet::set_always_confirm_transfers(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
@@ -4686,12 +4686,12 @@ boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char
   return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_button_request()
+void simple_wallet::on_device_button_request(uint64_t code)
 {
   message_writer(console_color_white, false) << tr("Device requires attention");
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_pin_request(epee::wipeable_string & pin)
+boost::optional<epee::wipeable_string> simple_wallet::on_device_pin_request()
 {
 #ifdef HAVE_READLINE
   rdln::suspend_readline pause_readline;
@@ -4699,14 +4699,14 @@ void simple_wallet::on_pin_request(epee::wipeable_string & pin)
   std::string msg = tr("Enter device PIN");
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device PIN"));
-  pin = pwd_container->password();
+  return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_passphrase_request(bool on_device, epee::wipeable_string & passphrase)
+boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_request(bool on_device)
 {
   if (on_device){
     message_writer(console_color_white, true) << tr("Please enter the device passphrase on the device");
-    return;
+    return boost::none;
   }
 
 #ifdef HAVE_READLINE
@@ -4715,13 +4715,13 @@ void simple_wallet::on_passphrase_request(bool on_device, epee::wipeable_string 
   std::string msg = tr("Enter device passphrase");
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device passphrase"));
-  passphrase = pwd_container->password();
+  return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::on_refresh_finished(uint64_t start_height, uint64_t fetched_blocks, bool is_init, bool received_money)
 {
   // Key image sync after the first refresh
-  if (!m_wallet->get_account().get_device().has_tx_cold_sign()) {
+  if (!m_wallet->get_account().get_device().has_tx_cold_sign() || m_wallet->get_account().get_device().has_ki_live_refresh()) {
     return;
   }
 
@@ -6752,7 +6752,7 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
 {
   std::vector<std::string> local_args = args_;
 
-  if (m_wallet->key_on_device())
+  if (m_wallet->key_on_device() && m_wallet->get_account().get_device().get_type() != hw::device::TREZOR)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -6773,7 +6773,9 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
 
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_keys;
-  if (m_wallet->get_tx_key(txid, tx_key, additional_tx_keys))
+
+  bool found_tx_key = m_wallet->get_tx_key(txid, tx_key, additional_tx_keys);
+  if (found_tx_key)
   {
     ostringstream oss;
     oss << epee::string_tools::pod_to_hex(tx_key);
@@ -6849,7 +6851,7 @@ bool simple_wallet::set_tx_key(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet->key_on_device() && m_wallet->get_account().get_device().get_type() != hw::device::TREZOR)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -300,9 +300,9 @@ namespace cryptonote
     virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index);
     virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx);
     virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason);
-    virtual void on_button_request();
-    virtual void on_pin_request(epee::wipeable_string & pin);
-    virtual void on_passphrase_request(bool on_device, epee::wipeable_string & passphrase);
+    virtual void on_device_button_request(uint64_t code);
+    virtual boost::optional<epee::wipeable_string> on_device_pin_request();
+    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device);
     //----------------------------------------------------------
 
     friend class refresh_progress_reporter_t;

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -109,6 +109,23 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
         }
 
         m_wallet.pauseRefresh();
+
+        const bool tx_cold_signed = m_wallet.m_wallet->get_account().get_device().has_tx_cold_sign();
+        if (tx_cold_signed){
+          std::unordered_set<size_t> selected_transfers;
+          for(const tools::wallet2::pending_tx & ptx : m_pending_tx){
+            for(size_t s : ptx.selected_transfers){
+              selected_transfers.insert(s);
+            }
+          }
+
+          m_wallet.m_wallet->cold_tx_aux_import(m_pending_tx, m_tx_device_aux);
+          bool r = m_wallet.m_wallet->import_key_images(m_key_images, 0, selected_transfers);
+          if (!r){
+            throw runtime_error("Cold sign transaction submit failed - key image sync fail");
+          }
+        }
+
         while (!m_pending_tx.empty()) {
             auto & ptx = m_pending_tx.back();
             m_wallet.m_wallet->commit_tx(ptx);

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -67,6 +67,8 @@ private:
     std::string m_errorString;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;
     std::unordered_set<crypto::public_key> m_signers;
+    std::vector<std::string> m_tx_device_aux;
+    std::vector<crypto::key_image> m_key_images;
 };
 
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -89,6 +89,8 @@ public:
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString) const override;
     bool setPassword(const std::string &password) override;
+    bool setDevicePin(const std::string &password) override;
+    bool setDevicePassphrase(const std::string &password) override;
     std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const override;
     std::string integratedAddress(const std::string &payment_id) const override;
     std::string secretViewKey() const override;
@@ -198,6 +200,7 @@ public:
     virtual bool lockKeysFile() override;
     virtual bool unlockKeysFile() override;
     virtual bool isKeysFileLocked() override;
+    virtual uint64_t coldKeyImageSync(uint64_t &spent, uint64_t &unspent) override;
 
 private:
     void clearStatus() const;
@@ -209,6 +212,7 @@ private:
     bool daemonSynced() const;
     void stopRefresh();
     bool isNewWallet() const;
+    void pendingTxPostProcess(PendingTransactionImpl * pending);
     bool doInit(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
 
 private:

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -103,9 +103,10 @@ namespace tools
     virtual void on_lw_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) {}
     virtual void on_lw_money_spent(uint64_t height, const crypto::hash &txid, uint64_t amount) {}
     // Device callbacks
-    virtual void on_button_request() {}
-    virtual void on_pin_request(epee::wipeable_string & pin) {}
-    virtual void on_passphrase_request(bool on_device, epee::wipeable_string & passphrase) {}
+    virtual void on_device_button_request(uint64_t code) {}
+    virtual boost::optional<epee::wipeable_string> on_device_pin_request() { return boost::none; }
+    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device) { return boost::none; }
+    virtual void on_device_progress(const hw::device_progress& event) {};
     // Common callbacks
     virtual void on_pool_tx_removed(const crypto::hash &txid) {}
     virtual ~i_wallet2_callback() {}
@@ -115,9 +116,10 @@ namespace tools
   {
   public:
     wallet_device_callback(wallet2 * wallet): wallet(wallet) {};
-    void on_button_request() override;
-    void on_pin_request(epee::wipeable_string & pin) override;
-    void on_passphrase_request(bool on_device, epee::wipeable_string & passphrase) override;
+    void on_button_request(uint64_t code=0) override;
+    boost::optional<epee::wipeable_string> on_pin_request() override;
+    boost::optional<epee::wipeable_string> on_passphrase_request(bool on_device) override;
+    void on_progress(const hw::device_progress& event) override;
   private:
     wallet2 * wallet;
   };
@@ -1004,8 +1006,9 @@ namespace tools
     const std::string & device_derivation_path() const { return m_device_derivation_path; }
     void device_derivation_path(const std::string &device_derivation_path) { m_device_derivation_path = device_derivation_path; }
 
-    bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const;
+    bool get_tx_key_cached(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const;
     void set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys);
+    bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys);
     void check_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     void check_tx_key_helper(const crypto::hash &txid, const crypto::key_derivation &derivation, const std::vector<crypto::key_derivation> &additional_derivations, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     std::string get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message);
@@ -1127,7 +1130,8 @@ namespace tools
     std::pair<size_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> export_key_images(bool all = false) const;
     uint64_t import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, size_t offset, uint64_t &spent, uint64_t &unspent, bool check_spent = true);
     uint64_t import_key_images(const std::string &filename, uint64_t &spent, uint64_t &unspent);
-    bool import_key_images(std::vector<crypto::key_image> key_images);
+    bool import_key_images(std::vector<crypto::key_image> key_images, size_t offset=0, boost::optional<std::unordered_set<size_t>> selected_transfers=boost::none);
+    bool import_key_images(signed_tx_set & signed_tx, size_t offset=0, bool only_selected_transfers=false);
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
 
     void update_pool_state(bool refreshed = false);
@@ -1333,9 +1337,10 @@ namespace tools
     void create_keys_file(const std::string &wallet_, bool watch_only, const epee::wipeable_string &password, bool create_address_file);
 
     wallet_device_callback * get_device_callback();
-    void on_button_request();
-    void on_pin_request(epee::wipeable_string & pin);
-    void on_passphrase_request(bool on_device, epee::wipeable_string & passphrase);
+    void on_device_button_request(uint64_t code);
+    boost::optional<epee::wipeable_string> on_device_pin_request();
+    boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device);
+    void on_device_progress(const hw::device_progress& event);
 
     std::string get_rpc_status(const std::string &s) const;
     void throw_on_rpc_response_error(const boost::optional<std::string> &status, const char *method) const;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -754,7 +754,7 @@ struct get_test_options {
 };
 //--------------------------------------------------------------------------
 template<class t_test_class>
-inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cryptonote::core **core)
+inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cryptonote::core *core)
 {
   boost::program_options::options_description desc("Allowed options");
   cryptonote::core::init_options(desc);
@@ -768,8 +768,7 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
   if (!r)
     return false;
 
-  *core = new cryptonote::core(nullptr);
-  auto & c = **core;
+  auto & c = *core;
 
   // FIXME: make sure that vm has arg_testnet_on set to true or false if
   // this test needs for it to be so.
@@ -825,9 +824,9 @@ inline bool replay_events_through_core_validate(std::vector<test_event_entry>& e
 template<class t_test_class>
 inline bool do_replay_events(std::vector<test_event_entry>& events)
 {
-  cryptonote::core * core;
+  cryptonote::core core(nullptr);
   bool ret = do_replay_events_get_core<t_test_class>(events, &core);
-  core->deinit();
+  core.deinit();
   return ret;
 }
 //--------------------------------------------------------------------------

--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -17,7 +17,6 @@ void wallet_accessor_test::set_account(tools::wallet2 * wallet, cryptonote::acco
 {
   wallet->clear();
   wallet->m_account = account;
-  wallet->m_nettype = MAINNET;
 
   wallet->m_key_device_type = account.get_device().get_type();
   wallet->m_account_public_address = account.get_keys().m_account_address;

--- a/tests/trezor/CMakeLists.txt
+++ b/tests/trezor/CMakeLists.txt
@@ -27,11 +27,15 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(trezor_tests_sources
+        tools.cpp
+        daemon.cpp
         trezor_tests.cpp
         ../core_tests/chaingen.cpp
         ../core_tests/wallet_tools.cpp)
 
 set(trezor_tests_headers
+        tools.h
+        daemon.h
         trezor_tests.h
         ../core_tests/chaingen.h
         ../core_tests/wallet_tools.h)
@@ -50,6 +54,15 @@ target_link_libraries(trezor_tests
     device
     device_trezor
     wallet
+    wallet_api
+    rpc
+    cryptonote_protocol
+    daemon_rpc_server
+    ${Boost_CHRONO_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${ZMQ_LIB}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -1,0 +1,368 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "daemon.h"
+#include <common/command_line.h>
+
+using namespace std;
+using namespace daemonize;
+namespace po = boost::program_options;
+
+bool mock_rpc_daemon::on_send_raw_tx_2(const cryptonote::COMMAND_RPC_SEND_RAW_TX::request& req, cryptonote::COMMAND_RPC_SEND_RAW_TX::response& res, const cryptonote::core_rpc_server::connection_context *ctx)
+{
+  cryptonote::COMMAND_RPC_SEND_RAW_TX::request req2(req);
+  req2.do_not_relay = true;  // Do not relay in test setup, only one daemon running.
+  return cryptonote::core_rpc_server::on_send_raw_tx(req2, res, ctx);
+}
+
+void mock_daemon::init_options(boost::program_options::options_description & option_spec)
+{
+  cryptonote::core::init_options(option_spec);
+  t_node_server::init_options(option_spec);
+  cryptonote::core_rpc_server::init_options(option_spec);
+
+  command_line::add_arg(option_spec, daemon_args::arg_zmq_rpc_bind_ip);
+  command_line::add_arg(option_spec, daemon_args::arg_zmq_rpc_bind_port);
+}
+
+void mock_daemon::default_options(boost::program_options::variables_map & vm)
+{
+  std::vector<std::string> exclusive_nodes{"127.0.0.1:65525"};
+  tools::options::set_option(vm, nodetool::arg_p2p_add_exclusive_node, po::variable_value(exclusive_nodes, false));
+
+  tools::options::set_option(vm, nodetool::arg_p2p_bind_ip, po::variable_value(std::string("127.0.0.1"), false));
+  tools::options::set_option(vm, nodetool::arg_no_igd, po::variable_value(true, false));
+  tools::options::set_option(vm, cryptonote::arg_offline, po::variable_value(true, false));
+  tools::options::set_option(vm, "disable-dns-checkpoints", po::variable_value(true, false));
+
+  const char *test_mainnet = getenv("TEST_MAINNET");
+  if (!test_mainnet || atoi(test_mainnet) == 0)
+  {
+    tools::options::set_option(vm, cryptonote::arg_testnet_on, po::variable_value(true, false));
+  }
+
+  // By default pick non-standard ports to avoid confusion with possibly locally running daemons (mainnet/testnet)
+  const char *test_p2p_port = getenv("TEST_P2P_PORT");
+  auto p2p_port = std::string(test_p2p_port && strlen(test_p2p_port) > 0 ? test_p2p_port : "61340");
+  tools::options::set_option(vm, nodetool::arg_p2p_bind_port, po::variable_value(p2p_port, false));
+
+  const char *test_rpc_port = getenv("TEST_RPC_PORT");
+  auto rpc_port = std::string(test_rpc_port && strlen(test_rpc_port) > 0 ? test_rpc_port : "61341");
+  tools::options::set_option(vm, cryptonote::core_rpc_server::arg_rpc_bind_port, po::variable_value(rpc_port, false));
+
+  const char *test_zmq_port = getenv("TEST_ZMQ_PORT");
+  auto zmq_port = std::string(test_zmq_port && strlen(test_zmq_port) > 0 ? test_zmq_port : "61342");
+  tools::options::set_option(vm, daemon_args::arg_zmq_rpc_bind_port, po::variable_value(zmq_port, false));
+
+  po::notify(vm);
+}
+
+void mock_daemon::set_ports(boost::program_options::variables_map & vm, unsigned initial_port)
+{
+  CHECK_AND_ASSERT_THROW_MES(initial_port < 65535-2, "Invalid port number");
+  tools::options::set_option(vm, nodetool::arg_p2p_bind_port, po::variable_value(std::to_string(initial_port), false));
+  tools::options::set_option(vm, cryptonote::core_rpc_server::arg_rpc_bind_port, po::variable_value(std::to_string(initial_port + 1), false));
+  tools::options::set_option(vm, daemon_args::arg_zmq_rpc_bind_port, po::variable_value(std::to_string(initial_port + 2), false));
+  po::notify(vm);
+}
+
+void mock_daemon::load_params(boost::program_options::variables_map const & vm)
+{
+  m_p2p_bind_port = command_line::get_arg(vm, nodetool::arg_p2p_bind_port);
+  m_rpc_bind_port = command_line::get_arg(vm, cryptonote::core_rpc_server::arg_rpc_bind_port);
+  m_zmq_bind_port = command_line::get_arg(vm, daemon_args::arg_zmq_rpc_bind_port);
+  m_network_type = command_line::get_arg(vm, cryptonote::arg_testnet_on) ? cryptonote::TESTNET : cryptonote::MAINNET;
+}
+
+mock_daemon::~mock_daemon()
+{
+  if (!m_terminated)
+  {
+    try
+    {
+      stop();
+    }
+    catch (...)
+    {
+      MERROR("Failed to stop");
+    }
+  }
+
+  if (!m_deinitalized)
+  {
+    deinit();
+  }
+}
+
+void mock_daemon::init()
+{
+  m_deinitalized = false;
+  const auto main_rpc_port = command_line::get_arg(m_vm, cryptonote::core_rpc_server::arg_rpc_bind_port);
+  m_rpc_server.nettype(m_network_type);
+
+  CHECK_AND_ASSERT_THROW_MES(m_protocol.init(m_vm), "Failed to initialize cryptonote protocol.");
+  CHECK_AND_ASSERT_THROW_MES(m_rpc_server.init(m_vm, false, main_rpc_port), "Failed to initialize RPC server.");
+
+  if (m_start_p2p)
+    CHECK_AND_ASSERT_THROW_MES(m_server.init(m_vm), "Failed to initialize p2p server.");
+
+  if(m_http_client.is_connected())
+    m_http_client.disconnect();
+
+  CHECK_AND_ASSERT_THROW_MES(m_http_client.set_server(rpc_addr(), boost::none), "RPC client init fail");
+}
+
+void mock_daemon::deinit()
+{
+  try
+  {
+    m_rpc_server.deinit();
+  }
+  catch (...)
+  {
+    MERROR("Failed to deinitialize RPC server...");
+  }
+
+  if (m_start_p2p)
+  {
+    try
+    {
+      m_server.deinit();
+    }
+    catch (...)
+    {
+      MERROR("Failed to deinitialize p2p...");
+    }
+  }
+
+  try
+  {
+    m_protocol.deinit();
+    m_protocol.set_p2p_endpoint(nullptr);
+  }
+  catch (...)
+  {
+    MERROR("Failed to stop cryptonote protocol!");
+  }
+
+  m_deinitalized = true;
+}
+
+void mock_daemon::init_and_run()
+{
+  init();
+  run();
+}
+
+void mock_daemon::stop_and_deinit()
+{
+  stop();
+  deinit();
+}
+
+void mock_daemon::try_init_and_run(boost::optional<unsigned> initial_port)
+{
+  const unsigned max_attempts = 3;
+  for(unsigned attempts=0; attempts < max_attempts; ++attempts)
+  {
+    if (initial_port)
+    {
+      set_ports(m_vm, initial_port.get());
+      load_params(m_vm);
+      MDEBUG("Ports changed, RPC: " << rpc_addr());
+    }
+
+    try
+    {
+      init_and_run();
+      return;
+    }
+    catch(const std::exception &e)
+    {
+      MWARNING("Could not init and start, attempt: " << attempts << ", reason: " << e.what());
+      if (attempts + 1 >= max_attempts)
+      {
+        throw;
+      }
+    }
+  }
+}
+
+void mock_daemon::run()
+{
+  m_run_thread = boost::thread(boost::bind(&mock_daemon::run_main, this));
+}
+
+bool mock_daemon::run_main()
+{
+  CHECK_AND_ASSERT_THROW_MES(!m_terminated, "Can't run stopped daemon");
+  CHECK_AND_ASSERT_THROW_MES(!m_start_zmq || m_start_p2p, "ZMQ requires P2P");
+  boost::thread stop_thread = boost::thread([this] {
+    while (!this->m_stopped)
+      epee::misc_utils::sleep_no_w(100);
+    this->stop_p2p();
+  });
+
+  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+    m_stopped = true;
+    stop_thread.join();
+  });
+
+  try
+  {
+    CHECK_AND_ASSERT_THROW_MES(m_rpc_server.run(2, false), "Failed to start RPC");
+    cryptonote::rpc::DaemonHandler rpc_daemon_handler(*m_core, m_server);
+    cryptonote::rpc::ZmqServer zmq_server(rpc_daemon_handler);
+
+    if (m_start_zmq)
+    {
+      if (!zmq_server.addTCPSocket("127.0.0.1", m_zmq_bind_port))
+      {
+        MERROR("Failed to add TCP Socket (127.0.0.1:" << m_zmq_bind_port << ") to ZMQ RPC Server");
+
+        stop_rpc();
+        return false;
+      }
+
+      MINFO("Starting ZMQ server...");
+      zmq_server.run();
+
+      MINFO("ZMQ server started at 127.0.0.1: " << m_zmq_bind_port);
+    }
+
+    if (m_start_p2p)
+    {
+      m_server.run();  // blocks until p2p goes down
+    }
+    else
+    {
+      while (!this->m_stopped)
+        epee::misc_utils::sleep_no_w(100);
+    }
+
+    if (m_start_zmq)
+      zmq_server.stop();
+
+    stop_rpc();
+    return true;
+  }
+  catch (std::exception const & ex)
+  {
+    MFATAL("Uncaught exception! " << ex.what());
+    return false;
+  }
+  catch (...)
+  {
+    MFATAL("Uncaught exception!");
+    return false;
+  }
+}
+
+void mock_daemon::stop()
+{
+  CHECK_AND_ASSERT_THROW_MES(!m_terminated, "Can't stop stopped daemon");
+  m_stopped = true;
+  m_terminated = true;
+  m_run_thread.join();
+}
+
+void mock_daemon::stop_rpc()
+{
+  m_rpc_server.send_stop_signal();
+  m_rpc_server.timed_wait_server_stop(5000);
+}
+
+void mock_daemon::stop_p2p()
+{
+  if (m_start_p2p)
+    m_server.send_stop_signal();
+}
+
+void mock_daemon::mine_blocks(size_t num_blocks, const std::string &miner_address)
+{
+  bool blocks_mined = false;
+  const uint64_t start_height = get_height();
+  const auto mining_timeout = std::chrono::seconds(30);
+  MDEBUG("Current height before mining: " << start_height);
+
+  start_mining(miner_address);
+  auto mining_started = std::chrono::system_clock::now();
+
+  while(true) {
+    epee::misc_utils::sleep_no_w(100);
+    const uint64_t cur_height = get_height();
+
+    if (cur_height - start_height >= num_blocks)
+    {
+      MDEBUG("Cur blocks: " << cur_height << " start: " << start_height);
+      blocks_mined = true;
+      break;
+    }
+
+    auto current_time = std::chrono::system_clock::now();
+    if (mining_timeout < current_time - mining_started)
+    {
+      break;
+    }
+  }
+
+  stop_mining();
+  CHECK_AND_ASSERT_THROW_MES(blocks_mined, "Mining failed in the time limit");
+}
+
+constexpr const std::chrono::seconds mock_daemon::rpc_timeout;
+
+void mock_daemon::start_mining(const std::string &miner_address, uint64_t threads_count, bool do_background_mining, bool ignore_battery)
+{
+  cryptonote::COMMAND_RPC_START_MINING::request req;
+  req.miner_address = miner_address;
+  req.threads_count = threads_count;
+  req.do_background_mining = do_background_mining;
+  req.ignore_battery = ignore_battery;
+
+  cryptonote::COMMAND_RPC_START_MINING::response resp;
+  bool r = epee::net_utils::invoke_http_json("/start_mining", req, resp, m_http_client, rpc_timeout);
+  CHECK_AND_ASSERT_THROW_MES(r, "RPC error - start mining");
+  CHECK_AND_ASSERT_THROW_MES(resp.status != CORE_RPC_STATUS_BUSY, "Daemon busy");
+  CHECK_AND_ASSERT_THROW_MES(resp.status == CORE_RPC_STATUS_OK, "Daemon response invalid: " << resp.status);
+}
+
+void mock_daemon::stop_mining()
+{
+  cryptonote::COMMAND_RPC_STOP_MINING::request req;
+  cryptonote::COMMAND_RPC_STOP_MINING::response resp;
+  bool r = epee::net_utils::invoke_http_json("/stop_mining", req, resp, m_http_client, rpc_timeout);
+  CHECK_AND_ASSERT_THROW_MES(r, "RPC error - stop mining");
+  CHECK_AND_ASSERT_THROW_MES(resp.status != CORE_RPC_STATUS_BUSY, "Daemon busy");
+  CHECK_AND_ASSERT_THROW_MES(resp.status == CORE_RPC_STATUS_OK, "Daemon response invalid: " << resp.status);
+}
+
+uint64_t mock_daemon::get_height()
+{
+  return m_core->get_blockchain_storage().get_current_blockchain_height();
+}

--- a/tests/trezor/daemon.h
+++ b/tests/trezor/daemon.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "misc_log_ex.h"
+#include "daemon/daemon.h"
+#include "rpc/daemon_handler.h"
+#include "rpc/zmq_server.h"
+#include "common/password.h"
+#include "common/util.h"
+#include "daemon/core.h"
+#include "daemon/p2p.h"
+#include "daemon/protocol.h"
+#include "daemon/rpc.h"
+#include "daemon/command_server.h"
+#include "daemon/command_server.h"
+#include "daemon/command_line_args.h"
+#include "version.h"
+#include "tools.h"
+
+
+class mock_rpc_daemon : public cryptonote::core_rpc_server {
+public:
+  mock_rpc_daemon(
+    cryptonote::core& cr
+  , nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& p2p
+  ): cryptonote::core_rpc_server(cr, p2p) {}
+
+  static void init_options(boost::program_options::options_description& desc){ cryptonote::core_rpc_server::init_options(desc); }
+  cryptonote::network_type nettype() const { return m_network_type; }
+  void nettype(cryptonote::network_type nettype) { m_network_type = nettype; }
+
+  CHAIN_HTTP_TO_MAP2(cryptonote::core_rpc_server::connection_context); //forward http requests to uri map
+  BEGIN_URI_MAP2()
+    MAP_URI_AUTO_JON2("/send_raw_transaction", on_send_raw_tx_2, cryptonote::COMMAND_RPC_SEND_RAW_TX)
+    MAP_URI_AUTO_JON2("/sendrawtransaction", on_send_raw_tx_2, cryptonote::COMMAND_RPC_SEND_RAW_TX)
+    else {  // Default to parent for non-overriden callbacks
+      return cryptonote::core_rpc_server::handle_http_request_map(query_info, response_info, m_conn_context);
+    }
+  END_URI_MAP2()
+
+  bool on_send_raw_tx_2(const cryptonote::COMMAND_RPC_SEND_RAW_TX::request& req, cryptonote::COMMAND_RPC_SEND_RAW_TX::response& res, const cryptonote::core_rpc_server::connection_context *ctx);
+
+protected:
+  cryptonote::network_type m_network_type;
+};
+
+class mock_daemon {
+public:
+  typedef cryptonote::t_cryptonote_protocol_handler<cryptonote::core> t_protocol_raw;
+  typedef nodetool::node_server<t_protocol_raw> t_node_server;
+
+  static constexpr const std::chrono::seconds rpc_timeout = std::chrono::seconds(60);
+
+  cryptonote::core * m_core;
+  t_protocol_raw m_protocol;
+  mock_rpc_daemon m_rpc_server;
+  t_node_server m_server;
+  cryptonote::network_type m_network_type;
+  epee::net_utils::http::http_simple_client m_http_client;
+
+  bool m_start_p2p;
+  bool m_start_zmq;
+  boost::program_options::variables_map m_vm;
+
+  std::string m_p2p_bind_port;
+  std::string m_rpc_bind_port;
+  std::string m_zmq_bind_port;
+
+  std::atomic<bool> m_stopped;
+  std::atomic<bool> m_terminated;
+  std::atomic<bool> m_deinitalized;
+  boost::thread m_run_thread;
+
+  mock_daemon(
+      cryptonote::core * core,
+      boost::program_options::variables_map const & vm
+  )
+      : m_core(core)
+      , m_vm(vm)
+      , m_start_p2p(false)
+      , m_start_zmq(false)
+      , m_terminated(false)
+      , m_deinitalized(false)
+      , m_stopped(false)
+      , m_protocol{*core, nullptr, command_line::get_arg(vm, cryptonote::arg_offline)}
+      , m_server{m_protocol}
+      , m_rpc_server{*core, m_server}
+  {
+    // Handle circular dependencies
+    m_protocol.set_p2p_endpoint(&m_server);
+    m_core->set_cryptonote_protocol(&m_protocol);
+    load_params(vm);
+  }
+
+  virtual ~mock_daemon();
+
+  static void init_options(boost::program_options::options_description & option_spec);
+  static void default_options(boost::program_options::variables_map & vm);
+  static void set_ports(boost::program_options::variables_map & vm, unsigned initial_port);
+
+  mock_daemon * set_start_p2p(bool fl) { m_start_p2p = fl; return this; }
+  mock_daemon * set_start_zmq(bool fl) { m_start_zmq = fl; return this; }
+
+  void init();
+  void deinit();
+  void run();
+  bool run_main();
+  void stop();
+  void stop_p2p();
+  void stop_rpc();
+  void init_and_run();
+  void stop_and_deinit();
+  void try_init_and_run(boost::optional<unsigned> initial_port=boost::none);
+
+  void mine_blocks(size_t num_blocks, const std::string &miner_address);
+  void start_mining(const std::string &miner_address, uint64_t threads_count=1, bool do_background_mining=false, bool ignore_battery=true);
+  void stop_mining();
+  uint64_t get_height();
+
+  void load_params(boost::program_options::variables_map const & vm);
+
+  std::string zmq_addr() const { return std::string("127.0.0.1:") + m_zmq_bind_port; }
+  std::string rpc_addr() const { return std::string("127.0.0.1:") + m_rpc_bind_port; }
+  std::string p2p_addr() const { return std::string("127.0.0.1:") + m_p2p_bind_port; }
+  cryptonote::network_type nettype() const { return m_network_type; }
+  cryptonote::core * core() const { return m_core; }
+};

--- a/tests/trezor/tools.cpp
+++ b/tests/trezor/tools.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "tools.h"
+
+namespace tools {
+
+namespace po = boost::program_options;
+
+void options::set_option(boost::program_options::variables_map &vm, const std::string & key, const po::variable_value &pv)
+{
+  auto it = vm.find(key);
+  if (it == vm.end())
+  {
+    vm.insert(std::make_pair(key, pv));
+  }
+  else
+    {
+    it->second = pv;
+  }
+}
+
+void options::build_options(boost::program_options::variables_map & vm, const po::options_description & desc_params)
+{
+  const char *argv[2] = {nullptr};
+  po::store(po::parse_command_line(1, argv, desc_params), vm);
+  po::notify(vm);
+}
+
+}
+

--- a/tests/trezor/tools.h
+++ b/tests/trezor/tools.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2014-2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "misc_log_ex.h"
+#include "daemon/daemon.h"
+#include "rpc/daemon_handler.h"
+#include "rpc/zmq_server.h"
+#include "common/password.h"
+#include "common/util.h"
+#include "daemon/core.h"
+#include "daemon/p2p.h"
+#include "daemon/protocol.h"
+#include "daemon/rpc.h"
+#include "daemon/command_server.h"
+#include "daemon/command_server.h"
+#include "daemon/command_line_args.h"
+#include "version.h"
+
+namespace tools {
+
+class options {
+public:
+  static void set_option(boost::program_options::variables_map &vm, const std::string &key, const boost::program_options::variable_value &pv);
+  static void build_options(boost::program_options::variables_map & vm, const boost::program_options::options_description & desc_params);
+
+  template<typename T, bool required, bool dependent, int NUM_DEPS>
+  static void set_option(boost::program_options::variables_map &vm, const command_line::arg_descriptor<T, required, dependent, NUM_DEPS> &arg, const boost::program_options::variable_value &pv)
+  {
+    set_option(vm, arg.name, pv);
+  }
+};
+
+};
+

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(unit_tests_sources
   json_serialization.cpp
   get_xtype_from_string.cpp
   hashchain.cpp
+  hmac_keccak.cpp
   http.cpp
   keccak.cpp
   logging.cpp

--- a/tests/unit_tests/hmac_keccak.cpp
+++ b/tests/unit_tests/hmac_keccak.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "../io.h"
+
+extern "C" {
+#include "crypto/hmac-keccak.h"
+}
+
+#define KECCAK_BLOCKLEN 136
+
+static const struct {
+  const char *key;
+  const char *inp;
+  const char *res;
+} keccak_hmac_vectors[] = {
+    {"",
+     "",
+     "042186ec4e98680a0866091d6fb89b60871134b44327f8f467c14e9841d3e97b",
+    },
+    {"00",
+     "",
+     "042186ec4e98680a0866091d6fb89b60871134b44327f8f467c14e9841d3e97b",
+    },
+    {"00000000000000000000000000000000",
+     "",
+     "042186ec4e98680a0866091d6fb89b60871134b44327f8f467c14e9841d3e97b",
+    },
+    {"",
+     "00",
+     "402541d5d678ad30217023a12efbd2f367388dc0253ccddb8f915d187e03d414",
+    },
+    {"0000000000000000000000000000000000000000000000000000000000000000",
+     "0000000000000000000000000000000000000000000000000000000000000000",
+     "d164c38ca454176281b3c09dc83cf70bd00290835ff5490356993d368cde0577",
+    },
+    {"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+     "0000000000000000000000000000000000000000000000000000000000000000",
+     "d52c9100301a9546d8c97d7f32e8178fd5f4b0a7646ab761db9e0f503f8b0542",
+    },
+    {"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+     "d52c9100301a9546d8c97d7f32e8178fd5f4b0a7646ab761db9e0f503f8b0542",
+     "5b9d98c5d3249176230d70fdb215ee2f93e4783064c9564384ddc396e63c18cb",
+    },
+    {"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+     "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+     "98d033ba0c95bb3aaf5709733443cbedba20f6451b710ccba4118fc5523013c8",
+    },
+    {"65768798a9bacbdcedfe0f2031425364758697a8b9cadbecfd0e1f30415263748596a7b8c9daebfc0d1e2f405162738495a6b7c8d9eafb0c1d2e3f5061728394a5b6c7d8e9fa0b1c2d3e4f60718293a4b5c6d7e8f90a1b2c3d4e5f708192a3b4c5d6e7f8091a2b3c4d5e6f8091a2b3c4d5e6f708192a3b4c5d6e7f90a1b2c3d4e5f60718293a4b5c6d7e8fa0b1c2d3e4f5061728394a5b6c7d8e9fb0c1d2e3f405162738495a6b7c8d9eafc0d1e2f30415263748596a7b8c9daebfd0e1f2031425364758697a8b9cadbecfe0f102132435465768798a9bacbdcedff00112233445566778899aabbccddeef00112233445566778899aabbccddeeff102132435465768798a9bacbdcedfe0f2031425364758697a8b9cadbecfd0e1f30415263748596a7b8c9daebfc0d1e2f405162738495a6b7c8d9eafb0c1d2e3f5061728394",
+     "7b8895a2afbcc9d6e3f0fd0a1724313e4b5865727f8c99a6b3c0cddae7f4010e1b2835424f5c697683909daab7c4d1deebf805121f2c394653606d7a8794a1aebbc8d5e2effc091623303d4a5764717e8b98a5b2bfccd9e6f3000d1a2734414e5b6875828f9ca9b6c3d0ddeaf704111e2b3845525f6c798693a0adbac7d4e1eefb0815222f3c495663707d8a97a4b1becbd8e5f2ff0c192633404d5a6774818e9ba8b5c2cfdce9f603101d2a3744515e6b7885929facb9c6d3e0edfa0714212e3b4855626f7c8996a3b0bdcad7e4f1fe0b1825323f4c596673808d9aa7b4c1cedbe8f5020f1c293643505d6a7784919eabb8c5d2dfecf90613202d3a4754616e7b8895a2afbcc9d6e3f0fd0a1724313e4b5865727f8c99a6b3c0cddae7f4010e1b2835424f5c697683909daab7c4d1deebf805121f2c394653606d7a8794a1ae",
+     "117b60a7f474fd2245adff82a69429367de8f5263fa96c411986009a743b0e70",
+    },
+    {"00112233445566778899aabbccddeeff102132435465768798a9bacbdcedfe0f",
+     "000d1a2734414e5b6875828f9ca9b6c3d0ddeaf704111e2b3845525f6c798693a0adbac7d4e1eefb0815222f3c495663707d8a97a4b1becbd8e5f2ff0c192633404d5a6774818e9ba8b5c2cfdce9f603101d2a3744515e6b7885929facb9c6d3e0edfa0714212e3b4855626f7c8996a3b0bdcad7e4f1fe0b1825323f4c596673808d9aa7b4c1cedbe8f5020f1c293643505d6a7784919eabb8c5d2dfecf90613202d3a4754616e7b8895a2afbcc9d6e3f0fd0a1724313e4b5865727f8c99a6b3c0cddae7f4010e1b",
+     "cbe3ca627c6432c9a66f07c6411fccca894c9b083b55d0773152460142a676ed",
+    },
+};
+
+static void test_keccak_hmac(const size_t * chunks)
+{
+  uint8_t inp_buff[1024];
+  uint8_t key_buff[1024];
+  uint8_t res_exp[32];
+  uint8_t res_comp[32];
+  const size_t len_chunks = chunks ? sizeof(chunks) / sizeof(*chunks) : 0;
+
+  for (size_t i = 0; i < (sizeof(keccak_hmac_vectors) / sizeof(*keccak_hmac_vectors)); i++)
+  {
+    const size_t inp_len = strlen(keccak_hmac_vectors[i].inp)/2;
+    const size_t key_len = strlen(keccak_hmac_vectors[i].key)/2;
+    ASSERT_TRUE(hexdecode(keccak_hmac_vectors[i].inp, inp_len, inp_buff));
+    ASSERT_TRUE(hexdecode(keccak_hmac_vectors[i].key, key_len, key_buff));
+    ASSERT_TRUE(hexdecode(keccak_hmac_vectors[i].res, 32, res_exp));
+    if (len_chunks == 0)
+    {
+      hmac_keccak_hash(res_comp, key_buff, key_len, inp_buff, inp_len);
+    }
+    else
+    {
+      hmac_keccak_state S;
+      hmac_keccak_init(&S, key_buff, key_len);
+      size_t inp_passed = 0;
+      size_t chunk_size = 0;
+      while(inp_passed < inp_len){
+        const size_t to_pass = std::min(inp_len - inp_passed, chunks[chunk_size]);
+        hmac_keccak_update(&S, inp_buff + inp_passed, to_pass);
+
+        inp_passed += to_pass;
+        chunk_size = (chunk_size + 1) % len_chunks;
+      }
+
+      hmac_keccak_finish(&S, res_comp);
+    }
+    ASSERT_EQ(memcmp(res_exp, res_comp, 32), 0);
+  }
+}
+
+
+TEST(keccak_hmac, )
+{
+  test_keccak_hmac({});
+}
+
+TEST(keccak_hmac, 1)
+{
+  static const size_t chunks[] = {1};
+  test_keccak_hmac(chunks);
+}
+
+TEST(keccak_hmac, 1_20)
+{
+  static const size_t chunks[] = {1, 20};
+  test_keccak_hmac(chunks);
+}
+
+TEST(keccak_hmac, 136_1)
+{
+  static const size_t chunks[] = {136, 1};
+  test_keccak_hmac(chunks);
+}
+
+TEST(keccak_hmac, 137_1)
+{
+  static const size_t chunks[] = {137, 1};
+  test_keccak_hmac(chunks);
+}


### PR DESCRIPTION
HF10 protocol upgrade for Trezor.
Related to https://github.com/trezor/trezor-core/pull/478

I am sorry for a larger PR, I thought it is easier for you to review all at once as it is easier to see dependencies and why particular choices have been made.

## HF 10
- Most of the changes relate to the deterministic output masks in HF10. Masks are generated when a destination is sent to the Trezor, this affects how BP offloading is done. 
- Transaction Inputs Commitments and outputs commitments balancing is now performed in the signing step of the protocol, thus `pseudo_out`s are updated in the sign step as Trezor adjusts masks so their sums equal. 
- We discontinued support for Borromean range signatures so I removed the related logic from the client protocol code (offloading, verification, serialization).
- `in_memory` variant of the protocol which enabled to do signature a bit faster for standard transactions was removed. Trezor and Monero client code is now cleaner, safer (fewer branches). Speedup was not significant. 
- When all users upgrade to new Monero and Trezor firmwares, support for old protocol (`client_version=0`) can be dropped.
- Key image import after the cold signing imports only key images computed by the Trezor, i.e., key images of spent inputs.
- Minor refactoring of the Trezor client code (consts), passphrase entry refactored.
- key image import only for device-computed inputs

## Get TX key
- Trezor supports `get_tx_key` for decrypting stored tx private keys.
- `wallet2::get_tx_key_device()` calls `get_tx_key` on the Trezor if applicable
- Simplewallet supports `get_tx_key` and `get_tx_proof` on hw device using the `get_tx_key` feature

## Live refresh
- Live refresh feature enables to do the `refresh` with Trezor, i.e., computing key images on the fly. More convenient and efficient for users (`hw_key_image_sync` was required before).
- The first live refresh requires user confirmation on the device.  
- A thread is watching whether live refresh is being computed. If it is not for 30 seconds, it terminates the live refresh process - switches the Trezor state (display changes).

## Wallet API
- Initial Trezor support added so Monero GUI supports Trezor. 
- Wallet API Works with Monero-GUI (https://github.com/monero-project/monero-gui/pull/2019)
- Functional tests of the Wallet::API cold signing and refresh via mocked core RPC daemon (could be also used in different tests later). Mocker RPC daemon is created with the test `cryptonote::core` and runs on a local port. Wallet::API uses RPC daemon.
