### PR TITLE
build: debug and test builds via contrib dockers

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -22,9 +22,16 @@ host_toolchain:=$(HOST)-
 endif
 
 ifneq ($(DEBUG),)
-release_type=debug
+release_type=Debug
 else
-release_type=release
+release_type=Release
+endif
+
+ifneq ($(TESTS),)
+build_tests=ON
+release_type=Debug
+else
+build_tests=OFF
 endif
 
 base_build_dir=$(BASEDIR)/work/build
@@ -164,6 +171,8 @@ $(host_prefix)/share/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@debug@|$(DEBUG)|' \
+            -e 's|@release_type@|$(release_type)|' \
+            -e 's|@build_tests@|$(build_tests)|' \
             -e 's|@depends@|$(host_cmake)|' \
             -e 's|@prefix@|$($(host_arch)_$(host_os)_prefix)|'\
             -e 's|@sdk@|$(SDK_PATH)|'\

--- a/contrib/depends/packages/gtest.mk
+++ b/contrib/depends/packages/gtest.mk
@@ -1,0 +1,38 @@
+package=gtest
+$(package)_version=1.8.1
+$(package)_download_path=https://github.com/google/googletest/archive/
+$(package)_file_name=release-$($(package)_version).tar.gz
+$(package)_sha256_hash=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+$(package)_cxxflags=-std=c++11
+$(package)_cxxflags_linux=-fPIC
+
+define $(package)_config_cmds
+  cd googletest && \
+    CC="$(host_prefix)/native/bin/$($(package)_cc)" \
+    CXX="$(host_prefix)/native/bin/$($(package)_cxx)" \
+    AR="$(host_prefix)/native/bin/$($(package)_ar)" \
+    RANLIB="$(host_prefix)/native/bin/$($(package)_ranlib)" \
+    LIBTOOL="$(host_prefix)/native/bin/$($(package)_libtool)" \
+    CXXFLAGS="$($(package)_cxxflags)" \
+    CCFLAGS="$($(package)_ccflags)" \
+    CPPFLAGS="$($(package)_cppflags)" \
+    CFLAGS="$($(package)_cflags) $($(package)_cppflags)" \
+    LDLAGS="$($(package)_ldflags)" \
+  cmake -DCMAKE_INSTALL_PREFIX=$(build_prefix) \
+    -DTOOLCHAIN_PREFIX=$(host_toolchain) \
+    -DCMAKE_AR="$(host_prefix)/native/bin/$($(package)_ar)" \
+    -DCMAKE_RANLIB="$(host_prefix)/native/bin/$($(package)_ranlib)" \
+    -DCMAKE_CXX_FLAGS_DEBUG=ON
+endef
+# -DCMAKE_TOOLCHAIN_FILE=$(HOST)/share/toolchain.cmake
+
+define $(package)_build_cmds
+  cd googletest && CC="$(host_prefix)/native/bin/$($(package)_cc)" $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  mkdir $($(package)_staging_prefix_dir)/lib $($(package)_staging_prefix_dir)/include &&\
+  cp googletest/libgtest.a $($(package)_staging_prefix_dir)/lib/ &&\
+  cp googletest/libgtest_main.a $($(package)_staging_prefix_dir)/lib/ &&\
+  cp -a googletest/include/* $($(package)_staging_prefix_dir)/include/
+endef

--- a/contrib/depends/packages/native_cctools.mk
+++ b/contrib/depends/packages/native_cctools.mk
@@ -52,6 +52,7 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  cp $($(package)_extract_dir)/cctools/misc/install_name_tool $($(package)_staging_prefix_dir)/bin/ &&\
   cd $($(package)_extract_dir)/toolchain && \
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin $($(package)_staging_prefix_dir)/include && \

--- a/contrib/depends/packages/native_cmake-unused.mk
+++ b/contrib/depends/packages/native_cmake-unused.mk
@@ -1,0 +1,23 @@
+package=native_cmake
+$(package)_version=3.14.0
+$(package)_version_dot=v3.14
+$(package)_download_path=https://cmake.org/files/$($(package)_version_dot)/
+$(package)_file_name=cmake-$($(package)_version).tar.gz
+$(package)_sha256_hash=aa76ba67b3c2af1946701f847073f4652af5cbd9f141f221c97af99127e75502
+
+define $(package)_set_vars
+$(package)_config_opts=
+endef
+
+define $(package)_config_cmds
+  ./bootstrap &&\
+  ./configure $($(package)_config_opts)
+endef
+
+define $(package)_build_cmd
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -7,6 +7,10 @@ darwin_packages = sodium-darwin
 linux_packages = eudev
 qt_packages = qt
 
+ifeq ($(build_tests),ON)
+packages += gtest
+endif
+
 ifeq ($(host_os),linux)
 packages += unwind
 packages += sodium

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -1,9 +1,16 @@
 # Set the system name, either Darwin, Linux, or Windows
 SET(CMAKE_SYSTEM_NAME @depends@)
-SET(CMAKE_BUILD_TYPE release)
+SET(CMAKE_BUILD_TYPE @release_type@)
 
-SET(STATIC true)
-SET(UNBOUND_STATIC true)
+OPTION(STATIC "Link libraries statically" ON)
+OPTION(TREZOR_DEBUG "Main trezor debugging switch" OFF)
+OPTION(BUILD_TESTS "Build tests." OFF)
+
+SET(STATIC ON)
+SET(UNBOUND_STATIC ON)
+
+SET(BUILD_TESTS @build_tests@)
+SET(TREZOR_DEBUG @build_tests@)
 
 # where is the target environment 
 SET(CMAKE_FIND_ROOT_PATH @prefix@ /usr)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ else ()
 
   # Emulate the FindGTest module's variable.
   set(GTEST_LIBRARIES gtest gtest_main)
+  set(GTEST_BOTH_LIBRARIES gtest gtest_main)
   include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest/include")
 endif (GTest_FOUND)
 


### PR DESCRIPTION
I've used this patch to cross-build debug versions and tests of the monero binaries, which was quite helpful.

What do you think @TheCharlatan ? 

Regarding tests - I had to add `contrib/depends/packages/gtest.mk` as embedded GTest is built as an external project which I found difficult to set toolchain file for. Thus I've rather created a cross-combiled library which is later picked up by the tests cmake file.

Regarding `option()` calls in the toolchain file - I had to add them as the first cmake run ignores `set()` for options from toolchain file if the `option` was not set before. This leads to strange behavior as the first run ignores those toolchain-set options but the second run takes them into consideration.

To build the tests it is needed just:

```cpp
$DOCKER_EXEC bash -c "CONFIG_SHELL="" TESTS=1 make $MAKEJOBS -C contrib/depends HOST=$HOST $DEP_OPTS"
```