### PR TITLE
readme: fork table, copy lines from release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Dates are provided in the format YYYY-MM-DD.
 | 1546000                        | 2018-04-06 | v7                | v0.12.0.0              | v0.12.3.0                  | Cryptonight variant 1, ringsize >= 7, sorted inputs
 | 1685555                        | 2018-10-18 | v8                | v0.13.0.0              | v0.13.0.4                  | max transaction size at half the penalty free block size, bulletproofs enabled, cryptonight variant 2, fixed ringsize [11](https://youtu.be/KOO5S4vxi0o)
 | 1686275                        | 2018-10-19 | v9                | v0.13.0.0              | v0.13.0.4                  | bulletproofs required
-| XXXXXXX                        | 2019-04-XX | XX                | XXXXXXXXX              | XXXXXXXXX                  | X
+| 1788000                        | 2019-03-09 | v10               | v0.14.0.0              | v0.14.0.1                  | New PoW based on Cryptonight-R, new block weight algorithm, slightly more efficient RingCT format
+| 1788720                        | 2019-03-10 | v11               | v0.14.0.0              | v0.14.0.1                  | forbid old RingCT transaction format
+| XXXXXXX                        | 2019-10-XX | XX                | XXXXXXXXX              | XXXXXXXXX                  | X
 
 X's indicate that these details have not been determined as of commit date.
 


### PR DESCRIPTION
copied lines from release-v013.0.0, tag v0.14.0.1 table, indicate recommending 0.14.0.1 (min at 0.14.0.0), include expected october fork.