### PR TITLE
Fix readline compilation 

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -217,4 +217,6 @@ download-win:
 	@$(MAKE) -s HOST=x86_64-w64-mingw32 download-one
 download: download-osx download-linux download-win
 
+ $(foreach package,$(all_packages),$(eval $(call ext_add_stages,$(package))))
+
 .PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources

--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -213,6 +213,14 @@ $(1): | $($(1)_cached_checksum)
 
 endef
 
+stages = fetched extracted preprocessed configured built staged postprocessed cached cached_checksum
+
+define ext_add_stages
+$(foreach stage,$(stages),
+          $(1)_$(stage): $($(1)_$(stage))
+          .PHONY: $(1)_$(stage))
+endef
+
 # These functions create the build targets for each package. They must be
 # broken down into small steps so that each part is done for all packages
 # before moving on to the next step. Otherwise, a package's info

--- a/contrib/depends/packages/eudev.mk
+++ b/contrib/depends/packages/eudev.mk
@@ -23,3 +23,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/contrib/depends/packages/expat.mk
+++ b/contrib/depends/packages/expat.mk
@@ -6,6 +6,7 @@ $(package)_sha256_hash=03ad85db965f8ab2d27328abcf0bc5571af6ec0a414874b2066ee3fdd
 
 define $(package)_set_vars
 $(package)_config_opts=--enable-static
+$(package)_config_opts=--disable-shared
 $(package)_config_opts+=--prefix=$(host_prefix)
 endef
 
@@ -20,3 +21,8 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef
+

--- a/contrib/depends/packages/hidapi.mk
+++ b/contrib/depends/packages/hidapi.mk
@@ -28,3 +28,8 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef
+

--- a/contrib/depends/packages/icu4c.mk
+++ b/contrib/depends/packages/icu4c.mk
@@ -21,11 +21,6 @@ define $(package)_config_cmds
   $(MAKE) $($(package)_build_opts)
 endef
 
-#define $(package)_build_cmds
-#  cd source &&\
-   $(MAKE) $($((package)_build_opts) `nproc`
-#endef
-
 define $(package)_stage_cmds
   cd buildb &&\
   $(MAKE) $($(package)_build_opts) DESTDIR=$($(package)_staging_dir) install lib/*

--- a/contrib/depends/packages/ldns.mk
+++ b/contrib/depends/packages/ldns.mk
@@ -6,8 +6,8 @@ $(package)_sha256_hash=8b88e059452118e8949a2752a55ce59bc71fa5bc414103e17f5b6b06f
 $(package)_dependencies=openssl
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --enable-static --disable-dane-ta-usage --with-drill 
-  $(package)_config_opts=--with-ssl=$(host_prefix) 
+  $(package)_config_opts=--disable-shared --enable-static --with-drill
+  $(package)_config_opts+=--with-ssl=$(host_prefix)
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
 endef
@@ -25,4 +25,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la
 endef
+

--- a/contrib/depends/packages/libiconv.mk
+++ b/contrib/depends/packages/libiconv.mk
@@ -28,3 +28,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/contrib/depends/packages/ncurses.mk
+++ b/contrib/depends/packages/ncurses.mk
@@ -1,0 +1,58 @@
+package=ncurses
+$(package)_version=6.1
+$(package)_download_path=https://ftp.gnu.org/gnu/ncurses
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17
+
+define $(package)_set_vars
+  $(package)_build_opts=CC="$($(package)_cc)"
+  $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
+  $(package)_config_env_darwin=RANLIB="$(host_prefix)/native/bin/x86_64-apple-darwin11-ranlib" AR="$(host_prefix)/native/bin/x86_64-apple-darwin11-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
+  $(package)_config_opts=--prefix=$(host_prefix)
+  $(package)_config_opts+=--disable-shared
+  $(package)_config_opts+=--with-build-cc=gcc
+  $(package)_config_opts+=--without-debug
+  $(package)_config_opts+=--without-ada
+  $(package)_config_opts+=--without-cxx-binding
+  $(package)_config_opts+=--without-cxx
+  $(package)_config_opts+=--without-ticlib
+  $(package)_config_opts+=--without-tic
+  $(package)_config_opts+=--without-progs
+  $(package)_config_opts+=--without-tests
+  $(package)_config_opts+=--without-tack
+  $(package)_config_opts+=--without-manpages
+  $(package)_config_opts+=--disable-tic-depends
+  $(package)_config_opts+=--disable-big-strings
+  $(package)_config_opts+=--disable-ext-colors
+  $(package)_config_opts+=--enable-pc-files
+  $(package)_config_opts+=--host=$(HOST)
+  $(pacakge)_config_opts+=--without-shared
+  $(pacakge)_config_opts+=--without-pthread
+  $(pacakge)_config_opts+=--disable-rpath
+  $(pacakge)_config_opts+=--disable-colorfgbg
+  $(pacakge)_config_opts+=--disable-ext-colors
+  $(pacakge)_config_opts+=--disable-ext-mouse
+  $(pacakge)_config_opts+=--disable-symlinks
+  $(pacakge)_config_opts+=--enable-warnings
+  $(pacakge)_config_opts+=--enable-assertions
+  $(pacakge)_config_opts+=--disable-home-terminfo
+  $(pacakge)_config_opts+=--enable-database
+  $(pacakge)_config_opts+=--enable-sp-funcs
+  $(pacakge)_config_opts+=--enable-term-driver
+  $(pacakge)_config_opts+=--enable-interop
+  $(pacakge)_config_opts+=--enable-widec
+  $(package)_build_opts=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
+endef
+
+define $(package)_config_cmds
+  ./configure $($(package)_config_opts)
+endef
+
+define $(package)_build_cmds
+  $(MAKE) $($(package)_build_opts) V=1
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) install DESTDIR=$($(package)_staging_dir)
+endef
+

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -15,6 +15,7 @@ ifeq ($(host_os),linux)
 packages += unwind
 packages += sodium
 endif
+
 ifeq ($(host_os),mingw32)
 packages += icu4c
 packages += sodium

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -1,19 +1,14 @@
-packages:=boost openssl zeromq cppzmq expat ldns readline libiconv hidapi protobuf libusb
+packages:=boost openssl zeromq cppzmq expat ldns libiconv hidapi protobuf libusb
 native_packages := native_ccache native_protobuf
 
 darwin_native_packages = native_biplist native_ds_store native_mac_alias
-darwin_packages = sodium-darwin
+darwin_packages = sodium-darwin ncurses readline 
 
-linux_packages = eudev
+linux_packages = eudev ncurses readline unwind sodium
 qt_packages = qt
 
 ifeq ($(build_tests),ON)
 packages += gtest
-endif
-
-ifeq ($(host_os),linux)
-packages += unwind
-packages += sodium
 endif
 
 ifeq ($(host_os),mingw32)

--- a/contrib/depends/packages/protobuf.mk
+++ b/contrib/depends/packages/protobuf.mk
@@ -25,5 +25,7 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/libprotoc.a
+  rm lib/libprotoc.a &&\
+  rm lib/*.la
 endef
+

--- a/contrib/depends/packages/readline.mk
+++ b/contrib/depends/packages/readline.mk
@@ -3,19 +3,19 @@ $(package)_version=8.0
 $(package)_download_path=https://ftp.gnu.org/gnu/readline
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
+$(package)_dependencies=ncurses
 
 define $(package)_set_vars
-  $(package)_build_opts=CC="$($(package)_cc)"
-  $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
   $(package)_config_opts=--prefix=$(host_prefix)
-  $(package)_config_opts+=--disable-shared --enable-multibye --without-purify --without-curses
+  $(package)_config_opts+=--exec-prefix=$(host_prefix)
+  $(package)_config_opts+=--host=$(HOST)
+  $(package)_config_opts+=--disable-shared --with-curses
   $(package)_config_opts_release=--disable-debug-mode
+  $(package)_config_opts_darwin+=RANLIB="$(host_prefix)/native/bin/x86_64-apple-darwin11-ranlib" AR="$(host_prefix)/native/bin/x86_64-apple-darwin11-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
   $(package)_build_opts=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
 endef
 
 define $(package)_config_cmds
-  export bash_cv_have_mbstate_t=yes &&\
-  export bash_cv_wcwidth_broken=yes &&\
   ./configure $($(package)_config_opts)
 endef
 
@@ -24,6 +24,6 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) install DESTDIR=$($(package)_staging_dir) prefix=$(host_prefix) exec-prefix=$(host_prefix)
 endef
 

--- a/contrib/depends/packages/sodium-darwin.mk
+++ b/contrib/depends/packages/sodium-darwin.mk
@@ -23,3 +23,8 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef
+

--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -23,3 +23,8 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef
+

--- a/contrib/depends/packages/unwind.mk
+++ b/contrib/depends/packages/unwind.mk
@@ -19,4 +19,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la
 endef
+

--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -30,5 +30,7 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf bin share
+  rm -rf bin share &&\
+  rm lib/*.la
 endef
+

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -21,6 +21,8 @@ SET(ENV{PKG_CONFIG_PATH} @prefix@/lib/pkgconfig)
 SET(LRELEASE_PATH @prefix@/native/bin CACHE FILEPATH "path to lrelease" FORCE)
 
 SET(Readline_ROOT_DIR @prefix@)
+SET(Readline_INCLUDE_DIR @prefix@/include)
+SET(Termcap_LIBRARY @prefix@/lib/libncurses.a)
 
 SET(LIBUNWIND_INCLUDE_DIR @prefix@/include)
 SET(LIBUNWIND_LIBRARIES @prefix@/lib/libunwind.a)


### PR DESCRIPTION
Readline is now compiled with ncurses as a backend. I also attempted to build with termcap instead of a full ncurses installation, but since the releases so far have not supported readline on windows and 
 the termap Makefile does not handle installation directories properly that are demanded by depends, 
Besides adding readline, this pull request also adds some debug targets to the depends Makefile. To check all the available targets now, you can run `cat Makefile | awk '!/SHELL/ && /^[A-z]/ {print $1}' | awk '{print substr($0, 1, length($0)-1)}' . 
To speedup the depends cached builds, remove some some clutter from the package files. This mainly includes removing all the shared libraries and .la linker files. It also gives stronger guarantees that monero only links the static libs without any external rvalues. 
Packages can now also be built individually and for each stage. This allows easier debugging.
The travis build fail currently with this build, but I am not sure why.