### PR TITLE
Command line option to disable ban RPC clients

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -152,6 +152,7 @@ namespace cryptonote
     : m_core(cr)
     , m_p2p(p2p)
     , m_was_bootstrap_ever_used(false)
+    , disable_rpc_ban(false)
   {}
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::set_bootstrap_daemon(const std::string &address, const std::string &username_password)
@@ -241,6 +242,7 @@ namespace cryptonote
     if (!rpc_config)
       return false;
 
+    disable_rpc_ban = rpc_config->disable_rpc_ban;
     std::string address = command_line::get_arg(vm, arg_rpc_payment_address);
     if (!address.empty())
     {
@@ -353,7 +355,7 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::add_host_fail(const connection_context *ctx, unsigned int score)
   {
-    if(!ctx || !ctx->m_remote_address.is_blockable())
+    if(!ctx || !ctx->m_remote_address.is_blockable() || disable_rpc_ban)
       return false;
 
     CRITICAL_REGION_LOCAL(m_host_fails_score_lock);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -285,6 +285,7 @@ private:
     epee::critical_section m_host_fails_score_lock;
     std::map<std::string, uint64_t> m_host_fails_score;
     std::unique_ptr<rpc_payment> m_rpc_payment;
+    bool disable_rpc_ban;
   };
 }
 

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -103,6 +103,7 @@ namespace cryptonote
      , rpc_ssl_allowed_fingerprints({"rpc-ssl-allowed-fingerprints", rpc_args::tr("List of certificate fingerprints to allow")})
      , rpc_ssl_allow_chained({"rpc-ssl-allow-chained", rpc_args::tr("Allow user (via --rpc-ssl-certificates) chain certificates"), false})
      , rpc_ssl_allow_any_cert({"rpc-ssl-allow-any-cert", rpc_args::tr("Allow any peer certificate"), false})
+     , disable_rpc_ban({"disable-rpc-ban", rpc_args::tr("Do not ban hosts on RPC errors"), false, false})
   {}
 
   const char* rpc_args::tr(const char* str) { return i18n_translate(str, "cryptonote::rpc_args"); }
@@ -123,6 +124,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg.rpc_ssl_ca_certificates);
     command_line::add_arg(desc, arg.rpc_ssl_allowed_fingerprints);
     command_line::add_arg(desc, arg.rpc_ssl_allow_chained);
+    command_line::add_arg(desc, arg.disable_rpc_ban);
     if (any_cert_option)
       command_line::add_arg(desc, arg.rpc_ssl_allow_any_cert);
   }
@@ -136,6 +138,7 @@ namespace cryptonote
     config.bind_ipv6_address = command_line::get_arg(vm, arg.rpc_bind_ipv6_address);
     config.use_ipv6 = command_line::get_arg(vm, arg.rpc_use_ipv6);
     config.require_ipv4 = !command_line::get_arg(vm, arg.rpc_ignore_ipv4);
+    config.disable_rpc_ban = command_line::get_arg(vm, arg.disable_rpc_ban);
     if (!config.bind_ip.empty())
     {
       // always parse IP here for error consistency

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -65,6 +65,7 @@ namespace cryptonote
       const command_line::arg_descriptor<std::vector<std::string>> rpc_ssl_allowed_fingerprints;
       const command_line::arg_descriptor<bool> rpc_ssl_allow_chained;
       const command_line::arg_descriptor<bool> rpc_ssl_allow_any_cert;
+      const command_line::arg_descriptor<bool> disable_rpc_ban;
     };
 
     // `allow_any_cert` bool toggles `--rpc-ssl-allow-any-cert` configuration
@@ -85,5 +86,6 @@ namespace cryptonote
     std::vector<std::string> access_control_origins;
     boost::optional<tools::login> login; // currently `boost::none` if unspecified by user
     epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    bool disable_rpc_ban = false;
   };
 }


### PR DESCRIPTION
RPC clients ban feature counts how many errors every host has made and after it gets more than certain threshold the host is banned for 24 hours.  

Often public monero nodes are not exposed directly to internet but resides behind web server or a proxy. In this valid case the only remote host the node sees is proxy server's one. If one of external clients makes some RPC calls that end up with ban the RPC becomes unavailable for all the clients.

This is what happened with our public node lately.

If `--disable-rpc-ban` option is set the feature is disabled. 