### PR TITLE
allow blocking whole subnets

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -70,7 +70,7 @@ namespace net_utils
 
   struct i_connection_filter
   {
-    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address)=0;
+    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address, time_t *t = NULL)=0;
   protected:
     virtual ~i_connection_filter(){}
   };

--- a/contrib/epee/src/net_utils_base.cpp
+++ b/contrib/epee/src/net_utils_base.cpp
@@ -22,6 +22,24 @@ namespace epee { namespace net_utils
 	bool ipv4_network_address::is_local() const { return net_utils::is_ip_local(ip()); }
 
 
+	bool ipv4_network_subnet::equal(const ipv4_network_subnet& other) const noexcept
+	{ return is_same_host(other) && m_mask == other.m_mask; }
+
+	bool ipv4_network_subnet::less(const ipv4_network_subnet& other) const noexcept
+	{ return subnet() < other.subnet() ? true : (other.subnet() < subnet() ? false : (m_mask < other.m_mask)); }
+
+	std::string ipv4_network_subnet::str() const
+	{ return string_tools::get_ip_string_from_int32(subnet()) + "/" + std::to_string(m_mask); }
+
+	std::string ipv4_network_subnet::host_str() const { return string_tools::get_ip_string_from_int32(subnet()) + "/" + std::to_string(m_mask); }
+	bool ipv4_network_subnet::is_loopback() const { return net_utils::is_ip_loopback(subnet()); }
+	bool ipv4_network_subnet::is_local() const { return net_utils::is_ip_local(subnet()); }
+	bool ipv4_network_subnet::matches(const ipv4_network_address &address) const
+	{
+		return (address.ip() & ~(0xffffffffull << m_mask)) == subnet();
+	}
+
+
 	bool network_address::equal(const network_address& other) const
 	{
 		// clang typeid workaround

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -596,6 +596,13 @@ bool t_command_parser_executor::unban(const std::vector<std::string>& args)
   return m_executor.unban(ip);
 }
 
+bool t_command_parser_executor::banned(const std::vector<std::string>& args)
+{
+  if (args.size() != 1) return false;
+  std::string address = args[0];
+  return m_executor.banned(address);
+}
+
 bool t_command_parser_executor::flush_txpool(const std::vector<std::string>& args)
 {
   if (args.size() > 1) return false;

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -127,6 +127,8 @@ public:
 
   bool unban(const std::vector<std::string>& args);
 
+  bool banned(const std::vector<std::string>& args);
+
   bool flush_txpool(const std::vector<std::string>& args);
 
   bool output_histogram(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -243,8 +243,14 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "unban"
     , std::bind(&t_command_parser_executor::unban, &m_parser, p::_1)
-    , "unban <IP>"
+    , "unban <address>"
     , "Unban a given <IP>."
+    );
+    m_command_lookup.set_handler(
+      "banned"
+    , std::bind(&t_command_parser_executor::banned, &m_parser, p::_1)
+    , "banned <address>"
+    , "Check whether an <address> is banned."
     );
     m_command_lookup.set_handler(
       "flush_txpool"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -137,9 +137,11 @@ public:
 
   bool print_bans();
 
-  bool ban(const std::string &ip, time_t seconds);
+  bool ban(const std::string &address, time_t seconds);
 
-  bool unban(const std::string &ip);
+  bool unban(const std::string &address);
+
+  bool banned(const std::string &address);
 
   bool flush_txpool(const std::string &txid);
 

--- a/src/net/error.h
+++ b/src/net/error.h
@@ -42,7 +42,8 @@ namespace net
         invalid_i2p_address,
         invalid_port,       //!< Outside of 0-65535 range
         invalid_tor_address,//!< Invalid base32 or length
-        unsupported_address //!< Type not supported by `get_network_address`
+        unsupported_address,//!< Type not supported by `get_network_address`
+        invalid_mask,       //!< Outside of 0-32 range
     };
 
     //! \return `std::error_category` for `net` namespace.

--- a/src/net/parse.h
+++ b/src/net/parse.h
@@ -50,5 +50,18 @@ namespace net
     */
     expect<epee::net_utils::network_address>
         get_network_address(boost::string_ref address, std::uint16_t default_port);
+
+    /*!
+      Identifies an IPv4 subnet in CIDR notatioa and returns it as a generic
+      `network_address`. If the type is unsupported, it might be a hostname,
+      and `error() == net::error::kUnsupportedAddress` is returned.
+
+      \param address An ipv4 address.
+      \param allow_implicit_32 whether to accept "raw" IPv4 addresses, with CIDR notation
+
+      \return A tor or IPv4 address, else error.
+    */
+    expect<epee::net_utils::ipv4_network_subnet>
+        get_ipv4_subnet_address(boost::string_ref address, bool allow_implicit_32 = false);
 }
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -248,7 +248,7 @@ namespace nodetool
     void change_max_in_public_peers(size_t count);
     virtual bool block_host(const epee::net_utils::network_address &adress, time_t seconds = P2P_IP_BLOCKTIME);
     virtual bool unblock_host(const epee::net_utils::network_address &address);
-    virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
+    virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
 
     virtual void add_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
     virtual void remove_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
@@ -462,7 +462,7 @@ namespace nodetool
     epee::critical_section m_conn_fails_cache_lock;
 
     epee::critical_section m_blocked_hosts_lock;
-    std::map<std::string, time_t> m_blocked_hosts;
+    std::map<epee::net_utils::network_address, time_t> m_blocked_hosts;
 
     epee::critical_section m_host_fails_score_lock;
     std::map<std::string, uint64_t> m_host_fails_score;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -248,7 +248,11 @@ namespace nodetool
     void change_max_in_public_peers(size_t count);
     virtual bool block_host(const epee::net_utils::network_address &adress, time_t seconds = P2P_IP_BLOCKTIME);
     virtual bool unblock_host(const epee::net_utils::network_address &address);
+    virtual bool block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
+    virtual bool unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet);
+    virtual bool is_host_blocked(const epee::net_utils::network_address &address, time_t *seconds) { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return !is_remote_host_allowed(address, seconds); }
     virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
+    virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_subnets; }
 
     virtual void add_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
     virtual void remove_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
@@ -319,7 +323,7 @@ namespace nodetool
     virtual bool for_connection(const boost::uuids::uuid&, std::function<bool(typename t_payload_net_handler::connection_context&, peerid_type, uint32_t)> f);
     virtual bool add_host_fail(const epee::net_utils::network_address &address);
     //----------------- i_connection_filter  --------------------------------------------------------
-    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address);
+    virtual bool is_remote_host_allowed(const epee::net_utils::network_address &address, time_t *t = NULL);
     //-----------------------------------------------------------------------------------------------
     bool parse_peer_from_string(epee::net_utils::network_address& pe, const std::string& node_addr, uint16_t default_port = 0);
     bool handle_command_line(
@@ -461,8 +465,9 @@ namespace nodetool
     std::map<epee::net_utils::network_address, time_t> m_conn_fails_cache;
     epee::critical_section m_conn_fails_cache_lock;
 
-    epee::critical_section m_blocked_hosts_lock;
+    epee::critical_section m_blocked_hosts_lock; // for both hosts and subnets
     std::map<epee::net_utils::network_address, time_t> m_blocked_hosts;
+    std::map<epee::net_utils::ipv4_network_subnet, time_t> m_blocked_subnets;
 
     epee::critical_section m_host_fails_score_lock;
     std::map<std::string, uint64_t> m_host_fails_score;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -158,7 +158,7 @@ namespace nodetool
   bool node_server<t_payload_net_handler>::is_remote_host_allowed(const epee::net_utils::network_address &address)
   {
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
-    auto it = m_blocked_hosts.find(address.host_str());
+    auto it = m_blocked_hosts.find(address);
     if(it == m_blocked_hosts.end())
       return true;
     if(time(nullptr) >= it->second)
@@ -184,7 +184,7 @@ namespace nodetool
       limit = std::numeric_limits<time_t>::max();
     else
       limit = now + seconds;
-    m_blocked_hosts[addr.host_str()] = limit;
+    m_blocked_hosts[addr] = limit;
 
     // drop any connection to that address. This should only have to look into
     // the zone related to the connection, but really make sure everything is
@@ -214,7 +214,7 @@ namespace nodetool
   bool node_server<t_payload_net_handler>::unblock_host(const epee::net_utils::network_address &address)
   {
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
-    auto i = m_blocked_hosts.find(address.host_str());
+    auto i = m_blocked_hosts.find(address);
     if (i == m_blocked_hosts.end())
       return false;
     m_blocked_hosts.erase(i);

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -56,7 +56,7 @@ namespace nodetool
     virtual bool for_connection(const boost::uuids::uuid&, std::function<bool(t_connection_context&, peerid_type, uint32_t)> f)=0;
     virtual bool block_host(const epee::net_utils::network_address &address, time_t seconds = 0)=0;
     virtual bool unblock_host(const epee::net_utils::network_address &address)=0;
-    virtual std::map<std::string, time_t> get_blocked_hosts()=0;
+    virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts()=0;
     virtual bool add_host_fail(const epee::net_utils::network_address &address)=0;
     virtual void add_used_stripe_peer(const t_connection_context &context)=0;
     virtual void remove_used_stripe_peer(const t_connection_context &context)=0;
@@ -112,9 +112,9 @@ namespace nodetool
     {
       return true;
     }
-    virtual std::map<std::string, time_t> get_blocked_hosts()
+    virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts()
     {
-      return std::map<std::string, time_t>();
+      return std::map<epee::net_utils::network_address, time_t>();
     }
     virtual bool add_host_fail(const epee::net_utils::network_address &address)
     {

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -57,6 +57,7 @@ namespace nodetool
     virtual bool block_host(const epee::net_utils::network_address &address, time_t seconds = 0)=0;
     virtual bool unblock_host(const epee::net_utils::network_address &address)=0;
     virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts()=0;
+    virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets()=0;
     virtual bool add_host_fail(const epee::net_utils::network_address &address)=0;
     virtual void add_used_stripe_peer(const t_connection_context &context)=0;
     virtual void remove_used_stripe_peer(const t_connection_context &context)=0;
@@ -115,6 +116,10 @@ namespace nodetool
     virtual std::map<epee::net_utils::network_address, time_t> get_blocked_hosts()
     {
       return std::map<epee::net_utils::network_address, time_t>();
+    }
+    virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets()
+    {
+      return std::map<epee::net_utils::ipv4_network_subnet, time_t>();
     }
     virtual bool add_host_fail(const epee::net_utils::network_address &address)
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1772,15 +1772,15 @@ namespace cryptonote
     PERF_TIMER(on_get_bans);
 
     auto now = time(nullptr);
-    std::map<std::string, time_t> blocked_hosts = m_p2p.get_blocked_hosts();
-    for (std::map<std::string, time_t>::const_iterator i = blocked_hosts.begin(); i != blocked_hosts.end(); ++i)
+    std::map<epee::net_utils::network_address, time_t> blocked_hosts = m_p2p.get_blocked_hosts();
+    for (std::map<epee::net_utils::network_address, time_t>::const_iterator i = blocked_hosts.begin(); i != blocked_hosts.end(); ++i)
     {
       if (i->second > now) {
         COMMAND_RPC_GETBANS::ban b;
-        b.host = i->first;
+        b.host = i->first.host_str();
         b.ip = 0;
         uint32_t ip;
-        if (epee::string_tools::get_ip_int32_from_string(ip, i->first))
+        if (epee::string_tools::get_ip_int32_from_string(ip, b.host))
           b.ip = ip;
         b.seconds = i->second - now;
         res.bans.push_back(b);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -154,6 +154,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("hard_fork_info",         on_hard_fork_info,             COMMAND_RPC_HARD_FORK_INFO)
         MAP_JON_RPC_WE_IF("set_bans",            on_set_bans,                   COMMAND_RPC_SETBANS, !m_restricted)
         MAP_JON_RPC_WE_IF("get_bans",            on_get_bans,                   COMMAND_RPC_GETBANS, !m_restricted)
+        MAP_JON_RPC_WE_IF("banned",              on_banned,                     COMMAND_RPC_BANNED, !m_restricted)
         MAP_JON_RPC_WE_IF("flush_txpool",        on_flush_txpool,               COMMAND_RPC_FLUSH_TRANSACTION_POOL, !m_restricted)
         MAP_JON_RPC_WE("get_output_histogram",   on_get_output_histogram,       COMMAND_RPC_GET_OUTPUT_HISTOGRAM)
         MAP_JON_RPC_WE("get_version",            on_get_version,                COMMAND_RPC_GET_VERSION)
@@ -220,6 +221,7 @@ namespace cryptonote
     bool on_hard_fork_info(const COMMAND_RPC_HARD_FORK_INFO::request& req, COMMAND_RPC_HARD_FORK_INFO::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_set_bans(const COMMAND_RPC_SETBANS::request& req, COMMAND_RPC_SETBANS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_bans(const COMMAND_RPC_GETBANS::request& req, COMMAND_RPC_GETBANS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_banned(const COMMAND_RPC_BANNED::request& req, COMMAND_RPC_BANNED::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_flush_txpool(const COMMAND_RPC_FLUSH_TRANSACTION_POOL::request& req, COMMAND_RPC_FLUSH_TRANSACTION_POOL::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_output_histogram(const COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request& req, COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_version(const COMMAND_RPC_GET_VERSION::request& req, COMMAND_RPC_GET_VERSION::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -84,7 +84,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 2
-#define CORE_RPC_VERSION_MINOR 6
+#define CORE_RPC_VERSION_MINOR 7
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1871,6 +1871,33 @@ namespace cryptonote
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
+  struct COMMAND_RPC_BANNED
+  {
+    struct request_t
+    {
+      std::string address;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(address)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+      std::string status;
+      bool banned;
+      uint32_t seconds;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(banned)
+        KV_SERIALIZE(seconds)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -524,6 +524,24 @@ TEST(get_network_address, ipv4)
     EXPECT_STREQ("23.0.0.254:2000", address->str().c_str());
 }
 
+TEST(get_network_address, ipv4subnet)
+{
+    expect<epee::net_utils::ipv4_network_subnet> address = net::get_ipv4_subnet_address("0.0.0.0", true);
+    EXPECT_STREQ("0.0.0.0/32", address->str().c_str());
+
+    address = net::get_ipv4_subnet_address("0.0.0.0");
+    EXPECT_TRUE(!address);
+
+    address = net::get_ipv4_subnet_address("0.0.0.0/32");
+    EXPECT_STREQ("0.0.0.0/32", address->str().c_str());
+
+    address = net::get_ipv4_subnet_address("0.0.0.0/0");
+    EXPECT_STREQ("0.0.0.0/0", address->str().c_str());
+
+    address = net::get_ipv4_subnet_address("12.34.56.78/16");
+    EXPECT_STREQ("12.34.0.0/16", address->str().c_str());
+}
+
 namespace
 {
     using stream_type = boost::asio::ip::tcp;


### PR DESCRIPTION
Note that while the subnet is a type of network address, it does not get serialized, to avoid issues with a peer sending those in a peerlist. I'm not sure whether this is best that way, or with a filter-on-receive in the caller. This seems safer though.