### PR TITLE
Add nbproject directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ local.properties
 # PDT-specific
 .buildpath
 
+# Netbeans-specific
+nbproject
+
 # sbteclipse plugin
 .target
 


### PR DESCRIPTION
Hi, this is my first patch.

I'm [one of the few] using NetBeans, and this PR adds the `nbproject` directory created by NetBeans to `.gitignore`.

Hope to make more contributions soon!
