### PR TITLE
Fix uninitialized values for output_distribution

### DIFF
--- a/tests/unit_tests/output_distribution.cpp
+++ b/tests/unit_tests/output_distribution.cpp
@@ -93,7 +93,7 @@ bool get_output_distribution(uint64_t amount, uint64_t from, uint64_t to, uint64
 
 crypto::hash get_block_hash(uint64_t height)
 {
-  crypto::hash hash;
+  crypto::hash hash = crypto::null_hash;
   *((uint64_t*)&hash) = height;
   return hash;
 }


### PR DESCRIPTION
-   Initialize the `hash` in the `get_block_hash()` function of the
    `output_distribution` unit test explicitly, to silence `valgrind`
    warnings.

Before this change, running the `output_distribution` unit test
through `valgrind` results in warnings about uninitialized values.

To reproduce, build (in `Debug` mode) and run the unit tests
through `valgrind`:

```bash
valgrind \
  --log-file=valgrind.output_distribution.log \
  --leak-check=full \
  --track-origins=yes \
  ./build/tests/unit_tests/unit_tests \
  --gtest_filter=output_distribution.*
```

(Checked with Clang 8.0.0, GCC 8.3.0 and Valgrind 3.13.0.)