### PR TITLE
rpc: fix unitialized 'core_rpc_server::m_was_bootstrap_ever_used'

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -103,6 +103,7 @@ namespace cryptonote
     )
     : m_core(cr)
     , m_p2p(p2p)
+    , m_was_bootstrap_ever_used(false)
   {}
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::set_bootstrap_daemon(const std::string &address, const std::string &username_password)


### PR DESCRIPTION
Reported by @hyc on IRC