### PR TITLE
Fix check for disconnecting peers when syncing

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -342,7 +342,7 @@ namespace cryptonote
 
     if(m_core.have_block(hshd.top_id))
     {
-      if (target > hshd.current_height)
+      if (target > m_core.get_current_blockchain_height())
       {
         MINFO(context << "peer is not ahead of us and we're syncing, disconnecting");
         return false;


### PR DESCRIPTION
The check added here (in #5732/#5733) is supposed to disconnect behind
peers when the current node is syncing, but actually disconnects behind
peers always.

We are syncing when `target > our_height`, but the check here triggers
when `target > remote_height`, which is basically always true when the
preceeding `m_core.have_block(hshd.top_id)` check is true.