### PR TITLE
blockchain: double check blocktemplate cache correctness

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1374,7 +1374,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     // just as we compare it, we'll just use a slightly old template, but
     // this would be the case anyway if we'd lock, and the change happened
     // just after the block template was created
-    if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce
+    if (m_btc.prev_id == get_tail_id() && !memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce
       && m_btc_pool_cookie == m_tx_pool.cookie() && m_btc.prev_id == get_tail_id()) {
       MDEBUG("Using cached template");
       m_btc.timestamp = time(NULL); // update timestamp unconditionally

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1806,6 +1806,10 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
     else
     {
       MGINFO_BLUE("----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT " << bei.height << std::endl << "id:\t" << id << std::endl << "PoW:\t" << proof_of_work << std::endl << "difficulty:\t" << current_diff);
+      MGINFO_BLUE("Alt chain root: " << alt_chain.front()->second.bl.prev_id);
+      MGINFO_BLUE("Alt chain blocks:");
+      for (auto it : alt_chain)
+        MGINFO_BLUE("  " << it->first);
       return true;
     }
   }


### PR DESCRIPTION
I've noticed on Aeon testnet pool http://aeon.lol:8080/ that the pool often mines on a block older than the current top hash. This was caused by the blocktemplate cache not being updated properly, but I'm not sure exactly where the problem lies (as `invalidate_block_template_cache()` seems to be called as needed in blockchain.cpp).

This patch adds a cheap correctness check on the blocktemplate cache.