### PR TITLE
Trezor: test fixes and improvements

### DIFF
--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -163,15 +163,7 @@ namespace trezor {
   public:
     BridgeTransport(
         boost::optional<std::string> device_path = boost::none,
-        boost::optional<std::string> bridge_host = boost::none):
-        m_device_path(device_path),
-        m_bridge_host(bridge_host ? bridge_host.get() : DEFAULT_BRIDGE),
-        m_response(boost::none),
-        m_session(boost::none),
-        m_device_info(boost::none)
-    {
-      m_http_client.set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
-    }
+        boost::optional<std::string> bridge_host = boost::none);
 
     virtual ~BridgeTransport() = default;
 

--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -135,7 +135,7 @@ bool wallet_tools::fill_tx_sources(tools::wallet2 * wallet, std::vector<cryptono
         }
       }
 
-      MINFO("Selected " << i << " from tx: " << dump_keys(td.m_txid.data)
+      MDEBUG("Selected " << i << " from tx: " << dump_keys(td.m_txid.data)
                         << " ki: " << dump_keys(td.m_key_image.data)
                         << " amnt: " << td.amount()
                         << " rct: " << td.is_rct()

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -101,6 +101,9 @@ void mock_daemon::load_params(boost::program_options::variables_map const & vm)
 
 mock_daemon::~mock_daemon()
 {
+  if(m_http_client.is_connected())
+    m_http_client.disconnect();
+
   if (!m_terminated)
   {
     try
@@ -134,11 +137,14 @@ void mock_daemon::init()
   if(m_http_client.is_connected())
     m_http_client.disconnect();
 
-  CHECK_AND_ASSERT_THROW_MES(m_http_client.set_server(rpc_addr(), boost::none), "RPC client init fail");
+  CHECK_AND_ASSERT_THROW_MES(m_http_client.set_server(rpc_addr(), boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled), "RPC client init fail");
 }
 
 void mock_daemon::deinit()
 {
+  if(m_http_client.is_connected())
+    m_http_client.disconnect();
+
   try
   {
     m_rpc_server.deinit();

--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
     // Bootstrapping common chain & accounts
     const uint8_t initial_hf =  (uint8_t)get_env_long("TEST_MIN_HF", 11);
     const uint8_t max_hf = (uint8_t)get_env_long("TEST_MAX_HF", 11);
-    MINFO("Test versions " << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL);
+    MINFO("Test versions " << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")");
     MINFO("Testing hardforks [" << (int)initial_hf << ", " << (int)max_hf << "]");
 
     cryptonote::core core_obj(nullptr);

--- a/tests/trezor/trezor_tests.h
+++ b/tests/trezor/trezor_tests.h
@@ -84,6 +84,8 @@ public:
 
   virtual void mine_and_test(std::vector<test_event_entry>& events);
 
+  virtual void rewind_blocks(std::vector<test_event_entry>& events, size_t rewind_n, uint8_t hf);
+
   virtual void set_hard_fork(uint8_t hf);
 
   crypto::hash head_hash() const { return get_block_hash(m_head); }


### PR DESCRIPTION
- Tested blockchain hardforks modifiable via environment variable, default: test only HF 11
- Hardfork switching fixes (e.g., rewind 10 blocks to apply v10 rules after switch)
- Enable to change emulator and bridge ports via environment variables.