### PR TITLE
utils: Increase max block size for import/export

### DIFF
--- a/src/blockchain_utilities/blockchain_utilities.h
+++ b/src/blockchain_utilities/blockchain_utilities.h
@@ -33,7 +33,7 @@
 
 // bounds checking is done before writing to buffer, but buffer size
 // should be a sensible maximum
-#define BUFFER_SIZE 1000000
+#define BUFFER_SIZE (2 * 1024 * 1024)
 #define CHUNK_SIZE_WARNING_THRESHOLD 500000
 #define NUM_BLOCKS_PER_CHUNK 1
 #define BLOCKCHAIN_RAW "blockchain.raw"


### PR DESCRIPTION
This limit must be increased, otherwise the stagenet blockchain cannot be imported. Fixes #5957 