### PR TITLE
Gitian build script fixes for MacOS (osx)

### DIFF
--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -64,7 +64,7 @@ def build():
 
     if args.macos:
         print('\nCompiling ' + args.version + ' MacOS')
-        subprocess.check_call(['bin/gbuild', '-j', args.jobs, '-m', args.memory, '--commit', 'monero='+args.commit, '--url', 'monero'+args.url, '../monero/contrib/gitian/gitian-osx.yml'])
+        subprocess.check_call(['bin/gbuild', '-j', args.jobs, '-m', args.memory, '--commit', 'monero='+args.commit, '--url', 'monero='+args.url, '../monero/contrib/gitian/gitian-osx.yml'])
         subprocess.check_call(['bin/gsign', '-p', args.sign_prog, '--signer', args.signer, '--release', args.version+'-osx', '--destination', '../gitian.sigs/', '../monero/contrib/gitian/gitian-osx.yml'])
         subprocess.check_call('mv build/out/monero*.tar.gz ../monero-binaries/'+args.version, shell=True)
 
@@ -141,8 +141,8 @@ def main():
         if not 'LXC_GUEST_IP' in os.environ.keys():
             os.environ['LXC_GUEST_IP'] = '10.0.3.5'
 
-    # Disable for MacOS if no SDK found
-    if args.macos and not os.path.isfile('gitian-builder/inputs/MacOSX10.11.sdk.tar.gz'):
+    # Disable MacOS build if no SDK found
+    if args.build and args.macos and not os.path.isfile('gitian-builder/inputs/MacOSX10.11.sdk.tar.gz'):
         print('Cannot build for MacOS, SDK does not exist. Will build for other OSes')
         args.macos = False
 


### PR DESCRIPTION
Two non-critical issues being fixed here for MacOS.
1. Missing `=`.  Surprisingly this was not breaking the MacOS build ([gbuild](https://github.com/devrandom/gitian-builder/blob/master/bin/gbuild) expects `name=value` pairs!)  The reason this still builds is that the remote `url` was being interpreted as `nil` by ruby and then _defaulting_ to the url specified at [gitian-osx.yml#L27](https://github.com/monero-project/monero/blob/master/contrib/gitian/gitian-osx.yml#L27) 
2. A warning message _"Cannot build for MacOS, SDK does not exist. Will build for other OSes"_ was being shown incorrectly during the "setup" phase.  Explanation: During setup, `gitian-builder` will be cloned from https://github.com/devrandom/gitian-builder ... only after that can the MacOS SDK be added the the `inputs` subfolder.  The SDK will then be used only later in the "build" phase (where this warning message makes sense and will now be displayed).
<br>The correct order is: first to run the _setup_, then create the `inputs` subdir of `gitian-builder`, then copy the MacOS SDK there, then start the _build_ process.

@TheCharlatan Please review when possible.