### PR TITLE
CMakeLists.txt: suggest to update all submodules if one of them is outdated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(NOT MANUAL_SUBMODULES)
       if (upToDate)
         message(STATUS "Submodule '${relative_path}' is up-to-date")
       else()
-        message(FATAL_ERROR "Submodule '${relative_path}' is not up-to-date. Please update with\ngit submodule update --init --force ${relative_path}\nor run cmake with -DMANUAL_SUBMODULES=1")
+        message(FATAL_ERROR "Submodule '${relative_path}' is not up-to-date. Please update all submodules with\ngit submodule update --init --force\nor run cmake with -DMANUAL_SUBMODULES=1\n")
       endif()
     endfunction ()
     


### PR DESCRIPTION
I noticed that when building, if a submodule is found out to date, the user is asked to update that single submodule. If there are more outdated submodules, the user's build will stop every time until all submodules are updated. With this change, the suggestion is to run `git submodule update --init --force` without specifing a submodule, so that all of them will be updated in one go. I don't know if this change is wanted/needed, @moneromooo-monero it's up to you. 

I also added a newline at the end of `or run cmake with -DMANUAL_SUBMODULES=1")`, to make the string more visible.