### PR TITLE
wallet2: key image import fixes

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8597,13 +8597,8 @@ bool simple_wallet::import_key_images(const std::vector<std::string> &args)
   {
     uint64_t spent = 0, unspent = 0;
     uint64_t height = m_wallet->import_key_images(filename, spent, unspent);
-    if (height > 0)
-    {
-      success_msg_writer() << "Signed key images imported to height " << height << ", "
-          << print_money(spent) << " spent, " << print_money(unspent) << " unspent"; 
-    } else {
-      fail_msg_writer() << "Failed to import key images";
-    }
+    success_msg_writer() << "Signed key images imported to height " << height << ", "
+        << print_money(spent) << " spent, " << print_money(unspent) << " unspent"; 
   }
   catch (const std::exception &e)
   {


### PR DESCRIPTION
- return the right output data when offset is not zero
- do not consider import failed if result height is zero
  (it can be 0 if unknown)
- select the right tx pubkey when using subaddresses (it's faster,
  and we might select the wrong one if we got an output using one
  of the additional tx keys)
- account for skipped outputs for spent/unspent balance info

"spent" is arguably wrong, since it will count spent change
multiple times as it goes through receive/spend cycles.