### PR TITLE
Gitian: Change lxc ip link

### DIFF
--- a/contrib/gitian/README.md
+++ b/contrib/gitian/README.md
@@ -62,7 +62,7 @@ echo "%sudo ALL=NOPASSWD: /usr/bin/lxc-execute" >> /etc/sudoers.d/gitian-lxc
 # make /etc/rc.local script that sets up bridge between guest and host
 echo '#!/bin/sh -e' > /etc/rc.local
 echo 'brctl addbr br0' >> /etc/rc.local
-echo 'ip addr add 10.0.3.1/24 broadcast 10.0.3.255 dev br0' >> /etc/rc.local
+echo 'ip addr add 10.0.2.2/24 broadcast 10.0.2.255 dev br0' >> /etc/rc.local
 echo 'ip link set br0 up' >> /etc/rc.local
 echo 'firewall-cmd --zone=trusted --add-interface=br0' >> /etc/rc.local
 echo 'exit 0' >> /etc/rc.local
@@ -70,8 +70,8 @@ chmod +x /etc/rc.local
 # make sure that USE_LXC is always set when logging in as gitianuser,
 # and configure LXC IP addresses
 echo 'export USE_LXC=1' >> /home/gitianuser/.profile
-echo 'export GITIAN_HOST_IP=10.0.3.1' >> /home/gitianuser/.profile
-echo 'export LXC_GUEST_IP=10.0.3.5' >> /home/gitianuser/.profile
+echo 'export GITIAN_HOST_IP=10.0.2.2' >> /home/gitianuser/.profile
+echo 'export LXC_GUEST_IP=10.0.2.5' >> /home/gitianuser/.profile
 reboot
 ```
 

--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -157,9 +157,9 @@ def main():
     elif not args.kvm:
         os.environ['USE_LXC'] = '1'
         if not 'GITIAN_HOST_IP' in os.environ.keys():
-            os.environ['GITIAN_HOST_IP'] = '10.0.3.1'
+            os.environ['GITIAN_HOST_IP'] = '10.0.2.2'
         if not 'LXC_GUEST_IP' in os.environ.keys():
-            os.environ['LXC_GUEST_IP'] = '10.0.3.5'
+            os.environ['LXC_GUEST_IP'] = '10.0.2.5'
 
     # Disable MacOS build if no SDK found
     args.nomac = False


### PR DESCRIPTION
The ip link currently listed in the README no longer works on the newest version of lxc shipped with ubuntu 18.04, this commit corrects this.