### PR TITLE
gitian: fix out dir location

### DIFF
--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -50,7 +50,7 @@ def rebuild():
     global args, workdir
 
     print('\nBuilding Dependencies\n')
-    os.makedirs('out/' + args.version, exist_ok=True)
+    os.makedirs('../out/' + args.version, exist_ok=True)
 
     if args.linux:
         print('\nCompiling ' + args.version + ' Linux')


### PR DESCRIPTION
Create out dir in workdir, not in builder dir to make copying of archives succeed.