### PR TITLE
Allow pruning before v10

### DIFF
--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -611,24 +611,6 @@ int main(int argc, char* argv[])
       }
       already_pruned = true;
     }
-    if (n == 0)
-    {
-      const uint64_t blockchain_height = core_storage[0]->get_current_blockchain_height();
-      const crypto::hash hash = core_storage[0]->get_block_id_by_height(blockchain_height - 1);
-      cryptonote::block block;
-      if (core_storage[0]->get_block_by_hash(hash, block))
-      {
-        if (block.major_version < 10)
-        {
-          time_t now = time(NULL);
-          if (now < 1555286400) // 15 april 2019
-          {
-            MERROR("Pruning before v10 will confuse peers. Wait for v10 first");
-            return 1;
-          }
-        }
-      }
-    }
   }
   core_storage[0]->deinit();
   core_storage[0].reset(NULL);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3767,12 +3767,6 @@ leave:
 //------------------------------------------------------------------
 bool Blockchain::prune_blockchain(uint32_t pruning_seed)
 {
-  uint8_t hf_version = m_hardfork->get_current_version();
-  if (hf_version < 10)
-  {
-    MERROR("Most of the network will only be ready for pruned blockchains from v10, not pruning");
-    return false;
-  }
   return m_db->prune_blockchain(pruning_seed);
 }
 //------------------------------------------------------------------

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2175,7 +2175,7 @@ bool t_rpc_command_executor::check_blockchain_pruning()
 
     if (res.pruning_seed)
     {
-      tools::success_msg_writer() << "Blockchain pruning checked";
+      tools::success_msg_writer() << "Blockchain is pruned";
     }
     else
     {


### PR DESCRIPTION
This check is now not needed anymore, and would prevent people
from using --prune-blockchain when starting a new sync