### PR TITLE
Revert disconnection of peers "less synced" when we're syncing

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -342,7 +342,7 @@ namespace cryptonote
 
     if(m_core.have_block(hshd.top_id))
     {
-      if (target > m_core.get_current_blockchain_height())
+      if (target > hshd.current_height)
       {
         MINFO(context << "peer is not ahead of us and we're syncing, disconnecting");
         return false;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -342,11 +342,6 @@ namespace cryptonote
 
     if(m_core.have_block(hshd.top_id))
     {
-      if (target > hshd.current_height)
-      {
-        MINFO(context << "peer is not ahead of us and we're syncing, disconnecting");
-        return false;
-      }
       context.m_state = cryptonote_connection_context::state_normal;
       if(is_inital && target == m_core.get_current_blockchain_height())
         on_connection_synchronized();


### PR DESCRIPTION
It's not great and seems vulnerable to peers lying to cause disconnections of other peers, so we'll come up with a better way later.