### PR TITLE
libwallet_merged: add missing net target

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -127,6 +127,7 @@ if (BUILD_GUI_DEPS)
             ringct_basic
             checkpoints
             version
+            net
             device_trezor)
 
     foreach(lib ${libs_to_merge})


### PR DESCRIPTION
```
18:57 <vtnerd> selsta : the tor-wallet-proxy code is missing in the link stage in the `BUILD_GUI_DEPS` section. I've never seen a technique quite like that before, but it looks like its not grabbing targets to link against
19:49 <vtnerd> I "net" needs to be added to the "libs_to_merge" at the bottom of src/wallet/CMakeLists.txt
19:49 <vtnerd> *I think
```
