### PR TITLE
[depends] update openssl to 1.0.2r

### DIFF
--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.0.2q
+$(package)_version=1.0.2r
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684
+$(package)_sha256_hash=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"


### PR DESCRIPTION
- This addresses https://www.openssl.org/news/secadv/20190226.txt (CVE: 2019-1559) which impacted all versions of openssl-1.0.

Note that this does not address CVE-2019-1543 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1543), which impacts all versions of openssl 1.1 through 1.1.0j and 1.1.1b ... I do not believe monero uses any of this functionality from openssl, and 1543 does not affect 1.0.2r.

The above is patched in openssl, where it was marked as low severity.  Similar issues possibly present in monero (unrelated to openssl, directly), should be looked into w.r.t. the specific issue present in CVE-2019-1543.