### PR TITLE
ssl: allow multiple version of TLS

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -285,7 +285,7 @@ ssl_options_t::ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints
 
 boost::asio::ssl::context ssl_options_t::create_context() const
 {
-  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::tlsv12};
+  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::tls};
   if (!bool(*this))
     return ssl_context;
 


### PR DESCRIPTION
boost::asio::ssl::context is created using specifically TLSv1.2, which
block the ability to use superior version of TLS.

Filtering is also made specially later in the code to remove unsafe
version for TLS such SSLv2, SSLv3 etc..

This change is removing double filtering to allow TLSv1.2 and above to
be used.