### PR TITLE
Fix daemon startup parameter '--limit-rate' processing after parameter defaults

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2236,11 +2236,10 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::set_rate_up_limit(const boost::program_options::variables_map& vm, int64_t limit)
   {
-    this->islimitup=true;
+    this->islimitup=(limit != -1) && (limit != default_limit_up);
 
     if (limit==-1) {
       limit=default_limit_up;
-      this->islimitup=false;
     }
 
     epee::net_utils::connection<epee::levin::async_protocol_handler<p2p_connection_context> >::set_rate_up_limit( limit );
@@ -2251,10 +2250,9 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::set_rate_down_limit(const boost::program_options::variables_map& vm, int64_t limit)
   {
-    this->islimitdown=true;
+    this->islimitdown=(limit != -1) && (limit != default_limit_down);
     if(limit==-1) {
       limit=default_limit_down;
-      this->islimitdown=false;
     }
     epee::net_utils::connection<epee::levin::async_protocol_handler<p2p_connection_context> >::set_rate_down_limit( limit );
     MINFO("Set limit-down to " << limit << " kB/s");


### PR DESCRIPTION
PR #4770 introduced visible defaults for the `--limit-rate-up` and `--limit-rate-down` daemon startup parameters. This broke processing of the bidirectional parameter `--limit-rate` i.e. that parameter got ignored:

That processing only tries to set what is not yet set by processing the more specific "up" and "down" parameters. It failed because the defaults made it look as if "up" and "down" were **always** set.