### PR TITLE
Increment m_threads_active when mining thread starts

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -528,6 +528,7 @@ namespace cryptonote
     uint32_t local_template_ver = 0;
     block b;
     slow_hash_allocate_state();
+    ++m_threads_active;
     while(!m_stop)
     {
       if(m_pausers_count)//anti split workaround


### PR DESCRIPTION
Not super familiar with this code, but m_threads_active only has an instance of a decrement in the codebase and not any increment so it overflows and locks up the daemon and wallet.

See line 596 in miner.cpp for the decrement.