### PR TITLE
workflows: windows j3 -> j2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: install monero dependencies
       run: msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
     - name: build
-      run: msys2do make release-static-win64 -j3
+      run: msys2do make release-static-win64 -j2
 
   build-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
```
cc1plus.exe: out of memory allocating 600896 bytes
```

Looks like 7GB RAM is not enough for -j3 on Windows. While monero compiles fine most of the time, it appears that it ran out of RAM twice.

https://github.com/monero-project/monero/runs/429237309
https://github.com/monero-project/monero/runs/429239677