### PR TITLE
Add depends riscv 64 bit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
     - SDK_URL=https://bitcoincore.org/depends-sources/sdks
     - DOCKER_PACKAGES="build-essential libtool cmake autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache"
   matrix:
+# RISCV 64bit
+    - HOST=riscv64-linux-gnu PACKAGES="python3 gperf g++-riscv64-linux-gnu"
 # ARM v7
     - HOST=arm-linux-gnueabihf PACKAGES="python3 gperf g++-arm-linux-gnueabihf"
 # ARM v8

--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ You can also cross-compile static binaries on Linux for Windows and macOS with t
   * Requires: `g++-arm-linux-gnueabihf`
 * ```make depends target=aarch64-linux-gnu``` for armv8 binaries.
   * Requires: `g++-aarch64-linux-gnu`
+* ```make depends target=riscv64-linux-gnu``` for RISC V 64 bit binaries.
+  * Requires: `g++-riscv64-linux-gnu`
 
 The required packages are the names for each toolchain on apt. Depending on your distro, they may have different names.
 

--- a/contrib/depends/README.md
+++ b/contrib/depends/README.md
@@ -33,6 +33,7 @@ Common `host-platform-triplets` for cross compilation are:
 - `x86_64-apple-darwin11` for MacOSX
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit
+- `riscv64-linux-gnu` for Linux RISCV 64 bit
 
 No other options are needed, the paths are automatically configured.
 

--- a/contrib/depends/packages/ldns.mk
+++ b/contrib/depends/packages/ldns.mk
@@ -12,6 +12,10 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -40,6 +40,7 @@ $(package)_config_opts_x86_64_linux=linux-x86_64
 $(package)_config_opts_i686_linux=linux-generic32
 $(package)_config_opts_arm_linux=linux-generic32
 $(package)_config_opts_aarch64_linux=linux-generic64
+$(package)_config_opts_riscv64_linux=linux-generic64
 $(package)_config_opts_mipsel_linux=linux-generic32
 $(package)_config_opts_mips_linux=linux-generic32
 $(package)_config_opts_powerpc_linux=linux-generic32

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -4,11 +4,15 @@ native_packages := native_ccache native_protobuf
 darwin_native_packages = native_biplist native_ds_store native_mac_alias
 darwin_packages = sodium-darwin ncurses readline 
 
-linux_packages = eudev ncurses readline unwind sodium
+linux_packages = eudev ncurses readline sodium
 qt_packages = qt
 
 ifeq ($(build_tests),ON)
 packages += gtest
+endif
+
+ifneq ($(host_arch),riscv64)
+	packages += unwind
 endif
 
 ifeq ($(host_os),mingw32)

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -98,6 +98,11 @@ elseif(ARCHITECTURE STREQUAL "aarch64")
   set(BUILD_64 ON)
 endif()
 
+if(ARCHITECTURE STREQUAL "riscv64")
+    set(NO_AES ON)
+    set(ARCH "rv64imafdc")
+endif()
+
 if(ARCHITECTURE STREQUAL "i686" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
   SET(LINUX_32 ON)
   SET(ARCH_ID "i386")


### PR DESCRIPTION
It is now possible to cross compile to riscv64 with `make depends target=riscv64-linux-gnu` in the top level Makefile.