### PR TITLE
tests: functional: fix python syntax

### DIFF
--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -65,7 +65,7 @@ try:
   for i in range(len(command_lines)):
     #print('Running: ' + str(command_lines[i]))
     processes.append(subprocess.Popen(command_lines[i], stdout = outputs[i]))
-except Exception, e:
+except Exception as e:
   print('Error: ' + str(e))
   sys.exit(1)
 


### PR DESCRIPTION
Without this functional_tests_rpc failed on Arch Linux with Python 3.7.3:

```
"functional_tests_rpc" start time: Jun 19 21:52 EDT
Output:
----------------------------------------------------------
  File "/.../tests/functional_tests/functional_tests_rpc.py", line 68
    except Exception, e:
                    ^
SyntaxError: invalid syntax
<end of output>
Test time =   0.17 sec
----------------------------------------------------------
Test Failed.
```