### PR TITLE
depends: bump cppzmq/zeromq4-1 to latest versions

### DIFF
--- a/contrib/depends/packages/cppzmq.mk
+++ b/contrib/depends/packages/cppzmq.mk
@@ -1,8 +1,8 @@
 package=cppzmq
-$(package)_version=4.2.3
+$(package)_version=4.4.1
 $(package)_download_path=https://github.com/zeromq/cppzmq/archive/
 $(package)_file_name=v$($(package)_version).tar.gz
-$(package)_sha256_hash=3e6b57bf49115f4ae893b1ff7848ead7267013087dc7be1ab27636a97144d373
+$(package)_sha256_hash=117fc1ca24d98dbe1a60c072cde13be863d429134907797f8e03f654ce679385
 $(package)_dependencies=zeromq
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.1.5
+$(package)_version=4.1.7
 $(package)_download_path=https://github.com/zeromq/zeromq4-1/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=04aac57f081ffa3a2ee5ed04887be9e205df3a7ddade0027460b8042432bdbcf
+$(package)_sha256_hash=31c383cfcd3be1dc8a66e448c403029e793687e70473b89c4cc0bd626e7da299
 $(package)_patches=9114d3957725acd34aa8b8d011585812f3369411.patch 9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
 
 define $(package)_set_vars


### PR DESCRIPTION
- 4.1.7 is a required security release
- `$(package)_patches` should still apply
- I have not looked into why exactly we are building against the 4.1 series instead of the 4.3 series though I assume 4.1 is somehow a repro build requisite (4.3 is the standard on the distributions I've seen - and it seems to build correctly)
- I have not tested these diffs (the build should still work though). Testers welcome.