### PR TITLE
Fix build on FreeBSD (release-v0.13)

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -48,7 +48,7 @@ set(crypto_sources
   CryptonightR_JIT.c
   tree-hash.c)
 
-if(ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64")
+if(ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64" OR ARCH_ID STREQUAL "amd64")
 list(APPEND crypto_sources CryptonightR_template.S)
 endif()
 


### PR DESCRIPTION
`CryptonightR_template.S` is being omitted on FreeBSD, resulting in many linker errors along the lines of 
``    ../../src/crypto/libcncrypto.a(CryptonightR_JIT.c.o):(.data+0x3d8): undefined reference to `CryptonightR_instruction123'``

This seems to fix that.