### PR TITLE
Do not compile monero-wallet-rpc when building GUI deps

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -74,42 +74,44 @@ target_link_libraries(wallet
   PRIVATE
     ${EXTRA_LIBRARIES})
 
-set(wallet_rpc_sources
-  wallet_rpc_server.cpp)
+# Do not build monero-wallet-rpc when building wallet_merged
+if (NOT BUILD_GUI_DEPS)
+    set(wallet_rpc_sources
+      wallet_rpc_server.cpp)
 
-set(wallet_rpc_headers)
+    set(wallet_rpc_headers)
 
-set(wallet_rpc_private_headers
-  wallet_rpc_server.h)
+    set(wallet_rpc_private_headers
+      wallet_rpc_server.h)
 
-monero_private_headers(wallet_rpc_server
-  ${wallet_rpc_private_headers})
-monero_add_executable(wallet_rpc_server
-  ${wallet_rpc_sources}
-  ${wallet_rpc_headers}
-  ${wallet_rpc_private_headers})
+    monero_private_headers(wallet_rpc_server
+      ${wallet_rpc_private_headers})
+    monero_add_executable(wallet_rpc_server
+      ${wallet_rpc_sources}
+      ${wallet_rpc_headers}
+      ${wallet_rpc_private_headers})
 
-target_link_libraries(wallet_rpc_server
-  PRIVATE
-    wallet
-    rpc_base
-    cryptonote_core
-    cncrypto
-    common
-    version
-    daemonizer
-    ${EPEE_READLINE}
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${EXTRA_LIBRARIES})
-set_property(TARGET wallet_rpc_server
-  PROPERTY
-    OUTPUT_NAME "monero-wallet-rpc")
-install(TARGETS wallet_rpc_server DESTINATION bin)
-
+    target_link_libraries(wallet_rpc_server
+      PRIVATE
+        wallet
+        rpc_base
+        cryptonote_core
+        cncrypto
+        common
+        version
+        daemonizer
+        ${EPEE_READLINE}
+        ${Boost_CHRONO_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT}
+        ${EXTRA_LIBRARIES})
+    set_property(TARGET wallet_rpc_server
+      PROPERTY
+        OUTPUT_NAME "monero-wallet-rpc")
+    install(TARGETS wallet_rpc_server DESTINATION bin)
+endif()
 
 # build and install libwallet_merged only if we building for GUI
 if (BUILD_GUI_DEPS)


### PR DESCRIPTION
Stops `monero-wallet-rpc` from being compiled whilst building libraries for the GUI. Saves ~1m20s from compilation (depending on cpu count).

If this change raises concerns regarding CMake readability we can choose to ignore this PR.