### PR TITLE
make_address_v6 not introduced until boost 1.66

### DIFF
--- a/contrib/epee/include/net/local_ip.h
+++ b/contrib/epee/include/net/local_ip.h
@@ -39,7 +39,7 @@ namespace epee
     inline
     bool is_ipv6_local(const std::string& ip)
     {
-      auto addr = boost::asio::ip::make_address_v6(ip);
+      auto addr = boost::asio::ip::address_v6::from_string(ip);
 
       // ipv6 link-local unicast addresses are fe80::/10
       bool is_link_local = addr.is_link_local();

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -76,7 +76,7 @@ namespace net
             return i2p_address::make(address, default_port);
 
         boost::system::error_code ec;
-        boost::asio::ip::address_v6 v6 = boost::asio::ip::make_address_v6(host_str, ec);
+        boost::asio::ip::address_v6 v6 = boost::asio::ip::address_v6::from_string(host_str, ec);
         ipv6 = !ec;
 
         std::uint16_t port = default_port;


### PR DESCRIPTION
We support older boost than 1.66.