### PR TITLE
Depends: Use HIDAPI from master branch

### DIFF
--- a/contrib/depends/packages/hidapi.mk
+++ b/contrib/depends/packages/hidapi.mk
@@ -1,8 +1,8 @@
 package=hidapi
-$(package)_version=0.8.0-rc1
-$(package)_download_path=https://github.com/signal11/hidapi/archive
+$(package)_version=0.9.0
+$(package)_download_path=https://github.com/libusb/hidapi/archive
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=3c147200bf48a04c1e927cd81589c5ddceff61e6dac137a605f6ac9793f4af61
+$(package)_sha256_hash=630ee1834bdd5c5761ab079fd04f463a89585df8fcae51a7bfe4229b1e02a652
 $(package)_linux_dependencies=libusb eudev
 
 define $(package)_set_vars


### PR DESCRIPTION
The macos binaries in release v0.14.1.0 were compiled with the buggy
hidapi-0.8.0-rc1 version. This resulted in users not being able to use
their Ledger with the latest cli wallet. After the patch depends now
fetches the source from a separately published release.