### PR TITLE
device/trezor: button request callback fix

### DIFF
--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -412,10 +412,11 @@ namespace trezor {
       CHECK_AND_ASSERT_THROW_MES(msg, "Empty message");
       MDEBUG("on_button_request, code: " << msg->code());
 
+      TREZOR_CALLBACK(on_button_request, msg->code());
+
       messages::common::ButtonAck ack;
       write_raw(&ack);
 
-      TREZOR_CALLBACK(on_button_request, msg->code());
       resp = read_raw();
     }
 


### PR DESCRIPTION
Fix of the button request callback logic. Without this PR the GUI "Proceed to the device" does not work, which is rather confusing for users.