### PR TITLE
Fix Travis build on Windows + Mac

### DIFF
--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -12,7 +12,7 @@ packages += gtest
 endif
 
 ifneq ($(host_arch),riscv64)
-	packages += unwind
+linux_packages += unwind
 endif
 
 ifeq ($(host_os),mingw32)


### PR DESCRIPTION
Following 13c0b8c, the unwind package is being attempted to be built on
Windows and Mac when it should only be built on Linux.