### PR TITLE
miner: use verification mode for low diff one block nonce searches

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -476,7 +476,7 @@ namespace cryptonote
     for(; bl.nonce != std::numeric_limits<uint32_t>::max(); bl.nonce++)
     {
       crypto::hash h;
-      gbh(bl, height, tools::get_max_concurrency(), h);
+      gbh(bl, height, diffic <= 100 ? 0 : tools::get_max_concurrency(), h);
 
       if(check_hash(h, diffic))
       {


### PR DESCRIPTION
This avoids lengthy init times when testing