### PR TITLE
rpc: work around a GCC 7.4.0 (at least) bug

### DIFF
--- a/src/rpc/rpc_handler.cpp
+++ b/src/rpc/rpc_handler.cpp
@@ -63,7 +63,9 @@ namespace rpc
             d.cached_to -= 10;
             d.cached_top_hash = hash10;
             d.cached_m10_hash = crypto::null_hash;
-            d.cached_distribution.resize(d.cached_distribution.size() - 10);
+            CHECK_AND_ASSERT_MES(d.cached_distribution.size() >= 10, boost::none, "Cached distribution size does not match cached bounds");
+            for (int p = 0; p < 10; ++p)
+              d.cached_distribution.pop_back();
             can_extend = true;
           }
         }


### PR DESCRIPTION
In static member function ‘static boost::optional<cryptonote::rpc::output_distribution_data> cryptonote::rpc::RpcHandler::get_output_distribution(const std::function<bool(long unsigned int, long unsigned int, long unsigned int, long unsigned int&, std::vector<long unsigned int>&, long unsigned int&)>&, uint64_t, uint64_t, uint64_t, const std::function<crypto::hash(long unsigned int)>&, bool, uint64_t)’:
cc1plus: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’: specified size 18446744073709551536 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]