### PR TITLE
daemon: always use bootstrap daemon (if set) in '--no-sync' mode

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -112,6 +112,7 @@ namespace cryptonote
     void stop();
     void on_connection_close(cryptonote_connection_context &context);
     void set_max_out_peers(unsigned int max) { m_max_out_peers = max; }
+    bool no_sync() const { return m_no_sync; }
     void set_no_sync(bool value) { m_no_sync = value; }
     std::string get_peers_overview() const;
     std::pair<uint32_t, uint32_t> get_next_needed_pruning_stripe() const;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1903,7 +1903,8 @@ namespace cryptonote
     }
 
     auto current_time = std::chrono::system_clock::now();
-    if (current_time - m_bootstrap_height_check_time > std::chrono::seconds(30))  // update every 30s
+    if (!m_p2p.get_payload_object().no_sync() &&
+        current_time - m_bootstrap_height_check_time > std::chrono::seconds(30))  // update every 30s
     {
       {
         boost::upgrade_to_unique_lock<boost::shared_mutex> lock(upgrade_lock);
@@ -1927,9 +1928,10 @@ namespace cryptonote
       uint64_t top_height = m_core.get_current_blockchain_height();
       m_should_use_bootstrap_daemon = top_height + 10 < *bootstrap_daemon_height;
       MINFO((m_should_use_bootstrap_daemon ? "Using" : "Not using") << " the bootstrap daemon (our height: " << top_height << ", bootstrap daemon's height: " << *bootstrap_daemon_height << ")");
+
+      if (!m_should_use_bootstrap_daemon)
+        return false;
     }
-    if (!m_should_use_bootstrap_daemon)
-      return false;
 
     if (mode == invoke_http_mode::JON)
     {


### PR DESCRIPTION
Currently if a user restarts already synced daemon with `--bootstrap-daemon-address auto --no-sync` options, the daemon will immediately disable bootstrapping cause local blockchain is synced.
But it shouldn't do that if `--no-sync` is enabled.

Reported by @selsta 