### PR TITLE
build: link wallet_merged against blockchain_db and hardforks obj

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -117,12 +117,14 @@ if (BUILD_GUI_DEPS)
             wallet_api
             wallet
             multisig
+            blockchain_db
             cryptonote_core
             cryptonote_basic
             mnemonics
             common
             cncrypto
             device
+            hardforks
             ringct
             ringct_basic
             checkpoints


### PR DESCRIPTION
Required due to RandomX integration