### PR TITLE
Do not install trezor dep libs

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -142,11 +142,7 @@ if (BUILD_GUI_DEPS)
     install(TARGETS wallet_merged
         ARCHIVE DESTINATION ${lib_folder})
 
-    install(FILES ${TREZOR_DEP_LIBS}
-            DESTINATION ${lib_folder})
     file(WRITE "trezor_link_flags.txt" ${TREZOR_DEP_LINKER})
-    install(FILES "trezor_link_flags.txt"
-            DESTINATION ${lib_folder})
 endif()
 
 add_subdirectory(api)


### PR DESCRIPTION
The content of TREZOR_DEP_LIBS (libusb-1.0.so, libprotobuf.so) is
already coming from the local system.

trezor_link_flags.txt has very limited value to be installed in /usr/lib