### PR TITLE
Wallet: Fix unused variable compiler warning

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3257,6 +3257,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   std::vector<cryptonote::block_complete_entry> blocks;
   std::vector<parsed_block> parsed_blocks;
   bool refreshed = false;
+  (void)refreshed;  // Silence a compiler warning.
   std::shared_ptr<std::map<std::pair<uint64_t, uint64_t>, size_t>> output_tracker_cache;
   hw::device &hwdev = m_account.get_device();
 


### PR DESCRIPTION
g++ 7.4.0 on Ubuntu 18.04

Alternatively, if we prefer to keep the variable around, we can silence it with something like 

```
   bool refreshed = false;
+  (void)refreshed;
```