### PR TITLE
Add __pycache__ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ nbproject
 .idea/
 
 /testnet
+
+__pycache__/


### PR DESCRIPTION
When running the functional_tests I noticed that this directory got created, probably should be ignored.