### PR TITLE
threadpool: use std::move when taking an element off the queue

### DIFF
--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -145,7 +145,7 @@ void threadpool::run(bool flush) {
     if (!running) break;
 
     active++;
-    e = queue.front();
+    e = std::move(queue.front());
     queue.pop_front();
     lock.unlock();
     ++depth;


### PR DESCRIPTION
It has a std::function, which can have a capture context, and
the function runtime might be small