### PR TITLE
p2p: fix frequent weak_ptr exception on connection

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -949,7 +949,12 @@ bool async_protocol_handler_config<t_connection_context>::close(boost::uuids::uu
 {
   CRITICAL_REGION_LOCAL(m_connects_lock);
   async_protocol_handler<t_connection_context>* aph = find_connection(connection_id);
-  return 0 != aph ? aph->close() : false;
+  if (!aph)
+    return false;
+  if (!aph->close())
+    return false;
+  m_connects.erase(connection_id);
+  return true;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>


### PR DESCRIPTION
When a handshake fails, the handshake method was closing the
connection, and the caller was also doing so on error, triggering
the noisy (but harmless) exception.