### PR TITLE
Add Brewfile to allow for easier management of dependencies on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ Install all dependencies at once on Debian/Ubuntu:
 
 ``` sudo apt update && sudo apt install build-essential cmake pkg-config libboost-all-dev libssl-dev libzmq3-dev libunbound-dev libsodium-dev libunwind8-dev liblzma-dev libreadline6-dev libldns-dev libexpat1-dev doxygen graphviz libpgm-dev```
 
-Install all dependencies at once on macOS:
-``` brew update && brew install cmake pkg-config openssl boost hidapi zmq libpgm unbound libsodium miniupnpc readline ldns expat doxygen graphviz protobuf ```
+Install all dependencies at once on macOS with the provided Brewfile:
+``` brew update && brew bundle --file=contrib/brew/Brewfile ```
 
 FreeBSD one liner for required to build dependencies
 ```pkg install git gmake cmake pkgconf boost-libs cppzmq libsodium```

--- a/contrib/brew/Brewfile
+++ b/contrib/brew/Brewfile
@@ -1,0 +1,34 @@
+# Brewfile for Monero
+# A homebrew Brewfile installs all required dependencies in one shot
+# see https://coderwall.com/p/afmnbq/homebrew-s-new-feature-brewfiles
+#     https://github.com/Homebrew/homebrew-bundle
+# execute brew bundle in the directory containing the Brewfile
+
+tap "homebrew/bundle"
+tap "homebrew/cask"
+tap "homebrew/cask-versions"
+tap "homebrew/core"
+
+brew "autoconf"
+brew "autogen"
+brew "automake"
+brew "binutils"
+brew "coreutils"
+brew "cmake"
+brew "pkg-config"
+brew "boost"
+brew "openssl"
+brew "hidapi"
+brew "zmq"
+brew "libpgm"
+brew "unbound"
+brew "libsodium"
+brew "miniupnpc"
+brew "readline"
+brew "ldns"
+brew "expat"
+brew "doxygen"
+brew "graphviz"
+brew "libunwind-headers"
+brew "xz"
+brew "protobuf"


### PR DESCRIPTION
This pull requests adds  support for a feature of homebrew that allows to maintain the dependencies of a project within the codebase, in form of a `Brewfile`.

This pull request:
- Adds the Brewfile itself
- Adapts the brew formulae command in the project README

With this file in place, all that needs to be done to install all dependencies is execute `brew bundle`.

There are more benefits for developers and/or testers. For example, this Brewfile can be used as a whitelist to remove all Homebrew formulae _not listed_ in this `Brewfile` by running `brew bundle cleanup`.