### PR TITLE
Add missing lock in tx_pool::check_tx_inputs

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1047,6 +1047,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::check_tx_inputs(const std::function<cryptonote::transaction&(void)> &get_tx, const crypto::hash &txid, uint64_t &max_used_block_height, crypto::hash &max_used_block_id, tx_verification_context &tvc, bool kept_by_block) const
   {
+    CRITICAL_REGION_LOCAL(m_transactions_lock);
     if (!kept_by_block)
     {
       const std::unordered_map<crypto::hash, std::tuple<bool, tx_verification_context, uint64_t, crypto::hash>>::const_iterator i = m_input_cache.find(txid);


### PR DESCRIPTION
Both the read from and the write to m_input_cache need to be protected
by a lock on the mempool. Parallel writes are clearly a problem, but the
read also needs coverage because a parallel write during the read could
cause issues.

This might not be an issue now due to the conditions in which `tx_pool::check_tx_inputs` is called, but at least it's good for consistency, I think.