### PR TITLE
epee: reorder a couple init list fields to match declaration

### DIFF
--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -103,8 +103,8 @@ namespace net_utils
 			blocked_mode_client() :
 				m_io_service(),
 				m_ctx(boost::asio::ssl::context::tlsv12),
-				m_connector(direct_connect{}),
 				m_ssl_socket(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(m_io_service, m_ctx)),
+				m_connector(direct_connect{}),
 				m_ssl_options(epee::net_utils::ssl_support_t::e_ssl_support_autodetect),
 				m_initialized(true),
 				m_connected(false),

--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -584,8 +584,8 @@ namespace
       explicit server_parameters(const auth_message& request, const DigestIter& digest)
         : nonce(request.nonce)
         , opaque(request.opaque)
-        , stale(request.stale)
         , realm(request.realm)
+        , stale(request.stale)
         , value_generator()
         , index(boost::fusion::distance(boost::fusion::begin(digest_algorithms), digest))
       {


### PR DESCRIPTION
This is a bug waiting to happen