### PR TITLE
Replace std::random_shuffle with std::shuffle

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -354,7 +354,7 @@ namespace cryptonote
 
     if (shuffle_outs)
     {
-      std::shuffle(destinations.begin(), destinations.end(), std::default_random_engine(crypto::rand<unsigned int>()));
+      std::shuffle(destinations.begin(), destinations.end(), crypto::random_device{});
     }
 
     // sort ins by their key image

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -290,7 +290,7 @@ namespace nodetool
 
     if (anonymize)
     {
-      std::random_shuffle(bs_head.begin(), bs_head.end());
+      std::shuffle(bs_head.begin(), bs_head.end(), crypto::random_device{});
       if (bs_head.size() > depth)
         bs_head.resize(depth);
       for (auto &e: bs_head)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7448,7 +7448,7 @@ void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_
     order.resize(light_wallet_requested_outputs_count);
     for (size_t n = 0; n < order.size(); ++n)
       order[n] = n;
-    std::shuffle(order.begin(), order.end(), std::default_random_engine(crypto::rand<unsigned>()));
+    std::shuffle(order.begin(), order.end(), crypto::random_device{});
     
     
     LOG_PRINT_L2("Looking for " << (fake_outputs_count+1) << " outputs with amounts " << print_money(td.is_rct() ? 0 : td.amount()));
@@ -8023,7 +8023,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       order.resize(requested_outputs_count);
       for (size_t n = 0; n < order.size(); ++n)
         order[n] = n;
-      std::shuffle(order.begin(), order.end(), std::default_random_engine(crypto::rand<unsigned>()));
+      std::shuffle(order.begin(), order.end(), crypto::random_device{});
 
       LOG_PRINT_L2("Looking for " << (fake_outputs_count+1) << " outputs of size " << print_money(td.is_rct() ? 0 : td.amount()));
       for (size_t o = 0; o < requested_outputs_count && outs.back().size() < fake_outputs_count + 1; ++o)

--- a/tests/unit_tests/ringct.cpp
+++ b/tests/unit_tests/ringct.cpp
@@ -779,8 +779,8 @@ TEST(ringct, range_proofs_accept_very_long_simple)
     inputs[n] = n;
     outputs[n] = n;
   }
-  std::random_shuffle(inputs, inputs + N);
-  std::random_shuffle(outputs, outputs + N);
+  std::shuffle(inputs, inputs + N, crypto::random_device{});
+  std::shuffle(outputs, outputs + N, crypto::random_device{});
   EXPECT_TRUE(range_proof_test(true, NELTS(inputs), inputs, NELTS(outputs), outputs, false, true));
 }
 

--- a/tests/unit_tests/rolling_median.cpp
+++ b/tests/unit_tests/rolling_median.cpp
@@ -143,7 +143,7 @@ TEST(rolling_median, order)
     m.insert(random[i]);
   ASSERT_EQ(med, m.median());
 
-  std::shuffle(random.begin(), random.end(), std::default_random_engine(crypto::rand<unsigned>()));
+  std::shuffle(random.begin(), random.end(), crypto::random_device{});
   m.clear();
   for (int i = 0; i < 1000; ++i)
     m.insert(random[i]);


### PR DESCRIPTION
According to [the docs][1], `std::random_shuffle` is deprecated in C++14 and removed in C++17. Since `std::shuffle` is available since C++11 as a replacement and monero already requires C++11, I think it is a good idea to use `std::shuffle` instead.

The choice of random number generator was inspired by the other usages of `std::shuffle` in the codebase; since the original `std::random_shuffle` made no guarantees whatsoever about the quality of its randomness, this does not introduce problems there.

[1]: https://en.cppreference.com/w/cpp/algorithm/random_shuffle