### PR TITLE
v12 fork heights

### DIFF
--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -64,6 +64,9 @@ const hardfork_t mainnet_hard_forks[] = {
 
   // version 11 starts from block 1788720, which is on or around the 10th of March, 2019. Fork time finalised on 2019-02-15.
   { 11, 1788720, 0, 1550225678 },
+
+  // version 12 starts from block 1978433, which is on or around the 30th of November, 2019. Fork time finalised on 2019-10-18.
+  { 12, 1978433, 0, 1571419280 },
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
@@ -106,5 +109,6 @@ const hardfork_t stagenet_hard_forks[] = {
   { 9, 177176, 0, 1537821771 },
   { 10, 269000, 0, 1550153694 },
   { 11, 269720, 0, 1550225678 },
+  { 12, 454721, 0, 1571419280 },
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);


### PR DESCRIPTION
* Mainnet: 1978433 (~30th November), according to preliminary consensus from the 2019-09-22 dev meeting.
* Stagenet: 454721 (~16th November), 2 weeks before the mainnet as has been the case for the v8 and v10 forks.
* Testnet: already forked

All fork heights correspond to the beginning of a RandomX epoch (`height % 2048 == 65`).