### PR TITLE
zmq: fix for MacPorts latest zmq/cppzmq

### DIFF
--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -59,7 +59,7 @@ void ZmqServer::serve()
       {
         throw std::runtime_error("ZMQ RPC server reply socket is null");
       }
-      while (rep_socket->recv(&message))
+      while (rep_socket->recv(&message, 0))
       {
         std::string message_string(reinterpret_cast<const char *>(message.data()), message.size());
 


### PR DESCRIPTION
The actually addresses (rather negates the need for), #5697 too.