### PR TITLE
unit_tests: remove invalid bulletproofs unit test

### DIFF
--- a/tests/unit_tests/bulletproofs.cpp
+++ b/tests/unit_tests/bulletproofs.cpp
@@ -179,15 +179,6 @@ TEST(bulletproofs, invalid_31)
   ASSERT_FALSE(rct::bulletproof_VERIFY(proof));
 }
 
-TEST(bulletproofs, invalid_gamma_0)
-{
-  rct::key invalid_amount = rct::zero();
-  invalid_amount[8] = 1;
-  rct::key gamma = rct::zero();
-  rct::Bulletproof proof = bulletproof_PROVE(invalid_amount, gamma);
-  ASSERT_FALSE(rct::bulletproof_VERIFY(proof));
-}
-
 static const char * const torsion_elements[] =
 {
   "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",


### PR DESCRIPTION
It was intended to check a case which is actually valid (0 gamma),
but was actually duplicating the bad amount test.

Reported by WhatDo_ on IRC.