### PR TITLE
build fix: combinator.h stdexcept include added

### DIFF
--- a/src/common/combinator.h
+++ b/src/common/combinator.h
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <vector>
+#include <stdexcept>
 
 namespace tools {
 


### PR DESCRIPTION
GCC 4.8.4 compilation fails as `runtime_error` is defined in `stdexcept` which was not included. 

