### PR TITLE
Various improvements to the ZMQ JSON-RPC handling:

### DIFF
--- a/contrib/epee/include/hex.h
+++ b/contrib/epee/include/hex.h
@@ -51,9 +51,19 @@ namespace epee
     template<std::size_t N>
     static std::array<char, N * 2> array(const std::array<std::uint8_t, N>& src) noexcept
     {
-      std::array<char, N * 2> out{{}};
+      std::array<char, N * 2> out;
       static_assert(N <= 128, "keep the stack size down");
       buffer_unchecked(out.data(), {src.data(), src.size()});
+      return out;
+    }
+
+    //! \return An array containing hex of `src`.
+    template<typename T>
+    static std::array<char, sizeof(T) * 2> array(const T& src) noexcept
+    {
+      std::array<char, sizeof(T) * 2> out;
+      static_assert(sizeof(T) <= 128, "keep the stack size down");
+      buffer_unchecked(out.data(), as_byte_span(src));
       return out;
     }
 

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -28,6 +28,10 @@
 
 #include "daemon_handler.h"
 
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+
 #include <boost/uuid/nil_generator.hpp>
 // likely included by daemon_handler.h's includes,
 // but including here for clarity
@@ -42,6 +46,74 @@ namespace cryptonote
 
 namespace rpc
 {
+  namespace
+  {
+    using handler_function = std::string(DaemonHandler& handler, const rapidjson::Value& id, const rapidjson::Value& msg);
+    struct handler_map
+    {
+      const char* method_name;
+      handler_function* call;
+    };
+
+    bool operator<(const handler_map& lhs, const handler_map& rhs) noexcept
+    {
+      return std::strcmp(lhs.method_name, rhs.method_name) < 0;
+    }
+
+    bool operator<(const handler_map& lhs, const std::string& rhs) noexcept
+    {
+      return std::strcmp(lhs.method_name, rhs.c_str()) < 0;
+    }
+
+    template<typename Message>
+    std::string handle_message(DaemonHandler& handler, const rapidjson::Value& id, const rapidjson::Value& parameters)
+    {
+      typename Message::Request request{};
+      request.fromJson(parameters);
+
+      typename Message::Response response{};
+      handler.handle(request, response);
+      return FullMessage::getResponse(response, id);
+    }
+
+    constexpr const handler_map handlers[] =
+    {
+      {u8"get_block_hash", handle_message<GetBlockHash>},
+      {u8"get_block_header_by_hash", handle_message<GetBlockHeaderByHash>},
+      {u8"get_block_header_by_height", handle_message<GetBlockHeaderByHeight>},
+      {u8"get_block_headers_by_height", handle_message<GetBlockHeadersByHeight>},
+      {u8"get_blocks_fast", handle_message<GetBlocksFast>},
+      {u8"get_dynamic_fee_estimate", handle_message<GetFeeEstimate>},
+      {u8"get_hashes_fast", handle_message<GetHashesFast>},
+      {u8"get_height", handle_message<GetHeight>},
+      {u8"get_info", handle_message<GetInfo>},
+      {u8"get_last_block_header", handle_message<GetLastBlockHeader>},
+      {u8"get_output_distribution", handle_message<GetOutputDistribution>},
+      {u8"get_output_histogram", handle_message<GetOutputHistogram>},
+      {u8"get_output_keys", handle_message<GetOutputKeys>},
+      {u8"get_peer_list", handle_message<GetPeerList>},
+      {u8"get_rpc_version", handle_message<GetRPCVersion>},
+      {u8"get_transaction_pool", handle_message<GetTransactionPool>},
+      {u8"get_transactions", handle_message<GetTransactions>},
+      {u8"get_tx_global_output_indices", handle_message<GetTxGlobalOutputIndices>},
+      {u8"hard_fork_info", handle_message<HardForkInfo>},
+      {u8"key_images_spent", handle_message<KeyImagesSpent>},
+      {u8"mining_status", handle_message<MiningStatus>},
+      {u8"save_bc", handle_message<SaveBC>},
+      {u8"send_raw_tx", handle_message<SendRawTxHex>},
+      {u8"set_log_level", handle_message<SetLogLevel>},
+      {u8"start_mining", handle_message<StartMining>},
+      {u8"stop_mining", handle_message<StopMining>}
+    };
+  } // anonymous
+
+  DaemonHandler::DaemonHandler(cryptonote::core& c, t_p2p& p2p)
+    : m_core(c), m_p2p(p2p)
+  {
+    const auto last_sorted = std::is_sorted_until(std::begin(handlers), std::end(handlers));
+    if (last_sorted != std::end(handlers))
+      throw std::logic_error{std::string{"ZMQ JSON-RPC handlers map is not properly sorted, see "} + last_sorted->method_name};
+  }
 
   void DaemonHandler::handle(const GetHeight::Request& req, GetHeight::Response& res)
   {
@@ -840,68 +912,21 @@ namespace rpc
   {
     MDEBUG("Handling RPC request: " << request);
 
-    Message* resp_message = NULL;
-
     try
     {
       FullMessage req_full(request, true);
 
-      rapidjson::Value& req_json = req_full.getMessage();
-
       const std::string request_type = req_full.getRequestType();
-
-      // create correct Message subclass and call handle() on it
-      REQ_RESP_TYPES_MACRO(request_type, GetHeight, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetBlocksFast, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetHashesFast, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetTransactions, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, KeyImagesSpent, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetTxGlobalOutputIndices, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, SendRawTx, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, SendRawTxHex, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetInfo, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, StartMining, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, StopMining, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, MiningStatus, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, SaveBC, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetBlockHash, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetLastBlockHeader, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetBlockHeaderByHash, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetBlockHeaderByHeight, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetBlockHeadersByHeight, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetPeerList, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, SetLogLevel, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetTransactionPool, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, HardForkInfo, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetOutputHistogram, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetOutputKeys, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetRPCVersion, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetFeeEstimate, req_json, resp_message, handle);
-      REQ_RESP_TYPES_MACRO(request_type, GetOutputDistribution, req_json, resp_message, handle);
-
-      // if none of the request types matches
-      if (resp_message == NULL)
-      {
+      const auto matched_handler = std::lower_bound(std::begin(handlers), std::end(handlers), request_type);
+      if (matched_handler == std::end(handlers) || matched_handler->method_name != request_type)
         return BAD_REQUEST(request_type, req_full.getID());
-      }
 
-      FullMessage resp_full = FullMessage::responseMessage(resp_message, req_full.getID());
-
-      const std::string response = resp_full.getJson();
-      delete resp_message;
-      resp_message = NULL;
-
+      std::string response = matched_handler->call(*this, req_full.getID(), req_full.getMessage());
       MDEBUG("Returning RPC response: " << response);
-
       return response;
     }
     catch (const std::exception& e)
     {
-      if (resp_message)
-      {
-        delete resp_message;
-      }
-
       return BAD_JSON(e.what());
     }
   }

--- a/src/rpc/daemon_handler.h
+++ b/src/rpc/daemon_handler.h
@@ -50,7 +50,7 @@ class DaemonHandler : public RpcHandler
 {
   public:
 
-    DaemonHandler(cryptonote::core& c, t_p2p& p2p) : m_core(c), m_p2p(p2p) { }
+    DaemonHandler(cryptonote::core& c, t_p2p& p2p);
 
     ~DaemonHandler() { }
 

--- a/src/rpc/daemon_messages.cpp
+++ b/src/rpc/daemon_messages.cpp
@@ -34,99 +34,47 @@ namespace cryptonote
 
 namespace rpc
 {
+void GetHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-const char* const GetHeight::name = "get_height";
-const char* const GetBlocksFast::name = "get_blocks_fast";
-const char* const GetHashesFast::name = "get_hashes_fast";
-const char* const GetTransactions::name = "get_transactions";
-const char* const KeyImagesSpent::name = "key_images_spent";
-const char* const GetTxGlobalOutputIndices::name = "get_tx_global_output_indices";
-const char* const SendRawTx::name = "send_raw_tx";
-const char* const SendRawTxHex::name = "send_raw_tx_hex";
-const char* const StartMining::name = "start_mining";
-const char* const StopMining::name = "stop_mining";
-const char* const MiningStatus::name = "mining_status";
-const char* const GetInfo::name = "get_info";
-const char* const SaveBC::name = "save_bc";
-const char* const GetBlockHash::name = "get_block_hash";
-const char* const GetLastBlockHeader::name = "get_last_block_header";
-const char* const GetBlockHeaderByHash::name = "get_block_header_by_hash";
-const char* const GetBlockHeaderByHeight::name = "get_block_header_by_height";
-const char* const GetBlockHeadersByHeight::name = "get_block_headers_by_height";
-const char* const GetPeerList::name = "get_peer_list";
-const char* const SetLogLevel::name = "set_log_level";
-const char* const GetTransactionPool::name = "get_transaction_pool";
-const char* const HardForkInfo::name = "hard_fork_info";
-const char* const GetOutputHistogram::name = "get_output_histogram";
-const char* const GetOutputKeys::name = "get_output_keys";
-const char* const GetRPCVersion::name = "get_rpc_version";
-const char* const GetFeeEstimate::name = "get_dynamic_fee_estimate";
-const char* const GetOutputDistribution::name = "get_output_distribution";
-
-
-
-
-rapidjson::Value GetHeight::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
-
-void GetHeight::Request::fromJson(rapidjson::Value& val)
+void GetHeight::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetHeight::Response::toJson(rapidjson::Document& doc) const
+void GetHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  val.AddMember("height", height, al);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
 
-void GetHeight::Response::fromJson(rapidjson::Value& val)
+void GetHeight::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, height, height);
 }
 
 
-rapidjson::Value GetBlocksFast::Request::toJson(rapidjson::Document& doc) const
+void GetBlocksFast::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, block_ids, block_ids);
-  val.AddMember("start_height", start_height, al);
-  val.AddMember("prune", prune, al);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, block_ids, block_ids);
+  INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
+  INSERT_INTO_JSON_OBJECT(dest, prune, prune);
 }
 
-void GetBlocksFast::Request::fromJson(rapidjson::Value& val)
+void GetBlocksFast::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, block_ids, block_ids);
   GET_FROM_JSON_OBJECT(val, start_height, start_height);
   GET_FROM_JSON_OBJECT(val, prune, prune);
 }
 
-rapidjson::Value GetBlocksFast::Response::toJson(rapidjson::Document& doc) const
+void GetBlocksFast::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, blocks, blocks);
-  val.AddMember("start_height", start_height, al);
-  val.AddMember("current_height", current_height, al);
-  INSERT_INTO_JSON_OBJECT(val, doc, output_indices, output_indices);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, blocks, blocks);
+  INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
+  INSERT_INTO_JSON_OBJECT(dest, current_height, current_height);
+  INSERT_INTO_JSON_OBJECT(dest, output_indices, output_indices);
 }
 
-void GetBlocksFast::Response::fromJson(rapidjson::Value& val)
+void GetBlocksFast::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, blocks, blocks);
   GET_FROM_JSON_OBJECT(val, start_height, start_height);
@@ -135,38 +83,26 @@ void GetBlocksFast::Response::fromJson(rapidjson::Value& val)
 }
 
 
-rapidjson::Value GetHashesFast::Request::toJson(rapidjson::Document& doc) const
+void GetHashesFast::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, known_hashes, known_hashes);
-  val.AddMember("start_height", start_height, al);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, known_hashes, known_hashes);
+  INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
 }
 
-void GetHashesFast::Request::fromJson(rapidjson::Value& val)
+void GetHashesFast::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, known_hashes, known_hashes);
   GET_FROM_JSON_OBJECT(val, start_height, start_height);
 }
 
-rapidjson::Value GetHashesFast::Response::toJson(rapidjson::Document& doc) const
+void GetHashesFast::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, hashes, hashes);
-  val.AddMember("start_height", start_height, al);
-  val.AddMember("current_height", current_height, al);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, hashes, hashes);
+  INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
+  INSERT_INTO_JSON_OBJECT(dest, current_height, current_height);
 }
 
-void GetHashesFast::Response::fromJson(rapidjson::Value& val)
+void GetHashesFast::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, hashes, hashes);
   GET_FROM_JSON_OBJECT(val, start_height, start_height);
@@ -174,154 +110,114 @@ void GetHashesFast::Response::fromJson(rapidjson::Value& val)
 }
 
 
-rapidjson::Value GetTransactions::Request::toJson(rapidjson::Document& doc) const
+void GetTransactions::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, tx_hashes, tx_hashes);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, tx_hashes, tx_hashes);
 }
 
-void GetTransactions::Request::fromJson(rapidjson::Value& val)
+void GetTransactions::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, tx_hashes, tx_hashes);
 }
 
-rapidjson::Value GetTransactions::Response::toJson(rapidjson::Document& doc) const
+void GetTransactions::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  rapidjson::Value val(rapidjson::kObjectType);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, txs, txs);
-  INSERT_INTO_JSON_OBJECT(val, doc, missed_hashes, missed_hashes);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, txs, txs);
+  INSERT_INTO_JSON_OBJECT(dest, missed_hashes, missed_hashes);
 }
 
-void GetTransactions::Response::fromJson(rapidjson::Value& val)
+void GetTransactions::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, txs, txs);
   GET_FROM_JSON_OBJECT(val, missed_hashes, missed_hashes);
 }
 
 
-rapidjson::Value KeyImagesSpent::Request::toJson(rapidjson::Document& doc) const
+void KeyImagesSpent::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, key_images, key_images);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, key_images, key_images);
 }
 
-void KeyImagesSpent::Request::fromJson(rapidjson::Value& val)
+void KeyImagesSpent::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, key_images, key_images);
 }
 
-rapidjson::Value KeyImagesSpent::Response::toJson(rapidjson::Document& doc) const
+void KeyImagesSpent::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, spent_status, spent_status);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, spent_status, spent_status);
 }
 
-void KeyImagesSpent::Response::fromJson(rapidjson::Value& val)
+void KeyImagesSpent::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, spent_status, spent_status);
 }
 
 
-rapidjson::Value GetTxGlobalOutputIndices::Request::toJson(rapidjson::Document& doc) const
+void GetTxGlobalOutputIndices::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, tx_hash, tx_hash);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, tx_hash, tx_hash);
 }
 
-void GetTxGlobalOutputIndices::Request::fromJson(rapidjson::Value& val)
+void GetTxGlobalOutputIndices::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, tx_hash, tx_hash);
 }
 
-rapidjson::Value GetTxGlobalOutputIndices::Response::toJson(rapidjson::Document& doc) const
+void GetTxGlobalOutputIndices::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, output_indices, output_indices);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, output_indices, output_indices);
 }
 
-void GetTxGlobalOutputIndices::Response::fromJson(rapidjson::Value& val)
+void GetTxGlobalOutputIndices::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, output_indices, output_indices);
 }
 
-rapidjson::Value SendRawTx::Request::toJson(rapidjson::Document& doc) const
+void SendRawTx::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, tx, tx);
-  INSERT_INTO_JSON_OBJECT(val, doc, relay, relay);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, tx, tx);
+  INSERT_INTO_JSON_OBJECT(dest, relay, relay);
 }
 
-void SendRawTx::Request::fromJson(rapidjson::Value& val)
+void SendRawTx::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, tx, tx);
   GET_FROM_JSON_OBJECT(val, relay, relay);
 }
 
-rapidjson::Value SendRawTx::Response::toJson(rapidjson::Document& doc) const
+void SendRawTx::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, relayed, relayed);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, relayed, relayed);
 }
 
 
-void SendRawTx::Response::fromJson(rapidjson::Value& val)
+void SendRawTx::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, relayed, relayed);
 }
 
-rapidjson::Value SendRawTxHex::Request::toJson(rapidjson::Document& doc) const
+void SendRawTxHex::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, tx_as_hex, tx_as_hex);
-  INSERT_INTO_JSON_OBJECT(val, doc, relay, relay);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, tx_as_hex, tx_as_hex);
+  INSERT_INTO_JSON_OBJECT(dest, relay, relay);
 }
 
-void SendRawTxHex::Request::fromJson(rapidjson::Value& val)
+void SendRawTxHex::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, tx_as_hex, tx_as_hex);
   GET_FROM_JSON_OBJECT(val, relay, relay);
 }
 
-rapidjson::Value StartMining::Request::toJson(rapidjson::Document& doc) const
+void StartMining::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, miner_address, miner_address);
-  INSERT_INTO_JSON_OBJECT(val, doc, threads_count, threads_count);
-  INSERT_INTO_JSON_OBJECT(val, doc, do_background_mining, do_background_mining);
-  INSERT_INTO_JSON_OBJECT(val, doc, ignore_battery, ignore_battery);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, miner_address, miner_address);
+  INSERT_INTO_JSON_OBJECT(dest, threads_count, threads_count);
+  INSERT_INTO_JSON_OBJECT(dest, do_background_mining, do_background_mining);
+  INSERT_INTO_JSON_OBJECT(dest, ignore_battery, ignore_battery);
 }
 
-void StartMining::Request::fromJson(rapidjson::Value& val)
+void StartMining::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, miner_address, miner_address);
   GET_FROM_JSON_OBJECT(val, threads_count, threads_count);
@@ -329,58 +225,46 @@ void StartMining::Request::fromJson(rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, ignore_battery, ignore_battery);
 }
 
-rapidjson::Value StartMining::Response::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void StartMining::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void StartMining::Response::fromJson(rapidjson::Value& val)
+void StartMining::Response::fromJson(const rapidjson::Value& val)
 {
 }
 
 
-rapidjson::Value StopMining::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void StopMining::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void StopMining::Request::fromJson(rapidjson::Value& val)
+void StopMining::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value StopMining::Response::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void StopMining::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void StopMining::Response::fromJson(rapidjson::Value& val)
+void StopMining::Response::fromJson(const rapidjson::Value& val)
 {
 }
 
 
-rapidjson::Value MiningStatus::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void MiningStatus::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void MiningStatus::Request::fromJson(rapidjson::Value& val)
+void MiningStatus::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value MiningStatus::Response::toJson(rapidjson::Document& doc) const
+void MiningStatus::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, active, active);
-  INSERT_INTO_JSON_OBJECT(val, doc, speed, speed);
-  INSERT_INTO_JSON_OBJECT(val, doc, threads_count, threads_count);
-  INSERT_INTO_JSON_OBJECT(val, doc, address, address);
-  INSERT_INTO_JSON_OBJECT(val, doc, is_background_mining_enabled, is_background_mining_enabled);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, active, active);
+  INSERT_INTO_JSON_OBJECT(dest, speed, speed);
+  INSERT_INTO_JSON_OBJECT(dest, threads_count, threads_count);
+  INSERT_INTO_JSON_OBJECT(dest, address, address);
+  INSERT_INTO_JSON_OBJECT(dest, is_background_mining_enabled, is_background_mining_enabled);
 }
 
-void MiningStatus::Response::fromJson(rapidjson::Value& val)
+void MiningStatus::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, active, active);
   GET_FROM_JSON_OBJECT(val, speed, speed);
@@ -390,318 +274,230 @@ void MiningStatus::Response::fromJson(rapidjson::Value& val)
 }
 
 
-rapidjson::Value GetInfo::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void GetInfo::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void GetInfo::Request::fromJson(rapidjson::Value& val)
+void GetInfo::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetInfo::Response::toJson(rapidjson::Document& doc) const
+void GetInfo::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, info, info);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, info, info);
 }
 
-void GetInfo::Response::fromJson(rapidjson::Value& val)
+void GetInfo::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, info, info);
 }
 
 
-rapidjson::Value SaveBC::Request::toJson(rapidjson::Document& doc) const
-{
-  auto val = Message::toJson(doc);
+void SaveBC::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-  return val;
-}
-
-void SaveBC::Request::fromJson(rapidjson::Value& val)
+void SaveBC::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value SaveBC::Response::toJson(rapidjson::Document& doc) const
-{
-  auto val = Message::toJson(doc);
+void SaveBC::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-  return val;
-}
-
-void SaveBC::Response::fromJson(rapidjson::Value& val)
+void SaveBC::Response::fromJson(const rapidjson::Value& val)
 {
 }
 
 
-rapidjson::Value GetBlockHash::Request::toJson(rapidjson::Document& doc) const
+void GetBlockHash::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, height, height);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
 
-void GetBlockHash::Request::fromJson(rapidjson::Value& val)
+void GetBlockHash::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, height, height);
 }
 
-rapidjson::Value GetBlockHash::Response::toJson(rapidjson::Document& doc) const
+void GetBlockHash::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, hash, hash);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, hash, hash);
 }
 
-void GetBlockHash::Response::fromJson(rapidjson::Value& val)
+void GetBlockHash::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, hash, hash);
 }
 
 
-rapidjson::Value GetLastBlockHeader::Request::toJson(rapidjson::Document& doc) const
-{
-  auto val = Message::toJson(doc);
+void GetLastBlockHeader::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-  return val;
-}
-
-void GetLastBlockHeader::Request::fromJson(rapidjson::Value& val)
+void GetLastBlockHeader::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetLastBlockHeader::Response::toJson(rapidjson::Document& doc) const
+void GetLastBlockHeader::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, header, header);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
 
-void GetLastBlockHeader::Response::fromJson(rapidjson::Value& val)
+void GetLastBlockHeader::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, header, header);
 }
 
 
-rapidjson::Value GetBlockHeaderByHash::Request::toJson(rapidjson::Document& doc) const
+void GetBlockHeaderByHash::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, hash, hash);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, hash, hash);
 }
 
-void GetBlockHeaderByHash::Request::fromJson(rapidjson::Value& val)
+void GetBlockHeaderByHash::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, hash, hash);
 }
 
-rapidjson::Value GetBlockHeaderByHash::Response::toJson(rapidjson::Document& doc) const
+void GetBlockHeaderByHash::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, header, header);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
 
-void GetBlockHeaderByHash::Response::fromJson(rapidjson::Value& val)
+void GetBlockHeaderByHash::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, header, header);
 }
 
 
-rapidjson::Value GetBlockHeaderByHeight::Request::toJson(rapidjson::Document& doc) const
+void GetBlockHeaderByHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, height, height);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
 
-void GetBlockHeaderByHeight::Request::fromJson(rapidjson::Value& val)
+void GetBlockHeaderByHeight::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, height, height);
 }
 
-rapidjson::Value GetBlockHeaderByHeight::Response::toJson(rapidjson::Document& doc) const
+void GetBlockHeaderByHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, header, header);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
 
-void GetBlockHeaderByHeight::Response::fromJson(rapidjson::Value& val)
+void GetBlockHeaderByHeight::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, header, header);
 }
 
 
-rapidjson::Value GetBlockHeadersByHeight::Request::toJson(rapidjson::Document& doc) const
+void GetBlockHeadersByHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, heights, heights);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, heights, heights);
 }
 
-void GetBlockHeadersByHeight::Request::fromJson(rapidjson::Value& val)
+void GetBlockHeadersByHeight::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, heights, heights);
 }
 
-rapidjson::Value GetBlockHeadersByHeight::Response::toJson(rapidjson::Document& doc) const
+void GetBlockHeadersByHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, headers, headers);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, headers, headers);
 }
 
-void GetBlockHeadersByHeight::Response::fromJson(rapidjson::Value& val)
+void GetBlockHeadersByHeight::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, headers, headers);
 }
 
 
-rapidjson::Value GetPeerList::Request::toJson(rapidjson::Document& doc) const
-{
-  auto val = Message::toJson(doc);
+void GetPeerList::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-  return val;
-}
-
-void GetPeerList::Request::fromJson(rapidjson::Value& val)
+void GetPeerList::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetPeerList::Response::toJson(rapidjson::Document& doc) const
+void GetPeerList::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, white_list, white_list);
-  INSERT_INTO_JSON_OBJECT(val, doc, gray_list, gray_list);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, white_list, white_list);
+  INSERT_INTO_JSON_OBJECT(dest, gray_list, gray_list);
 }
 
-void GetPeerList::Response::fromJson(rapidjson::Value& val)
+void GetPeerList::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, white_list, white_list);
   GET_FROM_JSON_OBJECT(val, gray_list, gray_list);
 }
 
 
-rapidjson::Value SetLogLevel::Request::toJson(rapidjson::Document& doc) const
+void SetLogLevel::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  auto& al = doc.GetAllocator();
-
-  val.AddMember("level", level, al);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, level, level);
 }
 
-void SetLogLevel::Request::fromJson(rapidjson::Value& val)
+void SetLogLevel::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, level, level);
 }
 
-rapidjson::Value SetLogLevel::Response::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void SetLogLevel::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void SetLogLevel::Response::fromJson(rapidjson::Value& val)
+void SetLogLevel::Response::fromJson(const rapidjson::Value& val)
 {
 }
 
 
-rapidjson::Value GetTransactionPool::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void GetTransactionPool::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void GetTransactionPool::Request::fromJson(rapidjson::Value& val)
+void GetTransactionPool::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetTransactionPool::Response::toJson(rapidjson::Document& doc) const
+void GetTransactionPool::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, transactions, transactions);
-  INSERT_INTO_JSON_OBJECT(val, doc, key_images, key_images);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, transactions, transactions);
+  INSERT_INTO_JSON_OBJECT(dest, key_images, key_images);
 }
 
-void GetTransactionPool::Response::fromJson(rapidjson::Value& val)
+void GetTransactionPool::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, transactions, transactions);
   GET_FROM_JSON_OBJECT(val, key_images, key_images);
 }
 
 
-rapidjson::Value HardForkInfo::Request::toJson(rapidjson::Document& doc) const
+void HardForkInfo::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, version, version);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, version, version);
 }
 
-void HardForkInfo::Request::fromJson(rapidjson::Value& val)
+void HardForkInfo::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, version, version);
 }
 
-rapidjson::Value HardForkInfo::Response::toJson(rapidjson::Document& doc) const
+void HardForkInfo::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, info, info);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, info, info);
 }
 
-void HardForkInfo::Response::fromJson(rapidjson::Value& val)
+void HardForkInfo::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, info, info);
 }
 
 
-rapidjson::Value GetOutputHistogram::Request::toJson(rapidjson::Document& doc) const
+void GetOutputHistogram::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, amounts, amounts);
-  INSERT_INTO_JSON_OBJECT(val, doc, min_count, min_count);
-  INSERT_INTO_JSON_OBJECT(val, doc, max_count, max_count);
-  INSERT_INTO_JSON_OBJECT(val, doc, unlocked, unlocked);
-  INSERT_INTO_JSON_OBJECT(val, doc, recent_cutoff, recent_cutoff);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, amounts, amounts);
+  INSERT_INTO_JSON_OBJECT(dest, min_count, min_count);
+  INSERT_INTO_JSON_OBJECT(dest, max_count, max_count);
+  INSERT_INTO_JSON_OBJECT(dest, unlocked, unlocked);
+  INSERT_INTO_JSON_OBJECT(dest, recent_cutoff, recent_cutoff);
 }
 
-void GetOutputHistogram::Request::fromJson(rapidjson::Value& val)
+void GetOutputHistogram::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, amounts, amounts);
   GET_FROM_JSON_OBJECT(val, min_count, min_count);
@@ -710,100 +506,74 @@ void GetOutputHistogram::Request::fromJson(rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, recent_cutoff, recent_cutoff);
 }
 
-rapidjson::Value GetOutputHistogram::Response::toJson(rapidjson::Document& doc) const
+void GetOutputHistogram::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, histogram, histogram);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, histogram, histogram);
 }
 
-void GetOutputHistogram::Response::fromJson(rapidjson::Value& val)
+void GetOutputHistogram::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, histogram, histogram);
 }
 
 
-rapidjson::Value GetOutputKeys::Request::toJson(rapidjson::Document& doc) const
+void GetOutputKeys::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, outputs, outputs);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, outputs, outputs);
 }
 
-void GetOutputKeys::Request::fromJson(rapidjson::Value& val)
+void GetOutputKeys::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, outputs, outputs);
 }
 
-rapidjson::Value GetOutputKeys::Response::toJson(rapidjson::Document& doc) const
+void GetOutputKeys::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, keys, keys);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, keys, keys);
 }
 
-void GetOutputKeys::Response::fromJson(rapidjson::Value& val)
+void GetOutputKeys::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, keys, keys);
 }
 
 
-rapidjson::Value GetRPCVersion::Request::toJson(rapidjson::Document& doc) const
-{
-  return Message::toJson(doc);
-}
+void GetRPCVersion::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+{}
 
-void GetRPCVersion::Request::fromJson(rapidjson::Value& val)
+void GetRPCVersion::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-rapidjson::Value GetRPCVersion::Response::toJson(rapidjson::Document& doc) const
+void GetRPCVersion::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, version, version);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, version, version);
 }
 
-void GetRPCVersion::Response::fromJson(rapidjson::Value& val)
+void GetRPCVersion::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, version, version);
 }
 
-rapidjson::Value GetFeeEstimate::Request::toJson(rapidjson::Document& doc) const
+void GetFeeEstimate::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, num_grace_blocks, num_grace_blocks);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, num_grace_blocks, num_grace_blocks);
 }
 
-void GetFeeEstimate::Request::fromJson(rapidjson::Value& val)
+void GetFeeEstimate::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, num_grace_blocks, num_grace_blocks);
 }
 
-rapidjson::Value GetFeeEstimate::Response::toJson(rapidjson::Document& doc) const
+void GetFeeEstimate::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, estimated_base_fee, estimated_base_fee);
-  INSERT_INTO_JSON_OBJECT(val, doc, fee_mask, fee_mask);
-  INSERT_INTO_JSON_OBJECT(val, doc, size_scale, size_scale);
-  INSERT_INTO_JSON_OBJECT(val, doc, hard_fork_version, hard_fork_version);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, estimated_base_fee, estimated_base_fee);
+  INSERT_INTO_JSON_OBJECT(dest, fee_mask, fee_mask);
+  INSERT_INTO_JSON_OBJECT(dest, size_scale, size_scale);
+  INSERT_INTO_JSON_OBJECT(dest, hard_fork_version, hard_fork_version);
 }
 
-void GetFeeEstimate::Response::fromJson(rapidjson::Value& val)
+void GetFeeEstimate::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, estimated_base_fee, estimated_base_fee);
   GET_FROM_JSON_OBJECT(val, fee_mask, fee_mask);
@@ -811,19 +581,15 @@ void GetFeeEstimate::Response::fromJson(rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, hard_fork_version, hard_fork_version);
 }
 
-rapidjson::Value GetOutputDistribution::Request::toJson(rapidjson::Document& doc) const
+void GetOutputDistribution::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, amounts, amounts);
-  INSERT_INTO_JSON_OBJECT(val, doc, from_height, from_height);
-  INSERT_INTO_JSON_OBJECT(val, doc, to_height, to_height);
-  INSERT_INTO_JSON_OBJECT(val, doc, cumulative, cumulative);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, amounts, amounts);
+  INSERT_INTO_JSON_OBJECT(dest, from_height, from_height);
+  INSERT_INTO_JSON_OBJECT(dest, to_height, to_height);
+  INSERT_INTO_JSON_OBJECT(dest, cumulative, cumulative);
 }
 
-void GetOutputDistribution::Request::fromJson(rapidjson::Value& val)
+void GetOutputDistribution::Request::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, amounts, amounts);
   GET_FROM_JSON_OBJECT(val, from_height, from_height);
@@ -831,17 +597,13 @@ void GetOutputDistribution::Request::fromJson(rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, cumulative, cumulative);
 }
 
-rapidjson::Value GetOutputDistribution::Response::toJson(rapidjson::Document& doc) const
+void GetOutputDistribution::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
 {
-  auto val = Message::toJson(doc);
-
-  INSERT_INTO_JSON_OBJECT(val, doc, status, status);
-  INSERT_INTO_JSON_OBJECT(val, doc, distributions, distributions);
-
-  return val;
+  INSERT_INTO_JSON_OBJECT(dest, status, status);
+  INSERT_INTO_JSON_OBJECT(dest, distributions, distributions);
 }
 
-void GetOutputDistribution::Response::fromJson(rapidjson::Value& val)
+void GetOutputDistribution::Response::fromJson(const rapidjson::Value& val)
 {
   GET_FROM_JSON_OBJECT(val, status, status);
   GET_FROM_JSON_OBJECT(val, distributions, distributions);

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include <unordered_map>
 #include <vector>
 
@@ -40,26 +42,25 @@
 #define BEGIN_RPC_MESSAGE_CLASS(classname) \
 class classname \
 { \
-  public: \
-    static const char* const name;
+  public:
 
 #define BEGIN_RPC_MESSAGE_REQUEST \
-    class Request : public Message \
+    class Request final : public Message \
     { \
       public: \
         Request() { } \
         ~Request() { } \
-        rapidjson::Value toJson(rapidjson::Document& doc) const; \
-        void fromJson(rapidjson::Value& val);
+        void doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const override final; \
+        void fromJson(const rapidjson::Value& val) override final;
 
 #define BEGIN_RPC_MESSAGE_RESPONSE \
-    class Response : public Message \
+    class Response final : public Message \
     { \
       public: \
         Response() { } \
         ~Response() { } \
-        rapidjson::Value toJson(rapidjson::Document& doc) const; \
-        void fromJson(rapidjson::Value& val);
+        void doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const override final; \
+        void fromJson(const rapidjson::Value& val) override final;
 
 #define END_RPC_MESSAGE_REQUEST };
 #define END_RPC_MESSAGE_RESPONSE };

--- a/src/serialization/CMakeLists.txt
+++ b/src/serialization/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(serialization
   LINK_PRIVATE
     cryptonote_core
     cryptonote_protocol
+    epee
     ${Boost_CHRONO_LIBRARY}
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -28,8 +28,13 @@
 
 #pragma once
 
+#include <boost/utility/string_ref.hpp>
+#include <cstring>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
 #include "string_tools.h"
-#include "rapidjson/document.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "rpc/message_data_structs.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
@@ -44,10 +49,9 @@
     } \
   } while (0);
 
-#define INSERT_INTO_JSON_OBJECT(jsonVal, doc, key, source) \
-    rapidjson::Value key##Val; \
-    cryptonote::json::toJsonValue(doc, source, key##Val); \
-    jsonVal.AddMember(#key, key##Val, doc.GetAllocator());
+#define INSERT_INTO_JSON_OBJECT(dest, key, source) \
+    dest.Key(#key, sizeof(#key) - 1); \
+    cryptonote::json::toJsonValue(dest, source);
 
 #define GET_FROM_JSON_OBJECT(source, dst, key) \
     OBJECT_HAS_MEMBER_OR_THROW(source, #key) \
@@ -114,16 +118,24 @@ inline constexpr bool is_to_hex()
   return std::is_pod<Type>() && !std::is_integral<Type>();
 }
 
+// POD to json key
+template <class Type>
+inline typename std::enable_if<is_to_hex<Type>()>::type toJsonKey(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Type& pod)
+{
+  const auto hex = epee::to_hex::array(pod);
+  dest.Key(hex.data(), hex.size());
+}
 
 // POD to json value
 template <class Type>
-typename std::enable_if<is_to_hex<Type>()>::type toJsonValue(rapidjson::Document& doc, const Type& pod, rapidjson::Value& value)
+inline typename std::enable_if<is_to_hex<Type>()>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Type& pod)
 {
-  value = rapidjson::Value(epee::string_tools::pod_to_hex(pod).c_str(), doc.GetAllocator());
+  const auto hex = epee::to_hex::array(pod);
+  dest.String(hex.data(), hex.size());
 }
 
 template <class Type>
-typename std::enable_if<is_to_hex<Type>()>::type fromJsonValue(const rapidjson::Value& val, Type& t)
+inline typename std::enable_if<is_to_hex<Type>()>::type fromJsonValue(const rapidjson::Value& val, Type& t)
 {
   if (!val.IsString())
   {
@@ -139,10 +151,16 @@ typename std::enable_if<is_to_hex<Type>()>::type fromJsonValue(const rapidjson::
   }
 }
 
-void toJsonValue(rapidjson::Document& doc, const std::string& i, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rapidjson::Value& src);
+
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, boost::string_ref i);
+inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const std::string& i)
+{
+  toJsonValue(dest, boost::string_ref{i});
+}
 void fromJsonValue(const rapidjson::Value& val, std::string& str);
 
-void toJsonValue(rapidjson::Document& doc, bool i, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, bool i);
 void fromJsonValue(const rapidjson::Value& val, bool& b);
 
 // integers overloads for toJsonValue are not needed for standard promotions
@@ -157,144 +175,144 @@ void fromJsonValue(const rapidjson::Value& val, unsigned short& i);
 
 void fromJsonValue(const rapidjson::Value& val, short& i);
 
-void toJsonValue(rapidjson::Document& doc, const unsigned i, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned i);
 void fromJsonValue(const rapidjson::Value& val, unsigned& i);
 
-void toJsonValue(rapidjson::Document& doc, const int, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const int);
 void fromJsonValue(const rapidjson::Value& val, int& i);
 
 
-void toJsonValue(rapidjson::Document& doc, const unsigned long long i, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned long long i);
 void fromJsonValue(const rapidjson::Value& val, unsigned long long& i);
 
-void toJsonValue(rapidjson::Document& doc, const long long i, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const long long i);
 void fromJsonValue(const rapidjson::Value& val, long long& i);
 
-inline void toJsonValue(rapidjson::Document& doc, const unsigned long i, rapidjson::Value& val) {
-    toJsonValue(doc, static_cast<unsigned long long>(i), val);
+inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned long i) {
+    toJsonValue(dest, static_cast<unsigned long long>(i));
 }
 void fromJsonValue(const rapidjson::Value& val, unsigned long& i);
 
-inline void toJsonValue(rapidjson::Document& doc, const long i, rapidjson::Value& val) {
-    toJsonValue(doc, static_cast<long long>(i), val);
+inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const long i) {
+    toJsonValue(dest, static_cast<long long>(i));
 }
 void fromJsonValue(const rapidjson::Value& val, long& i);
 
 // end integers
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::transaction& tx, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::transaction& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::transaction& tx);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::block& b, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block& b);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::block& b);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_v& txin, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_v& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_gen& txin, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_gen& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_gen& txin);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_to_script& txin, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_script& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_to_scripthash& txin, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_scripthash& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& txin);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_to_key& txin, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_key& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_target_v& txout, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_target_v& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_target_v& txout);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_to_script& txout, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_script& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_to_scripthash& txout, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_scripthash& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_to_key& txout, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_key& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_key& txout);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::tx_out& txout, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_out& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::connection_info& info, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::connection_info& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::connection_info& info);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::tx_blob_entry& tx, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_blob_entry& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_blob_entry& tx);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::block_complete_entry& blk, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block_complete_entry& blk);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::block_complete_entry& blk);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::block_with_transactions& blk, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::block_with_transactions& blk);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::block_with_transactions& blk);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::transaction_info& tx_info, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::transaction_info& tx_info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::transaction_info& tx_info);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::output_key_and_amount_index& out, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_and_amount_index& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_and_amount_index& out);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::amount_with_random_outputs& out, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::amount_with_random_outputs& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::amount_with_random_outputs& out);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::peer& peer, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::peer& peer);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::peer& peer);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::tx_in_pool& tx, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::tx_in_pool& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::tx_in_pool& tx);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::hard_fork_info& info, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::hard_fork_info& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::hard_fork_info& info);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::output_amount_count& out, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_count& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_count& out);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::output_amount_and_index& out, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_and_index& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_and_index& out);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::output_key_mask_unlocked& out, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_mask_unlocked& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_mask_unlocked& out);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::error& err, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::error& err);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::error& error);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::BlockHeaderResponse& response, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::BlockHeaderResponse& response);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResponse& response);
 
-void toJsonValue(rapidjson::Document& doc, const rct::rctSig& i, rapidjson::Value& val);
-void fromJsonValue(const rapidjson::Value& i, rct::rctSig& sig);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rctSig& i);
+void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig);
 
-void toJsonValue(rapidjson::Document& doc, const rct::ecdhTuple& tuple, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::ecdhTuple& tuple);
 void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple);
 
-void toJsonValue(rapidjson::Document& doc, const rct::rangeSig& sig, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rangeSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::rangeSig& sig);
 
-void toJsonValue(rapidjson::Document& doc, const rct::Bulletproof& p, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::Bulletproof& p);
 void fromJsonValue(const rapidjson::Value& val, rct::Bulletproof& p);
 
-void toJsonValue(rapidjson::Document& doc, const rct::boroSig& sig, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::boroSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::boroSig& sig);
 
-void toJsonValue(rapidjson::Document& doc, const rct::mgSig& sig, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::mgSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::DaemonInfo& info, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::DaemonInfo& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& info);
 
-void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::output_distribution& dist, rapidjson::Value& val);
+void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_distribution& dist);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_distribution& dist);
 
 template <typename Map>
-typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Document& doc, const Map& map, rapidjson::Value& val);
+typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Map& map);
 
 template <typename Map>
 typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type fromJsonValue(const rapidjson::Value& val, Map& map);
 
 template <typename Vec>
-typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Document& doc, const Vec &vec, rapidjson::Value& val);
+typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Vec &vec);
 
 template <typename Vec>
 typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec);
@@ -304,24 +322,22 @@ typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJson
 // unfortunately because of how templates work they have to be here.
 
 template <typename Map>
-typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Document& doc, const Map& map, rapidjson::Value& val)
+inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Map& map)
 {
-  val.SetObject();
+  using key_type = typename Map::key_type;
+  static_assert(std::is_same<std::string, key_type>() || is_to_hex<key_type>(), "invalid map key type");
 
-  auto& al = doc.GetAllocator();
-
+  dest.StartObject();
   for (const auto& i : map)
   {
-    rapidjson::Value k;
-    rapidjson::Value m;
-    toJsonValue(doc, i.first, k);
-    toJsonValue(doc, i.second, m);
-    val.AddMember(k, m, al);
+    toJsonKey(dest, i.first);
+    toJsonValue(dest, i.second);
   }
+  dest.EndObject();
 }
 
 template <typename Map>
-typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type fromJsonValue(const rapidjson::Value& val, Map& map)
+inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type fromJsonValue(const rapidjson::Value& val, Map& map)
 {
   if (!val.IsObject())
   {
@@ -342,20 +358,16 @@ typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type fromJsonVal
 }
 
 template <typename Vec>
-typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Document& doc, const Vec &vec, rapidjson::Value& val)
+inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Vec &vec)
 {
-  val.SetArray();
-
+  dest.StartArray();
   for (const auto& t : vec)
-  {
-    rapidjson::Value v;
-    toJsonValue(doc, t, v);
-    val.PushBack(v, doc.GetAllocator());
-  }
+    toJsonValue(dest, t);
+  dest.EndArray(vec.size());
 }
 
 template <typename Vec>
-typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec)
+inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec)
 {
   if (!val.IsArray())
   {

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -850,6 +850,17 @@ TEST(ToHex, Array)
   );
 }
 
+TEST(ToHex, ArrayFromPod)
+{
+  std::array<char, 64> expected{{'5', 'f', '2', 'b', '0', '1'}};
+  std::fill(expected.begin() + 6, expected.end(), '0');
+
+  EXPECT_EQ(
+    expected,
+    (epee::to_hex::array(crypto::ec_point{{0x5F, 0x2B, 0x01, 0x00}}))
+  );
+}
+
 TEST(ToHex, Ostream)
 {
   std::stringstream out;

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -3,6 +3,8 @@
 #include <boost/range/adaptor/indexed.hpp>
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include <vector>
 
 #include "crypto/hash.h"
@@ -80,6 +82,27 @@ namespace
 
         return tx;
     }
+
+    template<typename T>
+    T test_json(const T& value)
+    {
+      rapidjson::StringBuffer buffer;
+      {
+        rapidjson::Writer<rapidjson::StringBuffer> dest{buffer};
+        cryptonote::json::toJsonValue(dest, value);
+      }
+
+      rapidjson::Document doc;
+      doc.Parse(buffer.GetString());
+      if (doc.HasParseError() || !doc.IsObject())
+      {
+        throw cryptonote::json::PARSE_FAIL();
+      }
+
+      T out{};
+      cryptonote::json::fromJsonValue(doc, out);
+      return out;
+    }
 } // anonymous
 
 TEST(JsonSerialization, MinerTransaction)
@@ -91,11 +114,7 @@ TEST(JsonSerialization, MinerTransaction)
     crypto::hash tx_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(miner_tx, tx_hash));
 
-    rapidjson::Document doc;
-    cryptonote::json::toJsonValue(doc, miner_tx, doc);
-
-    cryptonote::transaction miner_tx_copy;
-    cryptonote::json::fromJsonValue(doc, miner_tx_copy);
+    cryptonote::transaction miner_tx_copy = test_json(miner_tx);
 
     crypto::hash tx_copy_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(miner_tx_copy, tx_copy_hash));
@@ -126,11 +145,7 @@ TEST(JsonSerialization, RegularTransaction)
     crypto::hash tx_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
 
-    rapidjson::Document doc;
-    cryptonote::json::toJsonValue(doc, tx, doc);
-
-    cryptonote::transaction tx_copy;
-    cryptonote::json::fromJsonValue(doc, tx_copy);
+    cryptonote::transaction tx_copy = test_json(tx);
 
     crypto::hash tx_copy_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));
@@ -161,11 +176,7 @@ TEST(JsonSerialization, RingctTransaction)
     crypto::hash tx_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
 
-    rapidjson::Document doc;
-    cryptonote::json::toJsonValue(doc, tx, doc);
-
-    cryptonote::transaction tx_copy;
-    cryptonote::json::fromJsonValue(doc, tx_copy);
+    cryptonote::transaction tx_copy = test_json(tx);
 
     crypto::hash tx_copy_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));
@@ -196,11 +207,7 @@ TEST(JsonSerialization, BulletproofTransaction)
     crypto::hash tx_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
 
-    rapidjson::Document doc;
-    cryptonote::json::toJsonValue(doc, tx, doc);
-
-    cryptonote::transaction tx_copy;
-    cryptonote::json::fromJsonValue(doc, tx_copy);
+    cryptonote::transaction tx_copy = test_json(tx);
 
     crypto::hash tx_copy_hash{};
     ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));


### PR DESCRIPTION
  - Finding handling function in ZMQ JSON-RPC now uses binary search
  - Temporary `std::vector`s in JSON output now use `epee::span` to
    prevent allocations.
  - Binary -> hex in JSON output no longer allocates temporary buffer
  - C++ structs -> JSON skips intermediate DOM creation, and instead
    write directly to an output stream.

I ran a "hell test" for performance numbers - `GetBlocksFast` with unpruned txes during the biggest blocks (borromean!). The improvement is likely lower for smaller JSON messages, but is still representive of a decent speed improvement:
Fanless i7-7Y75 laptop -> ~33.7%, ryzen 3900x desktop -> ~34.1%

Unfortunately, there is lots of churn due to the function argument changes. And the JSON output can still use improvement (there will hopefully be more changes to the ZMQ JSON stuff).