### PR TITLE
typo: changed 'batttery' to 'battery'

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4913,7 +4913,7 @@ void simple_wallet::check_background_mining(const epee::wipeable_string &passwor
   if (setup == tools::wallet2::BackgroundMiningMaybe)
   {
     message_writer() << tr("The daemon is not set up to background mine.");
-    message_writer() << tr("With background mining enabled, the daemon will mine when idle and not on batttery.");
+    message_writer() << tr("With background mining enabled, the daemon will mine when idle and not on battery.");
     message_writer() << tr("Enabling this supports the network you are using, and makes you eligible for receiving new monero");
     std::string accepted = input_line(tr("Do you want to do it now? (Y/Yes/N/No): "));
     if (std::cin.eof() || !command_line::is_yes(accepted)) {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -288,7 +288,7 @@ namespace tools
     if (setup == tools::wallet2::BackgroundMiningMaybe)
     {
       MINFO("The daemon is not set up to background mine.");
-      MINFO("With background mining enabled, the daemon will mine when idle and not on batttery.");
+      MINFO("With background mining enabled, the daemon will mine when idle and not on battery.");
       MINFO("Enabling this supports the network you are using, and makes you eligible for receiving new monero");
       MINFO("Set setup-background-mining to 1 in monero-wallet-cli to change.");
       return;
@@ -307,7 +307,7 @@ namespace tools
       return;
     }
 
-    MINFO("Background mining enabled. The daemon will mine when idle and not on batttery.");
+    MINFO("Background mining enabled. The daemon will mine when idle and not on battery.");
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::not_open(epee::json_rpc::error& er)

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ar.ts
+++ b/translations/monero_ar.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_bg.ts
+++ b/translations/monero_bg.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_bn.ts
+++ b/translations/monero_bn.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_cat.ts
+++ b/translations/monero_cat.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_cs.ts
+++ b/translations/monero_cs.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_da.ts
+++ b/translations/monero_da.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_de.ts
+++ b/translations/monero_de.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_eo.ts
+++ b/translations/monero_eo.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_es.ts
+++ b/translations/monero_es.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_fa.ts
+++ b/translations/monero_fa.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_fi.ts
+++ b/translations/monero_fi.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -2944,7 +2944,7 @@ votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent 
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ga.ts
+++ b/translations/monero_ga.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_he.ts
+++ b/translations/monero_he.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_hi.ts
+++ b/translations/monero_hi.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_hr.ts
+++ b/translations/monero_hr.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_hu.ts
+++ b/translations/monero_hu.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_id.ts
+++ b/translations/monero_id.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -2107,7 +2107,7 @@ di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono in nessun ca
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -2153,7 +2153,7 @@ your wallet again (your wallet keys are NOT at risk in any case).
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_kmr.ts
+++ b/translations/monero_kmr.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ko.ts
+++ b/translations/monero_ko.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_lt.ts
+++ b/translations/monero_lt.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_nl.ts
+++ b/translations/monero_nl.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_pl.ts
+++ b/translations/monero_pl.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_pt-br.ts
+++ b/translations/monero_pt-br.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_pt-pt.ts
+++ b/translations/monero_pt-pt.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ro.ts
+++ b/translations/monero_ro.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ru.ts
+++ b/translations/monero_ru.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_sk.ts
+++ b/translations/monero_sk.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_sl.ts
+++ b/translations/monero_sl.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_sr.ts
+++ b/translations/monero_sr.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -2169,7 +2169,7 @@ din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som 
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_tr.ts
+++ b/translations/monero_tr.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_uk.ts
+++ b/translations/monero_uk.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_ur.ts
+++ b/translations/monero_ur.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_zh-cn.ts
+++ b/translations/monero_zh-cn.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_zh-tw.ts
+++ b/translations/monero_zh-tw.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero_zu.ts.ts
+++ b/translations/monero_zu.ts.ts
@@ -3427,7 +3427,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
-        <source>With background mining enabled, the daemon will mine when idle and not on batttery.</source>
+        <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
This is a serious PR.

#5862 