### PR TITLE
blockchain: tweak fee as a function of median values

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3334,7 +3334,8 @@ uint64_t Blockchain::get_dynamic_base_fee_estimate(uint64_t grace_blocks) const
   }
 
   const bool use_long_term_median_in_fee = version >= HF_VERSION_LONG_TERM_BLOCK_WEIGHT;
-  uint64_t fee = get_dynamic_base_fee(base_reward, use_long_term_median_in_fee ? m_long_term_effective_median_block_weight : median, version);
+  const uint64_t use_median_value = use_long_term_median_in_fee ? std::min<uint64_t>(median, m_long_term_effective_median_block_weight) : median;
+  const uint64_t fee = get_dynamic_base_fee(base_reward, use_median_value, version);
   const bool per_byte = version < HF_VERSION_PER_BYTE_FEE;
   MDEBUG("Estimating " << grace_blocks << "-block fee at " << print_money(fee) << "/" << (per_byte ? "byte" : "kB"));
   return fee;


### PR DESCRIPTION
Use the lesser of the short and long terms medians, rather then
the long term median alone

From ArticMine:

I found a bug in the new fee calculation formula with using only the long term median
It actually needs to be the lesser of the long term median and the old (modified short term median)
short term median with the last 10 blocks calculated as empty
Yes the issue occurs if there is a large long term median and, the short term median then falls and tries to then rise again
The fees are could be not high enough
for example LTM and STM rise to say 2000000 bytes
STM falls back to 300000 bytes
Fees are now based on 2000000 bytes until LTM also falls
So the STM is could prevented from rising back up
STM short term median LTM long term median