### PR TITLE
fix race condition when block is added at same time block template cache is created

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1305,7 +1305,7 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
     // just as we compare it, we'll just use a slightly old template, but
     // this would be the case anyway if we'd lock, and the change happened
     // just after the block template was created
-    if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce && m_btc_pool_cookie == m_tx_pool.cookie()) {
+    if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce && m_btc_pool_cookie == m_tx_pool.cookie() && m_btc.prev_id == get_tail_id()) {
       MDEBUG("Using cached template");
       m_btc.timestamp = time(NULL); // update timestamp unconditionally
       b = m_btc;


### PR DESCRIPTION
The problem i found was the daemon created a Block Template Cache at same time when a block is added (handle_block_to_main_chain)

When this race condition occurs the Block Template Cache remains using the old block.prev_id. so a new proposed block by a miner is rejected until it receives a block from another pool/node.
With lots of mining pools this problem is not visible for the normal user. But when the chain have less pools (like Sevabit coin) , the chain gets stuck until a restart of the daemon.

The proposed fix checks if the latest block in the database is different from cache and updates the cache if so.

Thanks for all your efforts 👍


[dev-chat.txt](https://github.com/monero-project/monero/files/2926826/dev-chat.txt)
