### PR TITLE
depends: update libsodium to 1.0.18

### DIFF
--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -1,8 +1,8 @@
 package=sodium
-$(package)_version=1.0.16
+$(package)_version=1.0.18
 $(package)_download_path=https://download.libsodium.org/libsodium/releases/
 $(package)_file_name=libsodium-$($(package)_version).tar.gz
-$(package)_sha256_hash=eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533
+$(package)_sha256_hash=6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
 $(package)_patches=fix-whitespace.patch
 
 define $(package)_set_vars

--- a/contrib/depends/patches/sodium/fix-whitespace.patch
+++ b/contrib/depends/patches/sodium/fix-whitespace.patch
@@ -5,8 +5,8 @@ index b29f769..ca008ae 100755
 @@ -591,7 +591,7 @@ MAKEFLAGS=
  PACKAGE_NAME='libsodium'
  PACKAGE_TARNAME='libsodium'
- PACKAGE_VERSION='1.0.16'
--PACKAGE_STRING='libsodium 1.0.16'
+ PACKAGE_VERSION='1.0.18'
+-PACKAGE_STRING='libsodium 1.0.18'
 +PACKAGE_STRING='libsodium'
  PACKAGE_BUGREPORT='https://github.com/jedisct1/libsodium/issues'
  PACKAGE_URL='https://github.com/jedisct1/libsodium'


### PR DESCRIPTION
Version 1.0.16 is no longer provided on the same path of the libsodium release website.