### PR TITLE
levin_protocol_handler_async: tune down preallocation a fair bit

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -266,7 +266,7 @@ public:
             m_pservice_endpoint(psnd_hndlr), 
             m_config(config), 
             m_connection_context(conn_context), 
-            m_cache_in_buffer(256 * 1024),
+            m_cache_in_buffer(4 * 1024),
             m_state(stream_state_head)
   {
     m_close_called = 0;


### PR DESCRIPTION
It can allocate a lot when getting a lot of connections
(in particular, the stress test on windows apparently pushes
that memory to actual use, rather than just allocated)