### PR TITLE
device/trezor: increase live-refresh timeout

### DIFF
--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -137,7 +137,7 @@ namespace trezor {
         }
 
         auto current_time = std::chrono::steady_clock::now();
-        if (current_time - m_last_live_refresh_time <= std::chrono::seconds(20))
+        if (current_time - m_last_live_refresh_time <= std::chrono::minutes(5))
         {
           continue;
         }


### PR DESCRIPTION
Increase monitor timeout to 5 minutes. 20 seconds was pretty annoying for slow sync