### PR TITLE
Fix git checkout commands, those tags do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ invokes cmake commands as needed.
 * Change to the root of the source code directory, change to the most recent release branch, and build:
 
         cd monero
-        git checkout release-v0.14
+        git checkout release-v0.14.0.2
         make
 
     *Optional*: If your machine has several cores and enough memory, enable
@@ -271,7 +271,7 @@ Tested on a Raspberry Pi Zero with a clean install of minimal Raspbian Stretch (
 ```
         git clone https://github.com/monero-project/monero.git
 	cd monero
-	git checkout tags/v0.14.1.0
+	git checkout tags/v0.14.0.2
 ```
 * Build:
 ```
@@ -368,9 +368,9 @@ application.
 
         cd monero
 
-* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.14.1.0'. If you don't care about the version and just want binaries from master, skip this step:
+* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.14.0.2'. If you don't care about the version and just want binaries from master, skip this step:
 	
-        git checkout v0.14.1.0
+        git checkout v0.14.0.2
 
 * If you are on a 64-bit system, run:
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ invokes cmake commands as needed.
 * Change to the root of the source code directory, change to the most recent release branch, and build:
 
         cd monero
-        git checkout release-v0.14.0.2
+        git checkout v0.14.0.2
         make
 
     *Optional*: If your machine has several cores and enough memory, enable


### PR DESCRIPTION
Only these 0.14.x tags exist, I updated the docs to use the most recent:
v0.14.0.0
v0.14.0.1
v0.14.0.2