### PR TITLE
core_tests: reset thread pool between tests

### DIFF
--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -69,12 +69,17 @@ public:
   // task to finish.
   void submit(waiter *waiter, std::function<void()> f, bool leaf = false);
 
+  // destroy and recreate threads
+  void recycle();
+
   unsigned int get_max_concurrency() const;
 
   ~threadpool();
 
   private:
     threadpool(unsigned int max_threads = 0);
+    void destroy();
+    void create(unsigned int max_threads);
     typedef struct entry {
       waiter *wo;
       std::function<void()> f;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -47,6 +47,7 @@
 #include "include_base_utils.h"
 #include "common/boost_serialization_helper.h"
 #include "common/command_line.h"
+#include "common/threadpool.h"
 
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -758,6 +759,7 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
 
   t_test_class validator;
   bool ret = replay_events_through_core<t_test_class>(c, events, validator);
+  tools::threadpool::getInstance().recycle();
 //  c.deinit();
   return ret;
 }


### PR DESCRIPTION
Avoids a DB error (leading to an assert) where a thread uses
a read txn previously created with an environment that was
since closed and reopened. While this usually works since
BlockchainLMDB renews txns if it detects the environment has
changed, this will not work if objects end up being allocated
at the same address as the previous instance, leading to stale
data usage.

Thanks hyc for the LMDB debugging.