### PR TITLE
Fixed error preventing build of monero-gui

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1705,7 +1705,9 @@ bool WalletImpl::setCacheAttribute(const std::string &key, const std::string &va
 
 std::string WalletImpl::getCacheAttribute(const std::string &key) const
 {
-    return m_wallet->get_attribute(key);
+    std::string value;
+    m_wallet->get_attribute(key, value);
+    return value;
 }
 
 bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)


### PR DESCRIPTION
get_attribute expects 2 values instead of 1