### PR TITLE
translations: add a ready file to control which translations to build

### DIFF
--- a/translations/ready
+++ b/translations/ready
@@ -1,0 +1,4 @@
+fr
+it
+ja
+sv

--- a/utils/translations/build-translations.sh
+++ b/utils/translations/build-translations.sh
@@ -12,5 +12,15 @@ then
 fi
 
 echo "using $lrelease"
-"$lrelease" translations/*.ts
+if test -f translations/ready
+then
+  languages=""
+  for language in $(cat translations/ready)
+  do
+    languages="$languages translations/$language.ts"
+  done
+else
+  languages="translations/*.ts"
+fi
+"$lrelease" $languages
 


### PR DESCRIPTION
Some translations are committed before they're ready to be used