### PR TITLE
Fix IPv6 addr parsing for boost <1.66

### DIFF
--- a/contrib/epee/include/net/local_ip.h
+++ b/contrib/epee/include/net/local_ip.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/ip/address_v6.hpp>
+#include <boost/version.hpp>
 
 namespace epee
 {
@@ -39,7 +40,11 @@ namespace epee
     inline
     bool is_ipv6_local(const std::string& ip)
     {
+#if BOOST_VERSION >= 106600
       auto addr = boost::asio::ip::make_address_v6(ip);
+#else
+      auto addr = boost::asio::ip::address_v6::from_string(ip);
+#endif
 
       // ipv6 link-local unicast addresses are fe80::/10
       bool is_link_local = addr.is_link_local();

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -28,6 +28,8 @@
 
 #include "parse.h"
 
+#include <boost/version.hpp>
+
 #include "net/tor_address.h"
 #include "net/i2p_address.h"
 #include "string_tools.h"
@@ -76,7 +78,11 @@ namespace net
             return i2p_address::make(address, default_port);
 
         boost::system::error_code ec;
-        boost::asio::ip::address_v6 v6 = boost::asio::ip::make_address_v6(host_str, ec);
+#if BOOST_VERSION >= 106600
+        auto v6 = boost::asio::ip::make_address_v6(host_str, ec);
+#else
+        auto v6 = boost::asio::ip::address_v6::from_string(host_str, ec);
+#endif
         ipv6 = !ec;
 
         std::uint16_t port = default_port;


### PR DESCRIPTION
Fixes a compilation failure under pre-1.66 boost introduced with PR #4851