### PR TITLE
Fix RandomX JIT on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,9 @@ We expect to add Monero into the ports tree in the near future, which will aid i
 You will need to add a few packages to your system. `pkg_add cmake gmake zeromq cppzmq libiconv boost`.
 
 The `doxygen` and `graphviz` packages are optional and require the xbase set.
-Running the test suite also requires `py-requests` package.
+Running the test suite also requires the `py-requests` package.
 
-Build monero: `env DEVELOPER_LOCAL_TOOLS=1 BOOST_ROOT=/usr/local gmake release-static`
+Build monero: `gmake release-static`
 
 Note: you may encounter the following error, when compiling the latest version of monero as a normal user:
 

--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -285,8 +285,12 @@ void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const ch
     randomx_flags flags = RANDOMX_FLAG_DEFAULT;
     if (use_rx_jit()) {
       flags |= RANDOMX_FLAG_JIT;
+#ifdef __OpenBSD__
+      flags |= RANDOMX_FLAG_SECURE;
+#else
       if (!miners)
           flags |= RANDOMX_FLAG_SECURE;
+#endif
     }
     if(!force_software_aes() && check_aes_hw())
       flags |= RANDOMX_FLAG_HARD_AES;


### PR DESCRIPTION
Added the `RANDOMX_FLAG_SECURE` for the JIT on OpenBSD.
For a successful build on OpenBSD PR https://github.com/tevador/RandomX/pull/139 needs to be merged and imported into the monero tree.

Cleaned up build instructions.