### PR TITLE
difficulty: fail check_hash on null hash

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -194,6 +194,9 @@ namespace cryptonote {
   }
 
   bool check_hash(const crypto::hash &hash, difficulty_type difficulty) {
+    crypto::hash null_hash = AUTO_VAL_INIT(null_hash);
+    if (hash == null_hash)
+      return false;
     if (difficulty <= max64bit) // if can convert to small difficulty - do it
       return check_hash_64(hash, difficulty.convert_to<std::uint64_t>());
     else


### PR DESCRIPTION
previously, the check_hash function would succeed for an empty/null hash (`0000000...`)

the likelihood of the check_hash function receiving an empty hash is very small. in our case we encountered it secondary to some bad code elsewhere. in the event check_hash does receive an empty hash, it does not seem intended to return `true`.