### PR TITLE
lmdb: Remove meaningless const qualifier on function type

### DIFF
--- a/src/lmdb/table.h
+++ b/src/lmdb/table.h
@@ -15,8 +15,8 @@ namespace lmdb
     {
         char const* const name;
         const unsigned flags;
-        MDB_cmp_func const* const key_cmp;
-        MDB_cmp_func const* const value_cmp;
+        MDB_cmp_func* const key_cmp;
+        MDB_cmp_func* const value_cmp;
 
         //! \pre `name != nullptr` \return Open table.
         expect<MDB_dbi> open(MDB_txn& write_txn) const noexcept;


### PR DESCRIPTION
> 23:04 <+hyc> would be nice sto shut these warnings up http://paste.debian.net/1113538/

> n file included from /home/ubuntu/build/monero/src/lmdb/table.cpp:27:
/home/ubuntu/build/monero/src/lmdb/table.h:18:22: warning: 'const' qualifier on function type 'MDB_cmp_func' (aka 'int (const MDB_val *, const MDB_val *)') has no effect [-Wignored-qualifiers]
        MDB_cmp_func const* const key_cmp;
                     ^~~~~
/home/ubuntu/build/monero/src/lmdb/table.h:19:22: warning: 'const' qualifier on function type 'MDB_cmp_func' (aka 'int (const MDB_val *, const MDB_val *)') has no effect [-Wignored-qualifiers]
        MDB_cmp_func const* const value_cmp;
                     ^~~~~


A free function cannot be const, so a pointer to a const one is meaningless. The compiler ignores this qualifier, but warns about it.

