### PR TITLE
hid_error() could return a null, which causes the program to crash with

### DIFF
--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -44,7 +44,8 @@ namespace hw {
     
     static std::string safe_hid_error(hid_device *hwdev) {
       if (hwdev) {
-        return  std::string((char*)hid_error(hwdev));
+        const char* error_str = (const char*)hid_error(hwdev);
+        return  std::string(error_str == nullptr ? "Unknown error" : error_str);
       }
       return std::string("NULL device");
     }


### PR DESCRIPTION
`hid_error()` could return a null, which causes the program to crash with std::logic_error(), since a string cannot take a null in its constructor.

I saw this error on reddit, and I'm facing the same problem. So I fixed it. 
