### PR TITLE
abstract_tcp_server2: fix lingering connections

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -736,6 +736,11 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       MERROR("Resetting timer on a dead object");
       return;
     }
+    if (m_was_shutdown)
+    {
+      MERROR("Setting timer on a shut down object");
+      return;
+    }
     if (add)
       ms += m_timer.expires_from_now();
     m_timer.expires_from_now(ms);


### PR DESCRIPTION
Resetting the timer after shutdown was initiated would keep
a reference to the object inside ASIO, which would keep the
connection alive until the timer timed out