### PR TITLE
device_ledger: always fetch keys on connect to speed up tx scanning

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -418,10 +418,13 @@ namespace hw {
       #ifdef DEBUG_HWDEVICE
       cryptonote::account_public_address pubkey;
       this->get_public_address(pubkey);
+      #endif
+
+      // as a side effect will cache secret view key in this->viewkey
+      // to speed up blockchain parsing
       crypto::secret_key vkey;
       crypto::secret_key skey;
       this->get_secret_keys(vkey,skey);
-      #endif
 
       return true;
     }


### PR DESCRIPTION
Revert 26f7a26ee3 'device: fix ledger requesting secret keys export twice'

`get_secret_keys` has unobvious side effect, it will cache secret view key in `this->viewkey` required to speed up blockchain scanning.

Added a comment.

PS: thanks to @selsta for reporting this