### PR TITLE
epee: use SO_REUSEADDR on non-Windows targets

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -984,7 +984,9 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       boost::asio::ip::tcp::resolver::query query(address, boost::lexical_cast<std::string>(port), boost::asio::ip::tcp::resolver::query::canonical_name);
       boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
       acceptor_.open(endpoint.protocol());
-      acceptor_.set_option(boost::asio::ip::tcp::acceptor::linger(true, 0));
+#if !defined(_WIN32)
+      acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+#endif
       acceptor_.bind(endpoint);
       acceptor_.listen();
       boost::asio::ip::tcp::endpoint binded_endpoint = acceptor_.local_endpoint();
@@ -1018,7 +1020,9 @@ PRAGMA_WARNING_DISABLE_VS(4355)
         boost::asio::ip::tcp::resolver::query query(address_ipv6, boost::lexical_cast<std::string>(port_ipv6), boost::asio::ip::tcp::resolver::query::canonical_name);
         boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
         acceptor_ipv6.open(endpoint.protocol());
-        acceptor_ipv6.set_option(boost::asio::ip::tcp::acceptor::linger(true, 0));
+#if !defined(_WIN32)
+        acceptor_ipv6.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+#endif
         acceptor_ipv6.set_option(boost::asio::ip::v6_only(true));
         acceptor_ipv6.bind(endpoint);
         acceptor_ipv6.listen();


### PR DESCRIPTION
Fixes #6005