### PR TITLE
epee: Explicitly define copy assignment operator

### DIFF
--- a/contrib/epee/include/storages/portable_storage_base.h
+++ b/contrib/epee/include/storages/portable_storage_base.h
@@ -84,6 +84,13 @@ namespace epee
       array_entry_t():m_it(m_array.end()){}        
       array_entry_t(const array_entry_t& other):m_array(other.m_array), m_it(m_array.end()){}
 
+      array_entry_t& operator=(const array_entry_t& other)
+      {
+        m_array = other.m_array;
+        m_it = m_array.end();
+        return *this;
+      }
+
       const t_entry_type* get_first_val() const 
       {
         m_it = m_array.begin();


### PR DESCRIPTION
The implicit copy assignment operator was deprecated because the class
has an explicit copy constructor. According to the standard:

> The generation of the implicitly-defined copy assignment operator is
> deprecated (since C++11) if T has a user-declared destructor or
> user-declared copy constructor.
> 

Recent versions of gcc (9.1+) and clang (10.0) warn about this.