### PR TITLE
Close file before exit to avoid potential resource leak

### DIFF
--- a/translations/generate_translations_header.c
+++ b/translations/generate_translations_header.c
@@ -48,6 +48,7 @@ int main(int argc, char *argv[]) {
 
   for (i = 1; i < argc; i++) {
     if ((fp = fopen(argv[i], "rb")) == NULL) {
+      fclose(foutput);
       exit(EXIT_FAILURE);
     } else {
       fprintf(foutput, "static const std::string translation_file_name_%d = \"%s\";\n", i, argv[i]);


### PR DESCRIPTION
Close opened file before call to exit(). This avoids potential resource leak.
To find this problem I have used Clang Static Analyzer with alpha.unix.Stream checker.