### PR TITLE
Fix reproducible builds

### DIFF
--- a/cmake/GenVersion.cmake
+++ b/cmake/GenVersion.cmake
@@ -29,7 +29,7 @@
 # Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 # Check what commit we're on
-execute_process(COMMAND "${GIT}" rev-parse --short HEAD RESULT_VARIABLE RET OUTPUT_VARIABLE COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND "${GIT}" rev-parse --short=9 HEAD RESULT_VARIABLE RET OUTPUT_VARIABLE COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(RET)
 	# Something went wrong, set the version tag to -unknown
@@ -38,6 +38,7 @@ if(RET)
     set(VERSIONTAG "unknown")
     configure_file("src/version.cpp.in" "${TO}")
 else()
+	string(SUBSTRING ${COMMIT} 0 9 COMMIT)
 	message(STATUS "You are currently on commit ${COMMIT}")
 	
 	# Get all the tags

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl zeromq cppzmq expat ldns cppzmq readline libiconv hidapi protobuf libusb
+packages:=boost openssl zeromq cppzmq expat ldns readline libiconv hidapi protobuf libusb
 native_packages := native_ccache native_protobuf
 
 darwin_native_packages = native_biplist native_ds_store native_mac_alias

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -8,6 +8,7 @@ OPTION(BUILD_TESTS "Build tests." OFF)
 
 SET(STATIC ON)
 SET(UNBOUND_STATIC ON)
+SET(ARCH "default")
 
 SET(BUILD_TESTS @build_tests@)
 SET(TREZOR_DEBUG @build_tests@)

--- a/contrib/gitian/gitian-linux.yml
+++ b/contrib/gitian/gitian-linux.yml
@@ -129,6 +129,7 @@ script: |
   chmod +x ${WRAP_DIR}/${prog}
   done
 
+  git config --global core.abbrev 9
   cd monero
   BASEPREFIX=`pwd`/contrib/depends
   # Build dependencies for each host

--- a/contrib/gitian/gitian-linux.yml
+++ b/contrib/gitian/gitian-linux.yml
@@ -153,7 +153,7 @@ script: |
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir build && cd build
     cmake .. -DCMAKE_TOOLCHAIN_FILE=${BASEPREFIX}/${i}/share/toolchain.cmake -DBACKCOMPAT=ON
-    make
+    make ${MAKEOPTS}
     DISTNAME=monero-${i}
     mv bin ${DISTNAME}
     find ${DISTNAME}/ | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}.tar.gz

--- a/contrib/gitian/gitian-osx.yml
+++ b/contrib/gitian/gitian-osx.yml
@@ -77,6 +77,7 @@ script: |
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
+  git config --global core.abbrev 9
   cd monero
   BASEPREFIX=`pwd`/contrib/depends
 

--- a/contrib/gitian/gitian-osx.yml
+++ b/contrib/gitian/gitian-osx.yml
@@ -100,7 +100,7 @@ script: |
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir build && cd build
     cmake .. -DCMAKE_TOOLCHAIN_FILE=${BASEPREFIX}/${i}/share/toolchain.cmake
-    make
+    make ${MAKEOPTS}
     DISTNAME=monero-${i}
     mv bin ${DISTNAME}
     find ${DISTNAME}/ | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}.tar.gz

--- a/contrib/gitian/gitian-win.yml
+++ b/contrib/gitian/gitian-win.yml
@@ -100,6 +100,7 @@ script: |
   create_per-host_linker_wrapper "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
+  git config --global core.abbrev 9
   cd monero
   BASEPREFIX=`pwd`/contrib/depends
   # Build dependencies for each host

--- a/contrib/gitian/gitian-win.yml
+++ b/contrib/gitian/gitian-win.yml
@@ -125,7 +125,7 @@ script: |
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir build && cd build
     cmake .. -DCMAKE_TOOLCHAIN_FILE=${BASEPREFIX}/${i}/share/toolchain.cmake
-    make
+    make ${MAKEOPTS}
     DISTNAME=monero-${i}
     mv bin ${DISTNAME}
     find ${DISTNAME}/ | sort | zip -X@ ${OUTDIR}/${DISTNAME}.zip


### PR DESCRIPTION
Don't use `-march=native`
Re-enable parallel make

Using `-march=native` made the binaries depend on the build system's CPU, and those binaries could crash on older machines. This was breaking the Mac binaries. It also meant that the binaries would differ between different build machines. This was causing the differences in the x86-64-linux builds. I've tested with both serial and parallel build, and results are now identical, so parallel make was never the issue.