### PR TITLE
gitian-build.py: Fixing check for docker command.

### DIFF
--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -36,8 +36,11 @@ def setup():
     os.chdir('..')
     make_image_prog = ['bin/make-base-vm', '--suite', 'bionic', '--arch', 'amd64']
     if args.docker:
-        if not subprocess.call(['docker', '--help'], shell=False, stdout=subprocess.DEVNULL):
-            print("Please install docker first manually")
+        try:
+            subprocess.check_output(['docker', '--help'])
+        except:
+            print("ERROR: Could not find 'docker' command. Ensure this is in your PATH.")
+            sys.exit(1)
         make_image_prog += ['--docker']
     elif not args.kvm:
         make_image_prog += ['--lxc']


### PR DESCRIPTION
The previous version was not working correctly as [subprocess.call](https://docs.python.org/2/library/subprocess.html#subprocess.call) returns the exit status (aka `returncode`) of the command executed.  The exit status will be `0` if the command succeeds, which is interpreted as `False`, then negated by the preceding `not`.

Exit status will be something other than `0` if it fails (eg `1`, `128`, etc) so we just catch them all.

The script should fail if `--docker` is specified, but the command is not available.

Finally, `shell=False` is the default, so no need to specify.

New version will correctly test if `docker` command is available and fail with a nice message if not.

**Note:** Let me know if you'd prefer this be switched to use the `which` command.  I was trying not to modify anything unnecessarily.