### PR TITLE
Support median block size > 4 GB

### DIFF
--- a/contrib/epee/include/int-util.h
+++ b/contrib/epee/include/int-util.h
@@ -129,6 +129,9 @@ static inline uint32_t div128_32(uint64_t dividend_hi, uint64_t dividend_lo, uin
   return remainder;
 }
 
+// Long divisor with 2^64 base
+void div128_64(uint64_t dividend_hi, uint64_t dividend_lo, uint64_t divisor, uint64_t* quotient_hi, uint64_t *quotient_lo, uint64_t *remainder_hi, uint64_t *remainder_lo);
+
 #define IDENT16(x) ((uint16_t) (x))
 #define IDENT32(x) ((uint32_t) (x))
 #define IDENT64(x) ((uint64_t) (x))

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -27,7 +27,8 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 add_library(epee STATIC byte_slice.cpp hex.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp
-    levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp)
+    levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
+    int-util.cpp)
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR DEPENDS AND NOT MINGW))
   add_library(epee_readline STATIC readline_buffer.cpp)

--- a/contrib/epee/src/int-util.cpp
+++ b/contrib/epee/src/int-util.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2019, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+void div128_64(uint64_t dividend_hi, uint64_t dividend_lo, uint64_t divisor, uint64_t* quotient_hi, uint64_t *quotient_lo, uint64_t *remainder_hi, uint64_t *remainder_lo)
+{
+  typedef boost::multiprecision::uint128_t uint128_t;
+
+  uint128_t dividend = dividend_hi;
+  dividend <<= 64;
+  dividend |= dividend_lo;
+
+  uint128_t q, r;
+  divide_qr(dividend, uint128_t(divisor), q, r);
+
+  *quotient_hi = ((q >> 64) & 0xffffffffffffffffull).convert_to<uint64_t>();
+  *quotient_lo = (q & 0xffffffffffffffffull).convert_to<uint64_t>();
+  if (remainder_hi)
+    *remainder_hi = ((r >> 64) & 0xffffffffffffffffull).convert_to<uint64_t>();
+  if (remainder_lo)
+    *remainder_lo = (r & 0xffffffffffffffffull).convert_to<uint64_t>();
+}

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -110,9 +110,6 @@ namespace cryptonote {
       return false;
     }
 
-    assert(median_weight < std::numeric_limits<uint32_t>::max());
-    assert(current_block_weight < std::numeric_limits<uint32_t>::max());
-
     uint64_t product_hi;
     // BUGFIX: 32-bit saturation bug (e.g. ARM7), the result was being
     // treated as 32-bit by default.
@@ -122,8 +119,8 @@ namespace cryptonote {
 
     uint64_t reward_hi;
     uint64_t reward_lo;
-    div128_32(product_hi, product_lo, static_cast<uint32_t>(median_weight), &reward_hi, &reward_lo);
-    div128_32(reward_hi, reward_lo, static_cast<uint32_t>(median_weight), &reward_hi, &reward_lo);
+    div128_64(product_hi, product_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
+    div128_64(reward_hi, reward_lo, median_weight, &reward_hi, &reward_lo, NULL, NULL);
     assert(0 == reward_hi);
     assert(reward_lo < base_reward);
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3223,8 +3223,8 @@ uint64_t Blockchain::get_dynamic_base_fee(uint64_t block_reward, size_t median_b
   if (version >= HF_VERSION_PER_BYTE_FEE)
   {
     lo = mul128(block_reward, DYNAMIC_FEE_REFERENCE_TRANSACTION_WEIGHT, &hi);
-    div128_32(hi, lo, min_block_weight, &hi, &lo);
-    div128_32(hi, lo, median_block_weight, &hi, &lo);
+    div128_64(hi, lo, min_block_weight, &hi, &lo, NULL, NULL);
+    div128_64(hi, lo, median_block_weight, &hi, &lo, NULL, NULL);
     assert(hi == 0);
     lo /= 5;
     return lo;
@@ -3234,12 +3234,7 @@ uint64_t Blockchain::get_dynamic_base_fee(uint64_t block_reward, size_t median_b
 
   uint64_t unscaled_fee_base = (fee_base * min_block_weight / median_block_weight);
   lo = mul128(unscaled_fee_base, block_reward, &hi);
-  static_assert(DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD % 1000000 == 0, "DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD must be divisible by 1000000");
-  static_assert(DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD / 1000000 <= std::numeric_limits<uint32_t>::max(), "DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD is too large");
-
-  // divide in two steps, since the divisor must be 32 bits, but DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD isn't
-  div128_32(hi, lo, DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD / 1000000, &hi, &lo);
-  div128_32(hi, lo, 1000000, &hi, &lo);
+  div128_64(hi, lo, DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD, &hi, &lo, NULL, NULL);
   assert(hi == 0);
 
   // quantize fee up to 8 decimals

--- a/tests/unit_tests/mul_div.cpp
+++ b/tests/unit_tests/mul_div.cpp
@@ -130,6 +130,19 @@ namespace
     // Division by zero is UB, so can be tested correctly
   }
 
+  TEST(div128_64, handles_zero)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+    div128_64(0, 0, 7, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 0);
+    ASSERT_EQ(qlo, 0);
+
+    // Division by zero is UB, so can be tested correctly
+  }
+
   TEST(div128_32, handles_one)
   {
     uint32_t reminder;
@@ -147,6 +160,23 @@ namespace
     ASSERT_EQ(lo, 0);
   }
 
+  TEST(div128_64, handles_one)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+     div128_64(0, 7, 1, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 0);
+    ASSERT_EQ(qlo, 7);
+
+    div128_64(7, 0, 1, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 7);
+    ASSERT_EQ(qlo, 0);
+  }
+
   TEST(div128_32, handles_if_dividend_less_divider)
   {
     uint32_t reminder;
@@ -159,6 +189,17 @@ namespace
     ASSERT_EQ(lo, 0);
   }
 
+  TEST(div128_64, handles_if_dividend_less_divider)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+    div128_64(0, 1383746, 1645825, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 1383746);
+    ASSERT_EQ(qhi, 0);
+    ASSERT_EQ(qlo, 0);
+  }
+
   TEST(div128_32, handles_if_dividend_dwords_less_divider)
   {
     uint32_t reminder;
@@ -169,6 +210,17 @@ namespace
     ASSERT_EQ(reminder, 0xB9C924E9);
     ASSERT_EQ(hi, 0x000000005B63C274);
     ASSERT_EQ(lo, 0x9084FC024383E48C);
+  }
+
+  TEST(div128_64, handles_if_dividend_dwords_less_divider)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+    div128_64(0x5AD629E441074F28, 0x0DBCAB2B231081F1, 0xFE735CD6, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0xB9C924E9);
+    ASSERT_EQ(qhi, 0x000000005B63C274);
+    ASSERT_EQ(qlo, 0x9084FC024383E48C);
   }
 
   TEST(div128_32, works_correctly)
@@ -201,5 +253,69 @@ namespace
     ASSERT_EQ(reminder, 0x1a6dc2e5);
     ASSERT_EQ(hi, 0x00000000f812c1f8);
     ASSERT_EQ(lo, 0xddf2fdb09bc2e2e9);
+  }
+
+  TEST(div128_64, works_correctly)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+    div128_64(2, 0, 2, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 1);
+    ASSERT_EQ(qlo, 0);
+
+    div128_64(0xffffffffffffffff, 0, 0xffffffff, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 0x0000000100000001);
+    ASSERT_EQ(qlo, 0);
+
+    div128_64(0xffffffffffffffff, 5846, 0xffffffff, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 5846);
+    ASSERT_EQ(qhi, 0x0000000100000001);
+    ASSERT_EQ(qlo, 0);
+
+    div128_64(0xffffffffffffffff - 1, 0, 0xffffffff, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0xfffffffe);
+    ASSERT_EQ(qhi, 0x0000000100000000);
+    ASSERT_EQ(qlo, 0xfffffffefffffffe);
+
+    div128_64(0x2649372534875028, 0xaedbfedc5adbc739, 0x27826534, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0x1a6dc2e5);
+    ASSERT_EQ(qhi, 0x00000000f812c1f8);
+    ASSERT_EQ(qlo, 0xddf2fdb09bc2e2e9);
+  }
+
+  TEST(div128_64, divisor_above_32_bit)
+  {
+    uint64_t qhi, qlo, rhi, rlo;
+
+    div128_64(0, 0xffffffff, (uint64_t)0x100000000, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0xffffffff);
+    ASSERT_EQ(qhi, 0);
+    ASSERT_EQ(qlo, 0);
+
+    div128_64(0, 65, 4, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 1);
+    ASSERT_EQ(qhi, 0);
+    ASSERT_EQ(qlo, 16);
+
+    div128_64(405997335029502627ull, 2552775575832427192ull, 489327483788363ull, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 198332080500810ull);
+    ASSERT_EQ(qhi, 829ull);
+    ASSERT_EQ(qlo, 13000245803763621514ull);
+
+    div128_64(405997335029502627ull, 2552775575832427192ull, 1ull, &qhi, &qlo, &rhi, &rlo);
+    ASSERT_EQ(rhi, 0);
+    ASSERT_EQ(rlo, 0);
+    ASSERT_EQ(qhi, 405997335029502627ull);
+    ASSERT_EQ(qlo, 2552775575832427192ull);
   }
 }


### PR DESCRIPTION
add a 128/64 division routine so we can use a > 32 bit median block
size in calculations