### PR TITLE
Fix build on *BSD

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -49,7 +49,7 @@ set(crypto_sources
   CryptonightR_JIT.c
   tree-hash.c)
 
-if(ARCH_ID STREQUAL "i386" OR ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64")
+if(ARCH_ID STREQUAL "i386" OR ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64" OR ARCH_ID STREQUAL "amd64")
 list(APPEND crypto_sources CryptonightR_template.S)
 endif()
 


### PR DESCRIPTION
Like #5336 but for `master`. This change is needed to successfully link the executables on FreeBSD/amd64.