### PR TITLE
Fix build on FreeBSD/!x86

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -62,7 +62,9 @@
   #include <devstat.h>
   #include <errno.h>
   #include <fcntl.h>
+#if defined(__amd64__) || defined(__i386__)
   #include <machine/apm_bios.h>
+#endif
   #include <stdio.h>
   #include <sys/resource.h>
   #include <sys/sysctl.h>
@@ -1086,6 +1088,7 @@ namespace cryptonote
           return boost::logic::tribool(boost::logic::indeterminate);
         }
 
+#if defined(__amd64__) || defined(__i386__)
         apm_info info;
         if( ioctl(fd, APMIO_GETINFO, &info) == -1 ) {
           close(fd);
@@ -1126,6 +1129,7 @@ namespace cryptonote
         LOG_ERROR("sysctlbyname(\"hw.acpi.acline\") output is unexpectedly "
           << n << " bytes instead of the expected " << sizeof(ac) << " bytes.");
         return boost::logic::tribool(boost::logic::indeterminate);
+#endif
       }
       return boost::logic::tribool(ac == 0);
     #endif

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -62,7 +62,7 @@
   #include <devstat.h>
   #include <errno.h>
   #include <fcntl.h>
-#if defined(__amd64__) || defined(__i386__)
+#if defined(__amd64__) || defined(__i386__) || defined(__x86_64__)
   #include <machine/apm_bios.h>
 #endif
   #include <stdio.h>
@@ -1088,7 +1088,7 @@ namespace cryptonote
           return boost::logic::tribool(boost::logic::indeterminate);
         }
 
-#if defined(__amd64__) || defined(__i386__)
+#if defined(__amd64__) || defined(__i386__) || defined(__x86_64__)
         apm_info info;
         if( ioctl(fd, APMIO_GETINFO, &info) == -1 ) {
           close(fd);


### PR DESCRIPTION
Checking battery status uses x86-only headers and functions. Remove this functionality to get it to build on other architectures.