### PR TITLE
Add translations for it, fr, ja, sv from Pootle and refresh template file

### DIFF
--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.1">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
@@ -37,42 +37,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="124"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="133"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="211"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="233"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,384 +134,384 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1383"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1392"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1428"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1592"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1512"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1594"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1432"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1464"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1546"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1438"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1521"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1520"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1603"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="541"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="575"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="584"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="588"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="594"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="598"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="621"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="695"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="885"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1049"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1068"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1144"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1084"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1168"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1184"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1153"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1166"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1183"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1259"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1200"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1214"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1305"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1232"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1248"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1324"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1266"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1342"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1352"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1366"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1318"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1394"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1358"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
         <source>Invalid destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2275"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2186"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2282"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2208"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2304"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2230"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2326"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1445"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1529"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1527"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1611"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1534"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1619"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1467"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1551"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1633"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1554"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1475"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1641"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1477"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1479"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1481"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1483"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1485"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1569"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1598"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1644"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1671"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1719"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1747"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1775"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1796"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1753"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1801"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1829"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1857"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1878"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2354"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1743"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1688"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1761"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1770"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1754"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1835"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1779"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1808"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1836"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1917"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1922"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1880"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1962"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1902"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1984"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2226"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2197"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2293"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2315"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2202"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2224"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2298"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2320"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2241"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2280"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2337"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2376"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2247"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2343"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2265"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2361"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2286"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2382"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -519,22 +519,22 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="301"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="308"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="316"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="326"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,803 +604,881 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3926"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5486"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5537"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5550"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6213"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6574"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3780"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="645"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1067"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7010"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8670"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1012"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="949"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1156"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1129"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1285"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
+        <source>Multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1500"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1330"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1471"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1379"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1448"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1508"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1602"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1534"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1812"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1703"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1733"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1767"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1862"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
+        <source>Invalid key image or txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1901"/>
+        <source>failed to unset ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2063"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2129"/>
+        <source>Frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2131"/>
+        <source>Not frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
+        <source> bytes sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
+        <source> bytes received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2145"/>
+        <source>Welcome to Monero, the private cryptocurrency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2147"/>
+        <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <source>Unlike Bitcoin, your Monero transactions and balance stay private, and not visible to the world by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>However, you have the option of making those available to select parties, if you choose to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2151"/>
+        <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
+        <source>no privacy technology can be 100% perfect, Monero included.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2153"/>
+        <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2155"/>
+        <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2157"/>
+        <source>Welcome to Monero and financial privacy. For more information, see https://getmonero.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2137"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2325"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2330"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2398"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2549"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2667"/>
+        <source>invalid argument: must be either 1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2745"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2759"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.
+
+Output format:
+Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2782"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2789"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2793"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2625"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2801"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2628"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2804"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2808"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2812"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1411,1384 +1489,47 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
-        <source>Display the encrypted Electrum-style mnemonic seed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
-        <source>Rescan the blockchain for spent outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
-        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2730"/>
-        <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
-        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
-        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
-        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2750"/>
-        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
-        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
-If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
-Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
-        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2780"/>
-        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2784"/>
-        <source>Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2788"/>
-        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2792"/>
-        <source>Get a string note for a txid.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2796"/>
-        <source>Set an arbitrary description for the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2800"/>
-        <source>Get the description of the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2803"/>
-        <source>Show the wallet&apos;s status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2806"/>
-        <source>Show the wallet&apos;s information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2810"/>
-        <source>Sign the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
-        <source>Verify a signature on the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
-        <source>Import a signed key images list and verify their spent status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
-        <source>Attempts to reconnect HW wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2834"/>
-        <source>Export a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2838"/>
-        <source>Import a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
-        <source>Show information about a transfer to/from this address.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
-        <source>Change the wallet&apos;s password.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2852"/>
-        <source>Print the information about the current fee and transaction backlog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
-        <source>Export data needed to create a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
-        <source>Turn this wallet into a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
-        <source>Export multisig info for other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Import multisig info from other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2877"/>
-        <source>Sign a multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <source>Submit a signed multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>Export a signed multisig transaction to a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
-        <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
-
-Output format:
-Key Image, &quot;absolute&quot;, list of rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
-        <source>Set the ring used for a given key image, so it can be reused in a fork</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
-        <source>Save known rings to the shared rings database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
-        <source>Returns version information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
-        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
-        <source>needs an argument</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
-        <source>set seed: needs an argument. available options: language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3097"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
-        <source>0 or 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
-        <source>integer &gt;= </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
-        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
-        <source>0, 1, 2, 3, or 4, or one of </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3090"/>
-        <source>0|1|2 (or never|action|decrypt)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
-        <source>monero, millinero, micronero, nanonero, piconero</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3103"/>
-        <source>unsigned integer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
-        <source>block height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
-        <source>&lt;major&gt;:&lt;minor&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
-        <source>set: unrecognized argument(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
-        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3178"/>
-        <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
-        <source>Wallet and key files found, loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
-        <source>Key file found but not wallet file. Regenerating...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
-        <source>Key file not found. Failed to open wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3203"/>
-        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3214"/>
-        <source>Generating new wallet...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
-        <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
-        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
-        <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3341"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3355"/>
-        <source>Multisig seed failed verification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3364"/>
-        <source>Electrum-style word list failed verification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3470"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
-        <source>No data supplied, cancelled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6243"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6886"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6950"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8454"/>
-        <source>failed to parse address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
-        <source>This address is a subaddress which cannot be used here.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
-        <source>failed to parse view key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3528"/>
-        <source>failed to verify view key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3434"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
-        <source>view key does not match standard address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3439"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3726"/>
-        <source>account creation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3638"/>
-        <source>failed to parse spend key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3658"/>
-        <source>failed to verify spend key secret key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
-        <source>spend key does not match standard address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3558"/>
-        <source>Error: expected M/N, but got: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3563"/>
-        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3568"/>
-        <source>Error: M/N is currently unsupported. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
-        <source>Generating master wallet from %u of %u multisig wallet keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
-        <source>failed to parse secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3608"/>
-        <source>failed to verify secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3651"/>
-        <source>Error: M/N is currently unsupported</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
-        <source>No restore height is specified.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <source>Use --restore-height if you want to restore an already setup account from a specific height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <source>account creation aborted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
-        <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
-        <source>bad m_restore_height parameter: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3766"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3779"/>
-        <source>Restore height is: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3802"/>
-        <source>Restore height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3803"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
-        <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
-        <source>failed to open account</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6854"/>
-        <source>wallet is null</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3829"/>
-        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
-        <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3887"/>
-        <source>wallet failed to connect to daemon: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3888"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
-        <source>List of available languages for your wallet&apos;s seed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
-        <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
-        <source>invalid language choice entered. Please try again.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3954"/>
-        <source>invalid password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
-        <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
-        <source>Generated new wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4019"/>
-        <source>View key: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4025"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4188"/>
-        <source>failed to generate new wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4130"/>
-        <source>Generated new wallet on hw device: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4180"/>
-        <source>failed to generate new mutlisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4183"/>
-        <source>Generated new %u/%u multisig wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4199"/>
-        <source>wallet file path not valid: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
-        <source>Key file not found. Failed to open wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
-        <source>Opened watch-only wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <source>Opened %u/%u multisig wallet%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4234"/>
-        <source>Opened wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4252"/>
-        <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4267"/>
-        <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4275"/>
-        <source>failed to load wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4292"/>
-        <source>Use the &quot;help&quot; command to see the list of available commands.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
-        <source>failed to deinitialize wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4337"/>
-        <source>Wallet data saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4351"/>
-        <source>wallet is multisig and cannot save a watch-only version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4359"/>
-        <source>failed to read wallet password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4367"/>
-        <source>Watch only wallet saved as: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
-        <source>Failed to save watch only wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4382"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8522"/>
-        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4431"/>
-        <source>Mining started in daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <source>mining has NOT been started: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
-        <source>Mining stopped in daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
-        <source>mining has NOT been stopped: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
-        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4498"/>
-        <source>Expected trusted or untrusted, got </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
-        <source>trusted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
-        <source>untrusted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4517"/>
-        <source>This does not seem to be a valid daemon URL.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
-        <source>Blockchain saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4539"/>
-        <source>blockchain can&apos;t be saved: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4589"/>
-        <source>Height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4590"/>
-        <source>txid </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
-        <source>idx </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
-        <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4572"/>
-        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
-        <source>spent </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4616"/>
-        <source>Enter password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4698"/>
-        <source>Starting refresh...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4712"/>
-        <source>Refresh done, blocks received: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5038"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5042"/>
-        <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5051"/>
-        <source>RPC error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4734"/>
-        <source>refresh error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4739"/>
-        <source>internal error: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
-        <source>refresh failed: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
-        <source>Blocks received: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4780"/>
-        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4782"/>
-        <source> (Some owned outputs have missing key images - import_key_images needed)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>Currently selected account: [</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>(No tag assigned)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>Tag: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4786"/>
-        <source>Balance: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
-        <source>unlocked balance: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
-        <source>Balance per address:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Unlocked balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4801"/>
-        <source>%8u %6s %21s %21s %7u %21s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>pubkey</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>key image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>unlocked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>ringct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>global index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>tx id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>addr index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
-        <source>RingCT</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4924"/>
-        <source>No incoming transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4928"/>
-        <source>No incoming available transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4932"/>
-        <source>No incoming unavailable transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>payment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>unlock time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
-        <source>No payments with id </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4990"/>
-        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
-        <source>failed to get blockchain height: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5046"/>
-        <source>failed to get spent status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5114"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
-        <source>failed to find construction data for tx input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5135"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5151"/>
-        <source>failed to get output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5163"/>
-        <source>
-Originating block heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <source>
-|</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
-        <source>|
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5192"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
-        <source>the same transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
-        <source>blocks that are temporally very close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6156"/>
-        <source>Ring size must not be 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
-        <source>ring size %u is too small, minimum is %u</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
-        <source>ring size %u is too large, maximum is %u</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5258"/>
-        <source>wrong number of arguments</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
-        <source>payment id failed to encode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
-        <source>failed to parse short payment ID from URI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5365"/>
-        <source>Invalid last argument: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
-        <source>a single transaction cannot use more than one payment id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5399"/>
-        <source>failed to parse payment id, though it was detected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6182"/>
-        <source>Failed to parse number of outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6187"/>
-        <source>Amount of outputs should be greater than 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
-        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5395"/>
-        <source>Unencrypted payment IDs are bad for privacy: ask the recipient to use subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5307"/>
-        <source>bad locked_blocks parameter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5978"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6251"/>
-        <source>a single transaction cannot use more than one payment id: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6219"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6259"/>
-        <source>failed to set up payment id, though it was decoded correctly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
-        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <source>Multisig wallet has been successfully created. Current wallet type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <source>Failed to perform multisig keys exchange: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
-        <source>Failed to load multisig transaction from MMS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
-        <source>Failed to mark output spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1962"/>
-        <source>Failed to mark output unspent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <source>Spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
-        <source>Not spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
-        <source>Failed to check whether output is spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2022"/>
-        <source>Please confirm the transaction on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2510"/>
-        <source>Device name not specified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
-        <source>Device reconnect failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
-        <source>Device reconnect failed: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <source>Show the incoming transfers, all or filtered by availability and address index.
-
-Output format:
-Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2673"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2806,8 +1547,10 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&qu
    Set the wallet&apos;s refresh behaviour.
  priority [0|1|2|3|4]
    Set the fee to default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
+ confirm-missing-payment-id &lt;1|0&gt; (obsolete)
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
+   action: ask the password before many actions such as transfer, etc
+   decrypt: same as action, but keeps the spend key encrypted in memory when not needed
  unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
    Set the default monero (sub-)unit.
  min-outputs-count [n]
@@ -2836,7 +1579,1388 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2904"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
+        <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2912"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2928"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2970"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2984"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
+        <source>Attempts to reconnect HW wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3016"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3020"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3023"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3032"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3039"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3055"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
+        <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
+
+Output format:
+Key Image, &quot;absolute&quot;, list of rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3156"/>
+        <source>Set the ring used for a given key image, so it can be reused in a fork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3160"/>
+        <source>Unsets the ring used for a given key image or transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
+        <source>Save known rings to the shared rings database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
+        <source>Freeze a single output by key image so it will not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>Thaw a single output by key image so it may be used again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3188"/>
+        <source>Checks whether a given output is currently frozen by key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3192"/>
+        <source>Prints simple network stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Prints basic info about Monero for first time users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
+        <source>Returns version information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source> (set this to support the network and to get a chance to receive new monero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
+        <source>needs an argument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
+        <source>set seed: needs an argument. available options: language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
+        <source>0 or 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3295"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3297"/>
+        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
+        <source>0, 1, 2, 3, or 4, or one of </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
+        <source>0|1|2 (or never|action|decrypt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
+        <source>monero, millinero, micronero, nanonero, piconero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
+        <source>unsigned integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3308"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <source>&lt;major&gt;:&lt;minor&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3316"/>
+        <source>1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
+        <source>set: unrecognized argument(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
+        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
+        <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
+        <source>Wallet and key files found, loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
+        <source>Key file found but not wallet file. Regenerating...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
+        <source>Key file not found. Failed to open wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
+        <source>Generating new wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3506"/>
+        <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
+        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3548"/>
+        <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3562"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
+        <source>Electrum-style word list failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3871"/>
+        <source>No data supplied, cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <source>failed to parse address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3718"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3748"/>
+        <source>failed to parse view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3765"/>
+        <source>failed to verify view key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3769"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3851"/>
+        <source>view key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3674"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3907"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3966"/>
+        <source>account creation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3733"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3876"/>
+        <source>failed to parse spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3896"/>
+        <source>failed to verify spend key secret key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3901"/>
+        <source>spend key does not match standard address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3838"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3846"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3941"/>
+        <source>No restore height is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3942"/>
+        <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3947"/>
+        <source>account creation aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3957"/>
+        <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
+        <source>bad m_restore_height parameter: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
+        <source>Restore height is: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
+        <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4073"/>
+        <source>failed to open account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <source>wallet is null</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
+        <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
+        <source>wallet failed to connect to daemon: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
+        <source>List of available languages for your wallet&apos;s seed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4194"/>
+        <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4217"/>
+        <source>invalid language choice entered. Please try again.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4231"/>
+        <source>invalid password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
+        <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
+        <source>Generated new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
+        <source>View key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
+        <source>failed to generate new wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4313"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
+        <source>Generated new wallet on hw device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4457"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
+        <source>wallet file path not valid: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4486"/>
+        <source>Key file not found. Failed to open wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
+        <source>Opened watch-only wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4511"/>
+        <source>Opened wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
+        <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4544"/>
+        <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
+        <source>failed to load wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
+        <source>Use the &quot;help&quot; command to see the list of available commands.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <source>failed to deinitialize wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
+        <source>Wallet data saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4628"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
+        <source>failed to read wallet password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4644"/>
+        <source>Watch only wallet saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
+        <source>Failed to save watch only wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4819"/>
+        <source>Mining started in daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
+        <source>mining has NOT been started: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
+        <source>Mining stopped in daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
+        <source>mining has NOT been stopped: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4864"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4886"/>
+        <source>Expected trusted or untrusted, got </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
+        <source>trusted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
+        <source>untrusted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4905"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
+        <source>Blockchain saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
+        <source>blockchain can&apos;t be saved: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <source>Height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <source>txid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <source>idx </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <source>spent </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <source>Enter password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <source>Starting refresh...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <source>New transfer received since rescan was started. Key images are incomplete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <source>Refresh done, blocks received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <source>daemon is busy. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <source>no connection to daemon. Please make sure daemon is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <source>RPC error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <source>refresh error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <source>internal error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <source>refresh failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <source>Blocks received: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <source> (Some owned outputs have missing key images - import_key_images needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Tag: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <source>Balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <source>unlocked balance: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Unlocked balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <source>pubkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <source>key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>unlocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>ringct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>global index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>tx id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <source>Used at heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>[frozen]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <source>RingCT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <source>No incoming transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <source>No incoming available transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <source>No incoming unavailable transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>unlock time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <source>No payments with id </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <source>failed to get blockchain height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <source>failed to get spent status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <source>failed to find construction data for tx input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <source>failed to get output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <source>
+Originating block heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <source>
+|</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <source>|
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <source>the same transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <source>blocks that are temporally very close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <source>ring size %u is too large, maximum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <source>wrong number of arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <source>payment id failed to encode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <source>failed to parse short payment ID from URI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <source>Invalid last argument: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <source>a single transaction cannot use more than one payment id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <source>failed to parse payment id, though it was detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <source>No payment id is included with this transaction. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Is this okay anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <source>Failed to parse number of outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <source>Amount of outputs should be greater than 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <source>bad locked_blocks parameter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <source>a single transaction cannot use more than one payment id: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <source>failed to set up payment id, though it was decoded correctly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1181"/>
+        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <source>Multisig wallet has been successfully created. Current wallet type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
+        <source>Failed to perform multisig keys exchange: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
+        <source>Failed to load multisig transaction from MMS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
+        <source>Failed to mark output spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2018"/>
+        <source>Failed to mark output unspent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2042"/>
+        <source>Spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <source>Not spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2048"/>
+        <source>Failed to check whether output is spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2171"/>
+        <source>Please confirm the transaction on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
+        <source>Device name not specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
+        <source>Device reconnect failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2700"/>
+        <source>Device reconnect failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -2850,32 +2974,42 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2962"/>
+        <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2996"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2865"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3027"/>
+        <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3043"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3067"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -2884,73 +3018,73 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3079"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3124"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2950"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3128"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -2958,1548 +3092,1638 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3172"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3317"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3338"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <source>Secret spend key (%u of %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <source>Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
+        <source>Still apply restore height?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4203"/>
+        <source>Enter the number corresponding to the language of your choice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete. Support will be withdrawn in the future. Use subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4675"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
+        <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4098"/>
+        <source>WARNING: obsolete long payment IDs are enabled. Sending transactions with those payment IDs are bad for your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4100"/>
+        <source>It is recommended that you do not use them, and ask recipients who ask for one to not endanger your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4696"/>
+        <source>Failed to query mining status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Failed to setup background mining: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4683"/>
+        <source>Background mining enabled. Thank you for supporting the Monero network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4719"/>
+        <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4725"/>
+        <source>Using an untrusted daemon, skipping background mining check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4750"/>
+        <source>The daemon is not set up to background mine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4752"/>
+        <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
-        <source>Heights: </source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <source>
+Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7115"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6268"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5502"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5738"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6059"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5539"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5611"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6328"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5616"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5625"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5721"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6310"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6444"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <source>Rescan anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <source>Warning: your restore height is higher than wallet restore height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <source>Rescan anyway ? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <source>Short payment IDs are to be used within an integrated address only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8388"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9380"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9405"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9415"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9436"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9460"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9483"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9853"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <source>MMS not available in this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8605"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8576"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8619"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8813"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="410"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3605"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4563"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
-        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6713"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6811"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6942"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6829"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6835"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6868"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6902"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6958"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7730"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7732"/>
-        <source>Rescan anyway ? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1946"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1952"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2035"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2400"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7799"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7931"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8100"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7996"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8005"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
         <source>failed to parse payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8241"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8247"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8250"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4751,311 +4975,321 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="133"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="143"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="144"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="146"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="149"/>
+        <source>Restore from estimated blockchain height on specified date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="297"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="447"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="544"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="529"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="550"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="546"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="576"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="617"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="599"/>
-        <source>File %s already exists. Are you sure to overwrite it? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="148"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="150"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="151"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="293"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
+        <source>Support obsolete long (unencrypted) payment ids (using them harms your privacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="323"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <source>Is this OK?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="564"/>
+        <source>transaction %s was rejected by daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
+        <source>File %s already exists. Are you sure to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5063,359 +5297,447 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="201"/>
+        <location filename="../src/wallet/wallet2.cpp" line="234"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="202"/>
+        <location filename="../src/wallet/wallet2.cpp" line="235"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="207"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="209"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
+        <location filename="../src/wallet/wallet2.cpp" line="361"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="355"/>
+        <location filename="../src/wallet/wallet2.cpp" line="480"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="368"/>
+        <location filename="../src/wallet/wallet2.cpp" line="493"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="519"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="239"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="203"/>
+        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="237"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="208"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="210"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <source>List of valid fingerprints of allowed RPC servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <source>Allow any SSL certificate from the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="212"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="223"/>
+        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="313"/>
+        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <source>Do not use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>Do not connect to a daemon, nor use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <source>Invalid argument for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source>Enabling --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source> requires --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or use of a .onion/.i2p domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="432"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="442"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="375"/>
+        <location filename="../src/wallet/wallet2.cpp" line="500"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="400"/>
+        <location filename="../src/wallet/wallet2.cpp" line="525"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="407"/>
+        <location filename="../src/wallet/wallet2.cpp" line="532"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="423"/>
+        <location filename="../src/wallet/wallet2.cpp" line="548"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="428"/>
-        <location filename="../src/wallet/wallet2.cpp" line="496"/>
-        <location filename="../src/wallet/wallet2.cpp" line="539"/>
+        <location filename="../src/wallet/wallet2.cpp" line="553"/>
+        <location filename="../src/wallet/wallet2.cpp" line="621"/>
+        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="439"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="444"/>
-        <location filename="../src/wallet/wallet2.cpp" line="506"/>
-        <location filename="../src/wallet/wallet2.cpp" line="565"/>
+        <location filename="../src/wallet/wallet2.cpp" line="569"/>
+        <location filename="../src/wallet/wallet2.cpp" line="631"/>
+        <location filename="../src/wallet/wallet2.cpp" line="692"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="456"/>
+        <location filename="../src/wallet/wallet2.cpp" line="581"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="476"/>
+        <location filename="../src/wallet/wallet2.cpp" line="601"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="605"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="490"/>
+        <location filename="../src/wallet/wallet2.cpp" line="615"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="499"/>
+        <location filename="../src/wallet/wallet2.cpp" line="624"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="509"/>
+        <location filename="../src/wallet/wallet2.cpp" line="634"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="517"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="551"/>
+        <location filename="../src/wallet/wallet2.cpp" line="678"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="557"/>
+        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
+        <location filename="../src/wallet/wallet2.cpp" line="701"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1383"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="3770"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4374"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4926"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10157"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10899"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <source>Path to a PEM format private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <source>Path to a PEM format certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="180"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="182"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="222"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="479"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3081"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3947"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3773"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3788"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3800"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3804"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3838"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3870"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3840"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3872"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3843"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3847"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3853"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3857"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3864"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3867"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3876"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5424,8 +5746,8 @@ daemon to work correctly.</source>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8908"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3928"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="fr_FR">
+<TS version="2.1" language="fr">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
@@ -37,42 +37,42 @@
         <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="124"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="133"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Raison : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Exception inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Exception non gérée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="211"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>Signature multisig des données impossible : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="233"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>Signature multisig de la transaction impossible : </translation>
     </message>
@@ -134,384 +134,384 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1383"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1392"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
         <translation>Échec de l&apos;ajout de l&apos;ID de paiement court : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1428"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1592"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1512"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1594"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1432"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>not enough outputs for specified ring size</source>
         <translation>pas assez de sorties pour la taille de cercle spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>found outputs to use</source>
         <translation>sorties à utiliser trouvées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1464"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1546"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Veuillez balayer les sorties non mélangeables.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1438"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1521"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1520"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1603"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="541"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="575"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="584"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="588"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="594"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="598"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="621"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="885"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Échec de l&apos;envoi de la requête d&apos;importation de portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1049"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Échec du chargement des transaction non signées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1068"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1144"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1084"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <source>Wallet is view only</source>
         <translation>Portefeuille d&apos;audit uniquement</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1168"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1184"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Les images de clé ne peuvent être importées qu&apos;avec un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
         <translation>Échec de l&apos;importation des images de clé : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1153"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
         <translation>Échec de la récupération de l&apos;étiquette de sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1166"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
         <translation>Échec de l&apos;affectation de l&apos;étiquette de sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Ni clé d&apos;audit ni clé de dépense fournie, annulation</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>La phrase Electrum est vide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="695"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1183"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1259"/>
         <source>Failed to get multisig info: </source>
         <translation>Échec de la récupération des infos multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1200"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1214"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
         <source>Failed to make multisig: </source>
         <translation>Échec de la création multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1305"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>Échec de la finalisation de la création du portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1232"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>Échec de la finalisation de la création du portefeuille multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1248"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1324"/>
         <source>Failed to export multisig images: </source>
         <translation>Échec de l&apos;exportation des images multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1266"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1342"/>
         <source>Failed to parse imported multisig images</source>
         <translation>Échec de l&apos;analyse des images multisig importées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1352"/>
         <source>Failed to import multisig images: </source>
         <translation>Échec de l&apos;importation des images multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1366"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation>Échec de la vérification des images de clé multisig partielles : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1318"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1394"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>Échec de la restauration de la transaction multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1358"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
         <source>Invalid destination address</source>
         <translation>Adresse de destination invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>échec de la récupération de sorties à mélanger : %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1445"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1529"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1527"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1611"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>pas assez de fonds pour le transfer, solde global disponible %s, montant envoyé %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1534"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1619"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>output amount</source>
         <translation>montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1467"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1551"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1633"/>
         <source>transaction was not constructed</source>
         <translation>la transaction n&apos;a pas été construite</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1554"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1475"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1641"/>
         <source>one of destinations is zero</source>
         <translation>une des destinations est zéro</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1477"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1479"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
         <translation>erreur de transfert inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1481"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1483"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1485"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1569"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1598"/>
         <source>failed to get outputs to mix</source>
         <translation>échec de la récupération de sorties à mélanger</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1644"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1671"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1719"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1747"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1775"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1796"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1753"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1801"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1829"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1857"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1878"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2354"/>
         <source>Failed to parse txid</source>
         <translation>Échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1743"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1688"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1761"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1770"/>
         <source>Failed to parse tx key</source>
         <translation>Échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1754"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1835"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1779"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1808"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1836"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1917"/>
         <source>Failed to parse address</source>
         <translation>Échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1922"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;adresse ne doit pas être une sous-adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1880"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1962"/>
         <source>The wallet must be in multisig ready state</source>
         <translation>Le portefeuille doit être multisig et prêt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1902"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1984"/>
         <source>Given string is not a key</source>
         <translation>La chaîne entrée n&apos;est pas une clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2226"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Réexaminer les dépenses ne peut se faire qu&apos;avec un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2275"/>
         <source>Invalid output: </source>
         <translation>Sortie invalide : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2186"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2282"/>
         <source>Failed to mark outputs as spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du marquage des sorties comme dépensées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2208"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2304"/>
         <source>Failed to mark output as spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du marquage de la sortie comme dépensée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2230"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2326"/>
         <source>Failed to mark output as unspent</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du marquage de la sortie comme non dépensée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2197"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2293"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2315"/>
         <source>Failed to parse output amount</source>
         <translation>Échec de l&apos;analyse du montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2202"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2224"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2298"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2320"/>
         <source>Failed to parse output offset</source>
         <translation>Échec de l&apos;analyse de l&apos;offset de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2241"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2280"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2337"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2376"/>
         <source>Failed to parse key image</source>
         <translation>Échec de l&apos;analyse de l&apos;image de clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2247"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2343"/>
         <source>Failed to get ring</source>
         <translation>Échec de la récupération du cercle</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2265"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2361"/>
         <source>Failed to get rings</source>
         <translation>Échec de la récupération des cercles</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2286"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2382"/>
         <source>Failed to set ring</source>
         <translation>Échec de l&apos;affectation du cercle</translation>
     </message>
@@ -519,22 +519,22 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="301"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="308"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Échec de l&apos;analyse de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="316"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>Échec de la vérification de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="326"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>la clé ne correspond pas à l&apos;adresse</translation>
     </message>
@@ -604,312 +604,1877 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="645"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
         <translation>Commandes : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
         <source>failed to read wallet password</source>
         <translation>échec de la lecture du mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4231"/>
         <source>invalid password</source>
         <translation>mot de passe invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed : requiert un argument. options disponibles : language</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set : argument(s) non reconnu(s)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
         <source>wallet file path not valid: </source>
         <translation>chemin du fichier portefeuille non valide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Tentative de génération ou de restauration d&apos;un portefeuille, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>needs an argument</source>
         <translation>requiert un argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3097"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>0 or 1</source>
         <translation>0 ou 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
         <source>unsigned integer</source>
         <translation>entier non signé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3548"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet utilise --generate-new-wallet, pas --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>spécifiez un paramètre de récupération avec --electrum-seed=&quot;liste de mots ici&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3957"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>spécifiez un chemin de portefeuille avec --generate-new-wallet (pas --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>échec de la connexion du portefeuille au démon : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Le démon utilise une version majeure de RPC (%u) différente de celle du portefeuille (%u) : %s. Mettez l&apos;un des deux à jour, ou utilisez --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Liste des langues disponibles pour la phrase mnémonique de votre portefeuille :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3926"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation>Entrez le nombre correspondant à la langue de votre choix : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez dorénavant utiliser la nouvelle phrase mnémonique que nous fournissons.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
         <source>Generated new wallet: </source>
         <translation>Nouveau portefeuille généré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4025"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
         <source>Opened watch-only wallet</source>
         <translation>Ouverture du portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4511"/>
         <source>Opened wallet</source>
         <translation>Ouverture du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez procéder à la mise à jour de votre portefeuille.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4267"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4544"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Le format de votre fichier portefeuille est en cours de mise à jour.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
         <source>failed to load wallet: </source>
         <translation>échec du chargement du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Utilisez la commande &quot;help&quot; pour voir la liste des commandes disponibles.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>Wallet data saved</source>
         <translation>Données du portefeuille sauvegardées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4819"/>
         <source>Mining started in daemon</source>
         <translation>La mine a démarré dans le démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
         <source>mining has NOT been started: </source>
         <translation>la mine n&apos;a PAS démarré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
         <source>Mining stopped in daemon</source>
         <translation>La mine a été stoppée dans le démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
         <source>mining has NOT been stopped: </source>
         <translation>la mine n&apos;a PAS été stoppée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
         <source>Blockchain saved</source>
         <translation>Chaîne de blocs sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
         <source>Height </source>
         <translation>Hauteur </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>spent </source>
         <translation>dépensé </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>Starting refresh...</source>
         <translation>Démarrage du rafraîchissement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
         <source>Refresh done, blocks received: </source>
         <translation>Rafraîchissement effectué, blocs reçus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
         <source>bad locked_blocks parameter:</source>
         <translation>mauvais paramètre locked_blocks :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5978"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6251"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6219"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>échec de la définition de l&apos;ID de paiement, bien qu&apos;il ait été décodé correctement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1181"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation type="unfinished"></translation>
+        <translation>Envoyez ces infos multisig à tous les autres participants, puis utilisez exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] avec les infos multisig des autres</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
-        <translation type="unfinished"></translation>
+        <translation>Le portefeuille multisig a été créé avec succès. Type du portefeuille actuel : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
         <source>Failed to perform multisig keys exchange: </source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;échange de clés multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
         <source>Failed to load multisig transaction from MMS</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du chargement de la transaction multisig à partir du MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
         <source>Failed to mark output spent: </source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du marquage de la sortie comme dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2018"/>
         <source>Failed to mark output unspent: </source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du marquage de la sortie comme non dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2042"/>
         <source>Spent: </source>
-        <translation type="unfinished"></translation>
+        <translation>Dépensé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
         <source>Not spent: </source>
-        <translation type="unfinished"></translation>
+        <translation>Non dépensé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2048"/>
         <source>Failed to check whether output is spent: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible de vérifier si la sortie est dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2171"/>
         <source>Please confirm the transaction on the device</source>
-        <translation type="unfinished"></translation>
+        <translation>Veuillez confirmer la transaction sur l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2510"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
         <source>Device name not specified</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom de l&apos;appareil non spécifié</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
         <source>Device reconnect failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la reconnexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2700"/>
         <source>Device reconnect failed: </source>
+        <translation>Échec de la reconnexion à l&apos;appareil : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
+        <source>Show the incoming/outgoing transfers within an optional height range.
+
+Output format:
+In or Coinbase:    Block Number, &quot;block&quot;|&quot;in&quot;,              Time, Amount,  Transaction Hash, Payment ID, Subaddress Index,                     &quot;-&quot;, Note
+Out:               Block Number, &quot;out&quot;,                     Time, Amount*, Transaction Hash, Payment ID, Fee, Destinations, Input addresses**, &quot;-&quot;, Note
+Pool:                            &quot;pool&quot;, &quot;in&quot;,              Time, Amount,  Transaction Hash, Payment Id, Subaddress Index,                     &quot;-&quot;, Note, Double Spend Note
+Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;out&quot;, Time, Amount*, Transaction Hash, Payment ID, Fee, Input addresses**,               &quot;-&quot;, Note
+
+* Excluding change and fee.
+** Set of address indices used as inputs in this transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
+        <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
+        <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2996"/>
+        <source>Export a signed set of key images to a &lt;filename&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
+        <source>Synchronizes key images with the hw wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3027"/>
+        <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3043"/>
+        <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3067"/>
+        <source>Interface with the MMS (Multisig Messaging System)
+&lt;subcommand&gt; is one of:
+  init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
+  send_signer_config, start_auto_config, stop_auto_config, auto_config
+Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;subcommand&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
+        <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3079"/>
+        <source>Display current MMS configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
+        <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
+        <source>List all messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
+        <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
+By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
+        <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
+        <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
+        <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <source>Send a single message by giving its id, or send all waiting messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
+        <source>Check right away for new messages to receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
+        <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
+        <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3124"/>
+        <source>Show detailed info about a single message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3128"/>
+        <source>Available options:
+ auto-send &lt;1|0&gt;
+   Whether to automatically send newly generated messages right away.
+ </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
+        <source>Send completed signer config to all other authorized signers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
+        <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
+        <source>Delete any auto-config tokens and abort a auto-config process</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
+        <source>Start auto-config by using the token received from the auto-config manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
+        <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3172"/>
+        <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
+        <source>Checks whether an output is marked as spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3317"/>
+        <source>&lt;device_name[:device_spec]&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3338"/>
+        <source>wrong number range, use: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
+        <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
+        <source>string</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
+        <source>25 words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <source>Secret spend key (%u of %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <source>Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
+        <source>Still apply restore height?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4203"/>
+        <source>Enter the number corresponding to the language of your choice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete. Support will be withdrawn in the future. Use subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <source>Device requires attention</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <source>Enter device PIN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <source>Failed to read device PIN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <source>Please enter the device passphrase on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <source>Enter device passphrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <source>Failed to read device passphrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <source>Do you want to do it now? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <source>Invalid keyword: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <source>transaction cancelled.</source>
+        <translation>transaction annulée.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Failed to check for backlog: </source>
+        <translation>Échec de la vérification du backlog : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <source>
+Transaction </source>
+        <translation>
+Transaction </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <source>Spending from address index %d
+</source>
+        <translation>Dépense depuis l&apos;adresse d&apos;index %d
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
+</source>
+        <translation>ATTENTION : Des sorties de multiples adresses sont utilisées ensemble, ce qui pourrait potentiellement compromettre votre confidentialité.
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <source>Sending %s.  </source>
+        <translation>Envoi de %s.  </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
+        <translation>Votre transaction doit être scindée en %llu transactions. Il en résulte que des frais de transaction doivent être appliqués à chaque transaction, pour un total de %s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <source>The transaction fee is %s</source>
+        <translation>Les frais de transaction sont de %s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <source>, of which %s is dust from change</source>
+        <translation>, dont %s est de la poussière de monnaie rendue</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <source>.</source>
+        <translation>.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <source>A total of %s from dust change will be sent to dust address</source>
+        <translation>Un total de %s de poussière de monnaie rendue sera envoyé à une adresse de poussière</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
+        <source>.
+This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation>.
+Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s jours (en supposant 2 minutes par bloc)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <source>Unsigned transaction(s) successfully written to MMS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <source>Unsigned transaction(s) successfully written to file: </source>
+        <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <source>Failed to cold sign transaction with HW wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <source>No unmixable outputs found</source>
+        <translation>Aucune sortie non mélangeable trouvée</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <source>No address given</source>
+        <translation>Aucune adresse fournie</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <source>failed to parse Payment ID</source>
+        <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <source>failed to parse key image</source>
+        <translation>échec de l&apos;analyse de l&apos;image de clé</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <source>No outputs found</source>
+        <translation>Pas de sorties trouvées</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <source>Multiple transactions are created, which is not supposed to happen</source>
+        <translation>De multiples transactions sont crées, ce qui n&apos;est pas supposé arriver</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
+        <translation>La transaction utilise aucune ou de multiples entrées, ce qui n&apos;est pas supposé arriver</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <source>missing threshold amount</source>
+        <translation>montant seuil manquant</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <source>invalid amount threshold</source>
+        <translation>montant seuil invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <source>Rescan anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <source>Short payment IDs are to be used within an integrated address only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <source> (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <source>Choose processing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <source>Sign tx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <source>Send the tx for submission to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <source>Send the tx for signing to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <source>Submit tx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <source>Choice: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <source>Wrong choice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <source>Id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <source>I/O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <source>Authorized Signer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <source>Message Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <source>Message State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <source>Since</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <source> ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>#</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>Transport Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <source>Auto-Config Token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <source>Monero Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <source>&lt;not set&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <source>Message </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <source>In/out: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <source>State: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <source>%s since %s, %s ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <source>Sent: Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <source>Sent: %s, %s ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <source>Authorized signer: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <source>Content size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <source> bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <source>Content: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <source>(binary data)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <source>Send these messages now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <source>Queued for sending.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <source>Invalid message id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <source>Error in the number of required signers and/or authorized signers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <source>The MMS is not active.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <source>Invalid signer number </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <source>Invalid Monero address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <source>Wallet state does not allow changing Monero addresses anymore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <source>Usage: mms list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <source>Usage: mms next [sync]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <source>No next step: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <source>prepare_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <source>make_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <source>exchange_multisig_keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <source>export_multisig_info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <source>import_multisig_info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <source>sign_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <source>submit_multisig</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <source>Send tx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <source>Process signer config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <source>Replace current signer config with the one displayed above?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <source>Process auto config data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <source>Nothing ready to process</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <source>Usage: mms sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <source>Delete all messages?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <source>Usage: mms send [&lt;message_id&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <source>Usage: mms receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <source>Usage: mms export &lt;message_id&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <source>Message content saved to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <source>Failed to to save message content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <source>No signer found with label </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <source>Usage: mms show &lt;message_id&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <source>Wrong option value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <source>Auto-send is on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <source>Auto-send is off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <source>Unknown option</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <source>Usage: mms help [&lt;subcommand&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <source>Usage: mms send_signer_config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <source>Signer config not yet complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <source>Auto-config is already running. Cancel and restart?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <source>Usage: mms stop_auto_config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <source>Delete any auto-config tokens and stop auto-config?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <source>Invalid auto-config token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <source>Auto-config already running. Cancel and restart?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <source>MMS not available in this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <source>Invalid MMS subcommand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <source>Error in MMS command: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <source>Claimed change does not go to a paid address</source>
+        <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <source>Claimed change is larger than payment to the change address</source>
+        <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <source>sending %s to %s</source>
+        <translation>envoi de %s à %s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <source> dummy output(s)</source>
+        <translation> sortie(s) factice(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <source>with no destinations</source>
+        <translation>sans destination</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
+        <translation>Ceci est un portefeuille multisig, il ne peut signer qu&apos;avec sign_multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <source>Failed to sign transaction</source>
+        <translation>Échec de signature de transaction</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <source>Failed to sign transaction: </source>
+        <translation>Échec de signature de transaction : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <source>Transaction raw hex data exported to </source>
+        <translation>Données brutes hex de la transaction exportées vers </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <source>Failed to load transaction from file</source>
+        <translation>Échec du chargement de la transaction du fichier</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <source>RPC error: </source>
+        <translation>Erreur RPC : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
+        <source>wallet is watch-only and has no spend key</source>
+        <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de clé de dépense</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
+        <source>Your original password was incorrect.</source>
+        <translation>Votre mot de passe original est incorrect.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
+        <source>Error with wallet rewrite: </source>
+        <translation>Erreur avec la réécriture du portefeuille : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
+        <source>invalid unit</source>
+        <translation>unité invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
+        <source>invalid count: must be an unsigned integer</source>
+        <translation>nombre invalide : un entier non signé est attendu</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
+        <source>invalid value</source>
+        <translation>valeur invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
+        <source>bad m_restore_height parameter: </source>
+        <translation>mauvais paramètre m_restore_height : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
+        <source>Restore height is: </source>
+        <translation>La hauteur de restauration est : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
+        <source>Daemon is local, assuming trusted</source>
+        <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
+        <source>Password for new watch-only wallet</source>
+        <translation>Mot de passe pour le nouveau portefeuille d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <source>internal error: </source>
+        <translation>erreur interne : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <source>unexpected error: </source>
+        <translation>erreur inattendue : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <source>unknown error</source>
+        <translation>erreur inconnue</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <source>refresh failed: </source>
+        <translation>échec du rafraîchissement : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <source>Blocks received: </source>
+        <translation>Blocs reçus : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <source>unlocked balance: </source>
+        <translation>solde débloqué : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>amount</source>
+        <translation>montant</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
+        <source>false</source>
+        <translation>faux</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
+        <source>Unknown command: </source>
+        <translation>Commande inconnue : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
+        <source>Command usage: </source>
+        <translation>Usage de la commande : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
+        <source>Command description: </source>
+        <translation>Description de la commande : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
+        <source>wallet is multisig but not yet finalized</source>
+        <translation>le portefeuille est multisig mais pas encore finalisé</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
+        <source>Failed to retrieve seed</source>
+        <translation>Échec de la récupération de la phrase mnémonique</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
+        <source>wallet is multisig and has no seed</source>
+        <translation>le portefeuille est multisig et n&apos;a pas de phrase mnémonique</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
+        <source>Error: failed to estimate backlog array size: </source>
+        <translation>Erreur : échec de l&apos;estimation de la taille du tableau d&apos;arriéré : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
+        <source>Error: bad estimated backlog array size</source>
+        <translation>Erreur : mauvaise estimation de la taille du tableau d&apos;arriéré</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
+        <source> (current)</source>
+        <translation> (actuel)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
+        <source>%u block (%u minutes) backlog at priority %u%s</source>
+        <translation>arriéré de %u bloc(s) (%u minutes) à la priorité %u%s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
+        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
+        <translation>arriéré de %u à %u bloc(s) (%u à %u minutes) à la priorité %u</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
+        <source>No backlog at priority </source>
+        <translation>Pas d&apos;arriéré à la priorité </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1012"/>
+        <source>This wallet is already multisig</source>
+        <translation>Le portefeuille est déjà multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
+        <source>wallet is watch-only and cannot be made multisig</source>
+        <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas être tranformé en multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
+        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
+        <translation>Ce portefeuille a été utilisé auparavant, veuillez utiliser un nouveau portefeuille pour créer un portefeuille multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
+        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation>Envoyez ces infos multisig à tous les autres participants, ensuite utilisez make_multisig &lt;seuil&gt; &lt;info1&gt; [&lt;info2&gt;...] avec les infos multisig des autres</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
+        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
+        <translation>Ceci inclut la clé PRIVÉE d&apos;audit, donc ne doit être divulgué qu&apos;aux participants de ce portefeuille multisig </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
+        <source>Invalid threshold</source>
+        <translation>Seuil invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
+        <source>Another step is needed</source>
+        <translation>Une autre étape est nécessaire</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
+        <source>Error creating multisig: </source>
+        <translation>Erreur de création multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
+        <source>Error creating multisig: new wallet is not multisig</source>
+        <translation>Erreur de création multisig : le nouveau portefeuille n&apos;est pas multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
+        <source> multisig address: </source>
+        <translation> adresse multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1285"/>
+        <source>This wallet is not multisig</source>
+        <translation>Ce portefeuille n&apos;est pas multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
+        <source>This wallet is already finalized</source>
+        <translation>Ce portefeuille est déjà finalisé</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
+        <source>Failed to finalize multisig</source>
+        <translation>Échec de finalisation multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
+        <source>Failed to finalize multisig: </source>
+        <translation>Échec de finalisation multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
+        <source>Multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1500"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
+        <source>This multisig wallet is not yet finalized</source>
+        <translation>Ce portefeuille multisig n&apos;est pas encore finalisé</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
+        <source>Error exporting multisig info: </source>
+        <translation>Erreur d&apos;importation des infos multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
+        <source>Multisig info exported to </source>
+        <translation>Infos multisig exportées vers </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1330"/>
+        <source>Multisig info imported</source>
+        <translation>Infos multisig importées</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
+        <source>Failed to import multisig info: </source>
+        <translation>Échec de l&apos;importation des infos multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
+        <source>Failed to update spent status after importing multisig info: </source>
+        <translation>Échec de la mise à jour de l&apos;état des dépenses après l&apos;importation des infos multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
+        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
+        <translation>Pas un démon de confiance, l&apos;état des dépenses peut être incorrect. Utilisez un démon de confiance et executez &quot;rescan_spent&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1379"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
+        <source>This is not a multisig wallet</source>
+        <translation>Ceci n&apos;est pas un portefeuille multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
+        <source>Failed to sign multisig transaction</source>
+        <translation>Échec de la signature de la transaction multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
+        <source>Multisig error: </source>
+        <translation>Erreur multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
+        <source>Failed to sign multisig transaction: </source>
+        <translation>Échec de la signature de la transaction multisig : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
+        <source>It may be relayed to the network with submit_multisig</source>
+        <translation>Elle peut être transmise au réseau avec submit_multisig</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1602"/>
+        <source>Failed to load multisig transaction from file</source>
+        <translation>Échec du chargement de la transaction multisig du fichier</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
+        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
+        <translation>Transaction multisig signée par %u signataire(s) seulement, nécessite %u signature(s) de plus</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <source>Transaction successfully submitted, transaction </source>
+        <translation>Transaction transmise avec succès, transaction </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <source>You can check its status by using the `show_transfers` command.</source>
+        <translation>Vous pouvez vérifier son statut en utilisant la commane &apos;show_transfers&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
+        <source>Failed to export multisig transaction to file </source>
+        <translation>Échec de l&apos;exportation de la transaction multisig vers le fichier </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
+        <source>Saved exported multisig transaction file(s): </source>
+        <translation>Transaction multisig enregistrée dans le(s) fichier(s) : </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
+        <source>Invalid key image or txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1901"/>
+        <source>failed to unset ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2129"/>
+        <source>Frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2131"/>
+        <source>Not frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
+        <source> bytes sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
+        <source> bytes received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2145"/>
+        <source>Welcome to Monero, the private cryptocurrency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2147"/>
+        <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <source>Unlike Bitcoin, your Monero transactions and balance stay private, and not visible to the world by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>However, you have the option of making those available to select parties, if you choose to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2151"/>
+        <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
+        <source>no privacy technology can be 100% perfect, Monero included.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2153"/>
+        <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2155"/>
+        <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2157"/>
+        <source>Welcome to Monero and financial privacy. For more information, see https://getmonero.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
+        <source>ring size must be an integer &gt;= </source>
+        <translation>la taille de cercle doit être un nombre entier &gt;= </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
+        <source>could not change default ring size</source>
+        <translation>échec du changement de la taille de cercle par défaut</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2549"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
+        <source>Invalid height</source>
+        <translation>Hauteur invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2667"/>
+        <source>invalid argument: must be either 1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
+        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
+        <translation>Démarrer la mine dans le démon (mine_arrière_plan et ignorer_batterie sont des booléens facultatifs).</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
+        <source>Stop mining in the daemon.</source>
+        <translation>Arrêter la mine dans le démon.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2745"/>
+        <source>Set another daemon to connect to.</source>
+        <translation>Spécifier un autre démon auquel se connecter.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
+        <source>Save the current blockchain data.</source>
+        <translation>Sauvegarder les données actuelles de la châine de blocs.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
+        <source>Synchronize the transactions and balance.</source>
+        <translation>Synchroniser les transactions et le solde.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
+        <source>Show the wallet&apos;s balance of the currently selected account.</source>
+        <translation>Afficher le solde du compte actuellement sélectionné.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2759"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
-Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
+Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <source>Show the payments for the given payment IDs.</source>
+        <translation>Afficher les paiements pour les IDs de paiement donnés.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
+        <source>Show the blockchain height.</source>
+        <translation>Afficher la hauteur de la chaîne de blocs.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2782"/>
+        <source>Send all unmixable outputs to yourself with ring_size 1</source>
+        <translation>Envoyer toutes les sorties non mélangeables à vous-même avec une taille de cercle de 1</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2789"/>
+        <source>Send all unlocked outputs below the threshold to an address.</source>
+        <translation>Envoyer toutes les sorties débloquées d&apos;un montant inférieur au seuil à une adresse.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2793"/>
+        <source>Send a single output of the given key image to an address without change.</source>
+        <translation>Envoyer une unique sortie ayant une image de clé donnée à une adresse sans rendu de monnaie.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
+        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
+        <translation>Donner &lt;montant&gt; à l&apos;équipe de développement (donate.getmonero.org).</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2804"/>
+        <source>Submit a signed transaction from a file.</source>
+        <translation>Transmettre une transaction signée d&apos;un fichier.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2808"/>
+        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
+        <translation>Changer le niveau de détail du journal (le niveau doit être &lt;0-4&gt;).</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2812"/>
+        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
+If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
+If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
+If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
+If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
+If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
+        <translation>Si aucun argument n&apos;est spécifié, le portefeuille affiche tous les comptes existants ainsi que leurs soldes.
+Si l&apos;argument &quot;new&quot; est spécifié, le portefeuille crée un nouveau compte avec son étiquette initialisée par le texte fourni (qui peut être vide).
+Si l&apos;argument &quot;switch&quot; est spécifié, le portefeuille passe au compte spécifié par &lt;index&gt;.
+Si l&apos;argument &quot;label&quot; est spécifié, le portefeuille affecte le texte fourni à l&apos;étiquette du compte spécifié par &lt;index&gt;.
+Si l&apos;argument &quot;tag&quot; est spécifié, un mot clé &lt;mot_clé&gt; est assigné aux comptes spécifiés &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+Si l&apos;argument &quot;untag&quot; est spécifié, les mots clés assignés aux comptes spécifiés &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., sont supprimés.
+Si l&apos;argument &quot;tag_description&quot; est spécifié, le texte arbitraire &lt;description&gt; est assigné au mot clé &lt;mot_clé&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
+        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
+        <translation>Encoder un ID de paiement dans une adresse intégrée pour l&apos;adresse publique du portefeuille actuel (en l&apos;absence d&apos;argument un ID de paiement aléatoire est utilisé), ou décoder une adresse intégrée en une adresse standard et un ID de paiement</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
+        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
+        <translation>Afficher toutes les entrées du carnet d&apos;adresses, optionnellement en y ajoutant/supprimant une entrée.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
+        <source>Save the wallet data.</source>
+        <translation>Sauvegarder les données du portefeuille.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
+        <source>Save a watch-only keys file.</source>
+        <translation>Sauvegarder un fichier de clés d&apos;audit.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
+        <source>Display the private view key.</source>
+        <translation>Afficher la clé privée d&apos;audit.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
+        <source>Display the private spend key.</source>
+        <translation>Afficher la clé privée de dépense.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation>Afficher la phrase mnémonique de style Electrum</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -927,8 +2492,10 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&qu
    Set the wallet&apos;s refresh behaviour.
  priority [0|1|2|3|4]
    Set the fee to default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
+ confirm-missing-payment-id &lt;1|0&gt; (obsolete)
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
+   action: ask the password before many actions such as transfer, etc
+   decrypt: same as action, but keeps the spend key encrypted in memory when not needed
  unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
    Set the default monero (sub-)unit.
  min-outputs-count [n]
@@ -957,1481 +2524,47 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
-        <source>Show the incoming/outgoing transfers within an optional height range.
-
-Output format:
-In or Coinbase:    Block Number, &quot;block&quot;|&quot;in&quot;,              Time, Amount,  Transaction Hash, Payment ID, Subaddress Index,                     &quot;-&quot;, Note
-Out:               Block Number, &quot;out&quot;,                     Time, Amount*, Transaction Hash, Payment ID, Fee, Destinations, Input addresses**, &quot;-&quot;, Note
-Pool:                            &quot;pool&quot;, &quot;in&quot;,              Time, Amount,  Transaction Hash, Payment Id, Subaddress Index,                     &quot;-&quot;, Note, Double Spend Note
-Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;out&quot;, Time, Amount*, Transaction Hash, Payment ID, Fee, Input addresses**,               &quot;-&quot;, Note
-
-* Excluding change and fee.
-** Set of address indices used as inputs in this transfer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
-        <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2776"/>
-        <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2818"/>
-        <source>Export a signed set of key images to a &lt;filename&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
-        <source>Synchronizes key images with the hw wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2865"/>
-        <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
-        <source>Interface with the MMS (Multisig Messaging System)
-&lt;subcommand&gt; is one of:
-  init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
-  send_signer_config, start_auto_config, stop_auto_config, auto_config
-Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;subcommand&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
-        <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
-        <source>Display current MMS configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
-        <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
-        <source>List all messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2913"/>
-        <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
-By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
-        <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2922"/>
-        <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
-        <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
-        <source>Send a single message by giving its id, or send all waiting messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
-        <source>Check right away for new messages to receive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
-        <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
-        <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
-        <source>Show detailed info about a single message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2950"/>
-        <source>Available options:
- auto-send &lt;1|0&gt;
-   Whether to automatically send newly generated messages right away.
- </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2956"/>
-        <source>Send completed signer config to all other authorized signers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
-        <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2964"/>
-        <source>Delete any auto-config tokens and abort a auto-config process</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
-        <source>Start auto-config by using the token received from the auto-config manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
-        <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2990"/>
-        <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
-        <source>Checks whether an output is marked as spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3106"/>
-        <source>&lt;device_name[:device_spec]&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
-        <source>wrong number range, use: %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
-        <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <source>string</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
-        <source>25 words</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4631"/>
-        <source>Device requires attention</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4639"/>
-        <source>Enter device PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4641"/>
-        <source>Failed to read device PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
-        <source>Please enter the device passphrase on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4655"/>
-        <source>Enter device passphrase</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4657"/>
-        <source>Failed to read device passphrase</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4673"/>
-        <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4675"/>
-        <source>Do you want to do it now? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4677"/>
-        <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4855"/>
-        <source>Invalid keyword: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
-        <source>Heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5502"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5738"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6059"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6318"/>
-        <source>transaction cancelled.</source>
-        <translation>transaction annulée.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation>Est-ce correct quand même ?  (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5486"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Il y a actuellement un arriéré de %u blocs à ce niveau de frais. Est-ce correct quand même ?  (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Failed to check for backlog: </source>
-        <translation>Échec de la vérification du backlog : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
-        <source>
-Transaction </source>
-        <translation>
-Transaction </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5537"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6037"/>
-        <source>Spending from address index %d
-</source>
-        <translation>Dépense depuis l&apos;adresse d&apos;index %d
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5539"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6039"/>
-        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
-</source>
-        <translation>ATTENTION : Des sorties de multiples adresses sont utilisées ensemble, ce qui pourrait potentiellement compromettre votre confidentialité.
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5541"/>
-        <source>Sending %s.  </source>
-        <translation>Envoi de %s.  </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5544"/>
-        <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
-        <translation>Votre transaction doit être scindée en %llu transactions. Il en résulte que des frais de transaction doivent être appliqués à chaque transaction, pour un total de %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5550"/>
-        <source>The transaction fee is %s</source>
-        <translation>Les frais de transaction sont de %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
-        <source>, of which %s is dust from change</source>
-        <translation>, dont %s est de la poussière de monnaie rendue</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
-        <source>.</source>
-        <translation>.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
-        <source>A total of %s from dust change will be sent to dust address</source>
-        <translation>Un total de %s de poussière de monnaie rendue sera envoyé à une adresse de poussière</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation>.
-Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s jours (en supposant 2 minutes par bloc)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
-        <source>Unsigned transaction(s) successfully written to MMS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5611"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6328"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6340"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5616"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6344"/>
-        <source>Unsigned transaction(s) successfully written to file: </source>
-        <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5625"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6086"/>
-        <source>Failed to cold sign transaction with HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5708"/>
-        <source>No unmixable outputs found</source>
-        <translation>Aucune sortie non mélangeable trouvée</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5815"/>
-        <source>No address given</source>
-        <translation>Aucune adresse fournie</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6213"/>
-        <source>failed to parse Payment ID</source>
-        <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6236"/>
-        <source>failed to parse key image</source>
-        <translation>échec de l&apos;analyse de l&apos;image de clé</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
-        <source>No outputs found</source>
-        <translation>Pas de sorties trouvées</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
-        <source>Multiple transactions are created, which is not supposed to happen</source>
-        <translation>De multiples transactions sont crées, ce qui n&apos;est pas supposé arriver</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6300"/>
-        <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
-        <translation>La transaction utilise aucune ou de multiples entrées, ce qui n&apos;est pas supposé arriver</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6377"/>
-        <source>missing threshold amount</source>
-        <translation>montant seuil manquant</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
-        <source>invalid amount threshold</source>
-        <translation>montant seuil invalide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9015"/>
-        <source> (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9042"/>
-        <source>Choose processing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9051"/>
-        <source>Sign tx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
-        <source>Send the tx for submission to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9063"/>
-        <source>Send the tx for signing to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <source>Submit tx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9073"/>
-        <source>unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
-        <source>Choice: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
-        <source>Wrong choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
-        <source>Id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
-        <source>I/O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
-        <source>Authorized Signer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
-        <source>Message Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
-        <source>Height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
-        <source>Message State</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
-        <source>Since</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
-        <source> ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>Transport Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
-        <source>Auto-Config Token</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
-        <source>Monero Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
-        <source>&lt;not set&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9178"/>
-        <source>Message </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
-        <source>In/out: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
-        <source>State: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
-        <source>%s since %s, %s ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9185"/>
-        <source>Sent: Never</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9189"/>
-        <source>Sent: %s, %s ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9192"/>
-        <source>Authorized signer: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
-        <source>Content size: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
-        <source> bytes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
-        <source>Content: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
-        <source>(binary data)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9224"/>
-        <source>Send these messages now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9234"/>
-        <source>Queued for sending.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9254"/>
-        <source>Invalid message id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9263"/>
-        <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9269"/>
-        <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
-        <source>Error in the number of required signers and/or authorized signers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9301"/>
-        <source>The MMS is not active.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9324"/>
-        <source>Invalid signer number </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
-        <source>Invalid Monero address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
-        <source>Wallet state does not allow changing Monero addresses anymore</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9367"/>
-        <source>Usage: mms list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9380"/>
-        <source>Usage: mms next [sync]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9405"/>
-        <source>No next step: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9415"/>
-        <source>prepare_multisig</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9421"/>
-        <source>make_multisig</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9436"/>
-        <source>exchange_multisig_keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9571"/>
-        <source>export_multisig_info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9460"/>
-        <source>import_multisig_info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9473"/>
-        <source>sign_multisig</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9483"/>
-        <source>submit_multisig</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
-        <source>Send tx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9504"/>
-        <source>Process signer config</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9516"/>
-        <source>Replace current signer config with the one displayed above?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
-        <source>Process auto config data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9544"/>
-        <source>Nothing ready to process</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
-        <source>Usage: mms sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9588"/>
-        <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9595"/>
-        <source>Delete all messages?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
-        <source>Usage: mms send [&lt;message_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9638"/>
-        <source>Usage: mms receive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9655"/>
-        <source>Usage: mms export &lt;message_id&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9667"/>
-        <source>Message content saved to: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9671"/>
-        <source>Failed to to save message content</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9695"/>
-        <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <source>No signer found with label </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9724"/>
-        <source>Usage: mms show &lt;message_id&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
-        <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9760"/>
-        <source>Wrong option value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
-        <source>Auto-send is on</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
-        <source>Auto-send is off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9770"/>
-        <source>Unknown option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9778"/>
-        <source>Usage: mms help [&lt;subcommand&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
-        <source>Usage: mms send_signer_config</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9800"/>
-        <source>Signer config not yet complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
-        <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9820"/>
-        <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9826"/>
-        <source>Auto-config is already running. Cancel and restart?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9850"/>
-        <source>Usage: mms stop_auto_config</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9853"/>
-        <source>Delete any auto-config tokens and stop auto-config?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9866"/>
-        <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
-        <source>Invalid auto-config token</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9879"/>
-        <source>Auto-config already running. Cancel and restart?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9911"/>
-        <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9988"/>
-        <source>Invalid MMS subcommand</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
-        <source>Error in MMS command: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6516"/>
-        <source>Claimed change does not go to a paid address</source>
-        <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
-        <source>Claimed change is larger than payment to the change address</source>
-        <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6552"/>
-        <source>sending %s to %s</source>
-        <translation>envoi de %s à %s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6562"/>
-        <source> dummy output(s)</source>
-        <translation> sortie(s) factice(s)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6565"/>
-        <source>with no destinations</source>
-        <translation>sans destination</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>%lu transactions chargées, pour %s, frais %s, %s, %s, taille de cercle minimum %lu, %s. %sEst-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6606"/>
-        <source>This is a multisig wallet, it can only sign with sign_multisig</source>
-        <translation>Ceci est un portefeuille multisig, il ne peut signer qu&apos;avec sign_multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6629"/>
-        <source>Failed to sign transaction</source>
-        <translation>Échec de signature de transaction</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
-        <source>Failed to sign transaction: </source>
-        <translation>Échec de signature de transaction : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
-        <source>Transaction raw hex data exported to </source>
-        <translation>Données brutes hex de la transaction exportées vers </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6677"/>
-        <source>Failed to load transaction from file</source>
-        <translation>Échec du chargement de la transaction du fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5051"/>
-        <source>RPC error: </source>
-        <translation>Erreur RPC : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
-        <source>wallet is watch-only and has no spend key</source>
-        <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de clé de dépense</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
-        <source>Your original password was incorrect.</source>
-        <translation>Votre mot de passe original est incorrect.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
-        <source>Error with wallet rewrite: </source>
-        <translation>Erreur avec la réécriture du portefeuille : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
-        <source>invalid unit</source>
-        <translation>unité invalide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2364"/>
-        <source>invalid count: must be an unsigned integer</source>
-        <translation>nombre invalide : un entier non signé est attendu</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
-        <source>invalid value</source>
-        <translation>valeur invalide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation>(Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
-        <source>bad m_restore_height parameter: </source>
-        <translation>mauvais paramètre m_restore_height : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3766"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation>le format de date doit être AAAA-MM-JJ</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3779"/>
-        <source>Restore height is: </source>
-        <translation>La hauteur de restauration est : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3780"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
-        <source>Daemon is local, assuming trusted</source>
-        <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4355"/>
-        <source>Password for new watch-only wallet</source>
-        <translation>Mot de passe pour le nouveau portefeuille d&apos;audit</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4739"/>
-        <source>internal error: </source>
-        <translation>erreur interne : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5056"/>
-        <source>unexpected error: </source>
-        <translation>erreur inattendue : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1534"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6690"/>
-        <source>unknown error</source>
-        <translation>erreur inconnue</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
-        <source>refresh failed: </source>
-        <translation>échec du rafraîchissement : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
-        <source>Blocks received: </source>
-        <translation>Blocs reçus : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
-        <source>unlocked balance: </source>
-        <translation>solde débloqué : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>amount</source>
-        <translation>montant</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
-        <source>false</source>
-        <translation>faux</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
-        <source>Unknown command: </source>
-        <translation>Commande inconnue : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
-        <source>Command usage: </source>
-        <translation>Usage de la commande : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
-        <source>Command description: </source>
-        <translation>Description de la commande : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
-        <source>wallet is multisig but not yet finalized</source>
-        <translation>le portefeuille est multisig mais pas encore finalisé</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
-        <source>Failed to retrieve seed</source>
-        <translation>Échec de la récupération de la phrase mnémonique</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="792"/>
-        <source>wallet is multisig and has no seed</source>
-        <translation>le portefeuille est multisig et n&apos;a pas de phrase mnémonique</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
-        <source>Error: failed to estimate backlog array size: </source>
-        <translation>Erreur : échec de l&apos;estimation de la taille du tableau d&apos;arriéré : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="904"/>
-        <source>Error: bad estimated backlog array size</source>
-        <translation>Erreur : mauvaise estimation de la taille du tableau d&apos;arriéré</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
-        <source> (current)</source>
-        <translation> (actuel)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="919"/>
-        <source>%u block (%u minutes) backlog at priority %u%s</source>
-        <translation>arriéré de %u bloc(s) (%u minutes) à la priorité %u%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
-        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
-        <translation>arriéré de %u à %u bloc(s) (%u à %u minutes) à la priorité %u</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="924"/>
-        <source>No backlog at priority </source>
-        <translation>Pas d&apos;arriéré à la priorité </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
-        <source>This wallet is already multisig</source>
-        <translation>Le portefeuille est déjà multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="949"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
-        <source>wallet is watch-only and cannot be made multisig</source>
-        <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas être tranformé en multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1000"/>
-        <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
-        <translation>Ce portefeuille a été utilisé auparavant, veuillez utiliser un nouveau portefeuille pour créer un portefeuille multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="963"/>
-        <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation>Envoyez ces infos multisig à tous les autres participants, ensuite utilisez make_multisig &lt;seuil&gt; &lt;info1&gt; [&lt;info2&gt;...] avec les infos multisig des autres</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
-        <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
-        <translation>Ceci inclut la clé PRIVÉE d&apos;audit, donc ne doit être divulgué qu&apos;aux participants de ce portefeuille multisig </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1014"/>
-        <source>Invalid threshold</source>
-        <translation>Seuil invalide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1156"/>
-        <source>Another step is needed</source>
-        <translation>Une autre étape est nécessaire</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
-        <source>Error creating multisig: </source>
-        <translation>Erreur de création multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
-        <source>Error creating multisig: new wallet is not multisig</source>
-        <translation>Erreur de création multisig : le nouveau portefeuille n&apos;est pas multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1056"/>
-        <source> multisig address: </source>
-        <translation> adresse multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1129"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
-        <source>This wallet is not multisig</source>
-        <translation>Ce portefeuille n&apos;est pas multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
-        <source>This wallet is already finalized</source>
-        <translation>Ce portefeuille est déjà finalisé</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
-        <source>Failed to finalize multisig</source>
-        <translation>Échec de finalisation multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
-        <source>Failed to finalize multisig: </source>
-        <translation>Échec de finalisation multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
-        <source>This multisig wallet is not yet finalized</source>
-        <translation>Ce portefeuille multisig n&apos;est pas encore finalisé</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
-        <source>Error exporting multisig info: </source>
-        <translation>Erreur d&apos;importation des infos multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1240"/>
-        <source>Multisig info exported to </source>
-        <translation>Infos multisig exportées vers </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
-        <source>Multisig info imported</source>
-        <translation>Infos multisig importées</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <source>Failed to import multisig info: </source>
-        <translation>Échec de l&apos;importation des infos multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
-        <source>Failed to update spent status after importing multisig info: </source>
-        <translation>Échec de la mise à jour de l&apos;état des dépenses après l&apos;importation des infos multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1327"/>
-        <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
-        <translation>Pas un démon de confiance, l&apos;état des dépenses peut être incorrect. Utilisez un démon de confiance et executez &quot;rescan_spent&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1471"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <source>This is not a multisig wallet</source>
-        <translation>Ceci n&apos;est pas un portefeuille multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
-        <source>Failed to sign multisig transaction</source>
-        <translation>Échec de la signature de la transaction multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
-        <source>Multisig error: </source>
-        <translation>Erreur multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1426"/>
-        <source>Failed to sign multisig transaction: </source>
-        <translation>Échec de la signature de la transaction multisig : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <source>It may be relayed to the network with submit_multisig</source>
-        <translation>Elle peut être transmise au réseau avec submit_multisig</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1508"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <source>Failed to load multisig transaction from file</source>
-        <translation>Échec du chargement de la transaction multisig du fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
-        <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
-        <translation>Transaction multisig signée par %u signataire(s) seulement, nécessite %u signature(s) de plus</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8890"/>
-        <source>Transaction successfully submitted, transaction </source>
-        <translation>Transaction transmise avec succès, transaction </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
-        <source>You can check its status by using the `show_transfers` command.</source>
-        <translation>Vous pouvez vérifier son statut en utilisant la commane &apos;show_transfers&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
-        <source>Failed to export multisig transaction to file </source>
-        <translation>Échec de l&apos;exportation de la transaction multisig vers le fichier </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
-        <source>Saved exported multisig transaction file(s): </source>
-        <translation>Transaction multisig enregistrée dans le(s) fichier(s) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
-        <source>ring size must be an integer &gt;= </source>
-        <translation>la taille de cercle doit être un nombre entier &gt;= </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <source>could not change default ring size</source>
-        <translation>échec du changement de la taille de cercle par défaut</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2398"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
-        <source>Invalid height</source>
-        <translation>Hauteur invalide</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
-        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
-        <translation>Démarrer la mine dans le démon (mine_arrière_plan et ignorer_batterie sont des booléens facultatifs).</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2565"/>
-        <source>Stop mining in the daemon.</source>
-        <translation>Arrêter la mine dans le démon.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2569"/>
-        <source>Set another daemon to connect to.</source>
-        <translation>Spécifier un autre démon auquel se connecter.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
-        <source>Save the current blockchain data.</source>
-        <translation>Sauvegarder les données actuelles de la châine de blocs.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
-        <source>Synchronize the transactions and balance.</source>
-        <translation>Synchroniser les transactions et le solde.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2579"/>
-        <source>Show the wallet&apos;s balance of the currently selected account.</source>
-        <translation>Afficher le solde du compte actuellement sélectionné.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2589"/>
-        <source>Show the payments for the given payment IDs.</source>
-        <translation>Afficher les paiements pour les IDs de paiement donnés.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
-        <source>Show the blockchain height.</source>
-        <translation>Afficher la hauteur de la chaîne de blocs.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
-        <source>Send all unmixable outputs to yourself with ring_size 1</source>
-        <translation>Envoyer toutes les sorties non mélangeables à vous-même avec une taille de cercle de 1</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2613"/>
-        <source>Send all unlocked outputs below the threshold to an address.</source>
-        <translation>Envoyer toutes les sorties débloquées d&apos;un montant inférieur au seuil à une adresse.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
-        <source>Send a single output of the given key image to an address without change.</source>
-        <translation>Envoyer une unique sortie ayant une image de clé donnée à une adresse sans rendu de monnaie.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2621"/>
-        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
-        <translation>Donner &lt;montant&gt; à l&apos;équipe de développement (donate.getmonero.org).</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2628"/>
-        <source>Submit a signed transaction from a file.</source>
-        <translation>Transmettre une transaction signée d&apos;un fichier.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
-        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
-        <translation>Changer le niveau de détail du journal (le niveau doit être &lt;0-4&gt;).</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
-        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
-If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
-If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
-If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.
-If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
-If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
-If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
-        <translation>Si aucun argument n&apos;est spécifié, le portefeuille affiche tous les comptes existants ainsi que leurs soldes.
-Si l&apos;argument &quot;new&quot; est spécifié, le portefeuille crée un nouveau compte avec son étiquette initialisée par le texte fourni (qui peut être vide).
-Si l&apos;argument &quot;switch&quot; est spécifié, le portefeuille passe au compte spécifié par &lt;index&gt;.
-Si l&apos;argument &quot;label&quot; est spécifié, le portefeuille affecte le texte fourni à l&apos;étiquette du compte spécifié par &lt;index&gt;.
-Si l&apos;argument &quot;tag&quot; est spécifié, un mot clé &lt;mot_clé&gt; est assigné aux comptes spécifiés &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
-Si l&apos;argument &quot;untag&quot; est spécifié, les mots clés assignés aux comptes spécifiés &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., sont supprimés.
-Si l&apos;argument &quot;tag_description&quot; est spécifié, le texte arbitraire &lt;description&gt; est assigné au mot clé &lt;mot_clé&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
-        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation>Encoder un ID de paiement dans une adresse intégrée pour l&apos;adresse publique du portefeuille actuel (en l&apos;absence d&apos;argument un ID de paiement aléatoire est utilisé), ou décoder une adresse intégrée en une adresse standard et un ID de paiement</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2654"/>
-        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
-        <translation>Afficher toutes les entrées du carnet d&apos;adresses, optionnellement en y ajoutant/supprimant une entrée.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2657"/>
-        <source>Save the wallet data.</source>
-        <translation>Sauvegarder les données du portefeuille.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2660"/>
-        <source>Save a watch-only keys file.</source>
-        <translation>Sauvegarder un fichier de clés d&apos;audit.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
-        <source>Display the private view key.</source>
-        <translation>Afficher la clé privée d&apos;audit.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2666"/>
-        <source>Display the private spend key.</source>
-        <translation>Afficher la clé privée de dépense.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
-        <source>Display the Electrum-style mnemonic seed</source>
-        <translation>Afficher la phrase mnémonique de style Electrum</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation>Afficher la phrase mnémonique de style Electrum chiffrée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation>Rescanner la chaîne de blocs pour trouver les sorties dépensées.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2904"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation>Obtenir la clé de transaction (r) pour un &lt;ID_transaction&gt; donné.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2912"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation>Vérifier le montant allant à &lt;adresse&gt; dans &lt;ID_transaction&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation>Générer une signature prouvant l&apos;envoi de fonds à &lt;adresse&gt; dans &lt;ID_transaction&gt;, optionnellement avec un &lt;message&gt; comme challenge, en utilisant soit la clé secrète de transaction (quand &lt;adresse&gt; n&apos;est pas l&apos;adresse de votre portefeuille) soit la clé secrète d&apos;audit (dans le cas contraire), tout en ne divulgant pas la clé secrète.</translation>
+        <translation>Générer une signature prouvant l&apos;envoi de fonds à &lt;adresse&gt; dans &lt;ID_transaction&gt;, optionnellement avec un &lt;message&gt; comme challenge, en utilisant soit la clé secrète de transaction (quand &lt;adresse&gt; n&apos;est pas l&apos;adresse de votre portefeuille) soit la clé secrète d&apos;audit (dans le cas contraire), tout en ne divulguant pas la clé secrète.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation>Vérifier la validité de la preuve de fonds allant à &lt;adresse&gt; dans &lt;ID_transaction&gt; avec le &lt;message&gt; de challenge s&apos;il y en a un.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Générer une signature prouvant que vous avez créé &lt;ID_transaction&gt; en utilisant la clé secrète de dépense, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2928"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Vérifier la validité de la preuve que le signataire a créé &lt;ID_transaction&gt;, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
@@ -2440,238 +2573,283 @@ Si &apos;all&apos; est spécifié, vous prouvez la somme totale des soldes de to
 Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre compte actuel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Vérifier la validité d&apos;une signature prouvant que le propriétaire d&apos;une &lt;adresse&gt; détient au moins un montant, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation>Afficher les sorties non dépensées d&apos;une adresse spécifique dans un interval de montants facultatif.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2962"/>
+        <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation>Définir un texte arbitraire comme note pour &lt;ID_transaction&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2970"/>
         <source>Get a string note for a txid.</source>
-        <translation>Obtenir le texte de la note pour &lt;ID_transaction&gt;.</translation>
+        <translation>Obtenir le texte de la note pour un ID de transaction.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation>Définir un texte arbitraire comme description du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
         <source>Get the description of the wallet.</source>
         <translation>Obtenir la description du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
         <source>Show the wallet&apos;s status.</source>
         <translation>Afficher l&apos;état du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2984"/>
         <source>Show the wallet&apos;s information.</source>
         <translation>Afficher les informations du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2810"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
         <source>Sign the contents of a file.</source>
         <translation>Signer le contenu d&apos;un fichier.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation>Vérifier la signature du contenu d&apos;un fichier.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation>Importer un ensemble signé d&apos;images de clé et vérifier si elles correspondent à des dépenses.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation>Exporter un ensemble de sorties possédées par ce portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2838"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3016"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation>Importer un ensemble de sorties possédées par ce portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3020"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation>Afficher les information à propos d&apos;un transfert vers/depuis cette adresse.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3023"/>
         <source>Change the wallet&apos;s password.</source>
         <translation>Changer le mot de passe du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation>Générer un nouvel ID de paiement long aléatoire. Ceux-ci sont en clair dans la chaîne de blocs, voir integrated_address pour les IDs de paiement courts cryptés.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation>Afficher les informations à propos des frais et arriéré de transactions actuels.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3032"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation>Exporter les données nécessaires pour créer un portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation>Transformer ce portefeuille en portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3039"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation>Transformer ce portefeuille en portefeuille multisig, étape supplémentaire pour les portefeuilles N-1/N</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
         <source>Export multisig info for other participants</source>
         <translation>Exporter les infos multisig pour les autres participants</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
         <source>Import multisig info from other participants</source>
         <translation>Importer les infos multisig des autres participants</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3055"/>
         <source>Sign a multisig transaction from a file</source>
         <translation>Signer une transaction multisig d&apos;un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation>Transmettre une transaction multisig signée d&apos;un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation>Exporter une transaction multisig signée vers un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3160"/>
+        <source>Unsets the ring used for a given key image or transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
+        <source>Freeze a single output by key image so it will not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>Thaw a single output by key image so it may be used again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3188"/>
+        <source>Checks whether a given output is currently frozen by key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3192"/>
+        <source>Prints simple network stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Prints basic info about Monero for first time users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation>Afficher la section d&apos;aide ou la documentation d&apos;une &lt;commande&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source> (set this to support the network and to get a chance to receive new monero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3295"/>
         <source>integer &gt;= </source>
         <translation>entier &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3308"/>
         <source>block height</source>
         <translation>hauteur de bloc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3316"/>
+        <source>1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation>Aucun portefeuille avec ce nom trouvé. Confirmer la création d&apos;un nouveau portefeuille nommé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation>impossible de spécifier à la fois --restore-deterministic-wallet ou --restore-multisig-wallet et --non-deterministic</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-multisig-wallet utilise --generate-new-wallet, pas --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3562"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation>spécifiez un paramètre de récupération avec --electrum-seed=&quot;phrase mnémonique multisig ici&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
         <source>Multisig seed failed verification</source>
         <translation>Échec de la vérification de la phrase mnémonique multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3718"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation>Cette adresse est une sous-adresse qui ne peut pas être utilisée ici.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
         <source>Error: expected M/N, but got: </source>
         <translation>Erreur : M/N attendu, mais lu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3563"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation>Erreur : N &gt; 1 et N &lt;= M attendu, mais lu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3568"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation>Erreur : M/N n&apos;est actuellement pas supporté. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation>Génération du portefeuille principal à partir de %u de %u clés de portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3838"/>
         <source>failed to parse secret view key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3846"/>
         <source>failed to verify secret view key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation>Clé secrète de dépense (%u de %u) :</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
         <source>Error: M/N is currently unsupported</source>
         <translation>Erreur : M/N n&apos;est actuellement pas supporté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3802"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
         <source>Restore height </source>
         <translation>Hauteur de restauration </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3803"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation>Appliquer la hauteur de restauration quand même ?  (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3829"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
         <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
         <translation>Attention : en n&apos;utilisant %s qui n&apos;est pas un démon de confiance, la confidentialité sera réduite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3888"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
+        <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4098"/>
+        <source>WARNING: obsolete long payment IDs are enabled. Sending transactions with those payment IDs are bad for your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4100"/>
+        <source>It is recommended that you do not use them, and ask recipients who ask for one to not endanger your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation>Le démon n&apos;est pas lancé ou un mauvais port a été fourni. Veuillez vous assurer que le démon fonctionne ou changez l&apos;adresse de démon avec la commande &apos;set_daemon&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4313"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2690,1419 +2868,1467 @@ votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent 
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4457"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>échec de la génération du nouveau portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation>Nouveau portefeuille multisig %u/%u généré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation>Portefeuille multisig %u/%u ouvert%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation>Utilisez &quot;help &lt;commande&gt;&quot; pour voir la documentation d&apos;une commande.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4628"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation>c&apos;est un portefeuille multisig et il ne peut pas sauvegarder une version d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4696"/>
+        <source>Failed to query mining status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Failed to setup background mining: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4683"/>
+        <source>Background mining enabled. Thank you for supporting the Monero network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4719"/>
+        <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4725"/>
+        <source>Using an untrusted daemon, skipping background mining check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4750"/>
+        <source>The daemon is not set up to background mine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4752"/>
+        <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4864"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation>Taille de tableau inattendue - Sortie de simple_wallet::set_daemon()</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4905"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation>Ceci semble ne pas être une URL de démon valide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4590"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
         <source>txid </source>
         <translation>ID transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>idx </source>
         <translation>index </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4780"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <source>New transfer received since rescan was started. Key images are incomplete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Certaines sorties ont des images de clé partielles - import_multisig_info requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Currently selected account: [</source>
         <translation>Compte actuellement sélectionné : [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Tag: </source>
         <translation>Mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>(No tag assigned)</source>
         <translation>(Pas de mot clé assigné)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
         <source>Balance per address:</source>
         <translation>Solde par adresse :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
         <source>Outputs</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>spent</source>
         <translation>dépensé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>global index</source>
         <translation>index global</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>tx id</source>
         <translation>ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
         <source>addr index</source>
         <translation>index adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <source>Used at heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>[frozen]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
         <source>No incoming transfers</source>
         <translation>Aucun transfert entrant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4928"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
         <source>No incoming available transfers</source>
         <translation>Aucun transfert entrant disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4932"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
         <source>No incoming unavailable transfers</source>
         <translation>Aucun transfert entrant non disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
         <source>payment</source>
         <translation>paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
         <source>transaction</source>
         <translation>transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
         <source>height</source>
         <translation>hauteur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
         <source>unlock time</source>
         <translation>durée de déverrouillage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
         <source>No payments with id </source>
         <translation>Aucun paiement avec l&apos;ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
         <source>failed to get blockchain height: </source>
         <translation>échec de la récupération de la hauteur de la chaîne de blocs : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaction %llu/%llu : ID=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5135"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation>
-Entrée %llu/%llu : montant=%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5151"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
         <source>failed to get output: </source>
         <translation>échec de la récupération de la sortie : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>la hauteur du bloc d&apos;origine de la clé de la sortie ne devrait pas être supérieure à celle de la chaîne de blocs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5163"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
         <source>
 Originating block heights: </source>
         <translation>
 Hauteurs des blocs d&apos;origine : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Attention : Certaines clés d&apos;entrées étant dépensées sont issues de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, ce qui peut casser l&apos;anonymat du cercle de signature. Assurez-vous que c&apos;est intentionnel !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6156"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
         <source>Ring size must not be 0</source>
         <translation>La taille de cercle ne doit pas être 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>la taille de cercle %u est trop petite, le minimum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
         <source>wrong number of arguments</source>
         <translation>mauvais nombre d&apos;arguments</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6268"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Aucun ID de paiement n&apos;est inclus dans cette transaction. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Aucune sortie trouvée, ou le démon n&apos;est pas prêt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6444"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7750"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <source>Warning: your restore height is higher than wallet restore height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <source>Rescan anyway ? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8605"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
         <source>command only supported by HW wallet</source>
         <translation>commande supportée uniquement par un portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8576"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">Échec de l&apos;importation des images de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8614"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
         <source>Failed to reconnect device</source>
         <translation>Échec de la reconnexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8619"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
         <source>Failed to reconnect device: </source>
         <translation>Échec de la reconnexion à l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
         <source>Transaction successfully saved to </source>
         <translation>Transaction sauvegardée avec succès dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
         <source>, txid </source>
         <translation>, ID transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
         <source>Failed to save transaction to </source>
         <translation>Échec de la sauvegarde de la transaction dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Balayage de %s dans %llu transactions pour des frais totaux de %s. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6310"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Balayage de %s pour des frais totaux de %s. Est-ce correct ? (Y/Yes/Oui/N/No/Non) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
         <source>This is a watch only wallet</source>
         <translation>Ceci est un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8813"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation>Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
         <source>Transaction ID not found</source>
         <translation>ID de transaction non trouvé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="410"/>
         <source>failed to parse refresh type</source>
         <translation>échec de l&apos;analyse du type de rafraîchissement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1067"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7010"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8670"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
         <source>command not supported by HW wallet</source>
         <translation>commande non supportée par le portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>c&apos;est un portefeuille non déterministe et il n&apos;a pas de phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation>Entrer une phrase de passe facultative pour le décalage de la phrase mnémonique, effacer pour voir la phrase mnémonique brute</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
         <source>Incorrect password</source>
         <translation>Mot de passe invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
         <source>Current fee is %s %s per %s</source>
         <translation>Les frais sont actuellement de %s %s par %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1812"/>
         <source>Invalid key image</source>
         <translation>Image de clé invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
         <source>Invalid txid</source>
         <translation>ID de transaction invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation>Image de clé soit non dépensée, soit dépensée avec 0 mélange</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
         <source>Failed to get key image ring: </source>
         <translation>Échec de la récupération du cercle de l&apos;image de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1703"/>
         <source>File doesn&apos;t exist</source>
         <translation>Le fichier d&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
         <source>Invalid ring specification: </source>
         <translation>Spécification de cercle invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1733"/>
         <source>Invalid key image: </source>
         <translation>Image de clé invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation>Type de cercle invalide, &quot;relative&quot; ou &quot;absolute&quot; attendu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
         <source>Error reading line: </source>
         <translation>Erreur lors de la lecture de la ligne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1767"/>
         <source>Invalid ring: </source>
         <translation>Cercle invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Invalid relative ring: </source>
         <translation>Cercle relatif invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
         <source>Invalid absolute ring: </source>
         <translation>Cercle absolu invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
         <source>Failed to set ring for key image: </source>
         <translation>Échec de l&apos;affectation du cercle pour l&apos;image de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
         <source>Continuing.</source>
         <translation>On continue.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
         <source>Missing absolute or relative keyword</source>
         <translation>Mot clé &quot;absolute&quot; ou &quot;relative&quot; manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation>index invalide : doit être un nombre entier strictement positif</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
         <source>invalid index: indices wrap</source>
         <translation>index invalide : boucle des indices</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1862"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation>index invalide : les indices doivent être en ordre strictement croissant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
         <source>failed to set ring</source>
         <translation>échec de l&apos;affectation du cercle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1946"/>
         <source>First line is not an amount</source>
         <translation>La première ligne n&apos;est pas un montant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
         <source>Invalid output: </source>
         <translation>Sortie invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
         <source>Bad argument: </source>
         <translation>Mauvais argument : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
         <source>should be &quot;add&quot;</source>
         <translation>devrait être &quot;add&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
         <source>Failed to open file</source>
         <translation>Échec de l&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation>Clé de sortie invalide, et le fichier n&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1952"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2035"/>
         <source>Invalid output</source>
         <translation>Sortie invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2063"/>
         <source>Failed to save known rings: </source>
         <translation>Échec de la sauvegarde des cercles connus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas transférer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation>ATTENTION : ceci c&apos;est pas la taille de cercle par défaut, ce qui peut nuire à votre confidentialité. La valeur par défaut est recommandée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation>ATTENTION : ) partir de v8, la taille de cercle sera fixée et ce paramètre sera ignoré.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2137"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2325"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation>la priorité doit être 0, 1, 2, 3, 4 ou l&apos;une de : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2330"/>
         <source>could not change default priority</source>
         <translation>échec du changement de la priorité par défaut</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2400"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation>argument invalide : doit être soit 0/never, 1/action, ou 2/encrypt/decrypt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élévés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
+        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élévés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
+        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
-        <translation>Transférer tout le solde débloqué à une adresse et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par ces indices d&apos;adresse. Si il est omis, le portefeuille choisit un index d&apos;adresse à utiliser aléatoirement. &lt;priorité&gt; est la priorité du balayage. Plus la priorité est haute, plus les frais de transaction sont élévés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité.</translation>
+        <translation>Transférer tout le solde débloqué à une adresse et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par ces indices d&apos;adresse. Si il est omis, le portefeuille choisit un index d&apos;adresse à utiliser aléatoirement. &lt;priorité&gt; est la priorité du balayage. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation>Envoyer tout le solde débloqué à une adresse. Si le paramètre &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille balaye les sorties reçues par ces indices d&apos;adresse. Si il est omis, le portefeuille choisit un index d&apos;adresse à utiliser aléatoirement. Si le paramètre &quot;outputs=&lt;N&gt;&quot; est spécifié et N &gt; 0, le portefeuille scinde la transaction en N sorties égales.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2625"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2801"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation>Signer une transaction à partir d&apos;un fichier. Si le paramètre &quot;export_raw&quot; est spécifié, les données brutes hexadécimales adaptées au RPC /sendrawtransaction du démon sont exportées.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation>Si aucun argument n&apos;est spécifié ou si &lt;index&gt; est spécifié, le portefeuille affiche l&apos;adresse par défaut ou l&apos;adresse spécifiée. Si &quot;all&quot; est spécifié, le portefeuille affiche toutes les adresses existantes dans le comptes actuellement sélectionné. Si &quot;new&quot; est spécifié, le portefeuille crée une nouvelle adresse avec le texte d&apos;étiquette fourni (qui peut être vide). Si &quot;label&quot; est spécifié, le portefeuille affecte le texte fourni à l&apos;étiquette de l&apos;adresse spécifiée par &lt;index&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2730"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation>Définir la clé de transaction (r) pour un &lt;ID_transaction&gt; donné au cas où cette clé ait été créée par un appareil ou portefeuille tiers.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2784"/>
-        <source>Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself.</source>
-        <translation>Rescanner la chaîne de blocs à partir du début, en perdant toute information qui ne peut pas être retrouvée à partir de la chaîne elle même.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation>Essayer de se reconnecter à un portefeuille matériel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
 Key Image, &quot;absolute&quot;, list of rings</source>
-        <translation type="unfinished">Afficher le(s) cercle(s) utilisé(s) pour dépenser une image de clé ou une transaction (si la taille de cercle est &gt; 1)</translation>
+        <translation>Afficher le(s) cercle(s) utilisé(s) pour dépenser une image de clé ou une transaction (si la taille de cercle est &gt; 1)
+
+Format de sortie :
+Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3156"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation>Définir le cercle utilisé pour une image de clé donnée, afin de pouvoir le réutiliser dans un fork</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
         <source>Save known rings to the shared rings database</source>
         <translation>Sauvegarder les cercles connus dans la base de données des cercles partagés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
         <source>Returns version information</source>
         <translation>Retourne les informations de version</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3297"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (le plus lent, aucune supposition); optimize-coinbase (rapide, suppose que la récompense de bloc est payée à une unique adresse); no-coinbase (le plus rapide, suppose que l&apos;on ne reçoit aucune récompense de bloc), default (comme optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation>0, 1, 2, 3, 4 ou l&apos;une de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation>0|1|2 (ou never|action|decrypt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation>&lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nom de portefeuille non valide. Veuillez réessayer ou utilisez Ctrl-C pour quitter.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Fichier portefeuille et fichier de clés trouvés, chargement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Fichier de clés trouvé mais pas le fichier portefeuille. Régénération...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Fichier de clés non trouvé. Échec de l&apos;ouverture du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
         <source>Generating new wallet...</source>
         <translation>Génération du nouveau portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3506"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --generate-new-wallet=&quot;nom_portefeuille&quot;, --wallet-file=&quot;nom_portefeuille&quot;, --generate-from-view-key=&quot;nom_portefeuille&quot;, --generate-from-spend-key=&quot;nom_portefeuille&quot;, --generate-from-keys=&quot;nom_portefeuille&quot;, --generate-from-multisig-keys=&quot;nom_portefeuille&quot;, --generate-from-json=&quot;nom_fichier_json&quot; et --generate-from-device=&quot;nom_portefeuille&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3605"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation>Entrer une phrase de passe pour le décalage de la phrase mnémonique, vide si aucun</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3470"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3871"/>
         <source>No data supplied, cancelled</source>
         <translation>Pas de données fournies, annulation</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6243"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6886"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6950"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3748"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3765"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3434"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3769"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3851"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3439"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3674"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3907"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3966"/>
         <source>account creation failed</source>
         <translation>échec de la création du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3733"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3876"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3896"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3901"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3941"/>
         <source>No restore height is specified.</source>
         <translation>Aucune hauteur de restauration n&apos;est spécifiée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3942"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation>Nous supposons que vous créez un nouveau compte, la restauration sera faite à partir d&apos;une hauteur de la chaîne de blocs estimée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <source>Use --restore-height if you want to restore an already setup account from a specific height</source>
-        <translation>Utilisez --restore-height si vous voulez restaurer un compte existant à partir d&apos;une hauteur spécifique</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3947"/>
         <source>account creation aborted</source>
         <translation>création du compte annulée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation>Impossible de spécifier --subaddress-lookahead et --wallet-file en même temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4073"/>
         <source>failed to open account</source>
         <translation>échec de l&apos;ouverture du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>wallet is null</source>
         <translation>portefeuille est nul</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation>Impossible d&apos;initialiser la base de données des cercles : les fonctions d&apos;amélioration de la confidentialité seront inactives</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4194"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation>Si votre affichage se bloque, quittez en aveugle avec ^C, puis lancer à nouveau en utilisant --use-english-language-names</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4217"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>choix de langue passé invalide. Veuillez réessayer.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>View key: </source>
         <translation>Clé d&apos;audit : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
         <source>Generated new wallet on hw device: </source>
         <translation>Nouveau portefeuille généré sur l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4486"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation>Fichier des clés non trouvé. Échec d&apos;ouverture du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4563"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Vous pourriez vouloir supprimer le fichier &quot;%s&quot; et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>failed to deinitialize wallet</source>
         <translation>échec de la désinitialisation du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4644"/>
         <source>Watch only wallet saved as: </source>
         <translation>Portefeuille d&apos;audit sauvegardé vers : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
         <source>Failed to save watch only wallet: </source>
         <translation>Échec de la sauvegarde du portefeuille d&apos;audit : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4382"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>cette commande requiert un démon de confiance. Activer avec --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4886"/>
         <source>Expected trusted or untrusted, got </source>
         <translation>&quot;trusted&quot; ou &quot;untrusted&quot; attendu, mais lu </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>trusted</source>
         <translation>de confiance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>untrusted</source>
         <translation>non fiable</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4539"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>la chaîne de blocs ne peut pas être sauvegardée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
-        <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
-        <translation>NOTE: cette transaction utilise un ID de paiement chiffré: veuillez considérer l&apos;utilisation de sous-adresses à la place</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4572"/>
-        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead</source>
-        <translation>ATTENTION: cette transaction utilise un ID de paiement non chiffré: veuillez considérer l&apos;utilisation de sous-adresses à la place</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation>Mot de passe requis (%s) - utilisez la commande refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
         <source>Enter password</source>
         <translation>Entrez le mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
         <source>refresh error: </source>
         <translation>erreur du rafraîchissement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation> (Il manque les images de clé de certaines sorties - import_key_images requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
         <source>Balance: </source>
         <translation>Solde : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>pubkey</source>
         <translation>clé publique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>key image</source>
         <translation>image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>unlocked</source>
         <translation>déverrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>T</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
         <source>locked</source>
         <translation>vérrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
         <source>failed to get spent status</source>
         <translation>échec de la récupération du statut de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>failed to find construction data for tx input</source>
         <translation>échec de la recherche des données pour contruire l&apos;entrée de la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <source>
+Input %llu/%llu (%s): amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>the same transaction</source>
         <translation>la même transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>blocks that are temporally very close</source>
         <translation>blocs très proches dans le temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>la taille de cercle %u est trop grande, le maximum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5395"/>
-        <source>Unencrypted payment IDs are bad for privacy: ask the recipient to use subaddresses instead</source>
-        <translation>Les ID de paiment non chiffrés sont mauvais pour la confidentialité : demandez au bénéficiaire d&apos;utiliser les sous-adresses à la place</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source>payment id failed to encode</source>
         <translation>échec de l&apos;encodage de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
         <source>failed to parse short payment ID from URI</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement court à partir de l&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
         <source>Invalid last argument: </source>
         <translation>Dernier argument invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement, bien qu&apos;il ait été détecté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Pas assez de fonds dans le solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
-        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>On se débarrasse de %s de sorties non mélangeables qui ne peuvent pas être dépensées, ce qui peut être défait avec &quot;rescan_spent&quot;. Est-ce d&apos;accord ?  (Y/Yes/N/No) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
         <source>missing lockedblocks parameter</source>
         <translation>paramètre blocs_verrou manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>bad locked_blocks parameter</source>
         <translation>mauvais paramètre blocs_verrou</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>Failed to parse number of outputs</source>
         <translation>Échec de l&apos;analyse du nombre de sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6187"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>Le nombre de sorties doit être supérieur à 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation>Don de %s %s à The Monero Project (donate.getmonero.org ou %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6777"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
         <source>failed to parse tx_key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
         <source>Tx key successfully stored.</source>
         <translation>Clé de transaction sauvegardée avec succès.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Failed to store tx key: </source>
         <translation>Échec de la sauvegarde de la clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
         <source>Good signature</source>
         <translation>Bonne signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Bad signature</source>
         <translation>Mauvaise signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation>usage : show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]]</translation>
+        <translation>usage : show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>block</source>
         <translation>bloc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7730"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation>Attention : ceci pedra toute information qui ne peut pas être retrouvée à partir de la chaîne de blocs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7731"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation>Ceci inclut les adresses de destination, les clé secrètes de transaction, les notes de transaction, etc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7732"/>
-        <source>Rescan anyway ? (Y/Yes/N/No): </source>
-        <translation>Rescanner quand même ? (Y/Yes/N/No) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Standard address: </source>
         <translation>Adresse standard : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
         <source>failed to parse payment ID or address</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement ou de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
         <source>failed to parse payment ID</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
         <source>failed to parse index</source>
         <translation>échec de l&apos;analyse de l&apos;index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8241"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
         <source>Address book is empty.</source>
         <translation>Le carnet d&apos;adresses est vide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8247"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>Index: </source>
         <translation>Index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
         <source>Address: </source>
         <translation>Adresse : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>Payment ID: </source>
         <translation>ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8250"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
         <source>Description: </source>
         <translation>Description : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
         <source>Network type: </source>
         <translation>Type de réseau : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8388"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
         <source>Stagenet</source>
         <translation>Stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6958"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <source>No payment id is included with this transaction. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Is this okay anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
         <source>failed to load signature file</source>
         <translation>échec du chargement du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut générer de preuve</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>La preuve de réserve ne peut être généré que par un portefeuille complet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;adresse ne doit pas être une sous-adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation>Bonne signature -- total : %s, dépensé : %s, non dépensé : %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation>[Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Il n&apos;y a pas de sortie non dépensée pour l&apos;adresse spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7799"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
         <source> (no daemon)</source>
         <translation> (pas de démon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
         <source> (out of sync)</source>
         <translation> (désynchronisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
         <source>(Untitled account)</source>
         <translation>(compte sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7931"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8100"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
         <source>failed to parse index: </source>
         <translation>échec de l&apos;analyse de l&apos;index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
         <source>specify an index between 0 and </source>
         <translation>specifiez un index entre 0 et </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>
 Grand total:
   Balance: </source>
@@ -4111,386 +4337,386 @@ Somme finale :
   Solde : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>, unlocked balance: </source>
         <translation>, solde débloqué : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7996"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
         <source>Untagged accounts:</source>
         <translation>Comptes sans mot clé :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8005"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
         <source>Accounts with tag: </source>
         <translation>Comptes avec mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
         <source>Tag&apos;s description: </source>
         <translation>Description du mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Account</source>
         <translation>Compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>Primary address</source>
         <translation>Adresse primaire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>(used)</source>
         <translation>(utilisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
         <source>(Untitled address)</source>
         <translation>(adresse sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; est déjà hors limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; excède la limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Les adresses intégrées ne peuvent être créées que pour le compte 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation>Adresse intégrée : %s, ID de paiement : %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Subaddress: </source>
         <translation>Sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
         <source>no description found</source>
         <translation>pas de description trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
         <source>description found: </source>
         <translation>description trouvée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
         <source>Filename: </source>
         <translation>Fichier : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
         <source>Watch only</source>
         <translation>Audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
         <source>%u/%u multisig%s</source>
         <translation>Multisig %u/%u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
         <source>Type: </source>
         <translation>Type : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>C&apos;est un portefeuille multisig et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
         <source>Bad signature from </source>
         <translation>Mauvaise signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
         <source>Good signature from </source>
         <translation>Bonne signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas exporter les images de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>Signed key images exported to </source>
         <translation>Images de clé signées exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
         <source>Outputs exported to </source>
         <translation>Sorties exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7115"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
         <source>amount is wrong: </source>
         <translation>montant erroné : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
         <source>expected number from 0 to </source>
         <translation>attend un nombre de 0 à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5721"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
         <source>Sweeping </source>
         <translation>Balayage de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fonds envoyés avec succès, transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6574"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1448"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaction signée avec succès dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6713"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6811"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6942"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>failed to parse txid</source>
         <translation>échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>Tx key: </source>
         <translation>Clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6829"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
         <source>signature file saved to: </source>
         <translation>fichier signature sauvegardé dans : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>failed to save signature file</source>
         <translation>échec de la sauvegarde du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6868"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
         <source>failed to parse tx key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6835"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
         <source>error: </source>
         <translation>erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>received</source>
         <translation>a reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>in txid</source>
         <translation>dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
         <source>received nothing in txid</source>
         <translation>n&apos;a rien reçu dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6902"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>ATTENTION : cette transaction n&apos;est pas encore inclue dans la chaîne de blocs !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
         <source>This transaction has %u confirmations</source>
         <translation>Cette transaction a %u confirmations</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>ATTENTION : échec de la détermination du nombre de confirmations !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
         <source>bad min_height parameter:</source>
         <translation>mauvais paramètre hauteur_minimum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
         <source>bad max_height parameter:</source>
         <translation>mauvais paramètre hauteur_maximum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
         <source>in</source>
         <translation>reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;montant_minimum&gt; doit être inférieur à &lt;montant_maximum&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>, number of keys: </source>
         <translation>, nombre de clés : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
         <source>
 Min block height: </source>
         <translation>
 Hauteur de bloc minimum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>
 Max block height: </source>
         <translation>
 Hauteur de bloc maximum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
         <source>
 Min amount found: </source>
         <translation>
 Montant minimum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
         <source>
 Max amount found: </source>
         <translation>
 Montant maximum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
         <source>
 Total count: </source>
         <translation>
 Compte total : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
         <source>
 Bin size: </source>
         <translation>
 Taille de classe : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
         <source>
 Outputs per *: </source>
         <translation>
 Sorties par * : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
         <source>count
   ^
 </source>
@@ -4499,52 +4725,52 @@ Sorties par * : </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; hauteur de bloc
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
         <source>wallet</source>
         <translation>portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
         <source>Random payment ID: </source>
         <translation>ID de paiement aléatoire : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
         <source>Matching integrated address: </source>
         <translation>Adresse intégrée correspondante : </translation>
     </message>
@@ -4796,243 +5022,233 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Générer un nouveau portefeuille et le sauvegarder dans &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation>Générer un nouveau portefeuille à partir de l&apos;appareil et le sauvegarder dans &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Générer un portefeuille d&apos;audit à partir d&apos;une clé d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>Générer un portefeuille déterministe à partir d&apos;une clé de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
         <source>Generate wallet from private keys</source>
         <translation>Générer un portefeuille à partir de clés privées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>Générer un portefeuille principal à partir de clés de portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
         <source>Language for mnemonic</source>
         <translation>Langue de la phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="133"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="143"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Spécifier la phrase mnémonique Electrum pour la récupération/création d&apos;un portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="144"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Récupérer un portefeuille en utilisant une phrase mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Récupérer un portefeuille multisig en utilisant une phrase mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="146"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Générer des clés d&apos;audit et de dépense non déterministes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="149"/>
+        <source>Restore from estimated blockchain height on specified date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation>argument invalide : doit être soit 0/1, true/false, y/n, yes/no</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
         <source>DNSSEC validation passed</source>
         <translation>Validation DNSSEC réussie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation>ATTENTION: la validation DNSSEC a échoué, cette adresse n&apos;est peut être pas correcte !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
         <source>For URL: </source>
         <translation>Pour l&apos;URL : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="447"/>
         <source> Monero Address = </source>
         <translation> Adresse Monero = </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation>Est-ce correct ? (Y/n) </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
         <source>you have cancelled the transfer request</source>
         <translation>vous avez annulé la demande de transfert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
         <translation>échec de l&apos;analyse de l&apos;index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation>format invalide pour l&apos;anticipation des sous-addresses; doit être &lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
         <translation>échec de la récupération de sorties aléatoires à mélanger : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Pas assez de fonds dans le solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="544"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation>Impossible de trouver une façon de créer les transactions. Ceci est souvent dû à de la poussière si petite qu&apos;elle ne peut pas payer ses propres frais, ou à une tentative d&apos;envoi d&apos;un montant supérieur au solde débloqué, ou à un montant restant insuffisant pour payer les frais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="529"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="550"/>
         <source>not enough outputs for specified ring size</source>
         <translation>pas assez de sorties pour la taille de cercle spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>output amount</source>
         <translation>montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>found outputs to use</source>
         <translation>sorties à utiliser trouvées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
         <source>Please use sweep_unmixable.</source>
         <translation>Veuillez utiliser sweep_unmixable.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
         <source>transaction was not constructed</source>
         <translation>la transaction n&apos;a pas été construite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="546"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
         <source>Reason: </source>
         <translation>Raison : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="576"/>
         <source>one of destinations is zero</source>
         <translation>une des destinations est zéro</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
         <translation>erreur de transfert inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
         <translation>Erreur multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation>Il y a eu une erreur, ce qui pourrait signifier que le noeud essaye de vous faire réessayer de créer une transaction, pour tenter d&apos;identifier quelles sorties sont les votres. Ou il pourrait s&apos;agir d&apos;une erreur de bonne foi. Il pourrait être prudent de se déconnecter de ce noeud, et de ne pas essayer d&apos;envoyer une transaction immédiatement. Ou sinon, se connecter à un autre noeud pour que le noeud original ne puisse pas corréler les informations.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="617"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation>Le fichier %s contient probablement des clés privées de portefeuille ! Utilisez un nom de fichier différent.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="599"/>
-        <source>File %s already exists. Are you sure to overwrite it? (Y/Yes/N/No): </source>
-        <translation>Le fichier %s existe déjà. Êtes vous sûr de vouloir l&apos;écraser ? (Y/Yes/N/No) : </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
         <source> seconds</source>
         <translation> secondes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
         <source> minutes</source>
         <translation> minutes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> hours</source>
         <translation> heures</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> days</source>
         <translation> jours</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> months</source>
         <translation> mois</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
         <source>a long time</source>
         <translation>longtemps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
@@ -5041,68 +5257,88 @@ Il a besoin de se connecter à un démon monero pour fonctionner correctement.
 ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE ce fork inclue des mitigations contre la réutilisation des clés. Faire ceci nuira à votre confidentialité.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>Unknown command: </source>
         <translation>Commande inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Autoriser la communication avec un démon utilisant une version de RPC différente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="148"/>
         <source>Restore from specific blockchain height</source>
         <translation>Restaurer à partir d&apos;une hauteur de bloc spécifique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="150"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>La transaction nouvellement créée ne sera pas transmise au réseau monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="151"/>
         <source>Create an address file for new wallets</source>
         <translation>Créer un fichier d&apos;adresse pour les nouveaux portefeuilles</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Display English language names</source>
         <translation>Afficher les noms de langue en anglais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
+        <source>Support obsolete long (unencrypted) payment ids (using them harms your privacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="297"/>
         <source>failed to read wallet password</source>
         <translation>échec de la lecture du mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Enter a new password for the wallet</source>
         <translation>Entrer un nouveau mot de passe pour le portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Wallet password</source>
         <translation>Mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="293"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="323"/>
         <source>possibly lost connection to daemon</source>
         <translation>connexion avec le démon peut-être perdue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <source>Is this OK?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="564"/>
+        <source>transaction %s was rejected by daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
+        <source>File %s already exists. Are you sure to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
         <source>Failed to initialize wallet</source>
         <translation>Échec de l&apos;initialisation du portefeuille</translation>
     </message>
@@ -5110,360 +5346,448 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="201"/>
+        <location filename="../src/wallet/wallet2.cpp" line="234"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Utiliser l&apos;instance de démon située à &lt;hôte&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="202"/>
+        <location filename="../src/wallet/wallet2.cpp" line="235"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Utiliser l&apos;instance de démon située à l&apos;hôte &lt;arg&gt; au lieu de localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Wallet password file</source>
         <translation>Fichier mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="207"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Utiliser l&apos;instance de démon située au port &lt;arg&gt; au lieu de 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="209"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Pour testnet, le démon doit aussi être lancé avec l&apos;option --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
+        <location filename="../src/wallet/wallet2.cpp" line="361"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>impossible de spécifier l&apos;hôte ou le port du démon plus d&apos;une fois</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="355"/>
+        <location filename="../src/wallet/wallet2.cpp" line="480"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --password et --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="368"/>
+        <location filename="../src/wallet/wallet2.cpp" line="493"/>
         <source>the password file specified could not be read</source>
         <translation>le fichier mot de passe spécifié n&apos;a pas pu être lu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="519"/>
         <source>Failed to load file </source>
         <translation>Échec du chargement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="239"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Mot de passe du portefeuille (échapper/citer si nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="203"/>
+        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="237"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Activer les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation>Désactiver les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="208"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Spécifier le nom_utilisateur:[mot_de_passe] pour le client RPC du démon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="210"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <source>List of valid fingerprints of allowed RPC servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <source>Allow any SSL certificate from the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation>Pour stagenet, le démon doit aussi être lancé avec l&apos;option --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="212"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Set shared ring database path</source>
         <translation>Définir le chemin de la base de donnée de cercles partagés</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="223"/>
+        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Number of rounds for the key derivation function</source>
         <translation>Nombre de rondes de la fonction de dérivation de clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>HW device to use</source>
         <translation>Portefeuille matériel à utiliser</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="313"/>
+        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <source>Do not use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>Do not connect to a daemon, nor use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <source>Invalid argument for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source>Enabling --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source> requires --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or use of a .onion/.i2p domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="432"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation>--trusted-daemon et --untrusted-daemon présents simultanément, --untrusted-daemon choisi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="442"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="375"/>
+        <location filename="../src/wallet/wallet2.cpp" line="500"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>pas de mot de passe spécifié; utilisez --prompt-for-password pour demander un mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Enter a new password for the wallet</source>
         <translation>Entrer un nouveau mot de passe pour le portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Wallet password</source>
         <translation>Mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="400"/>
+        <location filename="../src/wallet/wallet2.cpp" line="525"/>
         <source>Failed to parse JSON</source>
         <translation>Échec de l&apos;analyse JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="407"/>
+        <location filename="../src/wallet/wallet2.cpp" line="532"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u trop récente, on comprend au mieux %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="423"/>
+        <location filename="../src/wallet/wallet2.cpp" line="548"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="428"/>
-        <location filename="../src/wallet/wallet2.cpp" line="496"/>
-        <location filename="../src/wallet/wallet2.cpp" line="539"/>
+        <location filename="../src/wallet/wallet2.cpp" line="553"/>
+        <location filename="../src/wallet/wallet2.cpp" line="621"/>
+        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="439"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="444"/>
-        <location filename="../src/wallet/wallet2.cpp" line="506"/>
-        <location filename="../src/wallet/wallet2.cpp" line="565"/>
+        <location filename="../src/wallet/wallet2.cpp" line="569"/>
+        <location filename="../src/wallet/wallet2.cpp" line="631"/>
+        <location filename="../src/wallet/wallet2.cpp" line="692"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="456"/>
+        <location filename="../src/wallet/wallet2.cpp" line="581"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="476"/>
+        <location filename="../src/wallet/wallet2.cpp" line="601"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation>Il faut spécifier au moins une des options parmis la liste de mots de style Electrum, la clé privée d&apos;audit et la clé privée de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="605"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Liste de mots de style Electrum et clé privée spécifiées en même temps</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="490"/>
+        <location filename="../src/wallet/wallet2.cpp" line="615"/>
         <source>invalid address</source>
         <translation>adresse invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="499"/>
+        <location filename="../src/wallet/wallet2.cpp" line="624"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="509"/>
+        <location filename="../src/wallet/wallet2.cpp" line="634"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="517"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossible de générer un portefeuille obsolète à partir de JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="551"/>
+        <location filename="../src/wallet/wallet2.cpp" line="678"/>
         <source>failed to parse address: </source>
         <translation>échec de l&apos;analyse de l&apos;adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="557"/>
+        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>L&apos;adresse doit être spécifiée afin de créer un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
+        <location filename="../src/wallet/wallet2.cpp" line="701"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation>Le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1383"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation>Mot de passe invalide : le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="3770"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4374"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4926"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
         <source>Primary account</source>
         <translation>Compte primaire</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10157"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
         <source>No funds received in this tx.</source>
         <translation>Aucun fonds n&apos;a été reçu dans cette transaction.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10899"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation>Définir les tailles d&apos;anticipation des sous-addresses à &lt;majeur&gt;:&lt;mineur&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <source>Path to a PEM format private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <source>Path to a PEM format certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <source>List of certificate fingerprints to allow</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="180"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
         <source>Failed to create directory </source>
         <translation>Échec de la création du répertoire </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="182"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
         <source>Failed to create directory %s: %s</source>
         <translation>Échec de la création du répertoire %s : %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source>Cannot specify --</source>
         <translation>Impossible de spécifier --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source> and --</source>
         <translation> et --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>Failed to create file </source>
         <translation>Échec de la création du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>. Check permissions or remove file</source>
         <translation>. Vérifiez les permissions ou supprimez le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="222"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
         <source>Error writing to file </source>
         <translation>Erreur d&apos;écriture dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
         <source>RPC username/password is stored in file </source>
         <translation>nom_utilisateur/mot_de_passe RPC sauvegardé dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="479"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3081"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Transaction impossible. Solde disponible : %s, montant de la transaction %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3947"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Ceci est le portefeuille monero par RPC. Il a besoin de se
 connecter à un démon monero pour fonctionner correctement.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3788"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --wallet-file et --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3773"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3800"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file, --generate-from-json ou --wallet-dir doit être spécifié</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3804"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
         <source>Loading wallet...</source>
         <translation>Chargement du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3838"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3870"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
         <source>Saving wallet...</source>
         <translation>Sauvegarde du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3840"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3872"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
         <source>Successfully saved</source>
         <translation>Sauvegardé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3843"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
         <source>Successfully loaded</source>
         <translation>Chargé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3847"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Wallet initialization failed: </source>
         <translation>Échec de l&apos;initialisation du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3853"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Échec de l&apos;initialisation du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3857"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
         <source>Starting wallet RPC server</source>
         <translation>Démarrage du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3864"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
         <source>Failed to run wallet: </source>
         <translation>Échec du lancement du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3867"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Stopped wallet RPC server</source>
         <translation>Arrêt du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3876"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
         <source>Failed to save wallet: </source>
         <translation>Échec de la sauvegarde du portefeuille : </translation>
     </message>
@@ -5472,8 +5796,8 @@ connecter à un démon monero pour fonctionner correctement.</translation>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8908"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3928"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Wallet options</source>
         <translation>Options du portefeuille</translation>
     </message>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="it" sourcelanguage="en">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
@@ -37,44 +37,44 @@
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="124"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Controlla che sia operativo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transazione %s è stata respinta dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="133"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Motivo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Eccezione sconosciuta: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Eccezione non gestita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="211"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile firmare dati multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="233"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile firmare la transazione multifirma: </translation>
     </message>
 </context>
 <context>
@@ -134,407 +134,407 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1383"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>L&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa esadecimale di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1392"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
         <translation>Impossibile aggiungere id pagamento corto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1428"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1592"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Riprova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1512"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1594"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Accertati che sia operativo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1432"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>not enough outputs for specified ring size</source>
         <translation>insufficiente numero di output per il ring size specificato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>found outputs to use</source>
         <translation>trovati output che possono essere usati</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1464"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1546"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Pulisci gli output non mixabili.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1438"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1521"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1520"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1603"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>non hai abbastanza fondi da trasferire, sono disponibili solo %s, ammontare inviato %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="541"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>parsing indirizzo fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>impossibile effettuare il parsing della chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="575"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>impossibile effettuare il parsing della chiave segreta di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="584"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>impossibile verificare la chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="588"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="594"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>verifica chiave segreta di visualizzazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="598"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="621"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare il nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="885"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Impossibile inviare la richiesta di importazione portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1049"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Impossibile caricare transazioni non firmate</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1068"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1144"/>
         <source>Failed to load transaction from file</source>
         <translation>Impossibile caricare la transazione da file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1084"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <source>Wallet is view only</source>
         <translation>Il portafoglio è di tipo solo visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1168"/>
         <source>failed to save file </source>
         <translation>impossibile salvare il file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1184"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Le key image possono essere importate solo con un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
         <translation>Impossibile importare le key images: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1153"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
         <translation>Impossibile recuperare l&apos;etichetta del sottoindirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1166"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
         <translation>Impossibile assegnare l&apos;etichetta del sottoindirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessuna chiave di visualizzazione né chiave di spesa fornita, operazione annullata</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Il seed Electrum è vuoto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="695"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifica dell&apos;elenco parole in stile Electrum non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1183"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1259"/>
         <source>Failed to get multisig info: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1200"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1214"/>
-        <source>Failed to make multisig: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
-        <source>Failed to finalize multisig wallet creation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1232"/>
-        <source>Failed to finalize multisig wallet creation: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1248"/>
-        <source>Failed to export multisig images: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1266"/>
-        <source>Failed to parse imported multisig images</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile ottenere informazioni multifirma: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
-        <source>Failed to import multisig images: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
+        <source>Failed to make multisig: </source>
+        <translation>Impossibile eseguire multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1305"/>
+        <source>Failed to finalize multisig wallet creation</source>
+        <translation>Impossibile finalizzare la creazione di un portafoglio multifirma</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
+        <source>Failed to finalize multisig wallet creation: </source>
+        <translation>Impossibile finalizzare la creazione di un portafoglio multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1324"/>
+        <source>Failed to export multisig images: </source>
+        <translation>Impossibile esportare immagini multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1342"/>
+        <source>Failed to parse imported multisig images</source>
+        <translation>Impossibile analizzare le immagini multifirma importate</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1352"/>
+        <source>Failed to import multisig images: </source>
+        <translation>Impossibile importare immagini multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1366"/>
         <source>Failed to check for partial multisig key images: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile controllare le immagini della chiave multifirma parziali: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1318"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1394"/>
         <source>Failed to restore multisig transaction: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1358"/>
-        <source>Invalid destination address</source>
-        <translation type="unfinished">Indirizzo destinatario non valido</translation>
+        <translation>Impossibile ripristinare la transazione multifirma: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
-        <source>failed to get outputs to mix: %s</source>
-        <translation type="unfinished"></translation>
+        <source>Invalid destination address</source>
+        <translation>Indirizzo destinatario non valido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1445"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1529"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <source>failed to get outputs to mix: %s</source>
+        <translation>impossibile ottenere gli output da mixare: %s</translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/api/wallet.cpp" line="1527"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1611"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>fondi non sufficienti per il trasferimento, saldo totale %s, importo inviato %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1534"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1619"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>fondi non sufficienti per il trasferimento, disponibili solo %s, ammontare transazione %s = %s + %s (commissione)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>output amount</source>
         <translation>ammontare output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1467"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1551"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1633"/>
         <source>transaction was not constructed</source>
         <translation>transazione non costruita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1554"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transazione %s è stata rifiutata dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1475"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1641"/>
         <source>one of destinations is zero</source>
         <translation>una delle destinazioni è zero</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1477"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>impossibile trovare un modo per dividere le transazioni</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1479"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
         <translation>errore trasferimento sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1481"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1483"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1485"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1569"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1598"/>
         <source>failed to get outputs to mix</source>
-        <translation type="unfinished"></translation>
+        <translation>impossibile ottenere gli output da mixare</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1644"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1671"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1719"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1747"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1775"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1796"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1753"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1801"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1829"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1857"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1878"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2354"/>
         <source>Failed to parse txid</source>
         <translation>Impossibile effettuare parsing del txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1743"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1688"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1761"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1770"/>
         <source>Failed to parse tx key</source>
         <translation>Impossibile effettuare parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1754"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1835"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1779"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1808"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1836"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1917"/>
         <source>Failed to parse address</source>
         <translation>Impossibile effettuare parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1922"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;indirizzo non può essere un sottoindirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1880"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1962"/>
         <source>The wallet must be in multisig ready state</source>
-        <translation type="unfinished"></translation>
+        <translation>Il portafoglio deve essere in stato multifirma</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1902"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1984"/>
         <source>Given string is not a key</source>
-        <translation type="unfinished"></translation>
+        <translation>La stringa inserita non è una chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2226"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>&quot;Riscannerizza spesi&quot; può essere utilizzato solo da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2275"/>
         <source>Invalid output: </source>
-        <translation type="unfinished"></translation>
+        <translation>Output non valido: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2186"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2282"/>
         <source>Failed to mark outputs as spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile contrassegnare gli outputs come spesi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2197"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2293"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2315"/>
         <source>Failed to parse output amount</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile analizzare la quantità di output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2202"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2224"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2298"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2320"/>
         <source>Failed to parse output offset</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile analizzare l&apos;offset di output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2208"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2304"/>
         <source>Failed to mark output as spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile contrassegnare l&apos;output come speso</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2230"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2326"/>
         <source>Failed to mark output as unspent</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile contrassegnare l&apos;output come non speso</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2241"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2280"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2337"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2376"/>
         <source>Failed to parse key image</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile analizzare l&apos;immagine della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2247"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2343"/>
         <source>Failed to get ring</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile ottenere l&apos;anello</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2265"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2361"/>
         <source>Failed to get rings</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile ottenere gli anelli</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2286"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2382"/>
         <source>Failed to set ring</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile impostare l&apos;anello</translation>
     </message>
 </context>
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="301"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Impossibile effettuare parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="308"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Impossibile effettuare parsing della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="316"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>impossibile effettuare la verifica della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="326"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>la chiave non corrisponde all&apos;indirizzo</translation>
     </message>
@@ -598,931 +598,996 @@
     <message>
         <location filename="../src/rpc/rpc_args.cpp" line="111"/>
         <source> requires RPC server password --</source>
-        <translation type="unfinished"></translation>
+        <translation> richiede la password del server RPC --</translation>
     </message>
 </context>
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="645"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
         <translation>Comandi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
         <source>failed to read wallet password</source>
         <translation>impossibile leggere la password del portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4231"/>
         <source>invalid password</source>
         <translation>password non valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>imposta seed: richiede un argomento. opzioni disponibili: lingua</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>set: unrecognized argument(s)</source>
         <translation>imposta: argomento/i non riconosciuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
         <source>wallet file path not valid: </source>
         <translation>percorso file portafoglio non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Sto tentando di generare o ripristinare il portafoglio, ma i(l) file specificato/i esiste/esistono già. Sto uscendo per non rischiare di sovrascrivere.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>needs an argument</source>
         <translation>ha bisogno di un argomento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3097"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>0 or 1</source>
         <translation>0 o 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
         <source>unsigned integer</source>
         <translation>intero senza segno</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>specificare un parametro di ripristino con --electrum-seed=&quot;lista parole qui&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>impossibile connettere il portafoglio al daemon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Il daemon usa una versione principale RPC (%u) diversa da quella del portafoglio (%u): %s. Aggiorna una delle due, o usa --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista delle lingue disponibili per il seed del tuo portafoglio:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3926"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation>Inserisci il numero corrispondente al linguaggio da te scelto: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
-        <translation>Hai usato una versione obsoleta del portafoglio. Per favore usa il nuovo seed che ti abbiamo fornito.</translation>
+        <translation>Hai usato una versione obsoleta del portafoglio. Per favore usa il nuovo seed che ti abbiamo fornito.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
         <source>Generated new wallet: </source>
         <translation>Nuovo portafoglio generato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4025"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
         <source>Opened watch-only wallet</source>
         <translation>Portafoglio solo-vista aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4511"/>
         <source>Opened wallet</source>
         <translation>Portafoglio aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
-        <translation>Stai utilizzando una versione disapprovata del portafoglio. Per favore procedi nell&apos;upgrade del portafoglio.</translation>
+        <translation>Stai utilizzando una versione disapprovata del portafoglio. Per favore procedi nell&apos;upgrade del portafoglio.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4267"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4544"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
-        <translation>Stai utilizzando una versione disapprovata del portafoglio. Il formato del tuo portafoglio sta venendo aggiornato adesso.</translation>
+        <translation>Stai utilizzando una versione disapprovata del portafoglio. Il formato del tuo portafoglio sta per essere aggiornato.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
         <source>failed to load wallet: </source>
         <translation>impossibile caricare portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
-        <translation>Usa il comando &quot;help&quot; per visualizzare la lista dei comandi disponibili.</translation>
+        <translation>Usa il comando &quot;help&quot; per visualizzare la lista dei comandi disponibili.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>Wallet data saved</source>
         <translation>Dati del portafoglio salvati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4819"/>
         <source>Mining started in daemon</source>
         <translation>Mining avviato nel daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
         <source>mining has NOT been started: </source>
         <translation>il mining NON è stato avviato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
         <source>Mining stopped in daemon</source>
         <translation>Mining nel daemon interrotto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
         <source>mining has NOT been stopped: </source>
         <translation>il mining NON è stato interrotto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
         <source>Blockchain saved</source>
         <translation>Blockchain salvata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
         <source>Height </source>
         <translation>Blocco </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>spent </source>
         <translation>speso/i </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>Starting refresh...</source>
         <translation>Sto iniziando il refresh...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
         <source>Refresh done, blocks received: </source>
         <translation>Refresh finito, blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento ha un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
         <source>bad locked_blocks parameter:</source>
         <translation>parametro locked_blocks non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5978"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6251"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>una singola transazione non può usare più di un id pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6219"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>impossibile impostare id pagamento, anche se è stato decodificado correttamente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
         <source>ring size %u is too large, maximum is %u</source>
-        <translation type="unfinished"></translation>
+        <translation>la dimensione dell&apos;anello %u è troppo grande, il massimo è %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5395"/>
-        <source>Unencrypted payment IDs are bad for privacy: ask the recipient to use subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source>payment id failed to encode</source>
-        <translation type="unfinished"></translation>
+        <translation>codifica dell&apos;ID di pagamento non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
         <source>failed to parse short payment ID from URI</source>
-        <translation type="unfinished"></translation>
+        <translation>impossibile analizzare l&apos;ID di pagamento breve dall&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
         <source>Invalid last argument: </source>
-        <translation type="unfinished"></translation>
+        <translation>Ultimo argomento non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
         <source>a single transaction cannot use more than one payment id</source>
-        <translation type="unfinished"></translation>
+        <translation>una singola transazione non può utilizzare più di un ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
         <source>failed to parse payment id, though it was detected</source>
-        <translation type="unfinished"></translation>
+        <translation>errore nell&apos;analisi dell&apos;ID di pagamento, anche se è stato rilevato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5502"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5738"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6059"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
         <source>transaction cancelled.</source>
         <translation>transazione cancellata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
         <source>Sending %s.  </source>
         <translation>Sto inviando %s. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>La tua transazione deve essere divisa in %llu transazioni. Una commissione verrà applicata per ogni transazione, per un totale di %s commissioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5550"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>The transaction fee is %s</source>
         <translation>La commissione per la transazione è %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
         <source>, of which %s is dust from change</source>
         <translation>, della quale %s è polvere dovuta allo scambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un totale di %s in polvere verrà inviato all&apos;indirizzo della polvere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation>.
 Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s giorni (supponendo 2 minuti per blocco)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
-        <translation type="unfinished"></translation>
+        <translation>Transazione(i) senza firma scritta(e) con successo su MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5611"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6328"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5616"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transazioni/e non firmata/e scritte/a con successo su file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5625"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
         <source>Failed to cold sign transaction with HW wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile firmare transazioni a freddo con il portafoglio hardware</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
         <source>No unmixable outputs found</source>
         <translation>Nessun output non-mixabile trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
         <source>Not enough money in unlocked balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Fondi insufficienti in saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
-        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
         <source>No address given</source>
         <translation>Non è stato fornito nessun indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
         <source>missing lockedblocks parameter</source>
-        <translation type="unfinished"></translation>
+        <translation>parametro lockedblocks mancante</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>bad locked_blocks parameter</source>
-        <translation type="unfinished"></translation>
+        <translation>parametro locked_blocks errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>Failed to parse number of outputs</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile analizzare il numero di outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6187"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>Amount of outputs should be greater than 0</source>
-        <translation type="unfinished"></translation>
+        <translation>La quantità di outputs deve essere maggiore di 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
         <source>Failed to parse donation address: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile analizzare l&apos;indirizzo di donazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
-        <translation type="unfinished"></translation>
+        <translation>Donare %s %s a The Monero Project (donate.getmonero.org o %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6444"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
         <source>Donating %s %s to %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Donare %s %s a %s.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
         <source>sending %s to %s</source>
         <translation>sto mandando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
         <source> dummy output(s)</source>
         <translation> output dummy</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Caricate %lu transazioni, per %s, commissione %s, %s, %s, con ring size minimo %lu, %s. %sOK?(Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Questo è un portafoglio multisig, può firmare solo con sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
         <source>Failed to sign transaction</source>
         <translation>Impossibile firmare la transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
         <source>Failed to sign transaction: </source>
         <translation>Impossibile firmare la transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Dati esadecimali grezzi della transazione esportati su </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
         <source>Failed to load transaction from file</source>
         <translation>Impossibile caricare la transazione da file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>il portafoglio è solo-vista e non ha una chiave di spesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
         <source>Your original password was incorrect.</source>
         <translation>La tua password originale era scorretta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
         <source>Error with wallet rewrite: </source>
         <translation>Errore riscrittura wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
         <source>invalid unit</source>
         <translation>unità invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>conteggio invalido: deve essere un intero senza segno</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>invalid value</source>
         <translation>valore invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation>(S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
         <source>bad m_restore_height parameter: </source>
         <translation>parametro m_restore_height non corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3766"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation>il formato della data deve essere YYYY-MM-DD</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
         <source>Restore height is: </source>
         <translation>Ripristina altezza è: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3780"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Va bene? (S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
         <source>Password for new watch-only wallet</source>
         <translation>Password per il nuovo portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1534"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>refresh failed: </source>
         <translation>refresh fallito: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>Blocks received: </source>
         <translation>Blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
         <source>unlocked balance: </source>
         <translation>bilancio sbloccato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>amount</source>
         <translation>ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Unknown command: </source>
         <translation>Comando sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Command usage: </source>
         <translation>Uso del comando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Command description: </source>
         <translation>Descrizione del comando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation>il portafoglio è multisig ma ancora non finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
         <source>Failed to retrieve seed</source>
         <translation>Impossibile recuperare il seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>wallet is multisig and has no seed</source>
         <translation>il portafoglio è multisig e non ha seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation>Errore: impossibile stimare la dimensione dell&apos;array di backlog: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>Error: bad estimated backlog array size</source>
         <translation>Errore: errata stima della dimensione dell&apos;array di backlog</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
         <source> (current)</source>
         <translation> (attuale)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation>Backlog blocco %u (%u minuti) a priorità %u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation>Backlog blocco %u a %u (%u a %u minuti) a priorità %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>No backlog at priority </source>
         <translation>Nessun backlog a priorità </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1012"/>
         <source>This wallet is already multisig</source>
         <translation>Questo portafoglio è già multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="949"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation>il portafoglio è sola-visualizzazione e non può essere reso multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Questo portafoglio è stato usato precedentmente, per cortesia utilizza un nuovo portafoglio per creare un portafoglio multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Invia queste informazioni multisig a tutti gli altri partecipanti, poi utilizza make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] con le informazioni multisig degli altri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation>Questo include la chiave PRIVATA di visualizzazione, pertanto deve essere comunicata solo ai partecipanti di quel portafoglio multisig </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>Invalid threshold</source>
         <translation>Soglia invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1156"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
         <source>Another step is needed</source>
         <translation>Ancora un ultimo passo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <source>Error creating multisig: </source>
         <translation>Impossibile creare multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation>Impossibile creare multisig: il nuovo portafoglio non è multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
         <source> multisig address: </source>
         <translation> indirizzo multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1129"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1285"/>
         <source>This wallet is not multisig</source>
         <translation>Questo portafoglio non è multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
         <source>This wallet is already finalized</source>
         <translation>Questo portafoglio è già finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
         <source>Failed to finalize multisig</source>
         <translation>Impossibile finalizzare multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>Failed to finalize multisig: </source>
         <translation>Impossibile finalizzare multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
+        <source>Multisig address: </source>
+        <translation>Indirizzo multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1500"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Questo portafoglio multisig non è ancora finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
         <source>Error exporting multisig info: </source>
         <translation>Impossibile esportare informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
         <source>Multisig info exported to </source>
         <translation>Informazioni sul multisig esportate su </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1330"/>
         <source>Multisig info imported</source>
         <translation>Informazioni su multisig importate</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
         <source>Failed to import multisig info: </source>
         <translation>Impossibile importare informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation>Impossibile aggiornare lo stato di spesa dopo aver importato le informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation>Daemon non fidato, lo stato di spesa potrebbe non essere corretto. Usare un daemon fidato ed eseguire &quot;rescan_spent&quot; </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1471"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1379"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
         <source>This is not a multisig wallet</source>
         <translation>Questo non è un portafoglio multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Impossibile firmare la transazione multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
         <source>Multisig error: </source>
         <translation>Errore multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Impossibile firmare la transazione multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation>Potrebbe essere trasmesso alla rete con submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1508"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1602"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Impossibile caricare la transazione multisig da file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation>Transazione multisig firmata da solo %u firmatari, necessita di altre %u firme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transazione inviata con successo, transazione </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>E&apos; possibile controllare il suo stato mediante il comando `show_transfers`.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
         <source>Failed to export multisig transaction to file </source>
         <translation>Impossibile esportare la transazione multisig su file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation>Transazioni esportate salvate su(i) file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
+        <source>Invalid key image or txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1901"/>
+        <source>failed to unset ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2129"/>
+        <source>Frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2131"/>
+        <source>Not frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
+        <source> bytes sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
+        <source> bytes received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2145"/>
+        <source>Welcome to Monero, the private cryptocurrency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2147"/>
+        <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <source>Unlike Bitcoin, your Monero transactions and balance stay private, and not visible to the world by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>However, you have the option of making those available to select parties, if you choose to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2151"/>
+        <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
+        <source>no privacy technology can be 100% perfect, Monero included.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2153"/>
+        <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2155"/>
+        <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2157"/>
+        <source>Welcome to Monero and financial privacy. For more information, see https://getmonero.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
         <source>ring size must be an integer &gt;= </source>
         <translation>il ring size deve essere un intero &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
         <source>could not change default ring size</source>
         <translation>impossibile modificare il ring size di default</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2398"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2549"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
         <source>Invalid height</source>
         <translation>Altezza invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2667"/>
+        <source>invalid argument: must be either 1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation>Avvia il mining sul daemon (bg_mining e ignore_battery sono booleani opzionali).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
         <source>Stop mining in the daemon.</source>
         <translation>Arresta il mining sul daemon.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2745"/>
         <source>Set another daemon to connect to.</source>
         <translation>Seleziona un altro daemon cui connettersi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
         <source>Save the current blockchain data.</source>
         <translation>Salva i dati blockchain correnti.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Sincronizza le transazioni ed il saldo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation>Mostra il saldo del portafoglio del conto attualmente selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2759"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.
+
+Output format:
+Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Mostra i pagamenti per gli id pagamento specificati.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
         <source>Show the blockchain height.</source>
         <translation>Mostra l&apos;altezza della blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2782"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation>Invia tutti gli output non mixabili a te stesso usando ring_size 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2789"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation>Invia tutti gli output sbloccati sotto la soglia ad un indirizzo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2793"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation>Invia un singolo output della key image specificata ad un indirizzo senza modifica.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Dona &lt;amount&gt; al team di sviluppo (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2628"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2804"/>
         <source>Submit a signed transaction from a file.</source>
         <translation>Invia una transazione firmata da file.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2808"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation>Modifica il dettaglio di log (il livello deve essere &lt;0-4&gt;).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2812"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1530,1168 +1595,51 @@ If the &quot;label&quot; argument is specified, the wallet sets the label of the
 If the &quot;tag&quot; argument is specified, a tag &lt;tag_name&gt; is assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
 If the &quot;untag&quot; argument is specified, the tags assigned to the specified accounts &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., are removed.
 If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&gt; is assigned an arbitrary text &lt;description&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se non vengono specificati argomenti, il portafoglio mostra tutti gli account esistenti insieme ai loro saldi.
+Se viene specificato l&apos;argomento &quot;new&quot;, il portafoglio crea un nuovo account con l&apos;etichetta inizializzata dal testo dell&apos;etichetta fornito (che può essere vuoto).
+Se viene specificato l&apos;argomento &quot;switch&quot;, il portafoglio passa all&apos;account specificato da &lt;index&gt;.
+Se viene specificato l&apos;argomento &quot;label&quot;, il portafoglio imposta l&apos;etichetta dell&apos;account specificato da &lt;index&gt; nel testo dell&apos;etichetta fornito.
+Se l&apos;argomento &quot;tag&quot; è specificato, un tag &lt;tag_name&gt; viene assegnato agli account specificati &lt;account_index_1&gt;, &lt;account_index_2&gt;, ....
+Se viene specificato l&apos;argomento &quot;untag&quot;, i tag assegnati agli account specificati &lt;account_index_1&gt;, &lt;account_index_2&gt; ..., vengono rimossi.
+Se viene specificato l&apos;argomento &quot;tag_description&quot;, al tag &lt;tag_name&gt; viene assegnato un testo arbitrario &lt;description&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Codifica un ID di pagamento in un indirizzo integrato per l&apos;indirizzo pubblico del portafoglio corrente (nessun argomento utilizza un ID di pagamento casuale) o decodifica un indirizzo integrato per l&apos;indirizzo standard e l&apos;ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Stampa tutte le voci nella rubrica, opzionalmente aggiungendo/eliminando una voce a/da esso.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
         <source>Save the wallet data.</source>
-        <translation type="unfinished"></translation>
+        <translation>Salva i dati del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
         <source>Save a watch-only keys file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Salva un file di chiavi in sola lettura.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
         <source>Display the private view key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2666"/>
-        <source>Display the private spend key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
-        <source>Display the Electrum-style mnemonic seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
-        <source>Display the encrypted Electrum-style mnemonic seed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
-        <source>Rescan the blockchain for spent outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
-        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
-        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
-        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
-        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2750"/>
-        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
-        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
-If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
-Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
-        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2780"/>
-        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2788"/>
-        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2792"/>
-        <source>Get a string note for a txid.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2796"/>
-        <source>Set an arbitrary description for the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2800"/>
-        <source>Get the description of the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2803"/>
-        <source>Show the wallet&apos;s status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2806"/>
-        <source>Show the wallet&apos;s information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2810"/>
-        <source>Sign the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
-        <source>Verify a signature on the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
-        <source>Import a signed key images list and verify their spent status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2834"/>
-        <source>Export a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2838"/>
-        <source>Import a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra la chiave privata di visualizzazione.</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
-        <source>Show information about a transfer to/from this address.</source>
-        <translation type="unfinished"></translation>
+        <source>Display the private spend key.</source>
+        <translation>Mostra la chiave di spesa privata.</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
-        <source>Change the wallet&apos;s password.</source>
-        <translation type="unfinished"></translation>
+        <source>Display the Electrum-style mnemonic seed</source>
+        <translation>Mostra il seed mnemonico di tipo Electrum</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2852"/>
-        <source>Print the information about the current fee and transaction backlog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
-        <source>Export data needed to create a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
-        <source>Turn this wallet into a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
-        <source>Export multisig info for other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Import multisig info from other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2877"/>
-        <source>Sign a multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <source>Submit a signed multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>Export a signed multisig transaction to a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
-        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
-        <source>integer &gt;= </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
-        <source>block height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3203"/>
-        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
-        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3355"/>
-        <source>Multisig seed failed verification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
-        <source>This address is a subaddress which cannot be used here.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3558"/>
-        <source>Error: expected M/N, but got: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3563"/>
-        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3568"/>
-        <source>Error: M/N is currently unsupported. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
-        <source>Generating master wallet from %u of %u multisig wallet keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
-        <source>failed to parse secret view key</source>
-        <translation type="unfinished">impossibile fare il parsing della chiave segreta di visualizzazione</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3608"/>
-        <source>failed to verify secret view key</source>
-        <translation type="unfinished">verifica chiave segreta di visualizzazione fallita</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3651"/>
-        <source>Error: M/N is currently unsupported</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3802"/>
-        <source>Restore height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3803"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3829"/>
-        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3888"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4180"/>
-        <source>failed to generate new mutlisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4183"/>
-        <source>Generated new %u/%u multisig wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <source>Opened %u/%u multisig wallet%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4351"/>
-        <source>wallet is multisig and cannot save a watch-only version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
-        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4517"/>
-        <source>This does not seem to be a valid daemon URL.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4590"/>
-        <source>txid </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
-        <source>idx </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4780"/>
-        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>Currently selected account: [</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>Tag: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>(No tag assigned)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
-        <source>Balance per address:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Unlocked balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4801"/>
-        <source>%8u %6s %21s %21s %7u %21s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>spent</source>
-        <translation>spesi</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>global index</source>
-        <translation>indice globale</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>tx id</source>
-        <translation>tx id</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>addr index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4924"/>
-        <source>No incoming transfers</source>
-        <translation>Nessun trasferimento in entrata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4928"/>
-        <source>No incoming available transfers</source>
-        <translation>Nessun trasferimento in entrata disponibile</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4932"/>
-        <source>No incoming unavailable transfers</source>
-        <translation>Nessun trasferimento indisponibile in entrata</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>payment</source>
-        <translation>pagamento</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>transaction</source>
-        <translation>transazione</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>height</source>
-        <translation>altezza</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>unlock time</source>
-        <translation>tempo sbloccato</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
-        <source>No payments with id </source>
-        <translation>Nessun pagamento con id </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
-        <source>failed to get blockchain height: </source>
-        <translation>impossibile recuperare altezza blockchain: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5114"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation>
-Transazione %llu/%llu: txid=%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5135"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5151"/>
-        <source>failed to get output: </source>
-        <translation>impossibile recuperare output: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation>l&apos;altezza del blocco di origine della chiave di output non dovrebbe essere più alta dell&apos;altezza della blockchain</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5163"/>
-        <source>
-Originating block heights: </source>
-        <translation>
-Originando blocchi: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <source>
-|</source>
-        <translation>
-|</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
-        <source>|
-</source>
-        <translation>|
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5192"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation>
-Avviso: alcune chiavi di input spese vengono da </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation>, che potrebbe compromettere l&apos;anonimità della ring signature. Assicurati di farlo intenzionalmente!</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6156"/>
-        <source>Ring size must not be 0</source>
-        <translation>Il ring size non può essere 0</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
-        <source>ring size %u is too small, minimum is %u</source>
-        <translation>il ring size %u è troppo piccolo, il minimo è %u</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5258"/>
-        <source>wrong number of arguments</source>
-        <translation>numero di argomenti errato</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6268"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Nessun id pagamento è incluso in questa transazione. Questo è corretto? (S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
-        <source>No outputs found, or daemon is not ready</source>
-        <translation>Nessun output trovato, o il daemon non è pronto</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6777"/>
-        <source>failed to parse tx_key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6786"/>
-        <source>Tx key successfully stored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6790"/>
-        <source>Failed to store tx key: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>block</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7440"/>
-        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7493"/>
-        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>timestamp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>running balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>hash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>fee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>note</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
-        <source>CSV exported to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7730"/>
-        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7731"/>
-        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7732"/>
-        <source>Rescan anyway ? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7750"/>
-        <source>MMS received new message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8387"/>
-        <source>Network type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8388"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8605"/>
-        <source>command only supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8564"/>
-        <source>hw wallet does not support cold KI sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8576"/>
-        <source>Please confirm the key image sync on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
-        <source>Key images synchronized to height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8585"/>
-        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> spent, </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> unspent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8592"/>
-        <source>Failed to import key images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8597"/>
-        <source>Failed to import key images: </source>
-        <translation type="unfinished">Impossibile importare le key images: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8614"/>
-        <source>Failed to reconnect device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8619"/>
-        <source>Failed to reconnect device: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <source>Transaction successfully saved to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>, txid </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>Failed to save transaction to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Sto eseguendo lo sweep di %s nelle transazioni %llu per un totale commissioni di %s.  Va bene?  (S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6310"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Sto eseguendo lo sweep di %s per un totale commissioni di %s.  Va bene?  (S/Sì/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
-        <source>This is a watch only wallet</source>
-        <translation>Questo è un portafoglio solo-vista</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8813"/>
-        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
-        <source>Transaction ID not found</source>
-        <translation>ID transazione non trovato</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="336"/>
-        <source>true</source>
-        <translation>vero</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
-        <source>failed to parse refresh type</source>
-        <translation>impossibile fare il parsing del tipo di refresh</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1067"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7010"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8670"/>
-        <source>command not supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation>il portafoglio è solo-vista e non possiede un seed</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation>il portafoglio è non-deterministico e non possiede un seed</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
-        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
-        <source>Incorrect password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
-        <source>Current fee is %s %s per %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
-        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <source>Multisig wallet has been successfully created. Current wallet type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <source>Failed to perform multisig keys exchange: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
-        <source>Failed to load multisig transaction from MMS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
-        <source>Invalid key image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <source>Invalid txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
-        <source>Key image either not spent, or spent with mixin 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
-        <source>Failed to get key image ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
-        <source>File doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
-        <source>Invalid ring specification: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1709"/>
-        <source>Invalid key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1714"/>
-        <source>Invalid ring type, expected relative or abosolute: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
-        <source>Error reading line: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
-        <source>Invalid ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1752"/>
-        <source>Invalid relative ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <source>Invalid absolute ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Failed to set ring for key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Continuing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
-        <source>Missing absolute or relative keyword</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
-        <source>invalid index: must be a strictly positive unsigned integer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
-        <source>invalid index: indices wrap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
-        <source>invalid index: indices should be in strictly ascending order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
-        <source>failed to set ring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
-        <source>First line is not an amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
-        <source>Invalid output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>Bad argument: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>should be &quot;add&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
-        <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
-        <source>Invalid output key, and file doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
-        <source>Failed to mark output spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1952"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
-        <source>Invalid output</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1962"/>
-        <source>Failed to mark output unspent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <source>Spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
-        <source>Not spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
-        <source>Failed to check whether output is spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2007"/>
-        <source>Failed to save known rings: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2022"/>
-        <source>Please confirm the transaction on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2088"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation>il portafoglio è solo-vista e non può eseguire trasferimenti</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5581"/>
-        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2108"/>
-        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2137"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2176"/>
-        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2181"/>
-        <source>could not change default priority</source>
-        <translation>impossibile cambiare priorità standard</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
-        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2510"/>
-        <source>Device name not specified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
-        <source>Device reconnect failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
-        <source>Device reconnect failed: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <source>Show the incoming transfers, all or filtered by availability and address index.
-
-Output format:
-Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
-        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2625"/>
-        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
-        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2673"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2709,8 +1657,10 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&qu
    Set the wallet&apos;s refresh behaviour.
  priority [0|1|2|3|4]
    Set the fee to default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
+ confirm-missing-payment-id &lt;1|0&gt; (obsolete)
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
+   action: ask the password before many actions such as transfer, etc
+   decrypt: same as action, but keeps the spend key encrypted in memory when not needed
  unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
    Set the default monero (sub-)unit.
  min-outputs-count [n]
@@ -2739,12 +1689,1242 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2730"/>
-        <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation>Mostra il seed mnemonico criptato di tipo Electrum.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation>Riscansiona la blockchain per gli outputs spesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2904"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation>Ottieni la chiave di transazione (r) per il dato &lt;txid&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2912"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation>Generare una firma che provi l&apos;invio dei fondi da &lt;address&gt; in &lt;txid&gt;, facoltativamente con una stringa di verifica &lt;message&gt;, utilizzando la chiave segreta della transazione (quando &lt;address&gt; non è l&apos;indirizzo del tuo portafoglio) o (in alternativa) la chiave di visualizzazione segreta, che non riveli la chiave segreta.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Genera una firma che dimostri che hai generato &lt;txid&gt; usando la chiave segreta di spesa, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2928"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Controlla la firma dimostrando che il firmatario ha generato &lt;txid&gt;, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Controlla una firma che dimostri che il proprietario di &lt;address&gt; conserva questo valore, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation>Mostra gli outputs non spesi di uno specifico indirizzo all&apos;interno di un intervallo di quantità opzionale.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2962"/>
+        <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
+        <translation>Scansiona la blockchain da zero. Se &quot;hard&quot; è specificato, perderai tutte le informazioni che non possono essere recuperate dalla blockchain stessa.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation>Imposta una nota arbitraria per un &lt;txid&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2970"/>
+        <source>Get a string note for a txid.</source>
+        <translation>Ottieni una nota di stringa per un txid.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation>Imposta una descrizione arbitraria per il portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <source>Get the description of the wallet.</source>
+        <translation>Ottieni la descrizione del portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation>Mostra lo stato del portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2984"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation>Mostra le informazioni del portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
+        <source>Sign the contents of a file.</source>
+        <translation>Firma il contenuto di un file.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation>Verifica una firma sul contenuto di un file.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation>Esporta un set di output posseduto da questo portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3016"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation>Importa un set di outputs posseduto da questo portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3020"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation>Mostra informazioni su un trasferimento da/verso questo indirizzo.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3023"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation>Cambia la password del portafoglio.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation>Stampa le informazioni sulla commissione corrente e sul backlog della transazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3032"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation>Esportare i dati necessari per creare un portafoglio multifirma</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation>Trasforma questo portafoglio in un portafoglio multifirma</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3039"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation>Trasforma questo portafoglio in un portafoglio multifirma, passo aggiuntivo per i portafogli N-1/N</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <source>Export multisig info for other participants</source>
+        <translation>Esporta informazioni multifirma per altri partecipanti</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <source>Import multisig info from other participants</source>
+        <translation>Importa informazioni multifirma da altri partecipanti</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3055"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation>Firma una transazione multifirma da un file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation>Invia una transazione multifirma firmata da un file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation>Esporta una transazione multifirma firmata in un file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3160"/>
+        <source>Unsets the ring used for a given key image or transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
+        <source>Freeze a single output by key image so it will not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>Thaw a single output by key image so it may be used again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3188"/>
+        <source>Checks whether a given output is currently frozen by key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3192"/>
+        <source>Prints simple network stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Prints basic info about Monero for first time users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation>Mostra la sezione di aiuto o la documentazione su un &lt;command&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source> (set this to support the network and to get a chance to receive new monero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3295"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3308"/>
+        <source>block height</source>
+        <translation>altezza del blocco</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3316"/>
+        <source>1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation>Nessun portafoglio trovato con quel nome. Conferma la creazione di un nuovo portafoglio chiamato: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation>non è possibile specificare sia --restore-deterministic-wallet o --restore-multisig-wallet e --non-deterministic</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation>--restore-multisig-wallet utilizza --generate-new-wallet, non --wallet-file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3562"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation>specifica un parametro di recupero con --electrum-seed=&quot; seed multifirma qui&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
+        <source>Multisig seed failed verification</source>
+        <translation>Verifica seed mulitfirma fallita</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3718"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation>Questo indirizzo è un sottoindirizzo che non può essere utilizzato qui.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation>Errore: atteso M/N, ma ottenuto: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation>Errore: M/N non è attualmente supportato. </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation>Generazione del portafoglio principale da %u di %u chiavi del portafoglio multifirma</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3838"/>
+        <source>failed to parse secret view key</source>
+        <translation type="unfinished">impossibile fare il parsing della chiave segreta di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3846"/>
+        <source>failed to verify secret view key</source>
+        <translation type="unfinished">verifica chiave segreta di visualizzazione fallita</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation>Errore: M/N non è attualmente supportato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
+        <source>Restore height </source>
+        <translation>Altezza di ripristino </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation>Attenzione: sto utilizzando un daemon non fidato su %s, la privacy sarà ridotta</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
+        <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4098"/>
+        <source>WARNING: obsolete long payment IDs are enabled. Sending transactions with those payment IDs are bad for your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4100"/>
+        <source>It is recommended that you do not use them, and ask recipients who ask for one to not endanger your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation>Il daemon non è stato avviato o la porta è errata. Assicurati che il daemon sia in esecuzione oppure cambia l&apos;indirizzo del daemon usando il comando &apos;set_daemon&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4203"/>
+        <source>Enter the number corresponding to the language of your choice</source>
+        <translation>Inserire il numero corrispondente alla lingua desiderata</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4313"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation>Il tuo portafoglio è stato generato!
+Per avviare la sincronizzazione con il daemon, utilizzare il comando &quot;refresh&quot;.
+Utilizzare il comando &quot;help&quot; per visualizzare l&apos;elenco dei comandi disponibili.
+Usa &quot;help &lt;command&gt;&quot; per vedere la documentazione di un comando.
+Usa sempre il comando &quot;exit&quot; quando chiudi monero-wallet-cli per salvare lo 
+stato della sessione corrente. In caso contrario, potrebbe essere necessario sincronizzare 
+di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono in nessun caso a rischio).
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4457"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation>impossibile generare un nuovo portafoglio multifirma</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation>Generato nuovo portafoglio %u/%u multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation>Aperto %u/%u portafoglio multifirma%s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation>Usa &quot;help &lt;command&gt;&quot; per vedere la documentazione di un comando.
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4628"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation>il portafoglio è multifirma e non è possibile salvarne una versione in sola lettura</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4696"/>
+        <source>Failed to query mining status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Failed to setup background mining: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4683"/>
+        <source>Background mining enabled. Thank you for supporting the Monero network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4719"/>
+        <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4725"/>
+        <source>Using an untrusted daemon, skipping background mining check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4750"/>
+        <source>The daemon is not set up to background mine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4752"/>
+        <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4864"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation>Lunghezza array imprevista - Exited simple_wallet:: set_daemon ()</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4905"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation>Questo URL del daemon non sembra essere valido.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <source>txid </source>
+        <translation>txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <source>idx </source>
+        <translation>idx </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead.</source>
+        <translation>ATTENZIONE: questa transazione utilizza un ID di pagamento non criptato: considera l&apos;utilizzo di sottoindirizzi.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete. Support will be withdrawn in the future. Use subaddresses instead.</source>
+        <translation>ATTENZIONE: questa transazione utilizza un ID di pagamento non criptato: questi sono obsoleti. Il supporto ad essi verrà sospeso in futuro. Utilizzare sottoindirizzi.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <source>New transfer received since rescan was started. Key images are incomplete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation> (Alcuni output contengono immagini chiave parziali - import_multisig_info necessario)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>Currently selected account: [</source>
+        <translation>Account attualmente selezionato: [</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>] </source>
+        <translation>] </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Tag: </source>
+        <translation>Etichetta: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>(No tag assigned)</source>
+        <translation>(Nessuna etichetta assegnata)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <source>Balance per address:</source>
+        <translation>Saldo per indirizzo:</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Address</source>
+        <translation>Indirizzo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Balance</source>
+        <translation>Saldo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Unlocked balance</source>
+        <translation>Saldo sbloccato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Outputs</source>
+        <translation>Outputs</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>Label</source>
+        <translation>Etichetta</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation>%8u %6s %21s %21s %7u %21s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>spent</source>
+        <translation>spesi</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>global index</source>
+        <translation>indice globale</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>tx id</source>
+        <translation>tx id</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>addr index</source>
+        <translation>indice indirizzo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <source>Used at heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>[frozen]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <source>No incoming transfers</source>
+        <translation>Nessun trasferimento in entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <source>No incoming available transfers</source>
+        <translation>Nessun trasferimento in entrata disponibile</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <source>No incoming unavailable transfers</source>
+        <translation>Nessun trasferimento indisponibile in entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>payment</source>
+        <translation>pagamento</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>transaction</source>
+        <translation>transazione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>height</source>
+        <translation>altezza</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>unlock time</source>
+        <translation>tempo sbloccato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <source>No payments with id </source>
+        <translation>Nessun pagamento con id </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <source>failed to get blockchain height: </source>
+        <translation>impossibile recuperare altezza blockchain: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation>
+Transazione %llu/%llu: txid=%s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <source>failed to get output: </source>
+        <translation>impossibile recuperare output: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation>l&apos;altezza del blocco di origine della chiave di output non dovrebbe essere più alta dell&apos;altezza della blockchain</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <source>
+Originating block heights: </source>
+        <translation>
+Originando blocchi: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <source>
+|</source>
+        <translation>
+|</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <source>|
+</source>
+        <translation>|
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation>
+Avviso: alcune chiavi di input spese vengono da </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation>, che potrebbe compromettere l&apos;anonimità della ring signature. Assicurati di farlo intenzionalmente!</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <source>Ring size must not be 0</source>
+        <translation>Il ring size non può essere 0</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation>il ring size %u è troppo piccolo, il minimo è %u</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <source>wrong number of arguments</source>
+        <translation>numero di argomenti errato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation>Nessun output trovato, o il daemon non è pronto</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <source>failed to parse tx_key</source>
+        <translation>impossibile analizzare tx_key</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <source>Tx key successfully stored.</source>
+        <translation>Tx key memorizzata con successo.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <source>Failed to store tx key: </source>
+        <translation>Impossibile memorizzare la chiave tx: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>block</source>
+        <translation>blocco</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation>utilizzo: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
+        <translation>utilizzo: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>direction</source>
+        <translation>direzione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>timestamp</source>
+        <translation>timestamp</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>running balance</source>
+        <translation>bilancio corrente</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>hash</source>
+        <translation>hash</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>payment ID</source>
+        <translation>ID di pagamento</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>fee</source>
+        <translation>tassa</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>destination</source>
+        <translation>destinazione</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>index</source>
+        <translation>indice</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>note</source>
+        <translation>nota</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <source>CSV exported to </source>
+        <translation>CSV esportato in </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
+        <translation>Attenzione: questo farà perdere ogni informazione che non può essere recuperata dalla blockchain.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
+        <translation>Questo include gli indirizzi di destinazione, le chiavi segrete di tx, le note di tx, ecc</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <source>Warning: your restore height is higher than wallet restore height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <source>Rescan anyway ? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <source>MMS received new message</source>
+        <translation>ricevuto un nuovo messaggio MMS</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <source>Network type: </source>
+        <translation>Tipo di rete: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <source>Testnet</source>
+        <translation>Testnet</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Stagenet</source>
+        <translation>Stagenet</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Mainnet</source>
+        <translation>Mainnet</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <source>command only supported by HW wallet</source>
+        <translation>comando supportato solo dal portafoglio HW</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <source>hw wallet does not support cold KI sync</source>
+        <translation>Il portafoglio hardware non supporta la sincronizzazione cold KI</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <source>Please confirm the key image sync on the device</source>
+        <translation>Si prega di confermare la sincronizzazione della chiave immagine sul dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <source>Key images synchronized to height </source>
+        <translation>Immagini della chiave sincronizzate all&apos;altezza </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
+        <translation>L&apos;esecuzione di un daemon non fidato non può determinare quale output di transazione viene speso. Utilizzare un daemon fidato con --trusted-daemon ed eseguire rescan_spent</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> spent, </source>
+        <translation> speso, </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> unspent</source>
+        <translation> non speso</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <source>Failed to import key images</source>
+        <translation>Impossibile importare le immagini della chiave</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <source>Failed to import key images: </source>
+        <translation type="unfinished">Impossibile importare le key images: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <source>Failed to reconnect device</source>
+        <translation>Impossibile ricollegare il dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <source>Failed to reconnect device: </source>
+        <translation>Impossibile ricollegare il dispositivo: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <source>Transaction successfully saved to </source>
+        <translation>Transazione salvata correttamente in </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>, txid </source>
+        <translation>, txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>Failed to save transaction to </source>
+        <translation>Impossibile salvare la transazione in </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <source>This is a watch only wallet</source>
+        <translation>Questo è un portafoglio solo-vista</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <source>Transaction ID not found</source>
+        <translation>ID transazione non trovato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
+        <source>true</source>
+        <translation>vero</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="410"/>
+        <source>failed to parse refresh type</source>
+        <translation>impossibile fare il parsing del tipo di refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <source>command not supported by HW wallet</source>
+        <translation>comando non supportato dal portafoglio HW</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation>il portafoglio è solo-vista e non possiede un seed</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation>il portafoglio è non-deterministico e non possiede un seed</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
+        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
+        <source>Incorrect password</source>
+        <translation>Password errata</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <source>Current fee is %s %s per %s</source>
+        <translation>La commissione attuale è %s %s per %s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1181"/>
+        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation>Invia queste informazioni multifirma a tutti i partecipanti, quindi utilizza exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] con le informazioni multifirma degli altri partecipanti</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <source>Multisig wallet has been successfully created. Current wallet type: </source>
+        <translation>Il portafoglio multifirma è stato creato con successo. Tipo di portafoglio corrente: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
+        <source>Failed to perform multisig keys exchange: </source>
+        <translation>Impossibile eseguire lo scambio di chiavi multifirma: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
+        <source>Failed to load multisig transaction from MMS</source>
+        <translation>Impossibile caricare la transazione multifirma da MMS</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1812"/>
+        <source>Invalid key image</source>
+        <translation>Immagine della chiave non valida</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Invalid txid</source>
+        <translation>Txid non valido</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Key image either not spent, or spent with mixin 0</source>
+        <translation>Immagine della chiave non spesa o spesa con mixin 0</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
+        <source>Failed to get key image ring: </source>
+        <translation>Impossibile ottenere l&apos;anello della chiave immagine: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1703"/>
+        <source>File doesn&apos;t exist</source>
+        <translation>Il file non esiste</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
+        <source>Invalid ring specification: </source>
+        <translation>Specifica dell&apos;anello non valida: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1733"/>
+        <source>Invalid key image: </source>
+        <translation>Immagine della chiave non valida: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
+        <source>Invalid ring type, expected relative or abosolute: </source>
+        <translation>Tipo di anello non valido, previsto relativo o assoluto: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
+        <source>Error reading line: </source>
+        <translation>Errore durante la lettura della riga: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1767"/>
+        <source>Invalid ring: </source>
+        <translation>Anello non valido: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>Invalid relative ring: </source>
+        <translation>Anello relativo non valido: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <source>Invalid absolute ring: </source>
+        <translation>Anello assoluto non valido: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Failed to set ring for key image: </source>
+        <translation>Impossibile impostare l&apos;anello per l&apos;immagine della chiave: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Continuing.</source>
+        <translation>Continuando.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>Missing absolute or relative keyword</source>
+        <translation>Parola chiave assoluta o relativa mancante</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>invalid index: must be a strictly positive unsigned integer</source>
+        <translation>indice non valido: deve essere un numero intero senza segno e positivo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>invalid index: indices wrap</source>
+        <translation>indice non valido: indici wrap</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1862"/>
+        <source>invalid index: indices should be in strictly ascending order</source>
+        <translation>indice non valido: gli indici devono essere rigorosamente in ordine crescente</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
+        <source>failed to set ring</source>
+        <translation>impossibile impostare l&apos;anello</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1946"/>
+        <source>First line is not an amount</source>
+        <translation>La prima riga non è un importo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
+        <source>Invalid output: </source>
+        <translation>Output non valido: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>Bad argument: </source>
+        <translation>Argomento non valido: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>should be &quot;add&quot;</source>
+        <translation>dovrebbe essere &quot;add&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
+        <source>Failed to open file</source>
+        <translation>Impossibile aprire il file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
+        <source>Invalid output key, and file doesn&apos;t exist</source>
+        <translation>Chiave di output non valida, il file non esiste</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
+        <source>Failed to mark output spent: </source>
+        <translation>Impossibile contrassegnare l&apos;output come speso: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2035"/>
+        <source>Invalid output</source>
+        <translation>Output non valido</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2018"/>
+        <source>Failed to mark output unspent: </source>
+        <translation>Impossibile contrassegnare l&apos;output non speso: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2042"/>
+        <source>Spent: </source>
+        <translation>Speso: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <source>Not spent: </source>
+        <translation>Non speso: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2048"/>
+        <source>Failed to check whether output is spent: </source>
+        <translation>Impossibile verificare se l&apos;output è stato speso: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2063"/>
+        <source>Failed to save known rings: </source>
+        <translation>Impossibile salvare gli anelli conosciuti: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2171"/>
+        <source>Please confirm the transaction on the device</source>
+        <translation>Si prega di confermare la transazione sul dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation>il portafoglio è solo-vista e non può eseguire trasferimenti</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
+        <translation>ATTENZIONE: impostazione dell&apos;anello non default, la tua privacy potrebbe essere compromessa. Si consiglia di utilizzare l&apos;impostazione predefinita</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
+        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
+        <translation>ATTENZIONE: dalla v8, la dimensione dell&apos;anello sarà fissa e questa impostazione verrà ignorata.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2325"/>
+        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
+        <translation>la priorità deve essere 0, 1, 2, 3 o 4 o una di: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2330"/>
+        <source>could not change default priority</source>
+        <translation>impossibile cambiare priorità standard</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2400"/>
+        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
+        <translation>argomento non valido: deve essere 0/never, 1/action, or 2/encrypt/decrypt</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
+        <source>Device name not specified</source>
+        <translation>Nome del dispositivo non specificato</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
+        <source>Device reconnect failed</source>
+        <translation>Riconnessione del dispositivo fallita</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2700"/>
+        <source>Device reconnect failed: </source>
+        <translation>Riconnessione del dispositivo fallita: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation>Trasferisci &lt;amount&gt; in &lt;address&gt;. Se viene specificato il parametro &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; il portafoglio utilizza le uscite ricevute dagli indirizzi di tali indici. Se omesso, il portafoglio sceglie casualmente gli indici dell&apos;indirizzo da utilizzare. In ogni caso, fa del suo meglio per non combinare gli output su più indirizzi. &lt;priority&gt; è la priorità della transazione. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità. È possibile effettuare pagamenti multipli contemporaneamente aggiungendo URI_2 o &lt;address_2&gt; &lt;amount_2&gt; eccetera (prima dell&apos;ID pagamento, se questo è incluso)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation>Trasferisci &lt;amount&gt; in &lt;address&gt; e bloccalo per &lt;lockblocks&gt; (massimo 1000000). Se viene specificato il parametro &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, il portafoglio utilizza le uscite ricevute dagli indirizzi di tali indici. Se omesso, il portafoglio sceglie casualmente gli indici dell&apos;indirizzo da utilizzare. In ogni caso, fa del suo meglio per non combinare gli output su più indirizzi. &lt;priority&gt; è la priorità della transazione. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità. È possibile effettuare pagamenti multipli contemporaneamente aggiungendo URI_2 o &lt;address_2&gt; &lt;amount_2&gt; eccetera (prima dell&apos;ID pagamento, se questo è incluso)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
+        <translation>Invia tutto il saldo sbloccato a un indirizzo e bloccalo per &lt;lockblocks&gt; (massimo 1000000). Se viene specificato il parametro &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, le uscite sweep del portafoglio vengono ricevute da tali indici dell&apos;indirizzo. Se omesso, il portafoglio sceglie casualmente un indice dell&apos;indirizzo da utilizzare. &lt;priority&gt; è la priorità dello sweep. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
+        <translation>Invia tutto il saldo sbloccato a un indirizzo. Se viene specificato il parametro &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, le uscite sweep del portafoglio vengono ricevute da tali indici dell&apos;indirizzo. Se omesso, il portafoglio sceglie casualmente un indice dell&apos;indirizzo da utilizzare. Se il parametro &quot;outputs=&lt;N&gt;&quot; è specificato e  N &gt; 0, il portafoglio divide la transazione in N uscite pari.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2801"/>
+        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
+        <translation>Firma una transazione da un file. Se viene specificato il parametro &quot;export_raw&quot;, vengono esportati i dati esadecimali grezzi della transazione adatti al daemon RPC /sendrawtransaction.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation>Se non viene specificato alcun argomento o viene specificato &lt;index&gt;, il portafoglio mostra l&apos;indirizzo predefinito o specificato. Se è specificato &quot;all&quot;, il portafoglio mostra tutti gli indirizzi esistenti nell&apos;account attualmente selezionato. Se viene specificato &quot;new&quot;, il portafoglio crea un nuovo indirizzo con il testo dell&apos;etichetta fornito (che può essere vuoto). Se si specifica &quot;label&quot;, il portafoglio imposta l&apos;etichetta dell&apos;indirizzo specificato da &lt;index&gt; sul testo dell&apos;etichetta fornito.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
+        <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
+        <translation>Imposta la chiave di transazione (r) per un dato &lt;txid&gt; nel caso in cui il tx sia stato creato da qualche altro dispositivo o portafoglio di terze parti.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -2758,42 +2938,42 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
-        <translation type="unfinished"></translation>
+        <translation>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
-        <translation type="unfinished"></translation>
+        <translation>Esporta in CSV i trasferimenti in entrata/uscita all&apos;interno di un intervallo di altezza opzionale.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2784"/>
-        <source>Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2996"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Esporta un set firmato di immagini chiave in un &lt;filename&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Synchronizes key images with the hw wallet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sincronizza le immagini chiave con il portafoglio hw.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>Attempts to reconnect HW wallet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tenta di ricollegare il portafoglio HW.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2865"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3027"/>
+        <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation>Genera un nuovo ID di pagamento lungo casuale (obsoleto). Questi non saranno crittati sulla blockchain, vedere integrated_address per gli ID di pagamento brevi crittografati.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3043"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Esegue scambi extra di chiavi multifirma. Necessario per portafogli multisig M/N arbitrari</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3067"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -2802,73 +2982,74 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>Inizializza e configura MMS per M/N = numero di firmatari richiesti/numero di multifirma dei firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3079"/>
         <source>Display current MMS configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra la configurazione MMS corrente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta o modifica le informazioni del firmatario autorizzato (etichetta con una sola parola, indirizzo di trasporto, indirizzo Monero) oppure elenca tutti i firmatari</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
         <source>List all messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Elenca tutti i messaggi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
-        <translation type="unfinished"></translation>
+        <translation>Valuta le azioni multifirma successive secondo lo stato del portafoglio, esegui o proponi una scelta
+Utilizzando l&apos;elaborazione &apos;sync&apos; dei messaggi in attesa con le informazioni di sincronizzazione multifirma, è possibile forzare indipendentemente dallo stato del wallet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
-        <translation type="unfinished"></translation>
+        <translation>Generazione forzata di informazioni di sincronizzazione multifirma indipendente dallo stato del wallet, per il ripristino da situazioni speciali come errori di &quot;stale data&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Elimina un singolo messaggio inserendo il suo id, o cancella tutti i messaggi usando &apos;all&apos;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia un singolo messaggio inserendo il suo id o inviando tutti i messaggi in attesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Check right away for new messages to receive</source>
-        <translation type="unfinished"></translation>
+        <translation>Controlla subito i nuovi messaggi da ricevere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Scrivi il contenuto di un messaggio in un file &quot;mms_message_content&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia un messaggio di una linea a un firmatario autorizzato, identificato dalla sua etichetta, o mostra eventuali note non lette in attesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3124"/>
         <source>Show detailed info about a single message</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra informazioni dettagliate su un singolo messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2950"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3128"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -2876,27 +3057,27 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Send completed signer config to all other authorized signers</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia la configurazione completa del firmatario a tutti gli altri firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
-        <translation type="unfinished"></translation>
+        <translation>Avvia auto-config sul portafoglio del gestore automatico di configurazione emettendo i token di auto-configurazione e opzionalmente imposta le etichette degli altri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
-        <translation type="unfinished"></translation>
+        <translation>Elimina tutti i token di configurazione automatica e interrompi il processo di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Avviare la configurazione automatica utilizzando il token ricevuto dal gestore di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -2904,1616 +3085,1680 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3156"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta l&apos;anello utilizzato per una determinata immagine chiave, in modo che possa essere riutilizzato in un fork</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
         <source>Save known rings to the shared rings database</source>
-        <translation type="unfinished"></translation>
+        <translation>Salva gli anelli noti nel database degli anelli condivisi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrassegna gli output come spesi in modo che non vengano mai selezionati come output falsi in un anello</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3172"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrassegna un output come non speso in modo che possa essere selezionato come un falso output in un anello</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Checks whether an output is marked as spent</source>
-        <translation type="unfinished"></translation>
+        <translation>Controlla se un output è contrassegnato come speso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
         <source>Returns version information</source>
-        <translation type="unfinished"></translation>
+        <translation>Restituisce informazioni sulla versione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3297"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>completo (più lento, nessuna ipotesi); optimize-coinbase (veloce, ipotizza che l&apos;intero coinbase viene pagato ad un indirizzo singolo); no-coinbase (il più veloce, ipotizza di non ricevere una transazione coinbase), default (come optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
-        <translation type="unfinished"></translation>
+        <translation>0, 1, 2, 3 o 4 o uno di </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
         <source>0|1|2 (or never|action|decrypt)</source>
-        <translation type="unfinished"></translation>
+        <translation>0|1|2 (o never|action|decrypt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;major&gt;:&lt;minor&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3317"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;device_name[:device_spec]&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3338"/>
         <source>wrong number range, use: %s</source>
-        <translation type="unfinished"></translation>
+        <translation>intervallo di numeri errato, utilizzare: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nome del portafoglio non valido. Prova di nuovo o usa Ctrl-C per uscire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Portafoglio e chiavi trovate, sto caricando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Ho trovato la chiave ma non il portafoglio. Sto rigenerando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Chiave non trovata. Impossibile aprire portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
         <source>Generating new wallet...</source>
         <translation>Sto generando un nuovo portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>NOTA: il seguente %s può essere utilizzato per recuperare l&apos;accesso al tuo portafoglio. Scrivili e salvali in un posto sicuro e protetto. Si prega di non archiviarli nella propria e-mail o in servizi di archiviazione di file al di fuori del proprio immediato controllo.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>string</source>
-        <translation type="unfinished"></translation>
+        <translation>stringa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>25 words</source>
-        <translation type="unfinished"></translation>
+        <translation>25 parole</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3506"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
-        <translation type="unfinished"></translation>
+        <translation>Non è possibile specificare più di un --testnet e --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>non è possibile specificare più di un --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3548"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet usa --generate-new-wallet, non --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>Electrum-style word list failed verification</source>
         <translation>La lista di parole stile Electrum ha fallito la verifica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3605"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3470"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3871"/>
         <source>No data supplied, cancelled</source>
         <translation>Nessun dato fornito, cancellato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6243"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6886"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6950"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
         <source>failed to parse address</source>
         <translation>impossibile fare il parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3748"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3765"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3434"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3769"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3851"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3439"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3674"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3907"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3966"/>
         <source>account creation failed</source>
         <translation>creazione dell&apos;account fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3733"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3876"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3896"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3901"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <source>Secret spend key (%u of %u)</source>
+        <translation>Chiave di spesa segreta (%u di %u)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3941"/>
         <source>No restore height is specified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessuna altezza di ripristino specificata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3942"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
-        <translation type="unfinished"></translation>
+        <translation>Supponendo che si stia creando un nuovo account, il ripristino verrà effettuato dall&apos;attuale altezza stimata sulla blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <source>Use --restore-height if you want to restore an already setup account from a specific height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3947"/>
         <source>account creation aborted</source>
-        <translation type="unfinished"></translation>
+        <translation>creazione account interrotta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3957"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>specifica un percorso per il portafoglio con --generate-new-wallet (non --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
-        <translation type="unfinished"></translation>
+        <translation>non è possibile specificare --subaddress-lookahead e --wallet-file nello stesso momento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4073"/>
         <source>failed to open account</source>
         <translation>impossibile aprire account</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>wallet is null</source>
         <translation>il portafoglio è nullo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inizializzare il database degli anelli: le funzionalità di miglioramento della privacy non saranno attive</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4194"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4217"/>
         <source>invalid language choice entered. Please try again.
 </source>
-        <translation>linguaggio selezionato scorretto. Prova di nuovo.</translation>
+        <translation>la lingua selezionata non è corretta. Prova di nuovo.
+</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>View key: </source>
         <translation>Chiave di visualizzazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
         <source>Generated new wallet on hw device: </source>
-        <translation type="unfinished"></translation>
+        <translation>Generato un nuovo portafoglio sul dispositivo hw: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4486"/>
         <source>Key file not found. Failed to open wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>File della chiave non trovato. Impossibile aprire il portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4563"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Potresti voler rimuovere il file &quot;%s&quot; e provare di nuovo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>failed to deinitialize wallet</source>
         <translation>deinizializzazione portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4644"/>
         <source>Watch only wallet saved as: </source>
-        <translation type="unfinished"></translation>
+        <translation>Portafoglio solo-lettura salvato come: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
         <source>Failed to save watch only wallet: </source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile salvare il portafoglio in sola lettura: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4382"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>questo comando richiede un daemon fidato. Abilita questa opzione con --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4886"/>
         <source>Expected trusted or untrusted, got </source>
-        <translation type="unfinished"></translation>
+        <translation>Previsto fidato o non fidato, ottenuto </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>untrusted</source>
-        <translation type="unfinished"></translation>
+        <translation>non fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4539"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>impossibile salvare la blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
-        <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4572"/>
-        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
         <source>Password needed (%s) - use the refresh command</source>
-        <translation type="unfinished"></translation>
+        <translation>Password necessaria (%s) - usa il comando refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
         <source>Enter password</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci la password</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
         <source>Device requires attention</source>
-        <translation type="unfinished"></translation>
+        <translation>Il dispositivo richiede attenzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
         <source>Enter device PIN</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Failed to read device PIN</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile leggere il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
         <source>Please enter the device passphrase on the device</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci la passphrase del dispositivo sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
         <source>Enter device passphrase</source>
-        <translation type="unfinished"></translation>
+        <translation>Immettere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Failed to read device passphrase</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile leggere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4675"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
+        <translation>Vuoi procedere adesso? (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Assicurati che sia in funzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
         <source>refresh error: </source>
         <translation>errore refresh: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
         <source>Balance: </source>
         <translation>Bilancio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
         <source>Invalid keyword: </source>
-        <translation type="unfinished"></translation>
+        <translation>Parola chiave non valida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>pubkey</source>
         <translation>pubkey</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>key image</source>
         <translation>immagine chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>unlocked</source>
         <translation>sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
-        <source>Heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
         <source>locked</source>
         <translation>bloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
         <source>failed to get spent status</source>
         <translation>impossibile recuperare status spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>failed to find construction data for tx input</source>
+        <translation>impossibile trovare i dati di costruzione per l&apos;input tx</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <source>
+Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>the same transaction</source>
         <translation>la stessa transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>blocks that are temporally very close</source>
         <translation>i blocchi che sono temporalmente molto vicini</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <source>No payment id is included with this transaction. Is this okay?</source>
+        <translation>Nessun ID di pagamento è incluso in questa transazione. Vuoi procedere comunque?</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Is this okay anyway?</source>
+        <translation>Vuoi procedere comunque?</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <source>Rescan anyway?</source>
+        <translation>Ripetere comunque la scansione?</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <source>Short payment IDs are to be used within an integrated address only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
         <source> (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
+        <translation> (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
         <source>Choose processing:</source>
-        <translation type="unfinished"></translation>
+        <translation>Scegli l&apos;elaborazione:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
         <source>Sign tx</source>
-        <translation type="unfinished"></translation>
+        <translation>Firma tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
         <source>Submit tx</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
         <source>Choice: </source>
-        <translation type="unfinished"></translation>
+        <translation>Scelta: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
         <source>Wrong choice</source>
-        <translation type="unfinished"></translation>
+        <translation>Scelta errata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Id</source>
-        <translation type="unfinished"></translation>
+        <translation>Id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>I/O</source>
-        <translation type="unfinished"></translation>
+        <translation>I/O</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Authorized Signer</source>
-        <translation type="unfinished"></translation>
+        <translation>Firmatario autorizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo di messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>R</source>
-        <translation type="unfinished"></translation>
+        <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message State</source>
-        <translation type="unfinished"></translation>
+        <translation>Stato del messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Since</source>
-        <translation type="unfinished"></translation>
+        <translation>Da</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source> ago</source>
-        <translation type="unfinished"></translation>
+        <translation> fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>#</source>
-        <translation type="unfinished"></translation>
+        <translation>#</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Transport Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo di trasporto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Auto-Config Token</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto-Config Token</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Monero Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
         <source>&lt;not set&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;not set&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
         <source>Message </source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggio </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
         <source>In/out: </source>
-        <translation type="unfinished"></translation>
+        <translation>In/out: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>State: </source>
-        <translation type="unfinished"></translation>
+        <translation>Stato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>%s since %s, %s ago</source>
-        <translation type="unfinished"></translation>
+        <translation>%s da %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
         <source>Sent: Never</source>
-        <translation type="unfinished"></translation>
+        <translation>Inviati: mai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
         <source>Sent: %s, %s ago</source>
-        <translation type="unfinished"></translation>
+        <translation>inviato/i: %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
         <source>Authorized signer: </source>
-        <translation type="unfinished"></translation>
+        <translation>Firmatario autorizzato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source>Content size: </source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensione del contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source> bytes</source>
-        <translation type="unfinished"></translation>
+        <translation> bytes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Content: </source>
-        <translation type="unfinished"></translation>
+        <translation>Contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>(binary data)</source>
-        <translation type="unfinished"></translation>
+        <translation>(dati binari)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
         <source>Send these messages now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Vuoi inviare questi messaggi adesso?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
         <source>Queued for sending.</source>
-        <translation type="unfinished"></translation>
+        <translation>In coda per l&apos;invio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
         <source>Invalid message id</source>
-        <translation type="unfinished"></translation>
+        <translation>ID messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>utilizzo: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;MMS è già inizializzato. Reinizializzare eliminando tutte le informazioni e i messaggi del firmatario?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
         <source>Error in the number of required signers and/or authorized signers</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore nel numero di firmatari richiesti e/o firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
         <source>The MMS is not active.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;MMS non è attivo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
         <source>Invalid signer number </source>
-        <translation type="unfinished"></translation>
+        <translation>Numero del firmatario non valido </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
-        <translation type="unfinished"></translation>
+        <translation>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
         <source>Invalid Monero address</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo Monero non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
-        <translation type="unfinished"></translation>
+        <translation>Lo stato del portafoglio non consente più di modificare gli indirizzi Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9380"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Usage: mms next [sync]</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilizzo: mms next [sync]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9405"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>No next step: </source>
-        <translation type="unfinished"></translation>
+        <translation>Nessun passo successivo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9415"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
         <source>prepare_multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>prepare_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
         <source>make_multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>make_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9436"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
         <source>exchange_multisig_keys</source>
-        <translation type="unfinished"></translation>
+        <translation>exchange_multisig_keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
         <source>export_multisig_info</source>
-        <translation type="unfinished"></translation>
+        <translation>export_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9460"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
         <source>import_multisig_info</source>
-        <translation type="unfinished"></translation>
+        <translation>import_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
         <source>sign_multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9483"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
         <source>submit_multisig</source>
-        <translation type="unfinished"></translation>
+        <translation>submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
         <source>Send tx</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
         <source>Replace current signer config with the one displayed above?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sostituire la configurazione attuale del firmatario con quella visualizzata sopra?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
         <source>Process auto config data</source>
-        <translation type="unfinished"></translation>
+        <translation>Elabora dati di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9853"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <source>MMS not available in this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5486"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5537"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5539"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6213"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
         <source>missing threshold amount</source>
         <translation>manca la soglia massima dell&apos;ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
         <source>invalid amount threshold</source>
         <translation>ammontare soglia invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento va a più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
         <source>Good signature</source>
         <translation>Firma valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Bad signature</source>
         <translation>Firma invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Standard address: </source>
         <translation>Indirizzo standard: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
         <source>failed to parse payment ID or address</source>
         <translation>impossibile fare il parsing di ID pagamento o indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
         <source>failed to parse payment ID</source>
         <translation>impossibile fare il parsing di ID pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
         <source>failed to parse index</source>
         <translation>impossibile fare il parsing dell&apos;indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8241"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
         <source>Address book is empty.</source>
         <translation>La rubrica è vuota.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8247"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>Index: </source>
         <translation>Indice: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
         <source>Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>Payment ID: </source>
         <translation>ID Pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8250"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
         <source>Description: </source>
         <translation>Descrizione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>il portafoglio è di tipo solo-visualizzazione e non può firmare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
         <source>failed to read file </source>
         <translation>impossibile leggere il file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6958"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <source>Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
+        <source>Still apply restore height?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished">L&apos;indirizzo non può essere un sottoindirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7799"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7931"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8100"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7996"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8005"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
         <source>Bad signature from </source>
         <translation>Firma non valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
         <source>Good signature from </source>
         <translation>Firma valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>il portafoglio è solo-vista e non può esportare immagini chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
         <source>failed to save file </source>
         <translation>impossibile salvare file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>Signed key images exported to </source>
         <translation>Chiave immagine firmata esportata in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
         <source>Outputs exported to </source>
         <translation>Outputs esportati in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7115"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
         <source>amount is wrong: </source>
         <translation>l&apos;ammontare non è corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
         <source>expected number from 0 to </source>
         <translation>deve essere un numero da 0 a </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5721"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
         <source>Sweeping </source>
         <translation>Eseguendo lo sweeping </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fondi inviati con successo, transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6574"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>no change</source>
         <translation>nessun cambiamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1448"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transazione firmata con successo nel file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6713"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6811"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6942"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>failed to parse txid</source>
         <translation>parsing txid fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>Tx key: </source>
         <translation>Chiave Tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6829"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6868"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
         <source>failed to parse tx key</source>
         <translation>impossibile fare il parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6835"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
         <source>error: </source>
         <translation>errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>received</source>
         <translation>ricevuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>in txid</source>
         <translation>in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
         <source>received nothing in txid</source>
         <translation>nulla ricevuto in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6902"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>AVVISO: questa transazione non è ancora inclusa nella blockchain!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
         <source>This transaction has %u confirmations</source>
         <translation>Questa transazione ha %u conferme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>AVVISO: impossibile determinare il numero di conferme!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
         <source>bad min_height parameter:</source>
         <translation>parametro min_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
         <source>bad max_height parameter:</source>
         <translation>parametro max_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_amount&gt; dovrebbe essere più piccolo di &lt;max_amount&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>
 Amount: </source>
         <translation>
 Ammontare: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>, number of keys: </source>
         <translation>, numero di chiavi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
         <source>
 Min block height: </source>
         <translation>
 Altezza minima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>
 Max block height: </source>
         <translation>
 Altezza massima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
         <source>
 Min amount found: </source>
         <translation>
 Ammontare minimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
         <source>
 Max amount found: </source>
         <translation>
 Ammontare massimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
         <source>
 Total count: </source>
         <translation>
 Conto totale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
         <source>
 Bin size: </source>
         <translation>
 Dimensione Bin: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
         <source>wallet</source>
         <translation>portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
         <source>Random payment ID: </source>
         <translation>ID pagamento casuale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
         <source>Matching integrated address: </source>
         <translation>Indirizzo integrato corrispondente: </translation>
     </message>
@@ -4699,7 +4944,7 @@ Use &quot;mms note&quot; to display the waiting notes</source>
     <message>
         <location filename="../src/wallet/message_store.cpp" line="1369"/>
         <source>note</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">nota</translation>
     </message>
     <message>
         <location filename="../src/wallet/message_store.cpp" line="1371"/>
@@ -4765,311 +5010,321 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Genera un nuovo portafoglio e salvalo in &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Genera un portafoglio solo-ricezione da chiave di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
         <source>Generate wallet from private keys</source>
         <translation>Genera portafoglio da chiavi private</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="133"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="143"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Specifica il seed stile Electrum per recuperare/creare il portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="144"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Recupera portafoglio usando il seed mnemonico stile-Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="146"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Crea chiavi di visualizzione e chiavi di spesa non-deterministiche</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="149"/>
+        <source>Restore from estimated blockchain height on specified date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="447"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
         <translation type="unfinished">errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
         <source>Not enough money in unlocked balance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Fondi insufficienti in saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="544"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="529"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="550"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">insufficiente numero di output per il ring size specificato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>output amount</source>
         <translation type="unfinished">ammontare output</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>found outputs to use</source>
         <translation type="unfinished">trovati output che possono essere usati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">transazione non costruita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="546"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="576"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">una delle destinazioni è zero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">impossibile trovare un modo per dividere le transazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">errore trasferimento sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
         <translation type="unfinished">Errore multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
         <translation type="unfinished">errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
         <translation type="unfinished">errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="617"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="599"/>
-        <source>File %s already exists. Are you sure to overwrite it? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>Unknown command: </source>
         <translation type="unfinished">Comando sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Permetti comunicazioni con un daemon che usa una versione RPC differente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="148"/>
         <source>Restore from specific blockchain height</source>
         <translation>Ripristina da specifico blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="150"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="151"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
+        <source>Support obsolete long (unencrypted) payment ids (using them harms your privacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="297"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished">impossibile leggere la password del portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="293"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è occupato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="323"/>
         <source>possibly lost connection to daemon</source>
         <translation>possibile perdita di connessione con il daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
         <translation>Errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <source>Is this OK?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="564"/>
+        <source>transaction %s was rejected by daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
+        <source>File %s already exists. Are you sure to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
         <source>Failed to initialize wallet</source>
         <translation>Inizializzazione wallet fallita</translation>
     </message>
@@ -5077,359 +5332,447 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="201"/>
+        <location filename="../src/wallet/wallet2.cpp" line="234"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Usa instanza daemon in &lt;host&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="202"/>
+        <location filename="../src/wallet/wallet2.cpp" line="235"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Usa istanza daemon all&apos;host &lt;arg&gt; invece che localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Wallet password file</source>
         <translation>File password portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="207"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Usa istanza daemon alla porta &lt;arg&gt; invece che alla 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="209"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Per testnet. Il daemon può anche essere lanciato con la flag --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
+        <location filename="../src/wallet/wallet2.cpp" line="361"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>non puoi specificare la porta o l&apos;host del daemon più di una volta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="355"/>
+        <location filename="../src/wallet/wallet2.cpp" line="480"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>non puoi specificare più di un --password e --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="368"/>
+        <location filename="../src/wallet/wallet2.cpp" line="493"/>
         <source>the password file specified could not be read</source>
         <translation>il file password specificato non può essere letto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="519"/>
         <source>Failed to load file </source>
         <translation>Impossibile caricare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="239"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Wallet password (escape/quote se necessario)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="203"/>
+        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="237"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">Abilita comandi dipendenti da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="208"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Specificare username[:password] per client del daemon RPC</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="210"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <source>List of valid fingerprints of allowed RPC servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <source>Allow any SSL certificate from the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="212"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="223"/>
+        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="313"/>
+        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <source>Do not use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>Do not connect to a daemon, nor use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <source>Invalid argument for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source>Enabling --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source> requires --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or use of a .onion/.i2p domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="432"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="442"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="375"/>
+        <location filename="../src/wallet/wallet2.cpp" line="500"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="400"/>
+        <location filename="../src/wallet/wallet2.cpp" line="525"/>
         <source>Failed to parse JSON</source>
         <translation>Impossibile fare il parsing di JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="407"/>
+        <location filename="../src/wallet/wallet2.cpp" line="532"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>La versione %u è troppo recente, possiamo comprendere solo fino alla versione %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="423"/>
+        <location filename="../src/wallet/wallet2.cpp" line="548"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing di chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="428"/>
-        <location filename="../src/wallet/wallet2.cpp" line="496"/>
-        <location filename="../src/wallet/wallet2.cpp" line="539"/>
+        <location filename="../src/wallet/wallet2.cpp" line="553"/>
+        <location filename="../src/wallet/wallet2.cpp" line="621"/>
+        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="439"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="444"/>
-        <location filename="../src/wallet/wallet2.cpp" line="506"/>
-        <location filename="../src/wallet/wallet2.cpp" line="565"/>
+        <location filename="../src/wallet/wallet2.cpp" line="569"/>
+        <location filename="../src/wallet/wallet2.cpp" line="631"/>
+        <location filename="../src/wallet/wallet2.cpp" line="692"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="456"/>
+        <location filename="../src/wallet/wallet2.cpp" line="581"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Verifica lista di parole stile-Electrum fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="476"/>
+        <location filename="../src/wallet/wallet2.cpp" line="601"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="605"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Specificate entrambe lista parole stile-Electrum e chiave/i privata/e </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="490"/>
+        <location filename="../src/wallet/wallet2.cpp" line="615"/>
         <source>invalid address</source>
         <translation>indirizzo invalido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="499"/>
+        <location filename="../src/wallet/wallet2.cpp" line="624"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="509"/>
+        <location filename="../src/wallet/wallet2.cpp" line="634"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="517"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossibile creare portafogli disapprovati da JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="551"/>
+        <location filename="../src/wallet/wallet2.cpp" line="678"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="557"/>
+        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
+        <location filename="../src/wallet/wallet2.cpp" line="701"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1383"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="3770"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4374"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4926"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10157"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10899"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
         <source>failed to read file </source>
         <translation>lettura file fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <source>Path to a PEM format private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <source>Path to a PEM format certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="180"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="182"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source>Cannot specify --</source>
         <translation>Impossibile specificare --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source> and --</source>
         <translation> e --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>Failed to create file </source>
         <translation>Impossibile creare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>. Check permissions or remove file</source>
         <translation>. Controlla permessi o rimuovi il file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="222"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
         <source>Error writing to file </source>
         <translation>Errore durante scrittura su file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
         <source>RPC username/password is stored in file </source>
         <translation>Username/password RPC conservato nel file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="479"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3081"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3947"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3788"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Non puoi specificare più di un --wallet-file e --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3773"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Non è possibile specificare più di un --testnet e --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3800"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Devi specificare --wallet-file o --generate-from-json o --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3804"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
         <source>Loading wallet...</source>
         <translation>Sto caricando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3838"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3870"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
         <source>Saving wallet...</source>
         <translation>Sto salvando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3840"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3872"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3843"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3847"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Wallet initialization failed: </source>
         <translation>Inizializzazione portafoglio fallita: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3853"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Inizializzazione server RPC portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3857"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
         <source>Starting wallet RPC server</source>
         <translation>Server RPC portafoglio in avvio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3864"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3867"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Stopped wallet RPC server</source>
         <translation>Server RPC portafoglio arrestato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3876"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
         <source>Failed to save wallet: </source>
         <translation>Impossibile salvare portafoglio: </translation>
     </message>
@@ -5438,8 +5781,8 @@ daemon to work correctly.</source>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8908"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3928"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Wallet options</source>
         <translation>Opzioni portafoglio</translation>
     </message>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ja" sourcelanguage="en">
+<TS version="2.1" language="ja" sourcelanguage="en">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
@@ -37,42 +37,42 @@
         <translation>取引をファイルに書き込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="124"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="133"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>。 理由： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>未知の例外： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>未処理の例外</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="211"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="233"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,384 +134,384 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1383"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>ペイメントIDのフォーマットは不正です。16文字または64文字の16進数の文字列が必要で： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1392"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
         <translation>短いペイメントIDの追加に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1428"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1592"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1512"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1594"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1432"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
         <translation>RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>not enough outputs for specified ring size</source>
         <translation>指定したリングサイズのアウトプットが不十分です</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>found outputs to use</source>
         <translation>使うためにアウトプットを見つかれました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1464"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1546"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>ミックス不能なアウトプットをスイープしてください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1438"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1521"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1520"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1603"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="541"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="575"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="584"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="588"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>スペンドキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="594"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="598"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>ビューキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="621"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="885"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>インポートウォレットリクエストの送信に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1049"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>未署名の取引を読み込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1068"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1144"/>
         <source>Failed to load transaction from file</source>
         <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1084"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <source>Wallet is view only</source>
         <translation>閲覧専用ウォレットです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1168"/>
         <source>failed to save file </source>
         <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1184"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>信頼できるデーモンしかでキーイメージをインポートしません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
         <translation>キーイメージをインポートできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1153"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
         <translation>サブアドレスラベルを取得できませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1166"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
         <translation>サブアドレスラベルをセットできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="695"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1183"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1259"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1200"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1214"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1305"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1232"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1248"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1324"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1266"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1342"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1352"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1366"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1318"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1394"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1358"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">不正な宛先アドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1445"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1529"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1527"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1611"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1534"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1619"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>output amount</source>
         <translation>アウトプットの金額</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1467"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1551"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1633"/>
         <source>transaction was not constructed</source>
         <translation>取引を作りませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1554"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1475"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1641"/>
         <source>one of destinations is zero</source>
         <translation>宛先の1つはゼロです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1477"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>取引を分割する適切な方法を見つけることができませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1479"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
         <translation>不明な転送エラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1481"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
         <translation>内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1483"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
         <translation>予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1485"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1569"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1598"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1644"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1671"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1719"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1747"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1775"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1796"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1753"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1801"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1829"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1857"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1878"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2354"/>
         <source>Failed to parse txid</source>
         <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1743"/>
         <source>no tx keys found for this txid</source>
         <translation>このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1688"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1761"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1770"/>
         <source>Failed to parse tx key</source>
         <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1754"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1835"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1779"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1808"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1836"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1917"/>
         <source>Failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1922"/>
         <source>Address must not be a subaddress</source>
         <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1880"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1962"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1902"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1984"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2226"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>信頼できるデーモンしかで再スキャンしません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2275"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2186"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2282"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2197"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2293"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2315"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2202"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2224"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2298"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2320"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2208"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2304"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2230"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2326"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2241"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2280"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2337"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2376"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2247"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2343"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2265"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2361"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2286"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2382"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -519,22 +519,22 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="301"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="308"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>キーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="316"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>キーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="326"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>キーがアドレスと一致しませんでした</translation>
     </message>
@@ -604,992 +604,1044 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="645"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4231"/>
         <source>invalid password</source>
         <translation>不正なパスワード</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3097"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>0 or 1</source>
         <translation>０や１</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
         <source>unsigned integer</source>
         <translation>符号無しの整数</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3548"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3957"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3926"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4025"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4511"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4267"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4544"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
         <source>failed to load wallet: </source>
         <translation>ウォレットをロードできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4819"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">ペイメントIDのフォーマットは不正です。16文字または64文字の16進数の文字列が必要で： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5978"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6251"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6219"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5395"/>
-        <source>Unencrypted payment IDs are bad for privacy: ask the recipient to use subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5502"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5738"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6059"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5486"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
         <source>
 Transaction </source>
         <translation>
 取引 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5537"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5539"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5550"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>.</source>
         <translation>。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5611"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6328"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">取引をファイルに書き込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5616"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5625"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
-        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6187"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6213"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
         <source>failed to parse key image</source>
         <translation>キーイメージの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">請求したお釣りはもうお金に送ったアドレス送りません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">請求したお釣りはお釣りのアドレスに送ったペイメントより大きいです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
         <source>sending %s to %s</source>
         <translation>%s を %s に送ってます</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
         <source>with no destinations</source>
         <translation>目的地なし</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>取引は %lu ロードした、 %s に、%s のの手数料、 %s 、 %s 、最小リングサイズ %lu 、%s。これは大丈夫ですか？　はい　(Y)　いいえ (N)： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
         <source>Failed to sign transaction</source>
         <translation>取引を署名できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
         <source>Failed to sign transaction: </source>
         <translation>取引を署名できませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
         <source>Failed to load transaction from file</source>
         <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
         <source>RPC error: </source>
         <translation>RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
         <source>invalid unit</source>
         <translation>不正なユニット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>invalid value</source>
         <translation>不正な金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation>(はい (Y)　いいえ (N)): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3766"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3780"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation>これは大丈夫ですか？ (はい (Y)　いいえ (N)): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
         <source>internal error: </source>
         <translation>内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
         <source>unexpected error: </source>
         <translation>予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1534"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
         <source>unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
         <source>unlocked balance: </source>
         <translation>ロック解除された残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Unknown command: </source>
         <translation>未知のコマンド： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Command usage: </source>
         <translation>コマンドの使用： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Command description: </source>
         <translation>コマンドの記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1012"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="949"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1156"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
         <source> multisig address: </source>
         <translation> マルチサインアドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1129"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1285"/>
         <source>This wallet is not multisig</source>
         <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
+        <source>Multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1500"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1330"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1471"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1379"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
         <source>This is not a multisig wallet</source>
         <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
         <source>Multisig error: </source>
         <translation>マルチサインエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1508"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1602"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
+        <source>Invalid key image or txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1901"/>
+        <source>failed to unset ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2129"/>
+        <source>Frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2131"/>
+        <source>Not frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
+        <source> bytes sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
+        <source> bytes received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2145"/>
+        <source>Welcome to Monero, the private cryptocurrency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2147"/>
+        <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <source>Unlike Bitcoin, your Monero transactions and balance stay private, and not visible to the world by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>However, you have the option of making those available to select parties, if you choose to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2151"/>
+        <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
+        <source>no privacy technology can be 100% perfect, Monero included.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2153"/>
+        <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2155"/>
+        <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2157"/>
+        <source>Welcome to Monero and financial privacy. For more information, see https://getmonero.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2398"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2549"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2667"/>
+        <source>invalid argument: must be either 1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2745"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2759"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.
+
+Output format:
+Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2782"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2789"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2793"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2628"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2804"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2808"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2812"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1600,1177 +1652,47 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
-        <source>Display the encrypted Electrum-style mnemonic seed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
-        <source>Rescan the blockchain for spent outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
-        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
-        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
-        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
-        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2750"/>
-        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
-        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
-If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
-Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
-        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2780"/>
-        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2788"/>
-        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2792"/>
-        <source>Get a string note for a txid.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2796"/>
-        <source>Set an arbitrary description for the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2800"/>
-        <source>Get the description of the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2803"/>
-        <source>Show the wallet&apos;s status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2806"/>
-        <source>Show the wallet&apos;s information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2810"/>
-        <source>Sign the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
-        <source>Verify a signature on the contents of a file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
-        <source>Import a signed key images list and verify their spent status.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2834"/>
-        <source>Export a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2838"/>
-        <source>Import a set of outputs owned by this wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
-        <source>Show information about a transfer to/from this address.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
-        <source>Change the wallet&apos;s password.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2852"/>
-        <source>Print the information about the current fee and transaction backlog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
-        <source>Export data needed to create a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
-        <source>Turn this wallet into a multisig wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
-        <source>Export multisig info for other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Import multisig info from other participants</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2877"/>
-        <source>Sign a multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <source>Submit a signed multisig transaction from a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>Export a signed multisig transaction to a file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
-        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
-        <source>integer &gt;= </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
-        <source>block height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3203"/>
-        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
-        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3355"/>
-        <source>Multisig seed failed verification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
-        <source>This address is a subaddress which cannot be used here.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3558"/>
-        <source>Error: expected M/N, but got: </source>
-        <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3563"/>
-        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでもこれを貰いました： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3568"/>
-        <source>Error: M/N is currently unsupported. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
-        <source>Generating master wallet from %u of %u multisig wallet keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
-        <source>failed to parse secret view key</source>
-        <translation>秘密なビューキーの解析に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3608"/>
-        <source>failed to verify secret view key</source>
-        <translation>秘密なビューキーの検証に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3651"/>
-        <source>Error: M/N is currently unsupported</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3802"/>
-        <source>Restore height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3803"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3829"/>
-        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3888"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4180"/>
-        <source>failed to generate new mutlisig wallet</source>
-        <translation>新しいマルチシッグウォレットの生成に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4183"/>
-        <source>Generated new %u/%u multisig wallet: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <source>Opened %u/%u multisig wallet%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4351"/>
-        <source>wallet is multisig and cannot save a watch-only version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
-        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4517"/>
-        <source>This does not seem to be a valid daemon URL.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4590"/>
-        <source>txid </source>
-        <translation>txid </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
-        <source>idx </source>
-        <translation>idx </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4780"/>
-        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>Currently selected account: [</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>] </source>
-        <translation>] </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>Tag: </source>
-        <translation>タグ： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>(No tag assigned)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
-        <source>Balance per address:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Address</source>
-        <translation>アドレス</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Balance</source>
-        <translation>残高</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Unlocked balance</source>
-        <translation>ロック解除された残高</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Outputs</source>
-        <translation>アウトプット</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>Label</source>
-        <translation>ラベル</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4801"/>
-        <source>%8u %6s %21s %21s %7u %21s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>global index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>tx id</source>
-        <translation>tx id</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>addr index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4924"/>
-        <source>No incoming transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4928"/>
-        <source>No incoming available transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4932"/>
-        <source>No incoming unavailable transfers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>payment</source>
-        <translation>ペイメント</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>transaction</source>
-        <translation>取引</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>unlock time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
-        <source>No payments with id </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
-        <source>failed to get blockchain height: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5114"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5135"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5151"/>
-        <source>failed to get output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5163"/>
-        <source>
-Originating block heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <source>
-|</source>
-        <translation>
-|</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
-        <source>|
-</source>
-        <translation>|
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5192"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6156"/>
-        <source>Ring size must not be 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
-        <source>ring size %u is too small, minimum is %u</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5258"/>
-        <source>wrong number of arguments</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6268"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
-        <source>No outputs found, or daemon is not ready</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
-        <source>Failed to parse donation address: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6444"/>
-        <source>Donating %s %s to %s.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6777"/>
-        <source>failed to parse tx_key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6786"/>
-        <source>Tx key successfully stored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6790"/>
-        <source>Failed to store tx key: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>block</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7440"/>
-        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7493"/>
-        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>timestamp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>running balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>hash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>fee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>note</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
-        <source>CSV exported to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7730"/>
-        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7731"/>
-        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7732"/>
-        <source>Rescan anyway ? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7750"/>
-        <source>MMS received new message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8387"/>
-        <source>Network type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8388"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8605"/>
-        <source>command only supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8564"/>
-        <source>hw wallet does not support cold KI sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8576"/>
-        <source>Please confirm the key image sync on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
-        <source>Key images synchronized to height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8585"/>
-        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> spent, </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> unspent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8592"/>
-        <source>Failed to import key images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8597"/>
-        <source>Failed to import key images: </source>
-        <translation type="unfinished">キーイメージをインポートできませんでした： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8614"/>
-        <source>Failed to reconnect device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8619"/>
-        <source>Failed to reconnect device: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <source>Transaction successfully saved to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>, txid </source>
-        <translation>、txid </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>Failed to save transaction to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6310"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
-        <source>This is a watch only wallet</source>
-        <translation>これは閲覧専用ウォレットです</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8813"/>
-        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
-        <source>Transaction ID not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="336"/>
-        <source>true</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
-        <source>failed to parse refresh type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1067"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7010"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8670"/>
-        <source>command not supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
-        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
-        <source>Incorrect password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
-        <source>Current fee is %s %s per %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
-        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <source>Multisig wallet has been successfully created. Current wallet type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <source>Failed to perform multisig keys exchange: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
-        <source>Failed to load multisig transaction from MMS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
-        <source>Invalid key image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <source>Invalid txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
-        <source>Key image either not spent, or spent with mixin 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
-        <source>Failed to get key image ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
-        <source>File doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
-        <source>Invalid ring specification: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1709"/>
-        <source>Invalid key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1714"/>
-        <source>Invalid ring type, expected relative or abosolute: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
-        <source>Error reading line: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
-        <source>Invalid ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1752"/>
-        <source>Invalid relative ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <source>Invalid absolute ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Failed to set ring for key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Continuing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
-        <source>Missing absolute or relative keyword</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
-        <source>invalid index: must be a strictly positive unsigned integer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
-        <source>invalid index: indices wrap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
-        <source>invalid index: indices should be in strictly ascending order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
-        <source>failed to set ring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
-        <source>First line is not an amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
-        <source>Invalid output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>Bad argument: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>should be &quot;add&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
-        <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
-        <source>Invalid output key, and file doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
-        <source>Failed to mark output spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1952"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
-        <source>Invalid output</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1962"/>
-        <source>Failed to mark output unspent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <source>Spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
-        <source>Not spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
-        <source>Failed to check whether output is spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2007"/>
-        <source>Failed to save known rings: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2022"/>
-        <source>Please confirm the transaction on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2088"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5581"/>
-        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2108"/>
-        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2137"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2176"/>
-        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2181"/>
-        <source>could not change default priority</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
-        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2510"/>
-        <source>Device name not specified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
-        <source>Device reconnect failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
-        <source>Device reconnect failed: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <source>Show the incoming transfers, all or filtered by availability and address index.
-
-Output format:
-Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
-        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2625"/>
-        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2673"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2788,8 +1710,10 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&qu
    Set the wallet&apos;s refresh behaviour.
  priority [0|1|2|3|4]
    Set the fee to default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
+ confirm-missing-payment-id &lt;1|0&gt; (obsolete)
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
+   action: ask the password before many actions such as transfer, etc
+   decrypt: same as action, but keeps the spend key encrypted in memory when not needed
  unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
    Set the default monero (sub-)unit.
  min-outputs-count [n]
@@ -2818,12 +1742,1241 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2730"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2904"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2912"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2928"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2962"/>
+        <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2970"/>
+        <source>Get a string note for a txid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <source>Get the description of the wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2984"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
+        <source>Sign the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3016"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3020"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3023"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3032"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3039"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <source>Export multisig info for other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <source>Import multisig info from other participants</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3055"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3160"/>
+        <source>Unsets the ring used for a given key image or transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
+        <source>Freeze a single output by key image so it will not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>Thaw a single output by key image so it may be used again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3188"/>
+        <source>Checks whether a given output is currently frozen by key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3192"/>
+        <source>Prints simple network stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Prints basic info about Monero for first time users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source> (set this to support the network and to get a chance to receive new monero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3295"/>
+        <source>integer &gt;= </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3308"/>
+        <source>block height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3316"/>
+        <source>1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3562"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
+        <source>Multisig seed failed verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3718"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでもこれを貰いました： </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3838"/>
+        <source>failed to parse secret view key</source>
+        <translation>秘密なビューキーの解析に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3846"/>
+        <source>failed to verify secret view key</source>
+        <translation>秘密なビューキーの検証に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
+        <source>Restore height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
+        <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4098"/>
+        <source>WARNING: obsolete long payment IDs are enabled. Sending transactions with those payment IDs are bad for your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4100"/>
+        <source>It is recommended that you do not use them, and ask recipients who ask for one to not endanger your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4203"/>
+        <source>Enter the number corresponding to the language of your choice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4313"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4457"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation>新しいマルチシッグウォレットの生成に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4628"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4696"/>
+        <source>Failed to query mining status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Failed to setup background mining: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4683"/>
+        <source>Background mining enabled. Thank you for supporting the Monero network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4719"/>
+        <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4725"/>
+        <source>Using an untrusted daemon, skipping background mining check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4750"/>
+        <source>The daemon is not set up to background mine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4752"/>
+        <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4864"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4905"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <source>txid </source>
+        <translation>txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <source>idx </source>
+        <translation>idx </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete. Support will be withdrawn in the future. Use subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <source>New transfer received since rescan was started. Key images are incomplete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>Currently selected account: [</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>] </source>
+        <translation>] </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Tag: </source>
+        <translation>タグ： </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>(No tag assigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <source>Balance per address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Address</source>
+        <translation>アドレス</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Balance</source>
+        <translation>残高</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Unlocked balance</source>
+        <translation>ロック解除された残高</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Outputs</source>
+        <translation>アウトプット</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>Label</source>
+        <translation>ラベル</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>global index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>tx id</source>
+        <translation>tx id</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>addr index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <source>Used at heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>[frozen]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <source>No incoming transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <source>No incoming available transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <source>No incoming unavailable transfers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>payment</source>
+        <translation>ペイメント</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>transaction</source>
+        <translation>取引</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>unlock time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <source>No payments with id </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <source>failed to get blockchain height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <source>failed to get output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <source>
+Originating block heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <source>
+|</source>
+        <translation>
+|</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <source>|
+</source>
+        <translation>|
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <source>Ring size must not be 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <source>wrong number of arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <source>Failed to parse donation address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <source>Donating %s %s to %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <source>failed to parse tx_key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <source>Tx key successfully stored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <source>Failed to store tx key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>timestamp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>running balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>hash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <source>CSV exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <source>Warning: your restore height is higher than wallet restore height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <source>Rescan anyway ? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <source>MMS received new message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <source>Network type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <source>Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Stagenet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <source>command only supported by HW wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <source>hw wallet does not support cold KI sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <source>Please confirm the key image sync on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <source>Key images synchronized to height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> spent, </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> unspent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <source>Failed to import key images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <source>Failed to import key images: </source>
+        <translation type="unfinished">キーイメージをインポートできませんでした： </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <source>Failed to reconnect device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <source>Failed to reconnect device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <source>Transaction successfully saved to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>, txid </source>
+        <translation>、txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>Failed to save transaction to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <source>This is a watch only wallet</source>
+        <translation>これは閲覧専用ウォレットです</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <source>Transaction ID not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="410"/>
+        <source>failed to parse refresh type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <source>command not supported by HW wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
+        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
+        <source>Incorrect password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <source>Current fee is %s %s per %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1181"/>
+        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <source>Multisig wallet has been successfully created. Current wallet type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
+        <source>Failed to perform multisig keys exchange: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
+        <source>Failed to load multisig transaction from MMS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1812"/>
+        <source>Invalid key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Invalid txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Key image either not spent, or spent with mixin 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
+        <source>Failed to get key image ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1703"/>
+        <source>File doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
+        <source>Invalid ring specification: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1733"/>
+        <source>Invalid key image: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
+        <source>Invalid ring type, expected relative or abosolute: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
+        <source>Error reading line: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1767"/>
+        <source>Invalid ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>Invalid relative ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <source>Invalid absolute ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Failed to set ring for key image: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Continuing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>Missing absolute or relative keyword</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>invalid index: must be a strictly positive unsigned integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>invalid index: indices wrap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1862"/>
+        <source>invalid index: indices should be in strictly ascending order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
+        <source>failed to set ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1946"/>
+        <source>First line is not an amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
+        <source>Invalid output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>Bad argument: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>should be &quot;add&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
+        <source>Failed to open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
+        <source>Invalid output key, and file doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
+        <source>Failed to mark output spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2035"/>
+        <source>Invalid output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2018"/>
+        <source>Failed to mark output unspent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2042"/>
+        <source>Spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <source>Not spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2048"/>
+        <source>Failed to check whether output is spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2063"/>
+        <source>Failed to save known rings: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2171"/>
+        <source>Please confirm the transaction on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
+        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2325"/>
+        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2330"/>
+        <source>could not change default priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2400"/>
+        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
+        <source>Device name not specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
+        <source>Device reconnect failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2700"/>
+        <source>Device reconnect failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2801"/>
+        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -2837,42 +2990,42 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2784"/>
-        <source>Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2996"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2865"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3027"/>
+        <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3043"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3067"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -2881,73 +3034,73 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3079"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3124"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2950"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3128"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -2955,27 +3108,27 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -2983,1529 +3136,1600 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3156"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3172"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3297"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3317"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3338"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
         <source>Generating new wallet...</source>
         <translation>新しいウォレットを生じてます...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3506"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3605"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3470"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3871"/>
         <source>No data supplied, cancelled</source>
         <translation>データをもらいませんでしたのでキャンセルしました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6243"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6886"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6950"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
         <source>failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3748"/>
         <source>failed to parse view key secret key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3765"/>
         <source>failed to verify view key secret key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3434"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3769"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3851"/>
         <source>view key does not match standard address</source>
         <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3439"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3674"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3907"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3966"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3733"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3876"/>
         <source>failed to parse spend key secret key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3896"/>
         <source>failed to verify spend key secret key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3901"/>
         <source>spend key does not match standard address</source>
         <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <source>Secret spend key (%u of %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3941"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3942"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <source>Use --restore-height if you want to restore an already setup account from a specific height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3947"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4073"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4194"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4217"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>View key: </source>
         <translation>ビューキー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4486"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4563"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4644"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4382"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4886"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4539"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
-        <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4572"/>
-        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4675"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
         <source>Balance: </source>
         <translation>残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>key image</source>
         <translation>キーイメージ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>unlocked</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
-        <source>Heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <source>
+Input %llu/%llu (%s): amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>the same transaction</source>
         <translation>同じ取引</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <source>No payment id is included with this transaction. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Is this okay anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <source>Rescan anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <source>Short payment IDs are to be used within an integrated address only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9380"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9405"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9415"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9436"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9460"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9483"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9853"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <source>MMS not available in this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
         <source>failed to parse payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8241"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8247"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>Index: </source>
         <translation>インデックス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
         <source>Address: </source>
         <translation>アドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>Payment ID: </source>
         <translation>ペイメントID： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8250"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
         <source>Description: </source>
         <translation>記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6958"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <source>Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
+        <source>Still apply restore height?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
         <source>Address must not be a subaddress</source>
         <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7799"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
         <source> (no daemon)</source>
         <translation> (デーモンありません）</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7931"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8100"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
         <source>failed to parse index: </source>
         <translation>インデックスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>, unlocked balance: </source>
         <translation>、ロック解除された残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7996"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished">タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8005"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
         <source>Accounts with tag: </source>
         <translation>タグを持ってるアカウント： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
         <source>Tag&apos;s description: </source>
         <translation>タグの記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>Primary address</source>
         <translation>プライマリアドレス</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Subaddress: </source>
         <translation>サブアドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
         <source>no description found</source>
         <translation>記述を見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
         <source>description found: </source>
         <translation>記述を見つかれました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
         <source>Filename: </source>
         <translation>ファイル名： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
         <source>Watch only</source>
         <translation>閲覧専用</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u マルチサイン%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
         <source>Normal</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
         <source>Type: </source>
         <translation>タイプ： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
         <source>failed to save file </source>
         <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7115"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5721"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">お釣りは複数のアドレスに送ります</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
         <source>%s change to %s</source>
         <translation>%s のお釣り %s に</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6574"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>no change</source>
         <translation>お釣りありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1448"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6713"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6811"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6942"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>failed to parse txid</source>
         <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>Tx key: </source>
         <translation>txキー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6829"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6868"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
         <source>failed to parse tx key</source>
         <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6835"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
         <source>error: </source>
         <translation>エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>received</source>
         <translation>貰いました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>in txid</source>
         <translation>txidに</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6902"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>
 Amount: </source>
         <translation>
 金額： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>, number of keys: </source>
         <translation>、キーの数： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; ブロック高
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
         <source>wallet</source>
         <translation>ウォレット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
         <source>Random payment ID: </source>
         <translation>ランダムなペイメントID： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4757,311 +4981,321 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>新しいウォレットを生じろ &lt;arg&gt; をこっちにセーブしてください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>ビューキーで閲覧専用ウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>スペンドキーで決定論的なウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
         <source>Generate wallet from private keys</source>
         <translation>秘密なキーでウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>マルチシガーウォレットキーでマスターウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
         <source>Language for mnemonic</source>
         <translation>ニーモニックのための言語</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="133"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="143"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>ウォレットの回収や作成のためにElectrumなニーモニックシードを指定してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="144"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Electrumなニーモニックシードでウォレットを復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Electrumなニーモニックシードでマルチシガーウォレットを復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="146"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>非決定論的のビューとスペンドキーを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="149"/>
+        <source>Restore from estimated blockchain height on specified date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="447"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
         <translation type="unfinished">インデックスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="544"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="529"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="550"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">指定したリングサイズのアウトプットが不十分です</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>output amount</source>
         <translation type="unfinished">アウトプットの金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>found outputs to use</source>
         <translation type="unfinished">使うためにアウトプットを見つかれました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">取引を作りませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished">取引 %s がデーモンによって拒否しました。ステータス： </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="546"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="576"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">宛先の1つはゼロです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">取引を分割する適切な方法を見つけることができませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">不明な転送エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
         <translation type="unfinished">マルチサインエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
         <translation type="unfinished">内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
         <translation type="unfinished">予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="617"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="599"/>
-        <source>File %s already exists. Are you sure to overwrite it? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>Unknown command: </source>
         <translation type="unfinished">未知のコマンド： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>別のRPCバージョンを使用してるデーモンとの通信を許可してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="148"/>
         <source>Restore from specific blockchain height</source>
         <translation>特定ブロックチェイン高で復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="150"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>新しい取引をネットワークに中継しません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="151"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
+        <source>Support obsolete long (unencrypted) payment ids (using them harms your privacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="297"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="293"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="323"/>
         <source>possibly lost connection to daemon</source>
         <translation>デモンの接続が切れましたかもしりません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
         <translation>エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <source>Is this OK?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="564"/>
+        <source>transaction %s was rejected by daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
+        <source>File %s already exists. Are you sure to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
         <source>Failed to initialize wallet</source>
         <translation>ウォレットを初期化できませんでした</translation>
     </message>
@@ -5069,359 +5303,448 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="201"/>
+        <location filename="../src/wallet/wallet2.cpp" line="234"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>&lt;host&gt;:&lt;port&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="202"/>
+        <location filename="../src/wallet/wallet2.cpp" line="235"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>localhostの代わりにホスト &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Wallet password file</source>
         <translation>ウォレットのパスワードファイル</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="207"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>１８０８１の代わりにポート &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="209"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>テストネットのためにデーモンは --testnet のフラグで開始する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
+        <location filename="../src/wallet/wallet2.cpp" line="361"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>デーモンのホストやポートを複数回指定することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="355"/>
+        <location filename="../src/wallet/wallet2.cpp" line="480"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>--password と --passwordfile を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="368"/>
+        <location filename="../src/wallet/wallet2.cpp" line="493"/>
         <source>the password file specified could not be read</source>
         <translation>指定されたパスワードファイルを読み取れません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="519"/>
         <source>Failed to load file </source>
         <translation>ファイルのロードに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="239"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>ウォレットのパスワード(随時にエスケープ文字を使ってください)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="203"/>
+        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="237"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">必要な信用できるデーモンのコマンドをエネーブルしてください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="208"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>デーモンのRPCクライアントを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="210"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <source>List of valid fingerprints of allowed RPC servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <source>Allow any SSL certificate from the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="212"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="223"/>
+        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="313"/>
+        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <source>Do not use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>Do not connect to a daemon, nor use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <source>Invalid argument for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source>Enabling --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source> requires --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or use of a .onion/.i2p domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="432"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="442"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="375"/>
+        <location filename="../src/wallet/wallet2.cpp" line="500"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>パスワードを指定しませんでした。パスワードプロンプトを見るために--prompt-for-password を使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="400"/>
+        <location filename="../src/wallet/wallet2.cpp" line="525"/>
         <source>Failed to parse JSON</source>
         <translation>JSONを解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="407"/>
+        <location filename="../src/wallet/wallet2.cpp" line="532"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>バージョン %u 新しすぎるです。%u までグロークできます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="423"/>
+        <location filename="../src/wallet/wallet2.cpp" line="548"/>
         <source>failed to parse view key secret key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="428"/>
-        <location filename="../src/wallet/wallet2.cpp" line="496"/>
-        <location filename="../src/wallet/wallet2.cpp" line="539"/>
+        <location filename="../src/wallet/wallet2.cpp" line="553"/>
+        <location filename="../src/wallet/wallet2.cpp" line="621"/>
+        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>failed to verify view key secret key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="439"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
         <source>failed to parse spend key secret key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="444"/>
-        <location filename="../src/wallet/wallet2.cpp" line="506"/>
-        <location filename="../src/wallet/wallet2.cpp" line="565"/>
+        <location filename="../src/wallet/wallet2.cpp" line="569"/>
+        <location filename="../src/wallet/wallet2.cpp" line="631"/>
+        <location filename="../src/wallet/wallet2.cpp" line="692"/>
         <source>failed to verify spend key secret key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="456"/>
+        <location filename="../src/wallet/wallet2.cpp" line="581"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="476"/>
+        <location filename="../src/wallet/wallet2.cpp" line="601"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="605"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Electrumな単語表と秘密なキーを指定しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="490"/>
+        <location filename="../src/wallet/wallet2.cpp" line="615"/>
         <source>invalid address</source>
         <translation>不正なアドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="499"/>
+        <location filename="../src/wallet/wallet2.cpp" line="624"/>
         <source>view key does not match standard address</source>
         <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="509"/>
+        <location filename="../src/wallet/wallet2.cpp" line="634"/>
         <source>spend key does not match standard address</source>
         <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="517"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>JSONで非推奨のウォレットを生成することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="551"/>
+        <location filename="../src/wallet/wallet2.cpp" line="678"/>
         <source>failed to parse address: </source>
         <translation>アドレスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="557"/>
+        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>閲覧専用ウォレットを作るためにアドレスを指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
+        <location filename="../src/wallet/wallet2.cpp" line="701"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1383"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="3770"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4374"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4926"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
         <source>Primary account</source>
         <translation>プライマリア カウント</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10157"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
         <source>No funds received in this tx.</source>
         <translation>この取引から資金貰いませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10899"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <source>Path to a PEM format private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <source>Path to a PEM format certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="180"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
         <source>Failed to create directory </source>
         <translation>ディレクトリの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="182"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
         <source>Failed to create directory %s: %s</source>
         <translation>%s %s ディレクトリの作成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source>Cannot specify --</source>
         <translation>これを指定しません： --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source> and --</source>
         <translation> と --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>Failed to create file </source>
         <translation>ファイルの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>. Check permissions or remove file</source>
         <translation>。 パーミッションを確認するか、ファイルを削除してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="222"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
         <source>Error writing to file </source>
         <translation>ファイルへの書き込みエラー </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
         <source>RPC username/password is stored in file </source>
         <translation>RPCユーザー名/パスワードはファイルに保存しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="479"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
         <source>Tag %s is unregistered.</source>
         <translation>タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3081"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3947"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
-        <translation>これはMoneroのコマンドラインウォレットです。別のMoneroデモンと接続する必要があります。</translation>
+        <translation>これはMoneroのRPCウォレットです。正しく動作させるには
+Moneroデーモンに接続する必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3788"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>--wallet-file と --generate-from-json を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3773"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3800"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file や --generate-from-json や --wallet-dir を指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3804"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
         <source>Loading wallet...</source>
         <translation>ウォレットをロードしてます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3838"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3870"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
         <source>Saving wallet...</source>
         <translation>ウォレットを保存してます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3840"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3872"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
         <source>Successfully saved</source>
         <translation>保存しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3843"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
         <source>Successfully loaded</source>
         <translation>ロードしました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3847"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Wallet initialization failed: </source>
         <translation>ウォレットを初期化できませんでした: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3853"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>ウォレットのRPCサーバを初期化できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3857"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
         <source>Starting wallet RPC server</source>
         <translation>ウォレットのRPCサーバを開始してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3864"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
         <source>Failed to run wallet: </source>
         <translation>ウォレットを起動することできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3867"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Stopped wallet RPC server</source>
         <translation>ウォレットのRPCサーバを停止しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3876"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
         <source>Failed to save wallet: </source>
         <translation>ウォレットを保存することできませんでした： </translation>
     </message>
@@ -5430,8 +5753,8 @@ daemon to work correctly.</source>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8908"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3928"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Wallet options</source>
         <translation>ウォレットのオプション</translation>
     </message>
@@ -5469,7 +5792,8 @@ daemon to work correctly.</source>
         <location filename="../src/wallet/wallet_args.cpp" line="144"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
-        <translation>これはMoneroのコマンドラインウォレットです。別のMoneroデモンと接続する必要があります。</translation>
+        <translation>これはMoneroのコマンドラインウォレットです。正しく動作させるには
+Moneroデーモンに接続する必要があります。</translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="169"/>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.1">
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
@@ -37,42 +37,42 @@
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="121"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="124"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="128"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="133"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Orsak: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="135"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Okänt undantag: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Ohanterat undantag</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="211"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="233"/>
+        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,384 +134,384 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1383"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1392"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
         <translation>Det gick inte att lägga till kort betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1428"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1592"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1430"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1512"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1594"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1432"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1460"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1627"/>
         <source>not enough outputs for specified ring size</source>
         <translation>inte tillräckligt med utgångar för angiven ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>found outputs to use</source>
         <translation>hittade utgångar att använda</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1464"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1546"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Svep upp omixbara utgångar.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1438"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1521"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1520"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1603"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>inte tillräckligt med pengar för överföring, endast tillgängligt %s, skickat belopp %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="541"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>det gick inte att parsa hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="575"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="584"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>det gick inte att verifiera hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="588"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>spendernyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="594"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="598"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>granskningsnyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="621"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="638"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="885"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Det gick inte att skicka begäran om att importera plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1049"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Det gick inte att läsa in osignerade transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1068"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1144"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1084"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1160"/>
         <source>Wallet is view only</source>
         <translation>Plånboken är endast för granskning</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1092"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1168"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1108"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1184"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Nyckelavbildningar kan bara importeras med en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1121"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
         <translation>Det gick inte att importera nyckelavbildningar: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1153"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
         <translation>Det gick inte att hämta etikett för underadress: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1166"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
         <translation>Det gick inte att ange etikett för underadress: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="695"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1183"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1259"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1200"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1214"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1305"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1232"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1308"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1248"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1324"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1266"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1342"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1276"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1352"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1290"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1366"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1318"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1394"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1358"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">Ogiltig måladress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1434"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1445"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1529"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1527"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1611"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>inte tillräckligt med pengar för överföring, totalt saldo är bara %s, skickat belopp %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1534"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1619"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>ej tillräckligt med pengar för överföring, endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1462"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1544"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>output amount</source>
         <translation>utgångens belopp</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1467"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1551"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1633"/>
         <source>transaction was not constructed</source>
         <translation>transaktionen konstruerades inte</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1470"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1554"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1475"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1641"/>
         <source>one of destinations is zero</source>
         <translation>ett av målen är noll</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1477"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1559"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1479"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
         <translation>okänt överföringsfel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1481"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1483"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1485"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1569"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1516"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1598"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1644"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1671"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1719"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1747"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1775"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1796"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1753"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1801"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1829"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1857"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1878"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2354"/>
         <source>Failed to parse txid</source>
         <translation>Det gick inte att parsa txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1743"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1679"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1688"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1761"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1770"/>
         <source>Failed to parse tx key</source>
         <translation>Det gick inte att parsa txnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1697"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1726"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1754"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1835"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1779"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1808"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1836"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1917"/>
         <source>Failed to parse address</source>
         <translation>Det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1922"/>
         <source>Address must not be a subaddress</source>
         <translation>Adressen får inte vara en underadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1880"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1962"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1902"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="1984"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2130"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2226"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Genomsök efter spenderade kan endast användas med en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2179"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2275"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2186"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2282"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2197"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2219"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2293"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2315"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2202"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2224"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2298"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2320"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2208"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2304"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2230"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2326"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2241"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2280"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2337"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2376"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2247"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2343"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2265"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2361"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2286"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="2382"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -519,22 +519,22 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="301"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="308"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Det gick inte att parsa nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="316"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>det gick inte att verifiera nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="326"/>
+        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>nyckeln matchar inte adressen</translation>
     </message>
@@ -604,999 +604,1051 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="645"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
         <translation>Kommandon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4359"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
         <source>failed to read wallet password</source>
         <translation>det gick inte att läsa lösenord för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4231"/>
         <source>invalid password</source>
         <translation>ogiltigt lösenord</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed: kräver ett argument. tillgängliga alternativ: språk</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set: okända argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
         <source>wallet file path not valid: </source>
         <translation>ogiltig sökväg till plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Försöker skapa eller återställa plånbok, men angivna filer finns redan.  Avslutar för att inte riskera att skriva över någonting.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>needs an argument</source>
         <translation>kräver ett argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3084"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3089"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3097"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3294"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3305"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3311"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>0 or 1</source>
         <translation>0 eller 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3313"/>
         <source>unsigned integer</source>
         <translation>positivt heltal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3548"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet använder --generate-new-wallet, inte --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>ange en återställningsparameter med --electrum-seed=&quot;ordlista här&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3957"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>ange sökväg till en plånbok med --generate-new-wallet (inte --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>plånboken kunde inte ansluta till daemonen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3895"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Daemonen använder en högre version av RPC (%u) än plånboken (%u): %s. Antingen uppdatera en av dem, eller använd --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista över tillgängliga språk för din plånboks startvärde:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3926"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation>Ange det tal som motsvarar det språk du vill använda: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Använd det nya startvärde som tillhandahålls.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
         <source>Generated new wallet: </source>
         <translation>Ny plånbok skapad: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4025"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4370"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4230"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
         <source>Opened watch-only wallet</source>
         <translation>Öppnade plånbok för granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4511"/>
         <source>Opened wallet</source>
         <translation>Öppnade plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Fortsätt för att uppgradera din plånbok.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4267"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4544"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Plånbokens filformat kommer nu att uppgraderas.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
         <source>failed to load wallet: </source>
         <translation>det gick inte att läsa in plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Använd kommandot &quot;help&quot; för att visa en lista över tillgängliga kommandon.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>Wallet data saved</source>
         <translation>Plånboksdata sparades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4819"/>
         <source>Mining started in daemon</source>
         <translation>Brytning startad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
         <source>mining has NOT been started: </source>
         <translation>brytning har INTE startats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
         <source>Mining stopped in daemon</source>
         <translation>Brytning stoppad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
         <source>mining has NOT been stopped: </source>
         <translation>brytning har INTE stoppats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4537"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
         <source>Blockchain saved</source>
         <translation>Blockkedjan sparades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
         <source>Height </source>
         <translation>Höjd </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>spent </source>
         <translation>spenderat </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
         <source>Starting refresh...</source>
         <translation>Startar uppdatering …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4712"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
         <source>Refresh done, blocks received: </source>
         <translation>Uppdatering färdig, mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5307"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
         <source>bad locked_blocks parameter:</source>
         <translation>felaktig parameter för locked_blocks:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5978"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6251"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>en enda transaktion kan inte använda fler än ett betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6219"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6259"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>det gick inte att upprätta betalnings-ID, trots att det avkodades korrekt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5395"/>
-        <source>Unencrypted payment IDs are bad for privacy: ask the recipient to use subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5293"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
-        <source>Locked blocks too high, max 1000000 (Ë4 yrs)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5422"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5502"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5590"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5738"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6059"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6273"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
         <source>transaction cancelled.</source>
         <translation>transaktion avbruten.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation>Är detta okej ändå?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5486"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Det finns för närvarande en %u blocks eftersläpning på den avgiftsnivån. Är detta okej?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
         <source>Failed to check for backlog: </source>
         <translation>Det gick inte att kontrollera eftersläpning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
         <source>
 Transaction </source>
         <translation>
 Transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5537"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
         <source>Spending from address index %d
 </source>
         <translation>Spendera från adressindex %d
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5539"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation>VARNING: Utgångar från flera adresser används tillsammans, vilket möjligen kan kompromettera din sekretess.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
         <source>Sending %s.  </source>
         <translation>Skickar %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Transaktionen behöver delas upp i %llu transaktioner.  Detta gör att en transaktionsavgift läggs till varje transaktion, med ett totalbelopp på %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5550"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>The transaction fee is %s</source>
         <translation>Transaktionsavgiften är %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5553"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
         <source>, of which %s is dust from change</source>
         <translation>, varav %s är damm från växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Ett totalt belopp på %s från växeldamm skickas till damm-adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
         <source>.
 This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation>.
 Denna transaktion låses upp vid block %llu, om ungefär %s dagar (förutsatt en blocktid på 2 minuter)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5611"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6328"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5616"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5653"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5765"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6344"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Osignerade transaktioner skrevs till fil: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5625"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6086"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
         <source>No unmixable outputs found</source>
         <translation>Inga omixbara utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5776"/>
-        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
         <source>No address given</source>
         <translation>Ingen adress har angivits</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5914"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6187"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6213"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
         <source>failed to parse Payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
         <source>failed to parse key image</source>
         <translation>det gick inte att parsa nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
         <source>No outputs found</source>
         <translation>Inga utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>Flera transaktioner skapas, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6300"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>Transaktionen använder flera eller inga ingångar, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
         <source>missing threshold amount</source>
         <translation>tröskelbelopp saknas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
         <source>invalid amount threshold</source>
         <translation>ogiltigt tröskelbelopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
         <source> dummy output(s)</source>
         <translation> dummy-utgångar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Läste in %lu transaktioner, för %s, avgift %s, %s, %s, med minsta ringstorlek %lu, %s. %sÄr detta okej? (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Detta är en multisig-plånbok, som endast kan signera med sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6629"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
         <source>Failed to sign transaction</source>
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
         <source>Failed to sign transaction: </source>
         <translation>Det gick inte att signera transaktionen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Hexadecimala rådata för transaktionen exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>plånboken är enbart för granskning och har ingen spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="839"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1021"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="860"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1164"/>
         <source>Your original password was incorrect.</source>
         <translation>Ditt ursprungliga lösenord var fel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
         <source>Error with wallet rewrite: </source>
         <translation>Ett fel uppstod vid återskrivning av plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
         <source>invalid unit</source>
         <translation>ogiltig enhet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>ogiltigt värde för count: måste vara ett heltal utan tecken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
         <source>invalid value</source>
         <translation>ogiltigt värde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation>(J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3788"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
         <source>bad m_restore_height parameter: </source>
         <translation>felaktig parameter för m_restore_height: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3766"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation>datumformat måste vara ÅÅÅÅ-MM-DD</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
         <source>Restore height is: </source>
         <translation>Återställningshöjd är: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3780"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Är detta okej?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
         <source>Password for new watch-only wallet</source>
         <translation>Lösenord för ny granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1534"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1613"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5669"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>refresh failed: </source>
         <translation>det gick inte att uppdatera: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
         <source>Blocks received: </source>
         <translation>Mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4787"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
         <source>unlocked balance: </source>
         <translation>upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>amount</source>
         <translation>belopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="341"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="362"/>
         <source>false</source>
         <translation>falskt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Unknown command: </source>
         <translation>Okänt kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Command usage: </source>
         <translation>Användning av kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Command description: </source>
         <translation>Beskrivning av kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="735"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation>plånboken är multisig men är ännu inte slutförd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="768"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
         <source>Failed to retrieve seed</source>
         <translation>Det gick inte att hämta startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="792"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>wallet is multisig and has no seed</source>
         <translation>plånboken är multisig och har inget startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation>Fel: det gick inte att uppskatta eftersläpningsmatrisens storlek: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="904"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>Error: bad estimated backlog array size</source>
         <translation>Fel: felaktigt uppskattat värde för eftersläpningsmatrisens storlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="916"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
         <source> (current)</source>
         <translation> (aktuellt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation>%u blocks (%u minuters) eftersläpning vid prioritet %u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="921"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation>%u till %u blocks (%u till %u minuters) eftersläpning vid prioritet %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>No backlog at priority </source>
         <translation>Ingen eftersläpning vid prioritet </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="989"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1012"/>
         <source>This wallet is already multisig</source>
         <translation>Denna plånbok är redan multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="949"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1017"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation>plånboken är enbart för granskning och kan inte göras om till multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="955"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1023"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Denna plånbok har använts tidigare. Använd en ny plånbok för att skapa en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="963"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="986"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Skicka denna multisig-info till alla andra deltagare och använd sedan make_multisig &lt;tröskelvärde&gt; &lt;info1&gt; [&lt;info2&gt;…] med de andras multisig-info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation>Detta innefattar den PRIVATA granskningsnyckeln, så den behöver endast lämnas ut till den multisig-plånbokens deltagare </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>Invalid threshold</source>
         <translation>Ogiltigt tröskelvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1034"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1156"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1179"/>
         <source>Another step is needed</source>
         <translation>Ytterligare ett steg krävs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <source>Error creating multisig: </source>
         <translation>Ett fel uppstod när multisig skapades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1053"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation>Ett fel uppstod när multisig skapades: den nya plånboken är inte multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
         <source> multisig address: </source>
         <translation> multisig-adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1129"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1261"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1219"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1285"/>
         <source>This wallet is not multisig</source>
         <translation>Denna plånbok är inte multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1085"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1157"/>
         <source>This wallet is already finalized</source>
         <translation>Denna plånbok är redan slutförd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1101"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
         <source>Failed to finalize multisig</source>
         <translation>Det gick inte att slutföra multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1107"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>Failed to finalize multisig: </source>
         <translation>Det gick inte att slutföra multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
+        <source>Multisig address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1384"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1500"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1581"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Denna multisig-plånbok är inte slutförd ännu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
         <source>Error exporting multisig info: </source>
         <translation>Ett fel uppstod när multisig-info exporterades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
         <source>Multisig info exported to </source>
         <translation>Multisig-info exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1330"/>
         <source>Multisig info imported</source>
         <translation>Multisig-info importerades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
         <source>Failed to import multisig info: </source>
         <translation>Det gick inte att importera multisig-info: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation>Det gick inte att uppdatera spenderstatus efter import av multisig-info: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation>Ej betrodd daemon. Spenderstatus kan vara felaktig. Använd en betrodd daemon och kör &quot;rescan_spent&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1471"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1379"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1495"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1576"/>
         <source>This is not a multisig wallet</source>
         <translation>Detta är inte en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1405"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1429"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1438"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Det gick inte att signera multisig-transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
         <source>Multisig error: </source>
         <translation>Multisig-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Det gick inte att signera multisig-transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation>Den kan skickas vidare till nätverket med submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1508"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1602"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Det gick inte att läsa in multisig-transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1607"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation>Multisig-transaktion har signerats av bara %u signerare. Den behöver %u ytterligare signaturer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8890"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaktionen skickades, transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>Du kan kontrollera dess status genom att använda kommandot &apos;show_transfers&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1623"/>
         <source>Failed to export multisig transaction to file </source>
         <translation>Det gick inte att exportera multisig-transaktion till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation>Sparade filer med exporterade multisig-transaktioner: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2101"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
+        <source>Invalid key image or txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1901"/>
+        <source>failed to unset ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2072"/>
+        <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2117"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2129"/>
+        <source>Frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2131"/>
+        <source>Not frozen: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2138"/>
+        <source> bytes sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
+        <source> bytes received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2145"/>
+        <source>Welcome to Monero, the private cryptocurrency.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2147"/>
+        <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2148"/>
+        <source>Unlike Bitcoin, your Monero transactions and balance stay private, and not visible to the world by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2149"/>
+        <source>However, you have the option of making those available to select parties, if you choose to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2151"/>
+        <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2152"/>
+        <source>no privacy technology can be 100% perfect, Monero included.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2153"/>
+        <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
+        <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2155"/>
+        <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2157"/>
+        <source>Welcome to Monero and financial privacy. For more information, see https://getmonero.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2250"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2269"/>
         <source>ring size must be an integer &gt;= </source>
         <translation>ringstorlek måste vara ett heltal &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2274"/>
         <source>could not change default ring size</source>
         <translation>det gick inte att ändra standardinställning för ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2398"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2549"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2620"/>
         <source>Invalid height</source>
         <translation>Ogiltig höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2562"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2667"/>
+        <source>invalid argument: must be either 1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation>Starta brytning i daemonen (bgbrytning och ignorera_batteri är valfri booleska värden).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
         <source>Stop mining in the daemon.</source>
         <translation>Stoppa brytning i daemonen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2745"/>
         <source>Set another daemon to connect to.</source>
         <translation>Ange en annan daemon att ansluta till.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2572"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2748"/>
         <source>Save the current blockchain data.</source>
         <translation>Spara aktuella blockkedjedata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2575"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2751"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Synkronisera transaktionerna och saldot.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2755"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation>Visa plånbokens saldo för det aktiva kontot.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2589"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2759"/>
+        <source>Show the incoming transfers, all or filtered by availability and address index.
+
+Output format:
+Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Visa betalningar för givna betalnings-ID.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2768"/>
         <source>Show the blockchain height.</source>
         <translation>Visa blockkedjans höjd.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2606"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2782"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation>Skicka alla omixbara utgångar till dig själv med ringstorlek 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2789"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation>Skicka alla upplåsta utgångar under tröskelvärdet till en adress.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2793"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation>Skicka en enda utgång hos den givna nyckelavbildningen till en adress utan växel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Donera &lt;belopp&gt; till utvecklingsteamet (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2628"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2804"/>
         <source>Submit a signed transaction from a file.</source>
         <translation>Skicka en signerad transaktion från en fil.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2632"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2808"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation>Ändra detaljnivån för aktuell logg (nivå måste vara 0-4).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2812"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1613,1190 +1665,42 @@ Om argumentet &quot;untag&quot; anges, tas tilldelade taggar bort från de angiv
 Om argumentet &quot;tag_description&quot; anges, så tilldelas taggen &lt;taggnamn&gt; den godtyckliga texten &lt;beskrivning&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation>Koda ett betalnings-ID till en integrerad adress för den aktuella plånbokens publika adress (om inget argument anges används ett slumpmässigt betalnings-ID), eller avkoda en integrerad adress till en standardadress och ett betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation>Skriv ut alla poster i adressboken, och valfritt lägg till/ta bort en post i den.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2833"/>
         <source>Save the wallet data.</source>
         <translation>Spara plånboksdata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2836"/>
         <source>Save a watch-only keys file.</source>
         <translation>Spara en fil med granskningsnycklar.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2839"/>
         <source>Display the private view key.</source>
         <translation>Visa privat granskningsnyckel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
         <source>Display the private spend key.</source>
         <translation>Visa privat spendernyckel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation>Visa det minnesbaserade startvärdet (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2719"/>
-        <source>Display the encrypted Electrum-style mnemonic seed.</source>
-        <translation>Visa det krypterade minnesbaserade startvärdet (Electrum-typ).</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2722"/>
-        <source>Rescan the blockchain for spent outputs.</source>
-        <translation>Genomsök blockkedjan efter spenderade utgångar.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2726"/>
-        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
-        <translation>Hämta transaktionsnyckel (r) för ett givet &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2734"/>
-        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
-        <translation>Kontrollera belopp som går till &lt;adress&gt; i &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2738"/>
-        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation>Skapa en signatur som bevisar att pengar skickades till &lt;adress&gt; i &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;, genom att använda antingen transaktionens hemliga nyckel (när &lt;adress&gt; inte är din plånboks adress) eller den hemliga granskningsnyckeln (annars), vilket inte lämnar ut den hemliga nyckeln.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2742"/>
-        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
-        <translation>Kontrollera beviset för pengar som skickats till &lt;adress&gt; i &lt;txid&gt; med kontrollsträngen &lt;meddelande&gt;, om den angivits.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2746"/>
-        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
-        <translation>Skapa en signatur som bevisar att du skapade &lt;txid&gt; genom att använda den hemliga spendernyckeln, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2750"/>
-        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
-        <translation>Kontrollera en signatur som bevisar att signeraren skapade &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2754"/>
-        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
-If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
-Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
-        <translation>Skapa en signatur som bevisar att du äger åtminstone så här mycket, valfritt med kontrollsträngen &lt;meddelande&gt;.
-Om &apos;all&apos; anges, bevisar du totalsumman av alla dina befintliga kontons saldo.
-Annars bevisar du reserven för det minsta möjliga belopp över &lt;belopp&gt; som är tillgängligt på ditt aktuella konto.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2760"/>
-        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
-        <translation>Kontrollera en signatur som bevisar att ägaren till &lt;adress&gt; har åtminstone så här mycket, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2780"/>
-        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
-        <translation>Visa de ej spenderade utgångarna hos en angiven adress inom ett valfritt beloppsintervall.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2788"/>
-        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
-        <translation>Ange en godtycklig stränganteckning för &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2792"/>
-        <source>Get a string note for a txid.</source>
-        <translation>Hämta en stränganteckning för ett txid.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2796"/>
-        <source>Set an arbitrary description for the wallet.</source>
-        <translation>Ange en godtycklig beskrivning av plånboken.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2800"/>
-        <source>Get the description of the wallet.</source>
-        <translation>Hämta plånbokens beskrivning.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2803"/>
-        <source>Show the wallet&apos;s status.</source>
-        <translation>Visa plånbokens status.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2806"/>
-        <source>Show the wallet&apos;s information.</source>
-        <translation>Visa information om plånboken.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2810"/>
-        <source>Sign the contents of a file.</source>
-        <translation>Signera innehållet i en fil.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
-        <source>Verify a signature on the contents of a file.</source>
-        <translation>Verifiera en signatur av innehållet in en fil.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
-        <source>Import a signed key images list and verify their spent status.</source>
-        <translation>Importera en signerad lista av nyckelavbildningar och verifiera deras spenderstatus.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2834"/>
-        <source>Export a set of outputs owned by this wallet.</source>
-        <translation>Exportera en uppsättning utgångar som ägs av denna plånbok.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2838"/>
-        <source>Import a set of outputs owned by this wallet.</source>
-        <translation>Importera en uppsättning utgångar som ägs av denna plånbok.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2842"/>
-        <source>Show information about a transfer to/from this address.</source>
-        <translation>Visa information om en transktion till/från denna adress.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2845"/>
-        <source>Change the wallet&apos;s password.</source>
-        <translation>Ändra plånbokens lösenord.</translation>
-    </message>
-    <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2849"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation>Skapa ett nytt slumpmässigt betalnings-ID av normalstorlek. Dessa kommer att vara okrypterade på blockkedjan. Se integrated_address för krypterade korta betalnings-ID.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2852"/>
-        <source>Print the information about the current fee and transaction backlog.</source>
-        <translation>Skriv ut information om aktuell avgift och transaktionseftersläpning.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2854"/>
-        <source>Export data needed to create a multisig wallet</source>
-        <translation>Exportera data som krävs för att skapa en multisig-plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2857"/>
-        <source>Turn this wallet into a multisig wallet</source>
-        <translation>Gör denna plånbok till en multisig-plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2861"/>
-        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
-        <translation>Gör denna plånbok till en multisig-plånbok, extra steg för plånböcker med N-1/N</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2869"/>
-        <source>Export multisig info for other participants</source>
-        <translation>Exportera multisig-info för andra deltagare</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2873"/>
-        <source>Import multisig info from other participants</source>
-        <translation>Importera multisig-info från andra deltagare</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2877"/>
-        <source>Sign a multisig transaction from a file</source>
-        <translation>Signera en a multisig-transaktion från en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2881"/>
-        <source>Submit a signed multisig transaction from a file</source>
-        <translation>Skicka en signerad multisig-transaktion från en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2885"/>
-        <source>Export a signed multisig transaction to a file</source>
-        <translation>Exportera en signerad multisig-transaktion till en fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3002"/>
-        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
-        <translation>Visa hjälpavsnittet eller dokumentationen för &lt;kommando&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
-        <source>integer &gt;= </source>
-        <translation>heltal &gt;= </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3098"/>
-        <source>block height</source>
-        <translation>blockhöjd</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3203"/>
-        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation>Ingen plånbok med det namnet kunde hittas. Bekräfta skapande av ny plånbok med namn: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
-        <translation>det går inte att ange både --restore-deterministic-wallet eller --restore-multisig-wallet och --non-deterministic</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3310"/>
-        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation>--restore-multisig-wallet använder --generate-new-wallet, inte --wallet-file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3326"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
-        <translation>ange en återställningsparameter med --electrum-seed=&quot;startvärde för multisig&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3355"/>
-        <source>Multisig seed failed verification</source>
-        <translation>Startvärde för multisig kunde inte verifieras</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
-        <source>This address is a subaddress which cannot be used here.</source>
-        <translation>Denna adress är en underadress som inte kan användas här.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3558"/>
-        <source>Error: expected M/N, but got: </source>
-        <translation>Fel: förväntade M/N, men fick: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3563"/>
-        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation>Fel: förväntade N &gt; 1 och N &lt;= M, men fick: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3568"/>
-        <source>Error: M/N is currently unsupported. </source>
-        <translation>Fel: M/N stöds för närvarande inte. </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3571"/>
-        <source>Generating master wallet from %u of %u multisig wallet keys</source>
-        <translation>Skapar huvudplånbok från %u av %u multisig-plånboksnycklar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
-        <source>failed to parse secret view key</source>
-        <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3608"/>
-        <source>failed to verify secret view key</source>
-        <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3628"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation>Hemlig spendernyckel (%u av %u):</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3651"/>
-        <source>Error: M/N is currently unsupported</source>
-        <translation>Fel: M/N stöds för närvarande inte</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3802"/>
-        <source>Restore height </source>
-        <translation>Återställningshöjd </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3803"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation>Ska återställningshöjd fortfarande appliceras?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3829"/>
-        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation>Varning: använder en ej betrodd daemon på %s; sekretessen kommer att vara mindre</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3888"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
-        <translation>Antingen har daemonen inte startat eller så angavs fel port. Se till att daemonen körs eller byt daemonadress med kommandot &apos;set_daemon&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use the &quot;refresh&quot; command.
-Use the &quot;help&quot; command to see the list of available commands.
-Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
-your current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation>Din plånbok har skapats!
-Använd kommandot &quot;refresh&quot; för att starta synkronisering med daemonen.
-Använd kommandot &quot;help&quot; för att visa en lista över tillgängliga kommandon.
-Använd &quot;help &lt;kommando&gt;&quot; för att visa dokumentation för kommandot.
-Använd alltid kommandot &quot;exit&quot; när du stänger monero-wallet-cli så att ditt aktuella sessionstillstånd sparas. Annars kan du bli tvungen att synkronisera
-din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som helst).
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4180"/>
-        <source>failed to generate new mutlisig wallet</source>
-        <translation>det gick inte att skapa ny multisig-plånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4183"/>
-        <source>Generated new %u/%u multisig wallet: </source>
-        <translation>Skapa ny %u/%u-multisig-plånbok: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <source>Opened %u/%u multisig wallet%s</source>
-        <translation>Öppnade %u/%u-multisig-plånbok%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
-        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-</source>
-        <translation>Använd &quot;help &lt;kommando&gt;&quot; för att visa dokumentation för kommandot.
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4351"/>
-        <source>wallet is multisig and cannot save a watch-only version</source>
-        <translation>plånboken är multisig och kan inte spara en granskningsversion</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
-        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
-        <translation>Oväntad matrislängd - Lämnade simple_wallet::set_daemon()</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4517"/>
-        <source>This does not seem to be a valid daemon URL.</source>
-        <translation>Detta verkar inte vara en giltig daemon-URL.</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4590"/>
-        <source>txid </source>
-        <translation>txid </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4555"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
-        <source>idx </source>
-        <translation>idx </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4780"/>
-        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
-        <translation> (Några ägda utgångar har partiella nyckelavbildningar - import_multisig_info krävs)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>Currently selected account: [</source>
-        <translation>Aktuellt valt konto: [</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4783"/>
-        <source>] </source>
-        <translation>] </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>Tag: </source>
-        <translation>Tagg: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4785"/>
-        <source>(No tag assigned)</source>
-        <translation>(Ingen tagg tilldelad)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4792"/>
-        <source>Balance per address:</source>
-        <translation>Saldo per adress:</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Address</source>
-        <translation>Adress</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Balance</source>
-        <translation>Saldo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <source>Unlocked balance</source>
-        <translation>Upplåst saldo</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <source>Outputs</source>
-        <translation>Utgångar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
-        <source>Label</source>
-        <translation>Etikett</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4801"/>
-        <source>%8u %6s %21s %21s %7u %21s</source>
-        <translation>%8u %6s %21s %21s %7u %21s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>spent</source>
-        <translation>spenderat</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>global index</source>
-        <translation>globalt index</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <source>tx id</source>
-        <translation>tx-ID</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>addr index</source>
-        <translation>addr index</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4924"/>
-        <source>No incoming transfers</source>
-        <translation>Inga inkommande överföringar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4928"/>
-        <source>No incoming available transfers</source>
-        <translation>Inga inkommande tillgängliga överföringar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4932"/>
-        <source>No incoming unavailable transfers</source>
-        <translation>Inga inkommande otillgängliga överföringar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>payment</source>
-        <translation>betalning</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>transaction</source>
-        <translation>transaktion</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>height</source>
-        <translation>höjd</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
-        <source>unlock time</source>
-        <translation>upplåsningstid</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4968"/>
-        <source>No payments with id </source>
-        <translation>Inga betalningar med ID </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5016"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5901"/>
-        <source>failed to get blockchain height: </source>
-        <translation>det gick inte att hämta blockkedjans höjd: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5114"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation>
-Transaktion %llu/%llu: txid=%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5135"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation>
-Ingång %llu/%llu: belopp=%s</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5151"/>
-        <source>failed to get output: </source>
-        <translation>det gick inte att hämta utgång: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation>utgångsnyckelns ursprungsblockhöjd får inte vara högre än blockkedjans höjd</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5163"/>
-        <source>
-Originating block heights: </source>
-        <translation>
-Ursprungsblockhöjder: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <source>
-|</source>
-        <translation>
-|</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
-        <source>|
-</source>
-        <translation>|
-</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5192"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation>
-Varning: Några ingångsnycklar som spenderas kommer från </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation>, vilket kan bryta ringsignaturens anonymitet. Se till att detta är avsiktligt!</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5853"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6156"/>
-        <source>Ring size must not be 0</source>
-        <translation>Ringstorlek för inte vara 0</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5246"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
-        <source>ring size %u is too small, minimum is %u</source>
-        <translation>ringstorlek %uär för liten, minimum är %u</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5258"/>
-        <source>wrong number of arguments</source>
-        <translation>fel antal argument</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6268"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Inget betalnings-ID har inkluderats med denna transaktion. Är detta okej?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5458"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
-        <source>No outputs found, or daemon is not ready</source>
-        <translation>Inga utgångar hittades, eller så är daemonen inte klar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
-        <source>Failed to parse donation address: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6444"/>
-        <source>Donating %s %s to %s.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6777"/>
-        <source>failed to parse tx_key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6786"/>
-        <source>Tx key successfully stored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6790"/>
-        <source>Failed to store tx key: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>block</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7440"/>
-        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7493"/>
-        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>timestamp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>running balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>hash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>fee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
-        <source>note</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
-        <source>CSV exported to </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7730"/>
-        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7731"/>
-        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7732"/>
-        <source>Rescan anyway ? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7750"/>
-        <source>MMS received new message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8387"/>
-        <source>Network type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8388"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8389"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8605"/>
-        <source>command only supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8564"/>
-        <source>hw wallet does not support cold KI sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8576"/>
-        <source>Please confirm the key image sync on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
-        <source>Key images synchronized to height </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8585"/>
-        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> spent, </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
-        <source> unspent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8592"/>
-        <source>Failed to import key images</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8597"/>
-        <source>Failed to import key images: </source>
-        <translation type="unfinished">Det gick inte att importera nyckelavbildningar: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8614"/>
-        <source>Failed to reconnect device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8619"/>
-        <source>Failed to reconnect device: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <source>Transaction successfully saved to </source>
-        <translation>Transaktionen sparades till </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>, txid </source>
-        <translation>, txid </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8885"/>
-        <source>Failed to save transaction to </source>
-        <translation>Det gick inte att spara transaktion till </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5723"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Sveper upp %s i %llu transaktioner för en total avgift på %s.  Är detta okej?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5729"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6310"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation>Sveper upp %s för en total avgift på %s.  Är detta okej?  (J/Ja/N/Nej): </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
-        <source>This is a watch only wallet</source>
-        <translation>Detta är en granskningsplånbok</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8813"/>
-        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
-        <translation>En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
-        <source>Transaction ID not found</source>
-        <translation>Transaktions-ID kunde inte hittas</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="336"/>
-        <source>true</source>
-        <translation>sant</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="389"/>
-        <source>failed to parse refresh type</source>
-        <translation>det gick inte att parsa uppdateringstyp</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="721"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="984"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1067"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1466"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6799"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7010"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8397"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8630"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8670"/>
-        <source>command not supported by HW wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="726"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="797"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation>plånboken är enbart för granskning och har inget startvärde</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="744"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="807"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation>plånboken är icke-deterministisk och har inget startvärde</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="751"/>
-        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="817"/>
-        <source>Incorrect password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="883"/>
-        <source>Current fee is %s %s per %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1158"/>
-        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <source>Multisig wallet has been successfully created. Current wallet type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <source>Failed to perform multisig keys exchange: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1499"/>
-        <source>Failed to load multisig transaction from MMS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
-        <source>Invalid key image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <source>Invalid txid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1649"/>
-        <source>Key image either not spent, or spent with mixin 0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1664"/>
-        <source>Failed to get key image ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1679"/>
-        <source>File doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1701"/>
-        <source>Invalid ring specification: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1709"/>
-        <source>Invalid key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1714"/>
-        <source>Invalid ring type, expected relative or abosolute: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1732"/>
-        <source>Error reading line: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1743"/>
-        <source>Invalid ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1752"/>
-        <source>Invalid relative ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <source>Invalid absolute ring: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Failed to set ring for key image: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1773"/>
-        <source>Continuing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1803"/>
-        <source>Missing absolute or relative keyword</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1813"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1820"/>
-        <source>invalid index: must be a strictly positive unsigned integer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1828"/>
-        <source>invalid index: indices wrap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1838"/>
-        <source>invalid index: indices should be in strictly ascending order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1845"/>
-        <source>failed to set ring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1890"/>
-        <source>First line is not an amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1904"/>
-        <source>Invalid output: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>Bad argument: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1914"/>
-        <source>should be &quot;add&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
-        <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1929"/>
-        <source>Invalid output key, and file doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1935"/>
-        <source>Failed to mark output spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1952"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
-        <source>Invalid output</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1962"/>
-        <source>Failed to mark output unspent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1986"/>
-        <source>Spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
-        <source>Not spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1992"/>
-        <source>Failed to check whether output is spent: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2007"/>
-        <source>Failed to save known rings: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2022"/>
-        <source>Please confirm the transaction on the device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2088"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation>plånboken är enbart för granskning och kan inte göra överföringar</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2106"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5581"/>
-        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2108"/>
-        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2137"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2160"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2176"/>
-        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2181"/>
-        <source>could not change default priority</source>
-        <translation>det gick inte att ändra standardinställning för prioritet</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
-        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2510"/>
-        <source>Device name not specified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2519"/>
-        <source>Device reconnect failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2524"/>
-        <source>Device reconnect failed: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2583"/>
-        <source>Show the incoming transfers, all or filtered by availability and address index.
-
-Output format:
-Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&quot;, RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2595"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2599"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2603"/>
-        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2609"/>
-        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2625"/>
-        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2646"/>
-        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2673"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2814,8 +1718,10 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;locked&quot;|&quot;unlocked&qu
    Set the wallet&apos;s refresh behaviour.
  priority [0|1|2|3|4]
    Set the fee to default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
+ confirm-missing-payment-id &lt;1|0&gt; (obsolete)
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
+   action: ask the password before many actions such as transfer, etc
+   decrypt: same as action, but keeps the spend key encrypted in memory when not needed
  unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
    Set the default monero (sub-)unit.
  min-outputs-count [n]
@@ -2844,12 +1750,1258 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2730"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <source>Display the encrypted Electrum-style mnemonic seed.</source>
+        <translation>Visa det krypterade minnesbaserade startvärdet (Electrum-typ).</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2900"/>
+        <source>Rescan the blockchain for spent outputs.</source>
+        <translation>Genomsök blockkedjan efter spenderade utgångar.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2904"/>
+        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
+        <translation>Hämta transaktionsnyckel (r) för ett givet &lt;txid&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2912"/>
+        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
+        <translation>Kontrollera belopp som går till &lt;adress&gt; i &lt;txid&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2916"/>
+        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
+        <translation>Skapa en signatur som bevisar att pengar skickades till &lt;adress&gt; i &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;, genom att använda antingen transaktionens hemliga nyckel (när &lt;adress&gt; inte är din plånboks adress) eller den hemliga granskningsnyckeln (annars), vilket inte lämnar ut den hemliga nyckeln.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2920"/>
+        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
+        <translation>Kontrollera beviset för pengar som skickats till &lt;adress&gt; i &lt;txid&gt; med kontrollsträngen &lt;meddelande&gt;, om den angivits.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2924"/>
+        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Skapa en signatur som bevisar att du skapade &lt;txid&gt; genom att använda den hemliga spendernyckeln, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2928"/>
+        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Kontrollera en signatur som bevisar att signeraren skapade &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2932"/>
+        <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
+If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
+Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
+        <translation>Skapa en signatur som bevisar att du äger åtminstone så här mycket, valfritt med kontrollsträngen &lt;meddelande&gt;.
+Om &apos;all&apos; anges, bevisar du totalsumman av alla dina befintliga kontons saldo.
+Annars bevisar du reserven för det minsta möjliga belopp över &lt;belopp&gt; som är tillgängligt på ditt aktuella konto.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
+        <translation>Kontrollera en signatur som bevisar att ägaren till &lt;adress&gt; har åtminstone så här mycket, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2958"/>
+        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
+        <translation>Visa de ej spenderade utgångarna hos en angiven adress inom ett valfritt beloppsintervall.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2962"/>
+        <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
+        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
+        <translation>Ange en godtycklig stränganteckning för &lt;txid&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2970"/>
+        <source>Get a string note for a txid.</source>
+        <translation>Hämta en stränganteckning för ett txid.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2974"/>
+        <source>Set an arbitrary description for the wallet.</source>
+        <translation>Ange en godtycklig beskrivning av plånboken.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <source>Get the description of the wallet.</source>
+        <translation>Hämta plånbokens beskrivning.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2981"/>
+        <source>Show the wallet&apos;s status.</source>
+        <translation>Visa plånbokens status.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2984"/>
+        <source>Show the wallet&apos;s information.</source>
+        <translation>Visa information om plånboken.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2988"/>
+        <source>Sign the contents of a file.</source>
+        <translation>Signera innehållet i en fil.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2992"/>
+        <source>Verify a signature on the contents of a file.</source>
+        <translation>Verifiera en signatur av innehållet in en fil.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3000"/>
+        <source>Import a signed key images list and verify their spent status.</source>
+        <translation>Importera en signerad lista av nyckelavbildningar och verifiera deras spenderstatus.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3012"/>
+        <source>Export a set of outputs owned by this wallet.</source>
+        <translation>Exportera en uppsättning utgångar som ägs av denna plånbok.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3016"/>
+        <source>Import a set of outputs owned by this wallet.</source>
+        <translation>Importera en uppsättning utgångar som ägs av denna plånbok.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3020"/>
+        <source>Show information about a transfer to/from this address.</source>
+        <translation>Visa information om en transktion till/från denna adress.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3023"/>
+        <source>Change the wallet&apos;s password.</source>
+        <translation>Ändra plånbokens lösenord.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3030"/>
+        <source>Print the information about the current fee and transaction backlog.</source>
+        <translation>Skriv ut information om aktuell avgift och transaktionseftersläpning.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3032"/>
+        <source>Export data needed to create a multisig wallet</source>
+        <translation>Exportera data som krävs för att skapa en multisig-plånbok</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3035"/>
+        <source>Turn this wallet into a multisig wallet</source>
+        <translation>Gör denna plånbok till en multisig-plånbok</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3039"/>
+        <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
+        <translation>Gör denna plånbok till en multisig-plånbok, extra steg för plånböcker med N-1/N</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3047"/>
+        <source>Export multisig info for other participants</source>
+        <translation>Exportera multisig-info för andra deltagare</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3051"/>
+        <source>Import multisig info from other participants</source>
+        <translation>Importera multisig-info från andra deltagare</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3055"/>
+        <source>Sign a multisig transaction from a file</source>
+        <translation>Signera en a multisig-transaktion från en fil</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3059"/>
+        <source>Submit a signed multisig transaction from a file</source>
+        <translation>Skicka en signerad multisig-transaktion från en fil</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3063"/>
+        <source>Export a signed multisig transaction to a file</source>
+        <translation>Exportera en signerad multisig-transaktion till en fil</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3160"/>
+        <source>Unsets the ring used for a given key image or transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3180"/>
+        <source>Freeze a single output by key image so it will not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3184"/>
+        <source>Thaw a single output by key image so it may be used again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3188"/>
+        <source>Checks whether a given output is currently frozen by key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3192"/>
+        <source>Prints simple network stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3196"/>
+        <source>Prints basic info about Monero for first time users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3204"/>
+        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
+        <translation>Visa hjälpavsnittet eller dokumentationen för &lt;kommando&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
+        <source> (set this to support the network and to get a chance to receive new monero)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3295"/>
+        <source>integer &gt;= </source>
+        <translation>heltal &gt;= </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3308"/>
+        <source>block height</source>
+        <translation>blockhöjd</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3316"/>
+        <source>1/yes or 0/no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
+        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
+        <translation>Ingen plånbok med det namnet kunde hittas. Bekräfta skapande av ny plånbok med namn: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
+        <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
+        <translation>det går inte att ange både --restore-deterministic-wallet eller --restore-multisig-wallet och --non-deterministic</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3546"/>
+        <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
+        <translation>--restore-multisig-wallet använder --generate-new-wallet, inte --wallet-file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3562"/>
+        <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
+        <translation>ange en återställningsparameter med --electrum-seed=&quot;startvärde för multisig&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3591"/>
+        <source>Multisig seed failed verification</source>
+        <translation>Startvärde för multisig kunde inte verifieras</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3718"/>
+        <source>This address is a subaddress which cannot be used here.</source>
+        <translation>Denna adress är en underadress som inte kan användas här.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
+        <source>Error: expected M/N, but got: </source>
+        <translation>Fel: förväntade M/N, men fick: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
+        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
+        <translation>Fel: förväntade N &gt; 1 och N &lt;= M, men fick: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
+        <source>Error: M/N is currently unsupported. </source>
+        <translation>Fel: M/N stöds för närvarande inte. </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
+        <source>Generating master wallet from %u of %u multisig wallet keys</source>
+        <translation>Skapar huvudplånbok från %u av %u multisig-plånboksnycklar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3838"/>
+        <source>failed to parse secret view key</source>
+        <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3846"/>
+        <source>failed to verify secret view key</source>
+        <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
+        <source>Error: M/N is currently unsupported</source>
+        <translation>Fel: M/N stöds för närvarande inte</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
+        <source>Restore height </source>
+        <translation>Återställningshöjd </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
+        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
+        <translation>Varning: använder en ej betrodd daemon på %s; sekretessen kommer att vara mindre</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
+        <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4098"/>
+        <source>WARNING: obsolete long payment IDs are enabled. Sending transactions with those payment IDs are bad for your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4100"/>
+        <source>It is recommended that you do not use them, and ask recipients who ask for one to not endanger your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
+        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
+        <translation>Antingen har daemonen inte startat eller så angavs fel port. Se till att daemonen körs eller byt daemonadress med kommandot &apos;set_daemon&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4203"/>
+        <source>Enter the number corresponding to the language of your choice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4313"/>
+        <source>Your wallet has been generated!
+To start synchronizing with the daemon, use the &quot;refresh&quot; command.
+Use the &quot;help&quot; command to see the list of available commands.
+Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+Always use the &quot;exit&quot; command when closing monero-wallet-cli to save 
+your current session&apos;s state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+</source>
+        <translation>Din plånbok har skapats!
+Använd kommandot &quot;refresh&quot; för att starta synkronisering med daemonen.
+Använd kommandot &quot;help&quot; för att visa en lista över tillgängliga kommandon.
+Använd &quot;help &lt;kommando&gt;&quot; för att visa dokumentation för kommandot.
+Använd alltid kommandot &quot;exit&quot; när du stänger monero-wallet-cli så att ditt aktuella sessionstillstånd sparas. Annars kan du bli tvungen att synkronisera
+din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som helst).
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4457"/>
+        <source>failed to generate new mutlisig wallet</source>
+        <translation>det gick inte att skapa ny multisig-plånbok</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
+        <source>Generated new %u/%u multisig wallet: </source>
+        <translation>Skapa ny %u/%u-multisig-plånbok: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
+        <source>Opened %u/%u multisig wallet%s</source>
+        <translation>Öppnade %u/%u-multisig-plånbok%s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4570"/>
+        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
+</source>
+        <translation>Använd &quot;help &lt;kommando&gt;&quot; för att visa dokumentation för kommandot.
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4628"/>
+        <source>wallet is multisig and cannot save a watch-only version</source>
+        <translation>plånboken är multisig och kan inte spara en granskningsversion</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4664"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4696"/>
+        <source>Failed to query mining status: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4679"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4707"/>
+        <source>Failed to setup background mining: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4683"/>
+        <source>Background mining enabled. Thank you for supporting the Monero network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4719"/>
+        <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4725"/>
+        <source>Using an untrusted daemon, skipping background mining check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4750"/>
+        <source>The daemon is not set up to background mine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4751"/>
+        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4752"/>
+        <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4757"/>
+        <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4864"/>
+        <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
+        <translation>Oväntad matrislängd - Lämnade simple_wallet::set_daemon()</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4905"/>
+        <source>This does not seem to be a valid daemon URL.</source>
+        <translation>Detta verkar inte vara en giltig daemon-URL.</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <source>txid </source>
+        <translation>txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <source>idx </source>
+        <translation>idx </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4956"/>
+        <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete. Support will be withdrawn in the future. Use subaddresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <source>New transfer received since rescan was started. Key images are incomplete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
+        <translation> (Några ägda utgångar har partiella nyckelavbildningar - import_multisig_info krävs)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>Currently selected account: [</source>
+        <translation>Aktuellt valt konto: [</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <source>] </source>
+        <translation>] </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>Tag: </source>
+        <translation>Tagg: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <source>(No tag assigned)</source>
+        <translation>(Ingen tagg tilldelad)</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <source>Balance per address:</source>
+        <translation>Saldo per adress:</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Address</source>
+        <translation>Adress</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Balance</source>
+        <translation>Saldo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <source>Unlocked balance</source>
+        <translation>Upplåst saldo</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <source>Outputs</source>
+        <translation>Utgångar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <source>Label</source>
+        <translation>Etikett</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <source>%8u %6s %21s %21s %7u %21s</source>
+        <translation>%8u %6s %21s %21s %7u %21s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>spent</source>
+        <translation>spenderat</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>global index</source>
+        <translation>globalt index</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <source>tx id</source>
+        <translation>tx-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>addr index</source>
+        <translation>addr index</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <source>Used at heights: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <source>[frozen]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <source>No incoming transfers</source>
+        <translation>Inga inkommande överföringar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <source>No incoming available transfers</source>
+        <translation>Inga inkommande tillgängliga överföringar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <source>No incoming unavailable transfers</source>
+        <translation>Inga inkommande otillgängliga överföringar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>payment</source>
+        <translation>betalning</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>transaction</source>
+        <translation>transaktion</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>height</source>
+        <translation>höjd</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <source>unlock time</source>
+        <translation>upplåsningstid</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <source>No payments with id </source>
+        <translation>Inga betalningar med ID </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <source>failed to get blockchain height: </source>
+        <translation>det gick inte att hämta blockkedjans höjd: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <source>
+Transaction %llu/%llu: txid=%s</source>
+        <translation>
+Transaktion %llu/%llu: txid=%s</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <source>failed to get output: </source>
+        <translation>det gick inte att hämta utgång: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
+        <translation>utgångsnyckelns ursprungsblockhöjd får inte vara högre än blockkedjans höjd</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <source>
+Originating block heights: </source>
+        <translation>
+Ursprungsblockhöjder: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <source>
+|</source>
+        <translation>
+|</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <source>|
+</source>
+        <translation>|
+</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <source>
+Warning: Some input keys being spent are from </source>
+        <translation>
+Varning: Några ingångsnycklar som spenderas kommer från </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
+        <translation>, vilket kan bryta ringsignaturens anonymitet. Se till att detta är avsiktligt!</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <source>Ring size must not be 0</source>
+        <translation>Ringstorlek för inte vara 0</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <source>ring size %u is too small, minimum is %u</source>
+        <translation>ringstorlek %uär för liten, minimum är %u</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <source>wrong number of arguments</source>
+        <translation>fel antal argument</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <source>No outputs found, or daemon is not ready</source>
+        <translation>Inga utgångar hittades, eller så är daemonen inte klar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <source>Failed to parse donation address: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <source>Donating %s %s to %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <source>failed to parse tx_key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <source>Tx key successfully stored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <source>Failed to store tx key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>timestamp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>running balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>hash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>payment ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <source>note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <source>CSV exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <source>Warning: your restore height is higher than wallet restore height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <source>Rescan anyway ? (Y/Yes/N/No): </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <source>MMS received new message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <source>Network type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <source>Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Stagenet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <source>Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <source>command only supported by HW wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <source>hw wallet does not support cold KI sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <source>Please confirm the key image sync on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <source>Key images synchronized to height </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> spent, </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <source> unspent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <source>Failed to import key images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <source>Failed to import key images: </source>
+        <translation type="unfinished">Det gick inte att importera nyckelavbildningar: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <source>Failed to reconnect device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <source>Failed to reconnect device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <source>Transaction successfully saved to </source>
+        <translation>Transaktionen sparades till </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>, txid </source>
+        <translation>, txid </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <source>Failed to save transaction to </source>
+        <translation>Det gick inte att spara transaktion till </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <source>This is a watch only wallet</source>
+        <translation>Detta är en granskningsplånbok</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
+        <translation>En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <source>Transaction ID not found</source>
+        <translation>Transaktions-ID kunde inte hittas</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="357"/>
+        <source>true</source>
+        <translation>sant</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="410"/>
+        <source>failed to parse refresh type</source>
+        <translation>det gick inte att parsa uppdateringstyp</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1147"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <source>command not supported by HW wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="747"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="818"/>
+        <source>wallet is watch-only and has no seed</source>
+        <translation>plånboken är enbart för granskning och har inget startvärde</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="828"/>
+        <source>wallet is non-deterministic and has no seed</source>
+        <translation>plånboken är icke-deterministisk och har inget startvärde</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="772"/>
+        <source>Enter optional seed offset passphrase, empty to see raw seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
+        <source>Incorrect password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="906"/>
+        <source>Current fee is %s %s per %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1181"/>
+        <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1190"/>
+        <source>Multisig wallet has been successfully created. Current wallet type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1196"/>
+        <source>Failed to perform multisig keys exchange: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1523"/>
+        <source>Failed to load multisig transaction from MMS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1812"/>
+        <source>Invalid key image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1661"/>
+        <source>Invalid txid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1673"/>
+        <source>Key image either not spent, or spent with mixin 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1688"/>
+        <source>Failed to get key image ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1703"/>
+        <source>File doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1725"/>
+        <source>Invalid ring specification: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1733"/>
+        <source>Invalid key image: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1738"/>
+        <source>Invalid ring type, expected relative or abosolute: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1744"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1756"/>
+        <source>Error reading line: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1767"/>
+        <source>Invalid ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
+        <source>Invalid relative ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1788"/>
+        <source>Invalid absolute ring: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Failed to set ring for key image: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1797"/>
+        <source>Continuing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1827"/>
+        <source>Missing absolute or relative keyword</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1837"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1844"/>
+        <source>invalid index: must be a strictly positive unsigned integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1852"/>
+        <source>invalid index: indices wrap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1862"/>
+        <source>invalid index: indices should be in strictly ascending order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1869"/>
+        <source>failed to set ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1946"/>
+        <source>First line is not an amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1960"/>
+        <source>Invalid output: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>Bad argument: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1970"/>
+        <source>should be &quot;add&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1979"/>
+        <source>Failed to open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
+        <source>Invalid output key, and file doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1991"/>
+        <source>Failed to mark output spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2035"/>
+        <source>Invalid output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2018"/>
+        <source>Failed to mark output unspent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2042"/>
+        <source>Spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2044"/>
+        <source>Not spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2048"/>
+        <source>Failed to check whether output is spent: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2063"/>
+        <source>Failed to save known rings: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2171"/>
+        <source>Please confirm the transaction on the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
+        <source>wallet is watch-only and cannot transfer</source>
+        <translation>plånboken är enbart för granskning och kan inte göra överföringar</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2257"/>
+        <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2309"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2325"/>
+        <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2330"/>
+        <source>could not change default priority</source>
+        <translation>det gick inte att ändra standardinställning för prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2400"/>
+        <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2686"/>
+        <source>Device name not specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2695"/>
+        <source>Device reconnect failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2700"/>
+        <source>Device reconnect failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
+        <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2785"/>
+        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2801"/>
+        <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2822"/>
+        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2908"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2943"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -2863,42 +3015,42 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2953"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2776"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2954"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2784"/>
-        <source>Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="2996"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3004"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3008"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2865"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3027"/>
+        <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3043"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2889"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3067"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -2907,73 +3059,73 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2901"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3079"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3083"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2913"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3100"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2926"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3104"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2930"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2938"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3120"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3124"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2950"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3128"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -2981,27 +3133,27 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2956"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2960"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2964"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3142"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3146"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3150"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -3009,1099 +3161,1170 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2978"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3156"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3164"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3168"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3172"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2998"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3200"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3087"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3297"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (långsammast, inga antaganden); optimize-coinbase (snabb, antar att hela coinbase-transaktionen betalas till en enda adress); no-coinbase (snabbast, antar att ingen coinbase-transaktion tas emot), default (samma som optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3298"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3090"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3300"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3301"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3312"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3317"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3338"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Plånbokens namn ej giltigt. Försök igen eller använd Ctrl-C för att avsluta.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Plånbok och nyckelfil hittades, läser in …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Nyckelfilen hittades men inte plånboksfilen. Återskapar …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Nyckelfilen kunde inte hittas. Det gick inte att öppna plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3214"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
         <source>Generating new wallet...</source>
         <translation>Skapar ny plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3232"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3445"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3506"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3600"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3605"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3395"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3415"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3470"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3594"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3633"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3630"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3650"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3742"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3791"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3871"/>
         <source>No data supplied, cancelled</source>
         <translation>Inga data angivna, avbryter</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3476"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3584"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5371"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6243"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6886"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6950"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8193"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3748"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3430"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3528"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3765"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3434"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3613"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3769"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3851"/>
         <source>view key does not match standard address</source>
         <translation>granskningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3439"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3459"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3536"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3669"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3674"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3773"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3907"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3934"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3966"/>
         <source>account creation failed</source>
         <translation>det gick inte att skapa konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3455"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3496"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3733"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3876"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3757"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3896"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3761"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3901"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3866"/>
+        <source>Secret spend key (%u of %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3941"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3942"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <source>Use --restore-height if you want to restore an already setup account from a specific height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3947"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4073"/>
         <source>failed to open account</source>
         <translation>det gick inte att öppna konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3824"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4391"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6854"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4078"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>wallet is null</source>
         <translation>plånbok är null</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4194"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3935"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4217"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>ogiltigt språkval har angivits. Försök igen.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>View key: </source>
         <translation>Granskningsnyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4486"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4286"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4563"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Du kan också prova att bort filen &quot;%s&quot; och försöka igen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4591"/>
         <source>failed to deinitialize wallet</source>
         <translation>det gick inte att avinitiera plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4644"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4371"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4382"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>detta kommando kräver en betrodd daemon. Aktivera med --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4886"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4903"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4539"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>blockkedjan kan inte sparas: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
-        <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4572"/>
-        <source>WARNING: this transaction uses an unencrypted payment ID: consider using subaddresses instead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4616"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4673"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4675"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4720"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4734"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
         <source>refresh error: </source>
         <translation>fel vid uppdatering: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4786"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
         <source>Balance: </source>
         <translation>Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4855"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>pubkey</source>
         <translation>publik nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
         <source>key image</source>
         <translation>nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7518"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>unlocked</source>
         <translation>upplåst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4894"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
-        <source>Heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>T</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4909"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4990"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5046"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
         <source>failed to get spent status</source>
         <translation>det gick inte att hämta spenderstatus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <source>
+Input %llu/%llu (%s): amount=%s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>the same transaction</source>
         <translation>samma transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
         <source>blocks that are temporally very close</source>
         <translation>block som ligger väldigt nära varandra i tiden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <source>No payment id is included with this transaction. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <source>Is this okay anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <source>Rescan anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <source>Short payment IDs are to be used within an integrated address only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9042"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9073"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9098"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9099"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9123"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9178"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9189"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9193"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9224"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9234"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9269"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9367"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9380"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9405"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9415"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9436"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9460"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9473"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9483"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9544"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9638"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9655"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9667"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9671"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9695"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9760"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9778"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9850"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9853"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9879"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9911"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <source>MMS not available in this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7079"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
         <source>Good signature</source>
         <translation>Godkänd signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6996"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7081"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7181"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Bad signature</source>
         <translation>Felaktig signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Standard address: </source>
         <translation>Standardadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8174"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
         <source>failed to parse payment ID or address</source>
         <translation>det gick inte att parsa betalnings-ID eller adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
         <source>failed to parse payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
         <source>failed to parse index</source>
         <translation>det gick inte att parsa index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8241"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
         <source>Address book is empty.</source>
         <translation>Adressboken är tom.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8247"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>Index: </source>
         <translation>Index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8378"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
         <source>Address: </source>
         <translation>Adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8249"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>Payment ID: </source>
         <translation>Betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8250"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8377"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
         <source>Description: </source>
         <translation>Beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>plånboken är enbart för granskning och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1289"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8447"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6958"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3943"/>
+        <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <source>Is this okay?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
+        <source>Still apply restore height?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
         <source>failed to load signature file</source>
         <translation>det gick inte att läsa in signaturfil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7020"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>plånboken är enbart för granskning och kan inte skapa beviset</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7104"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>Beviset på reserv kan endast skapas av en standardplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
         <source>Address must not be a subaddress</source>
         <translation>Adressen får inte vara en underadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation>Godkänd signatur -- summa: %s, spenderat: %s, ej spenderat: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7365"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation>[En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7641"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Det finns ingen ej spenderad utgång i den angivna adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7799"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
         <source> (no daemon)</source>
         <translation> (ingen daemon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7801"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
         <source> (out of sync)</source>
         <translation> (inte synkroniserad)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
         <source>(Untitled account)</source>
         <translation>(Ej namngivet konto)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7865"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7883"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7931"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8100"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
         <source>failed to parse index: </source>
         <translation>det gick inte att parsa index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8082"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
         <source>specify an index between 0 and </source>
         <translation>ange ett index mellan 0 och </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>
 Grand total:
   Balance: </source>
@@ -4110,386 +4333,386 @@ Totalsumma:
   Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7988"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
         <source>, unlocked balance: </source>
         <translation>, upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7996"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
         <source>Untagged accounts:</source>
         <translation>Otaggade konton:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8002"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8005"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
         <source>Accounts with tag: </source>
         <translation>Konton med tagg: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
         <source>Tag&apos;s description: </source>
         <translation>Taggens beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
         <source>Account</source>
         <translation>Konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>Primary address</source>
         <translation>Primär adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8048"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
         <source>(used)</source>
         <translation>(används)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8069"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
         <source>(Untitled address)</source>
         <translation>(Ej namngiven adress)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; är redan utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; är utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8152"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Integrerade adresser kan bara skapas för konto 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8164"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation>Integrerad adress: %s, betalnings-ID: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8169"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Subaddress: </source>
         <translation>Underadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8335"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
         <source>no description found</source>
         <translation>ingen beskrivning hittades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8337"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
         <source>description found: </source>
         <translation>beskrivning hittades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
         <source>Filename: </source>
         <translation>Filnamn: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
         <source>Watch only</source>
         <translation>Endast granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8383"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u multisig%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8386"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9180"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
         <source>Type: </source>
         <translation>Typ: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8412"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>Plånboken är multisig och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8461"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
         <source>Bad signature from </source>
         <translation>Felaktig signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8465"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
         <source>Good signature from </source>
         <translation>Godkänd signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>plånboken är enbart för granskning och kan inte exportera nyckelavbildningar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8651"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8509"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>Signed key images exported to </source>
         <translation>Signerade nyckelavbildningar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8662"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
         <source>Outputs exported to </source>
         <translation>Utgångar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5354"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7115"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7600"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
         <source>amount is wrong: </source>
         <translation>beloppet är fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5355"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
         <source>expected number from 0 to </source>
         <translation>förväntades: ett tal från 0 till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5721"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
         <source>Sweeping </source>
         <translation>Sveper upp </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6350"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Pengar skickades, transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till fler än en adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6574"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1435"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1448"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6646"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaktionen signerades till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6713"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6811"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6942"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7062"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8714"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>failed to parse txid</source>
         <translation>det gick inte att parsa txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6727"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>Tx key: </source>
         <translation>Tx-nyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6829"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
         <source>signature file saved to: </source>
         <translation>signaturfilen sparades till: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7043"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>failed to save signature file</source>
         <translation>det gick inte att spara signaturfilen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6868"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6877"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
         <source>failed to parse tx key</source>
         <translation>det gick inte att parsa txnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6835"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7001"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
         <source>error: </source>
         <translation>fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>received</source>
         <translation>mottaget</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6899"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
         <source>in txid</source>
         <translation>i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6918"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6991"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
         <source>received nothing in txid</source>
         <translation>tog emot ingenting i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6902"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>VARNING: denna transaktion är ännu inte inkluderad i blockkedjan!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
         <source>This transaction has %u confirmations</source>
         <translation>Denna transaktion har %u bekräftelser</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6912"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6985"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>VARNING: det gick inte att bestämma antal bekräftelser!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7266"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
         <source>bad min_height parameter:</source>
         <translation>felaktig parameter för min_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7278"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
         <source>bad max_height parameter:</source>
         <translation>felaktig parameter för max_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7296"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7615"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_belopp&gt; måste vara mindre än &lt;max_belopp&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>
 Amount: </source>
         <translation>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
         <source>, number of keys: </source>
         <translation>, antal nycklar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7652"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
         <source> </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7657"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
         <source>
 Min block height: </source>
         <translation>
 Minblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7658"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>
 Max block height: </source>
         <translation>
 Maxblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
         <source>
 Min amount found: </source>
         <translation>
 Minbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7660"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
         <source>
 Max amount found: </source>
         <translation>
 Maxbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
         <source>
 Total count: </source>
         <translation>
 Totalt antal: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7701"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
         <source>
 Bin size: </source>
         <translation>
 Storlek för binge: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
         <source>
 Outputs per *: </source>
         <translation>
 Utgångar per *: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
         <source>count
   ^
 </source>
@@ -4498,52 +4721,52 @@ Utgångar per *: </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7708"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; blockhöjd
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7709"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7710"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
         <source>  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
         <source>wallet</source>
         <translation>plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
         <source>Random payment ID: </source>
         <translation>Slumpmässigt betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8145"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
         <source>Matching integrated address: </source>
         <translation>Matchande integrerad adress: </translation>
     </message>
@@ -4795,311 +5018,321 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Skapa ny plånbok och spara den till &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="126"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="127"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Skapa granskningsplånbok från granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>Skapa deterministisk plånbok från spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
         <source>Generate wallet from private keys</source>
         <translation>Skapa plånbok från privata nycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="130"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>Skapa en huvudplånbok från multisig-plånboksnycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
         <source>Language for mnemonic</source>
         <translation>Språk för minnesbaserat startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="133"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="143"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Ange Electrum-startvärde för att återställa/skapa plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="144"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Återställ plånbok genom att använda minnesbaserat startvärde (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="135"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="145"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Återställ multisig-plånbok genom att använda minnesbaserat startvärde (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="136"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="146"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Skapa icke-deterministisk granskningsnyckel och spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="361"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="149"/>
+        <source>Restore from estimated blockchain height on specified date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="382"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="417"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="421"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="442"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="424"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="445"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="447"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="428"/>
-        <source>Is this OK? (Y/n) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="438"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
         <translation type="unfinished">det gick inte att parsa index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="472"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="489"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="510"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="505"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="513"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="544"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="529"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="550"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">inte tillräckligt med utgångar för angiven ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>output amount</source>
         <translation type="unfinished">utgångens belopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="553"/>
         <source>found outputs to use</source>
         <translation type="unfinished">hittade utgångar att använda</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="534"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="559"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">transaktionen konstruerades inte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation type="unfinished">transaktionen %s avvisades av daemonen med status: </translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="546"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="567"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="555"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="576"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">ett av målen är noll</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="560"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">okänt överföringsfel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
         <translation type="unfinished">Multisig-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
         <translation type="unfinished">internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="582"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
         <translation type="unfinished">oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="596"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="617"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="599"/>
-        <source>File %s already exists. Are you sure to overwrite it? (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7197"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7204"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8940"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>Unknown command: </source>
         <translation type="unfinished">Okänt kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Tillåt kommunikation med en daemon som använder en annan version av RPC</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="138"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="148"/>
         <source>Restore from specific blockchain height</source>
         <translation>Återställ från angiven blockkedjehöjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="139"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="150"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>Den nyss skapade transaktionen kommer inte att skickas vidare till monero-nätverket</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="140"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="151"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="276"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
+        <source>Support obsolete long (unencrypted) payment ids (using them harms your privacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="297"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished">det gick inte att läsa lösenord för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="283"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="304"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="293"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="314"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="506"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="323"/>
         <source>possibly lost connection to daemon</source>
         <translation>anslutning till daemonen kan ha förlorats</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
         <translation>Fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8959"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
+        <source>Is this OK?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="564"/>
+        <source>transaction %s was rejected by daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
+        <source>File %s already exists. Are you sure to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
         <source>Failed to initialize wallet</source>
         <translation>Det gick inte att initiera plånbok</translation>
     </message>
@@ -5107,360 +5340,448 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="201"/>
+        <location filename="../src/wallet/wallet2.cpp" line="234"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Använd daemonen på &lt;värddator&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="202"/>
+        <location filename="../src/wallet/wallet2.cpp" line="235"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Använd daemonen på värddatorn &lt;arg&gt; istället för localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="206"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Wallet password file</source>
         <translation>Lösenordsfil för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="207"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Använd daemonen på port &lt;arg&gt; istället för 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="209"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>För testnet. Daemonen måste också startas med flaggan --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="282"/>
+        <location filename="../src/wallet/wallet2.cpp" line="361"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>det går inte ange värd eller port för daemonen mer än en gång</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="355"/>
+        <location filename="../src/wallet/wallet2.cpp" line="480"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>det går inte att ange fler än en av --password och --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="368"/>
+        <location filename="../src/wallet/wallet2.cpp" line="493"/>
         <source>the password file specified could not be read</source>
         <translation>det gick inte att läsa angiven lösenordsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="394"/>
+        <location filename="../src/wallet/wallet2.cpp" line="519"/>
         <source>Failed to load file </source>
         <translation>Det gick inte att läsa in fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="205"/>
+        <location filename="../src/wallet/wallet2.cpp" line="239"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Lösenord för plånboken (använd escape-sekvenser eller citattecken efter behov)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="203"/>
+        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="237"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">Aktivera kommandon som kräver en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="204"/>
+        <location filename="../src/wallet/wallet2.cpp" line="238"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="208"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Ange användarnamn[:lösenord] för RPC-klient till daemonen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="210"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <source>List of valid fingerprints of allowed RPC servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <source>Allow any SSL certificate from the daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="212"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="223"/>
+        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="224"/>
+        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="225"/>
+        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="313"/>
+        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <source>Do not use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <source>Do not connect to a daemon, nor use DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <source>Invalid argument for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source>Enabling --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <source> requires --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or --</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <source> or use of a .onion/.i2p domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet2.cpp" line="432"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="323"/>
+        <location filename="../src/wallet/wallet2.cpp" line="442"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="375"/>
+        <location filename="../src/wallet/wallet2.cpp" line="500"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>inget lösenord har angivits; använd --prompt-for-password för att fråga efter lösenord</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="377"/>
+        <location filename="../src/wallet/wallet2.cpp" line="502"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="400"/>
+        <location filename="../src/wallet/wallet2.cpp" line="525"/>
         <source>Failed to parse JSON</source>
         <translation>Det gick inte att parsa JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="407"/>
+        <location filename="../src/wallet/wallet2.cpp" line="532"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u är för ny, vi förstår bara upp till %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="423"/>
+        <location filename="../src/wallet/wallet2.cpp" line="548"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="428"/>
-        <location filename="../src/wallet/wallet2.cpp" line="496"/>
-        <location filename="../src/wallet/wallet2.cpp" line="539"/>
+        <location filename="../src/wallet/wallet2.cpp" line="553"/>
+        <location filename="../src/wallet/wallet2.cpp" line="621"/>
+        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="439"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="444"/>
-        <location filename="../src/wallet/wallet2.cpp" line="506"/>
-        <location filename="../src/wallet/wallet2.cpp" line="565"/>
+        <location filename="../src/wallet/wallet2.cpp" line="569"/>
+        <location filename="../src/wallet/wallet2.cpp" line="631"/>
+        <location filename="../src/wallet/wallet2.cpp" line="692"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="456"/>
+        <location filename="../src/wallet/wallet2.cpp" line="581"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="476"/>
+        <location filename="../src/wallet/wallet2.cpp" line="601"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="605"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Både ordlista av Electrum-typ och privat nyckel har angivits</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="490"/>
+        <location filename="../src/wallet/wallet2.cpp" line="615"/>
         <source>invalid address</source>
         <translation>ogiltig adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="499"/>
+        <location filename="../src/wallet/wallet2.cpp" line="624"/>
         <source>view key does not match standard address</source>
         <translation>granskningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="509"/>
+        <location filename="../src/wallet/wallet2.cpp" line="634"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="517"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Det går inte att skapa inaktuella plånböcker från JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="551"/>
+        <location filename="../src/wallet/wallet2.cpp" line="678"/>
         <source>failed to parse address: </source>
         <translation>det gick inte att parsa adressen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="557"/>
+        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>Adress måste anges för att kunna skapa granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
+        <location filename="../src/wallet/wallet2.cpp" line="701"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1382"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1383"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="3770"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4374"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4926"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
         <source>Primary account</source>
         <translation>Primärt konto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10157"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
         <source>No funds received in this tx.</source>
         <translation>Inga pengar togs emot i denna tx.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10899"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="141"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <source>Path to a PEM format private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <source>Path to a PEM format certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="180"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
         <source>Failed to create directory </source>
         <translation>Det gick inte att skapa mapp </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="182"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
         <source>Failed to create directory %s: %s</source>
         <translation>Det gick inte att skapa mapp %s: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source>Cannot specify --</source>
         <translation>Det går inte att ange --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
         <source> and --</source>
         <translation> och --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>Failed to create file </source>
         <translation>Det gick inte att skapa fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="212"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
         <source>. Check permissions or remove file</source>
         <translation>. Kontrollera behörigheter eller ta bort filen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="222"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
         <source>Error writing to file </source>
         <translation>Ett fel uppstod vid skrivning till fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="225"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
         <source>RPC username/password is stored in file </source>
         <translation>Användarnamn/lösenord för RPC har sparats i fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="479"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3081"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Transaktion är inte möjlig. Endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3947"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Detta är RPC-plånboken för monero. Den måste ansluta till en Monero-
 daemon för att fungera korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3788"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Det går inte att ange fler än en av --wallet-file och --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3773"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3800"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Måste ange --wallet-file eller --generate-from-json eller --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3804"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
         <source>Loading wallet...</source>
         <translation>Läser in plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3838"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3870"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
         <source>Saving wallet...</source>
         <translation>Sparar plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3840"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3872"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
         <source>Successfully saved</source>
         <translation>Plånboken sparades</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3843"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
         <source>Successfully loaded</source>
         <translation>Plånboken lästes in</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3847"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Wallet initialization failed: </source>
         <translation>Det gick inte att initiera plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3853"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Det gick inte att initiera RPC-servern för plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3857"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
         <source>Starting wallet RPC server</source>
         <translation>Startar RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3864"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
         <source>Failed to run wallet: </source>
         <translation>Det gick inte att köra plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3867"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Stopped wallet RPC server</source>
         <translation>Stoppade RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3876"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
         <source>Failed to save wallet: </source>
         <translation>Det gick inte spara plånboken: </translation>
     </message>
@@ -5469,8 +5790,8 @@ daemon för att fungera korrekt.</translation>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8908"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3928"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Wallet options</source>
         <translation>Alternativ för plånbok</translation>
     </message>


### PR DESCRIPTION
Translations from https://translate.getmonero.org/projects/CLI/

Strings were submitted and reviewed on Pootle, before opening this PR i synced the files with the last merges. The result is: 41 new strings and 3 obsolete entries (removed). Ideally, all language files should be refreshed/resynced before tagging, if more commits get pushed.

I only submitted the translations for languages we already have, will add new languages as soon as one of them has enough translated strings.
