### PR TITLE
Daemon: Guard against reporting "synchronized" too early

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -346,7 +346,7 @@ namespace cryptonote
     if(m_core.have_block(hshd.top_id))
     {
       context.m_state = cryptonote_connection_context::state_normal;
-      if(is_inital && target == m_core.get_current_blockchain_height())
+      if(is_inital  && hshd.current_height >= target && target == m_core.get_current_blockchain_height())
         on_connection_synchronized();
       return true;
     }


### PR DESCRIPTION
The added condition "hshd.current_height >= target" guards against reporting "synchronized" too early in the special situation that the very first peer sending us data is synced to a lower height than ourselves.

In this situation, `target` gets set to our own current height at line 344 because core's `target_blockchain_height` is not yet set. `core.have_block` comes out as true because we already have that lower block, and the result is reporting "You are now synchronized with the network" too early.