### PR TITLE
daemon: if a log file has a /, interpret it from the cwd

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -257,7 +257,12 @@ int main(int argc, char const * argv[])
     bf::path log_file_path {data_dir / std::string(CRYPTONOTE_NAME ".log")};
     if (!command_line::is_arg_defaulted(vm, daemon_args::arg_log_file))
       log_file_path = command_line::get_arg(vm, daemon_args::arg_log_file);
-    log_file_path = bf::absolute(log_file_path, relative_path_base);
+#ifdef __WIN32
+    if (!strchr(log_file_path.c_str(), '/') && !strchr(log_file_path.c_str(), '\\'))
+#else
+    if (!strchr(log_file_path.c_str(), '/'))
+#endif
+      log_file_path = bf::absolute(log_file_path, relative_path_base);
     mlog_configure(log_file_path.string(), true, command_line::get_arg(vm, daemon_args::arg_max_log_file_size), command_line::get_arg(vm, daemon_args::arg_max_log_files));
 
     // Set log level


### PR DESCRIPTION
rather than from data dir where it normally is.

It makes things like --log-file ./foo.log behave as you'd expect.