### PR TITLE
fix tests bug added in #6110

### DIFF
--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -393,11 +393,17 @@ void test_generator::fill_nonce(cryptonote::block& blk, const difficulty_type& d
   const cryptonote::Blockchain *blockchain = nullptr;
   std::unique_ptr<cryptonote::Blockchain> bc;
 
-  if (blk.major_version >= RX_BLOCK_VERSION)
+  if (blk.major_version >= RX_BLOCK_VERSION && diffic > 1)
   {
-    CHECK_AND_ASSERT_THROW_MES(m_events != nullptr, "events not set, cannot compute valid RandomX PoW");
-    bc = init_blockchain(*m_events, m_nettype);
-    blockchain = bc.get();
+    if (m_events == nullptr)
+    {
+      MDEBUG("events not set, RandomX PoW can fail due to zero seed hash");
+    }
+    else
+    {
+      bc = init_blockchain(*m_events, m_nettype);
+      blockchain = bc.get();
+    }
   }
 
   blk.nonce = 0;


### PR DESCRIPTION
- e.g., fixes gen_block_big_major_version test, error: generation failed: what=events not set, cannot compute valid RandomX PoW
- ask for events only if difficulty > 1 (when it really matters)
- throwing an exception changed to logging, so it is easy to spot a problem if tests start to fail. Throwing an exception could be too harsh for some tests, it may be a desired situation.