### PR TITLE
rpc headers fix @ CMakeLists.txt

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -47,7 +47,7 @@ set(rpc_base_headers
   rpc_args.h)
 
 set(rpc_headers
-  rpc_handler.cpp)
+  rpc_handler.h)
 
 set(daemon_rpc_server_headers)
 


### PR DESCRIPTION
headers are defined at .h files instead of .cpp ones