### PR TITLE
net_ssl: SSL config tweaks for compatibility and security

### DIFF
--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -135,6 +135,9 @@ namespace net_utils
 	constexpr size_t get_ssl_magic_size() { return 9; }
 	bool is_ssl(const unsigned char *data, size_t len);
 	bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
+
+	bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
+	bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
 }
 }
 


### PR DESCRIPTION
When built with the depends system, openssl does not include any
cipher on the current whitelist, so add this one, which fixes the
problem, and does seem sensible.