### PR TITLE
tests: fix test_options initialization error

### DIFF
--- a/tests/core_tests/bulletproofs.h
+++ b/tests/core_tests/bulletproofs.h
@@ -97,7 +97,7 @@ template<>
 struct get_test_options<gen_bp_tx_validation_base> {
   const std::pair<uint8_t, uint64_t> hard_forks[4] = {std::make_pair(1, 0), std::make_pair(2, 1), std::make_pair(10, 73), std::make_pair(0, 0)};
   const cryptonote::test_options test_options = {
-    hard_forks
+    hard_forks, 0
   };
 };
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -748,7 +748,7 @@ template<typename t_test_class>
 struct get_test_options {
   const std::pair<uint8_t, uint64_t> hard_forks[2];
   const cryptonote::test_options test_options = {
-    hard_forks
+    hard_forks, 0
   };
   get_test_options():hard_forks{std::make_pair((uint8_t)1, (uint64_t)0), std::make_pair((uint8_t)0, (uint64_t)0)}{}
 };
@@ -776,7 +776,7 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
 
   // Hardforks can be specified in events.
   v_hardforks_t hardforks;
-  cryptonote::test_options test_options_tmp{};
+  cryptonote::test_options test_options_tmp{nullptr, 0};
   const cryptonote::test_options * test_options_ = &gto.test_options;
   if (extract_hard_forks(events, hardforks)){
     hardforks.push_back(std::make_pair((uint8_t)0, (uint64_t)0));  // terminator

--- a/tests/core_tests/multisig.h
+++ b/tests/core_tests/multisig.h
@@ -84,7 +84,7 @@ template<>
 struct get_test_options<gen_multisig_tx_validation_base> {
   const std::pair<uint8_t, uint64_t> hard_forks[3] = {std::make_pair(1, 0), std::make_pair(4, 1), std::make_pair(0, 0)};
   const cryptonote::test_options test_options = {
-    hard_forks
+    hard_forks, 0
   };
 };
 

--- a/tests/core_tests/rct.h
+++ b/tests/core_tests/rct.h
@@ -83,7 +83,7 @@ template<>
 struct get_test_options<gen_rct_tx_validation_base> {
   const std::pair<uint8_t, uint64_t> hard_forks[4] = {std::make_pair(1, 0), std::make_pair(2, 1), std::make_pair(4, 65), std::make_pair(0, 0)};
   const cryptonote::test_options test_options = {
-    hard_forks
+    hard_forks, 0
   };
 };
 

--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -293,7 +293,7 @@ static bool init_core_replay_events(std::vector<test_event_entry>& events, crypt
 
   // Hardforks can be specified in events.
   v_hardforks_t hardforks;
-  cryptonote::test_options test_options_tmp{};
+  cryptonote::test_options test_options_tmp{nullptr, 0};
   const cryptonote::test_options * test_options_ = &gto.test_options;
   if (extract_hard_forks(events, hardforks)){
     hardforks.push_back(std::make_pair((uint8_t)0, (uint64_t)0));  // terminator


### PR DESCRIPTION
GCC is unhappy about unitialized const `long_term_block_weight_window`
Fixes build error.

```cpp
struct test_options {
     const std::pair<uint8_t, uint64_t> *hard_forks;
     const size_t long_term_block_weight_window;
   };
```