### PR TITLE
Updated linked version of zmq.hpp which must be used for Monero to co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ invokes cmake commands as needed.
     available per thread.
 
     *Note*: If cmake can not find zmq.hpp file on macOS, installing `zmq.hpp` from
-    https://github.com/zeromq/cppzmq to `/usr/local/include` should fix that error.
+    [zeromq/cppzmq](https://github.com/zeromq/cppzmq/blob/c55379d6e2b7ed574a59d372aa7f99f3425165f3/zmq.hpp) to `/usr/local/include` should fix that error.
 
     *Note*: The instructions above will compile the most stable release of the
     Monero software. If you would like to use and test the most recent software,


### PR DESCRIPTION
I noticed when compiling 0.14.1 on macOS the version of zmq.hpp that was linked from the readme broke the build.

I found the version that compiles successfully....

I updated the linked version of zmq.hpp which must be used for Monero to compile on macOS to c55379d6e2b7ed574a59d372aa7f99f3425165f3. The version at the current HEAD breaks the compilation of Monero on macOS. zmq.hpp from c55379d6e2b7ed574a59d372aa7f99f3425165f3 is the version being used on Fluffys build machine.