### PR TITLE
protocol: drop broken peers

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -41,8 +41,8 @@ namespace cryptonote
 
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
-    cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
-        m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
+    cryptonote_connection_context(): m_state(state_before_handshake), m_original_remote_blockchain_height(0), m_remote_blockchain_height(0), m_last_response_height(0),
+        m_connection_time(boost::date_time::not_a_date_time), m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
         m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_anchor(false) {}
 
     enum state
@@ -57,8 +57,10 @@ namespace cryptonote
     state m_state;
     std::vector<crypto::hash> m_needed_objects;
     std::unordered_set<crypto::hash> m_requested_objects;
+    uint64_t m_original_remote_blockchain_height;
     uint64_t m_remote_blockchain_height;
     uint64_t m_last_response_height;
+    boost::posix_time::ptime m_connection_time;
     boost::posix_time::ptime m_last_request_time;
     epee::copyable_atomic m_callback_request_count; //in debug purpose: problem with double callback rise
     crypto::hash m_last_known_hash;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -141,6 +141,7 @@ namespace cryptonote
     bool kick_idle_peers();
     bool check_standby_peers();
     bool update_sync_search();
+    bool drop_broken_peers();
     int try_add_next_blocks(cryptonote_connection_context &context);
     void notify_new_stripe(cryptonote_connection_context &context, uint32_t stripe);
     void skip_unneeded_hashes(cryptonote_connection_context& context, bool check_block_queue) const;
@@ -164,6 +165,7 @@ namespace cryptonote
     uint64_t m_sync_spans_downloaded, m_sync_old_spans_downloaded, m_sync_bad_spans_downloaded;
     uint64_t m_sync_download_chain_size, m_sync_download_objects_size;
     size_t m_block_download_max_size;
+    epee::math_helper::once_a_time_seconds<20> m_broken_peer_dropper;
 
     boost::mutex m_buffer_mutex;
     double get_avg_block_size();

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -71,6 +71,8 @@
 #define PASSIVE_PEER_KICK_TIME (60 * 1000000) // microseconds
 #define DROP_ON_SYNC_WEDGE_THRESHOLD (30 * 1000000000ull) // nanoseconds
 #define LAST_ACTIVITY_STALL_THRESHOLD (2.0f) // seconds
+#define DETECT_BROKEN_PEERS_TIME (90 * 1000000) // microseconds
+#define DROP_PEER_HEIGHT_INCREASE_THRESHOLD 128
 
 namespace cryptonote
 {
@@ -329,7 +331,10 @@ namespace cryptonote
       }
     }
 
+    context.m_original_remote_blockchain_height = hshd.current_height;
     context.m_remote_blockchain_height = hshd.current_height;
+    if (context.m_connection_time == boost::date_time::not_a_date_time)
+      context.m_connection_time = boost::posix_time::microsec_clock::universal_time();
     context.m_pruning_seed = hshd.pruning_seed;
 #ifdef CRYPTONOTE_PRUNING_DEBUG_SPOOF_SEED
     context.m_pruning_seed = tools::make_pruning_seed(1 + (context.m_remote_address.as<epee::net_utils::ipv4_network_address>().ip()) % (1 << CRYPTONOTE_PRUNING_LOG_STRIPES), CRYPTONOTE_PRUNING_LOG_STRIPES);
@@ -1453,6 +1458,7 @@ skip:
     m_idle_peer_kicker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::kick_idle_peers, this));
     m_standby_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::check_standby_peers, this));
     m_sync_search_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::update_sync_search, this));
+    m_broken_peer_dropper.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::drop_broken_peers, this));
     return m_core.on_idle();
   }
   //------------------------------------------------------------------------------------------------------------------------
@@ -1535,6 +1541,64 @@ skip:
       }
       return true;
     });
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------
+  template<class t_core>
+  bool t_cryptonote_protocol_handler<t_core>::drop_broken_peers()
+  {
+    const uint64_t height = m_core.get_current_blockchain_height();
+    const boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
+    std::vector<boost::uuids::uuid> drop;
+    m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
+    {
+      // only consider connections that have handshaked already
+      if (context.m_state == cryptonote_connection_context::state_before_handshake)
+      {
+        MTRACE(context << "Still in handshake");
+        return true;
+      }
+      // keep connections for some time before checking, so they have the time to start syncing
+      if (context.m_connection_time == boost::date_time::not_a_date_time)
+      {
+        MTRACE(context << "Not ready to check yet");
+        return true;
+      }
+      const uint64_t us = (now - context.m_connection_time).total_microseconds();
+      if (us < DETECT_BROKEN_PEERS_TIME)
+      {
+        MTRACE(context << "Not ready to check yet: " << us << ", needed: " << DETECT_BROKEN_PEERS_TIME);
+        return true;
+      }
+      if (!m_core.is_within_compiled_block_hash_area(m_core.get_current_blockchain_height()))
+      {
+        // if the node is up to date, or at most two blocks out, deem it fine
+        if (context.m_remote_blockchain_height + 2 >= height)
+        {
+          MTRACE(context << "Up to date enough");
+          return true;
+        }
+      }
+      // if the height has gone up in this time, deem it fine
+      if (context.m_remote_blockchain_height >= context.m_original_remote_blockchain_height + DROP_PEER_HEIGHT_INCREASE_THRESHOLD)
+      {
+        MTRACE(context << "Height has gone up from " << context.m_original_remote_blockchain_height << " to " << context.m_remote_blockchain_height);
+        return true;
+      }
+
+      // drop connection
+      MINFO(context << "Dropping broken peer");
+      drop.push_back(context.m_connection_id);
+
+      return true;
+    });
+    for (const boost::uuids::uuid &id: drop)
+    {
+      m_p2p->for_connection(id, [&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t f)->bool{
+        drop_connection(context, true, false);
+        return true;
+      });
+    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
For now, broken peers are peers that do not progress when we think
they ought to