### PR TITLE
Revert "changed 'batttery' to 'battery'"

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5187,7 +5187,7 @@ void simple_wallet::check_background_mining(const epee::wipeable_string &passwor
   if (setup == tools::wallet2::BackgroundMiningMaybe)
   {
     message_writer() << tr("The daemon is not set up to background mine.");
-    message_writer() << tr("With background mining enabled, the daemon will mine when idle and not on battery.");
+    message_writer() << tr("With background mining enabled, the daemon will mine when idle and not on batttery.");
     message_writer() << tr("Enabling this supports the network you are using, and makes you eligible for receiving new monero");
     std::string accepted = input_line(tr("Do you want to do it now? (Y/Yes/N/No): "));
     if (std::cin.eof() || !command_line::is_yes(accepted)) {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -288,7 +288,7 @@ namespace tools
     if (setup == tools::wallet2::BackgroundMiningMaybe)
     {
       MINFO("The daemon is not set up to background mine.");
-      MINFO("With background mining enabled, the daemon will mine when idle and not on battery.");
+      MINFO("With background mining enabled, the daemon will mine when idle and not on batttery.");
       MINFO("Enabling this supports the network you are using, and makes you eligible for receiving new monero");
       MINFO("Set setup-background-mining to 1 in monero-wallet-cli to change.");
       return;
@@ -307,7 +307,7 @@ namespace tools
       return;
     }
 
-    MINFO("Background mining enabled. The daemon will mine when idle and not on battery.");
+    MINFO("Background mining enabled. The daemon will mine when idle and not on batttery.");
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::not_open(epee::json_rpc::error& er)


### PR DESCRIPTION
This reverts commit d60c1b631274b47c607dd1c858f963bbd16aeebe introduced with #6019.

Changing the language files create conflicts in the repository on Weblate (as can be seen in #6025). 

~~@jakehemmerle please open another PR which edits only the `.cpp` files~~. See https://github.com/monero-project/monero/pull/6019#issuecomment-546471233.

Edit: make more sense if i simply leave the good changes on this PR.