### PR TITLE
use crypto::rand instead of libc rand in a few tests

### DIFF
--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -82,7 +82,7 @@ namespace
     crypto::secret_key randkey;
     for (size_t ii = 0; ii < sizeof(randkey); ++ii)
     {
-      randkey.data[ii] = rand();
+      randkey.data[ii] = crypto::rand<uint8_t>();
     }
     crypto::ElectrumWords::bytes_to_words(randkey, w_seed, language.get_language_name());
     seed = std::string(w_seed.data(), w_seed.size());

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -138,7 +138,7 @@ TEST(select_outputs, density)
   static const size_t NPICKS = 1000000;
   std::vector<uint64_t> offsets;
 
-  MKOFFSETS(300000, 1 + (rand() & 0x1f));
+  MKOFFSETS(300000, 1 + (crypto::rand<size_t>() & 0x1f));
   tools::gamma_picker picker(offsets);
 
   std::vector<int> picks(/*n_outs*/offsets.size(), 0);
@@ -181,7 +181,7 @@ TEST(select_outputs, same_distribution)
   static const size_t NPICKS = 1000000;
   std::vector<uint64_t> offsets;
 
-  MKOFFSETS(300000, 1 + (rand() & 0x1f));
+  MKOFFSETS(300000, 1 + (crypto::rand<size_t>() & 0x1f));
   tools::gamma_picker picker(offsets);
 
   std::vector<int> chain_picks(offsets.size(), 0);

--- a/tests/unit_tests/rolling_median.cpp
+++ b/tests/unit_tests/rolling_median.cpp
@@ -69,7 +69,7 @@ TEST(rolling_median, series)
   v.reserve(100);
   for (int i = 0; i < 10000; ++i)
   {
-    uint64_t r = rand();
+    uint64_t r = crypto::rand<uint64_t>();
     v.push_back(r);
     if (v.size() > 100)
       v.erase(v.begin());
@@ -87,7 +87,7 @@ TEST(rolling_median, clear_whole)
   median.reserve(10000);
   for (int i = 0; i < 10000; ++i)
   {
-    random.push_back(rand());
+    random.push_back(crypto::rand<uint64_t>());
     m.insert(random.back());
     median.push_back(m.median());
   }
@@ -107,7 +107,7 @@ TEST(rolling_median, clear_partway)
   median.reserve(10000);
   for (int i = 0; i < 10000; ++i)
   {
-    random.push_back(rand());
+    random.push_back(crypto::rand<uint64_t>());
     m.insert(random.back());
     median.push_back(m.median());
   }
@@ -126,7 +126,7 @@ TEST(rolling_median, order)
   random.reserve(1000);
   for (int i = 0; i < 1000; ++i)
   {
-    random.push_back(rand());
+    random.push_back(crypto::rand<uint64_t>());
     m.insert(random.back());
   }
   const uint64_t med = m.median();


### PR DESCRIPTION
We don't need secure randomness here, but it should shut coverity up