### PR TITLE
cmake: fix some case of "backtrace lib not found" breaking

### DIFF
--- a/cmake/FindBacktrace.cmake
+++ b/cmake/FindBacktrace.cmake
@@ -83,6 +83,14 @@ else()
   set(_Backtrace_STD_ARGS Backtrace_LIBRARY ${_Backtrace_STD_ARGS})
 endif()
 
+message(STATUS "Backtrace_LIBRARY: ${Backtrace_LIBRARY}")
+if(Backtrace_LIBRARY STREQUAL "NOTFOUND")
+  set(Backtrace_LIBRARY "")
+endif()
+if(Backtrace_LIBRARY STREQUAL "Backtrace_LIBRARY-NOTFOUND")
+  set(Backtrace_LIBRARY "")
+endif()
+
 set(Backtrace_LIBRARIES ${Backtrace_LIBRARY})
 set(Backtrace_HEADER "${_Backtrace_HEADER_TRY}" CACHE STRING "Header providing backtrace(3) facility")
 


### PR DESCRIPTION
It fixes at least one case of building on ARM with Docker