### PR TITLE
unit_tests: add more leeway to the "same distribution" check

### DIFF
--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -211,10 +211,10 @@ TEST(select_outputs, same_distribution)
   {
     const double diff = (double)output_norm[i] - (double)chain_norm[i];
     double dev = fabs(2.0 * diff / (output_norm[i] + chain_norm[i]));
-    ASSERT_LT(dev, 0.1);
+    ASSERT_LT(dev, 0.15);
     avg_dev += dev;
   }
   avg_dev /= 100;
   MDEBUG("avg_dev: " << avg_dev);
-  ASSERT_LT(avg_dev, 0.015);
+  ASSERT_LT(avg_dev, 0.02);
 }


### PR DESCRIPTION
This is an inherently probabilistic check, which occasionally fails
for a matching distribution