### PR TITLE
console_handler: print newline on EOF

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -357,6 +357,7 @@ eof:
           if (m_stdin_reader.eos())
           {
             MGINFO("EOF on stdin, exiting");
+            std::cout << std::endl;
             break;
           }
           if (!get_line_ret)


### PR DESCRIPTION
This avoids the annoying case where the shell prints its prompt
after the last line from Monero output, causing line editing to
sometimes go wonky, for lack of a better term