### PR TITLE
functional_tests: fix rare get_output_distribution failure

### DIFF
--- a/tests/functional_tests/get_output_distribution.py
+++ b/tests/functional_tests/get_output_distribution.py
@@ -213,5 +213,14 @@ class GetOutputDistributionTest():
             assert d.distribution[h] == 0
 
 
+class Guard:
+    def __enter__(self):
+        for i in range(4):
+            Wallet(idx = i).auto_refresh(False)
+    def __exit__(self, exc_type, exc_value, traceback):
+        for i in range(4):
+            Wallet(idx = i).auto_refresh(True)
+
 if __name__ == '__main__':
-    GetOutputDistributionTest().run_test()
+    with Guard() as guard:
+        GetOutputDistributionTest().run_test()


### PR DESCRIPTION
When the wallet auto refreshes after mining the last two blocks
but before popping them, it will then try to use outputs which
are not unlocked yet. This is really a wallet problem, which
will be fixed later.