### PR TITLE
Fix computation of change address + Fix v11 fork

### DIFF
--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -79,5 +79,6 @@ target_link_libraries(device
     ringct_basic
     ${OPENSSL_CRYPTO_LIBRARIES}
   PRIVATE
+    version
     ${Blocks}
     ${EXTRA_LIBRARIES})

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -189,6 +189,8 @@ namespace hw {
             return encrypt_payment_id(payment_id, public_key, secret_key);
         }
 
+        virtual rct::key genCommitmentMask(const rct::key &amount_key) = 0;
+
         virtual bool  ecdhEncode(rct::ecdhTuple & unmasked, const rct::key & sharedSec, bool short_amount) = 0;
         virtual bool  ecdhDecode(rct::ecdhTuple & masked, const rct::key & sharedSec, bool short_amount) = 0;
 

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -349,6 +349,10 @@ namespace hw {
             return true;
         }
 
+        rct::key device_default::genCommitmentMask(const rct::key &amount_key) {
+            return rct::genCommitmentMask(amount_key);
+        }
+
         bool  device_default::ecdhEncode(rct::ecdhTuple & unmasked, const rct::key & sharedSec, bool short_amount) {
             rct::ecdhEncode(unmasked, sharedSec, short_amount);
             return true;

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -111,6 +111,8 @@ namespace hw {
 
             bool  encrypt_payment_id(crypto::hash8 &payment_id, const crypto::public_key &public_key, const crypto::secret_key &secret_key) override;
 
+            rct::key genCommitmentMask(const rct::key &amount_key) override;
+
             bool  ecdhEncode(rct::ecdhTuple & unmasked, const rct::key & sharedSec, bool short_amount) override;
             bool  ecdhDecode(rct::ecdhTuple & masked, const rct::key & sharedSec, bool short_amount) override;
 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -194,6 +194,8 @@ namespace hw {
 
         bool  encrypt_payment_id(crypto::hash8 &payment_id, const crypto::public_key &public_key, const crypto::secret_key &secret_key) override;
 
+        rct::key genCommitmentMask(const rct::key &amount_key) override;
+
         bool  ecdhEncode(rct::ecdhTuple & unmasked, const rct::key & sharedSec, bool short_format) override;
         bool  ecdhDecode(rct::ecdhTuple & masked, const rct::key & sharedSec, bool short_format) override;
 

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -45,12 +45,12 @@ using namespace std;
 #define CHECK_AND_ASSERT_MES_L1(expr, ret, message) {if(!(expr)) {MCERROR("verify", message); return ret;}}
 
 namespace rct {
-    Bulletproof proveRangeBulletproof(keyV &C, keyV &masks, const std::vector<uint64_t> &amounts, const std::vector<key> &sk)
+    Bulletproof proveRangeBulletproof(keyV &C, keyV &masks, const std::vector<uint64_t> &amounts, const std::vector<key> &sk, hw::device &hwdev)
     {
         CHECK_AND_ASSERT_THROW_MES(amounts.size() == sk.size(), "Invalid amounts/sk sizes");
         masks.resize(amounts.size());
         for (size_t i = 0; i < masks.size(); ++i)
-            masks[i] = genCommitmentMask(sk[i]);
+            masks[i] = hwdev.genCommitmentMask(sk[i]);
         Bulletproof proof = bulletproof_PROVE(amounts, masks);
         CHECK_AND_ASSERT_THROW_MES(proof.V.size() == amounts.size(), "V does not have the expected size");
         C = proof.V;
@@ -757,7 +757,7 @@ namespace rct {
             {
                 rct::keyV C, masks;
                 const std::vector<key> keys(amount_keys.begin(), amount_keys.end());
-                rv.p.bulletproofs.push_back(proveRangeBulletproof(C, masks, outamounts, keys));
+                rv.p.bulletproofs.push_back(proveRangeBulletproof(C, masks, outamounts, keys, hwdev));
                 #ifdef DBG
                 CHECK_AND_ASSERT_THROW_MES(verBulletproof(rv.p.bulletproofs.back()), "verBulletproof failed on newly created proof");
                 #endif
@@ -780,7 +780,7 @@ namespace rct {
                 std::vector<key> keys(batch_size);
                 for (size_t j = 0; j < batch_size; ++j)
                   keys[j] = amount_keys[amounts_proved + j];
-                rv.p.bulletproofs.push_back(proveRangeBulletproof(C, masks, batch_amounts, keys));
+                rv.p.bulletproofs.push_back(proveRangeBulletproof(C, masks, batch_amounts, keys, hwdev));
             #ifdef DBG
                 CHECK_AND_ASSERT_THROW_MES(verBulletproof(rv.p.bulletproofs.back()), "verBulletproof failed on newly created proof");
             #endif


### PR DESCRIPTION
Always send TX public key when generating output destination keys: it may be an additional TX public key in case of subaddress; before we always use R.
Fix the commitment mask generation: It must be delegated to device as it implies the amount key.
Send MONERO_VERSION string in reset command to allow version compatibility check.
Some enhancement of debug log.

I try various transaction from/to main/sub address, but additional test with both v9 and v11 hardfork are welcome. 

This patch required application v1.2.0. tagged here https://github.com/LedgerHQ/ledger-app-monero/tree/1.2.0. 