### PR TITLE
Add 'sponsor' button on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://web.getmonero.org/get-started/contributing/


### PR DESCRIPTION
Github has a new cool feature, the "Sponsor" button. When activated it will show a button on the left of the "watchers" button, which will show a link to the 'Contributing' page on getmonero.org.
Right now the link would be `https://web.getmonero.org/get-started/contributing/`, but i can change it to something else if necessary (maybe `https://ccs.getmonero.org/donate/`?).

It's basically just a button showing a link to a 'Donation' page, i though it's a nice feature.

If i understood correclty, the functionality should be activated on the GitHub UI as well (see link below). Ping @fluffypony.

More info: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository
A repository where the button is active: https://github.com/WeblateOrg/weblate