### PR TITLE
Allow wallet2.h to run in WebAssembly.

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+#include <boost/optional/optional.hpp>
+#include "http_auth.h"
+#include "net/net_ssl.h"
+
+namespace epee
+{
+namespace net_utils
+{
+  inline const char* get_hex_vals()
+  {
+    static constexpr const char hexVals[16] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    return hexVals;
+  }
+
+  inline const char* get_unsave_chars()
+  {
+    //static constexpr char unsave_chars[] = "\"<>%\\^[]`+$,@:;/!#?=&";
+    static constexpr const char unsave_chars[] = "\"<>%\\^[]`+$,@:;!#&";
+    return unsave_chars;
+  }
+
+  bool is_unsafe(unsigned char compare_char);
+  std::string dec_to_hex(char num, int radix);
+  int get_index(const char *s, char c);
+  std::string hex_to_dec_2bytes(const char *s);
+  std::string convert(char val);
+  std::string conver_to_url_format(const std::string& uri);
+  std::string convert_from_url_format(const std::string& uri);
+  std::string convert_to_url_format_force_all(const std::string& uri);
+
+namespace http
+{
+  class abstract_http_client
+  {
+  public:
+    abstract_http_client() {}
+    virtual ~abstract_http_client() {}
+    bool set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect);
+    virtual void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) = 0;
+    virtual void set_auto_connect(bool auto_connect) = 0;
+    virtual bool connect(std::chrono::milliseconds timeout) = 0;
+    virtual bool disconnect() = 0;
+    virtual bool is_connected(bool *ssl = NULL) = 0;
+    virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
+    virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
+    virtual bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
+    virtual uint64_t get_bytes_sent() const = 0;
+    virtual uint64_t get_bytes_received() const = 0;
+  };
+
+  class http_client_factory
+  {
+  public:
+    virtual ~http_client_factory() {}
+    virtual std::unique_ptr<abstract_http_client> create() = 0;
+  };
+}
+}
+}

--- a/contrib/epee/include/storages/http_abstract_invoke.h
+++ b/contrib/epee/include/storages/http_abstract_invoke.h
@@ -38,7 +38,7 @@ namespace epee
   namespace net_utils
   {
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_json(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref method = "GET")
+    bool invoke_http_json(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref method = "POST")
     {
       std::string req_param;
       if(!serialization::store_t_to_json(out_struct, req_param))
@@ -72,7 +72,7 @@ namespace epee
 
 
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_bin(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref method = "GET")
+    bool invoke_http_bin(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref method = "POST")
     {
       std::string req_param;
       if(!serialization::store_t_to_binary(out_struct, req_param))
@@ -101,7 +101,7 @@ namespace epee
     }
 
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, epee::json_rpc::error &error_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
+    bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, epee::json_rpc::error &error_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST", const std::string& req_id = "0")
     {
       epee::json_rpc::request<t_request> req_t = AUTO_VAL_INIT(req_t);
       req_t.jsonrpc = "2.0";
@@ -125,14 +125,14 @@ namespace epee
     }
 
     template<class t_request, class t_response, class t_transport>
-    bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
+    bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST", const std::string& req_id = "0")
     {
       epee::json_rpc::error error_struct;
       return invoke_http_json_rpc(uri, method_name, out_struct, result_struct, error_struct, transport, timeout, http_method, req_id);
     }
 
     template<class t_command, class t_transport>
-    bool invoke_http_json_rpc(const boost::string_ref uri, typename t_command::request& out_struct, typename t_command::response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
+    bool invoke_http_json_rpc(const boost::string_ref uri, typename t_command::request& out_struct, typename t_command::response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST", const std::string& req_id = "0")
     {
       return invoke_http_json_rpc(uri, t_command::methodname(), out_struct, result_struct, transport, timeout, http_method, req_id);
     }

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -150,7 +150,7 @@ namespace epee
   };
 
 
-#define  CRITICAL_REGION_LOCAL(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));}   epee::critical_region_t<decltype(x)>   critical_region_var(x)
+#define  CRITICAL_REGION_LOCAL(x) {} epee::critical_region_t<decltype(x)>   critical_region_var(x)
 #define  CRITICAL_REGION_BEGIN(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var(x)
 #define  CRITICAL_REGION_LOCAL1(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} epee::critical_region_t<decltype(x)>   critical_region_var1(x)
 #define  CRITICAL_REGION_BEGIN1(x) {  boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var1(x)

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -26,7 +26,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(epee STATIC byte_slice.cpp hex.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp
+add_library(epee STATIC byte_slice.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp
     levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
     int-util.cpp)
 

--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -1,0 +1,142 @@
+#include "net/abstract_http_client.h"
+#include "net/http_base.h"
+#include "net/net_parse_helpers.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "net.http"
+
+namespace epee
+{
+namespace net_utils
+{
+  //----------------------------------------------------------------------------------------------------
+  bool is_unsafe(unsigned char compare_char)
+  {
+    if(compare_char <= 32 || compare_char >= 123)
+      return true;
+
+    const char* punsave = get_unsave_chars();
+
+    for(int ichar_pos = 0; 0!=punsave[ichar_pos] ;ichar_pos++)
+      if(compare_char == punsave[ichar_pos])
+        return true;
+
+    return false;
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string dec_to_hex(char num, int radix)
+  {
+    int temp=0;
+    std::string csTmp;
+    int num_char;
+
+    num_char = (int) num;
+    if (num_char < 0)
+      num_char = 256 + num_char;
+
+    while (num_char >= radix)
+    {
+      temp = num_char % radix;
+      num_char = (int)floor((float)num_char / (float)radix);
+      csTmp = get_hex_vals()[temp];
+    }
+
+    csTmp += get_hex_vals()[num_char];
+
+    if(csTmp.size() < 2)
+    {
+      csTmp += '0';
+    }
+
+    std::reverse(csTmp.begin(), csTmp.end());
+    //_mbsrev((unsigned char*)csTmp.data());
+
+    return csTmp;
+  }
+  //----------------------------------------------------------------------------------------------------
+  int get_index(const char *s, char c)
+  {
+    const char *ptr = (const char*)memchr(s, c, 16);
+    return ptr ? ptr-s : -1;
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string hex_to_dec_2bytes(const char *s)
+  {
+    const char *hex = get_hex_vals();
+    int i0 = get_index(hex, toupper(s[0]));
+    int i1 = get_index(hex, toupper(s[1]));
+    if (i0 < 0 || i1 < 0)
+      return std::string("%") + std::string(1, s[0]) + std::string(1, s[1]);
+    return std::string(1, i0 * 16 | i1);
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string convert(char val)
+  {
+    std::string csRet;
+    csRet += "%";
+    csRet += dec_to_hex(val, 16);
+    return  csRet;
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string conver_to_url_format(const std::string& uri)
+  {
+
+    std::string result;
+
+    for(size_t i = 0; i!= uri.size(); i++)
+    {
+      if(is_unsafe(uri[i]))
+        result += convert(uri[i]);
+      else
+        result += uri[i];
+
+    }
+
+    return result;
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string convert_from_url_format(const std::string& uri)
+  {
+
+    std::string result;
+
+    for(size_t i = 0; i!= uri.size(); i++)
+    {
+      if(uri[i] == '%' && i + 2 < uri.size())
+      {
+        result += hex_to_dec_2bytes(uri.c_str() + i + 1);
+        i += 2;
+      }
+      else
+        result += uri[i];
+
+    }
+
+    return result;
+  }
+  //----------------------------------------------------------------------------------------------------
+  std::string convert_to_url_format_force_all(const std::string& uri)
+  {
+    std::string result;
+
+    for(size_t i = 0; i!= uri.size(); i++)
+    {
+        result += convert(uri[i]);
+    }
+    return result;
+  }
+
+namespace http
+{
+  //----------------------------------------------------------------------------------------------------
+  bool epee::net_utils::http::abstract_http_client::set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options)
+  {
+    http::url_content parsed{};
+    const bool r = parse_url(address, parsed);
+    CHECK_AND_ASSERT_MES(r, false, "failed to parse url: " << address);
+    set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), std::move(ssl_options));
+    return true;
+  }
+}
+}
+}

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -48,7 +48,7 @@
 namespace mms
 {
 
-message_store::message_store()
+message_store::message_store(std::unique_ptr<epee::net_utils::http::abstract_http_client> http_client) : m_transporter(std::move(http_client))
 {
   m_active = false;
   m_auto_send = false;

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -43,6 +43,7 @@
 #include "common/i18n.h"
 #include "common/command_line.h"
 #include "wipeable_string.h"
+#include "net/abstract_http_client.h"
 #include "message_transporter.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -202,7 +203,8 @@ namespace mms
   class message_store
   {
   public:
-    message_store();
+    message_store(std::unique_ptr<epee::net_utils::http::abstract_http_client> http_client);
+
     // Initialize and start to use the MMS, set the first signer, this wallet itself
     // Filename, if not null and not empty, is used to create the ".mms" file
     // reset it if already used, with deletion of all signers and messages

--- a/src/wallet/message_transporter.cpp
+++ b/src/wallet/message_transporter.cpp
@@ -80,7 +80,7 @@ namespace bitmessage_rpc
 
 }
 
-message_transporter::message_transporter()
+message_transporter::message_transporter(std::unique_ptr<epee::net_utils::http::abstract_http_client> http_client) : m_http_client(std::move(http_client))
 {
   m_run = true;
 }
@@ -96,7 +96,7 @@ void message_transporter::set_options(const std::string &bitmessage_address, con
   }
   m_bitmessage_login = bitmessage_login;
 
-  m_http_client.set_server(address_parts.host, std::to_string(address_parts.port), boost::none);
+  m_http_client->set_server(address_parts.host, std::to_string(address_parts.port), boost::none);
 }
 
 bool message_transporter::receive_messages(const std::vector<std::string> &destination_transport_addresses,
@@ -256,7 +256,7 @@ bool message_transporter::post_request(const std::string &request, std::string &
   additional_params.push_back(std::make_pair("Content-Type", "application/xml; charset=utf-8"));
   const epee::net_utils::http::http_response_info* response = NULL;
   std::chrono::milliseconds timeout = std::chrono::seconds(15);
-  bool r = m_http_client.invoke("/", "POST", request, timeout, std::addressof(response), std::move(additional_params));
+  bool r = m_http_client->invoke("/", "POST", request, timeout, std::addressof(response), std::move(additional_params));
   if (r)
   {
     answer = response->m_body;
@@ -266,7 +266,7 @@ bool message_transporter::post_request(const std::string &request, std::string &
     LOG_ERROR("POST request to Bitmessage failed: " << request.substr(0, 300));
     THROW_WALLET_EXCEPTION(tools::error::no_connection_to_bitmessage, m_bitmessage_url);
   }
-  m_http_client.disconnect();  // see comment above
+  m_http_client->disconnect();  // see comment above
   std::string string_value = get_str_between_tags(answer, "<string>", "</string>");
   if ((string_value.find("API Error") == 0) || (string_value.find("RPC ") == 0))
   {

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -34,9 +34,9 @@
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "net/http_server_impl_base.h"
 #include "net/http_client.h"
+#include "net/abstract_http_client.h"
 #include "common/util.h"
 #include "wipeable_string.h"
-#include "serialization/keyvalue_serialization.h"
 #include <vector>
 
 namespace mms
@@ -83,7 +83,7 @@ typedef epee::misc_utils::struct_init<transport_message_t> transport_message;
 class message_transporter
 {
 public:
-  message_transporter();
+  message_transporter(std::unique_ptr<epee::net_utils::http::abstract_http_client> http_client);
   void set_options(const std::string &bitmessage_address, const epee::wipeable_string &bitmessage_login);
   bool send_message(const transport_message &message);
   bool receive_messages(const std::vector<std::string> &destination_transport_addresses,
@@ -94,7 +94,7 @@ public:
   bool delete_transport_address(const std::string &transport_address);
 
 private:
-  epee::net_utils::http::http_simple_client m_http_client;
+  const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
   std::string m_bitmessage_url;
   epee::wipeable_string m_bitmessage_login;
   std::atomic<bool> m_run;

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -51,7 +51,7 @@ namespace tools
 
 static const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
 
-NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, rpc_payment_state_t &rpc_payment_state, boost::recursive_mutex &mutex)
+NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::abstract_http_client &http_client, rpc_payment_state_t &rpc_payment_state, boost::recursive_mutex &mutex)
   : m_http_client(http_client)
   , m_rpc_payment_state(rpc_payment_state)
   , m_daemon_rpc_mutex(mutex)

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -31,7 +31,7 @@
 #include <string>
 #include <boost/thread/mutex.hpp>
 #include "include_base_utils.h"
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "wallet_rpc_helpers.h"
 
@@ -41,7 +41,7 @@ namespace tools
 class NodeRPCProxy
 {
 public:
-  NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, rpc_payment_state_t &rpc_payment_state, boost::recursive_mutex &mutex);
+  NodeRPCProxy(epee::net_utils::http::abstract_http_client &http_client, rpc_payment_state_t &rpc_payment_state, boost::recursive_mutex &mutex);
 
   void set_client_secret_key(const crypto::secret_key &skey) { m_client_id_secret_key = skey; }
   void invalidate();
@@ -72,7 +72,7 @@ private:
 private:
   boost::optional<std::string> get_info();
 
-  epee::net_utils::http::http_simple_client &m_http_client;
+  epee::net_utils::http::abstract_http_client &m_http_client;
   rpc_payment_state_t &m_rpc_payment_state;
   boost::recursive_mutex &m_daemon_rpc_mutex;
   crypto::secret_key m_client_id_secret_key;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -269,7 +269,7 @@ private:
     static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev, uint64_t kdf_rounds);
     static bool query_device(hw::device::device_type& device_type, const std::string& keys_file_name, const epee::wipeable_string& password, uint64_t kdf_rounds = 1);
 
-    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, uint64_t kdf_rounds = 1, bool unattended = false);
+    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, uint64_t kdf_rounds = 1, bool unattended = false, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = std::unique_ptr<epee::net_utils::http::http_simple_client_factory>(new epee::net_utils::http::http_simple_client_factory()));
     ~wallet2();
 
     struct multisig_info
@@ -708,7 +708,7 @@ private:
      */
     void rewrite(const std::string& wallet_name, const epee::wipeable_string& password);
     void write_watch_only_wallet(const std::string& wallet_name, const epee::wipeable_string& password, std::string &new_keys_filename);
-    void load(const std::string& wallet, const epee::wipeable_string& password);
+    void load(const std::string& wallet, const epee::wipeable_string& password, const std::string& keys_buf = "", const std::string& cache_buf = "");
     void store();
     /*!
      * \brief store_to  Stores wallet to another file(s), deleting old ones
@@ -716,6 +716,19 @@ private:
      * \param password  Password to protect new wallet (TODO: probably better save the password in the wallet object?)
      */
     void store_to(const std::string &path, const epee::wipeable_string &password);
+    /*!
+     * \brief get_keys_file_data  Get wallet keys data which can be stored to a wallet file.
+     * \param password            Password of the encrypted wallet buffer (TODO: probably better save the password in the wallet object?)
+     * \param watch_only          true to include only view key, false to include both spend and view keys
+     * \return                    Encrypted wallet keys data which can be stored to a wallet file
+     */
+    boost::optional<wallet2::keys_file_data> get_keys_file_data(const epee::wipeable_string& password, bool watch_only);
+    /*!
+     * \brief get_cache_file_data   Get wallet cache data which can be stored to a wallet file.
+     * \param password              Password to protect the wallet cache data (TODO: probably better save the password in the wallet object?)
+     * \return                      Encrypted wallet cache data which can be stored to a wallet file
+     */
+    boost::optional<wallet2::cache_file_data> get_cache_file_data(const epee::wipeable_string& password);
 
     std::string path() const;
 
@@ -1319,25 +1332,25 @@ private:
     crypto::public_key get_multisig_signing_public_key(const crypto::secret_key &skey) const;
 
     template<class t_request, class t_response>
-    inline bool invoke_http_json(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET")
+    inline bool invoke_http_json(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST")
     {
       if (m_offline) return false;
       boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
-      return epee::net_utils::invoke_http_json(uri, req, res, m_http_client, timeout, http_method);
+      return epee::net_utils::invoke_http_json(uri, req, res, *m_http_client, timeout, http_method);
     }
     template<class t_request, class t_response>
-    inline bool invoke_http_bin(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET")
+    inline bool invoke_http_bin(const boost::string_ref uri, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST")
     {
       if (m_offline) return false;
       boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
-      return epee::net_utils::invoke_http_bin(uri, req, res, m_http_client, timeout, http_method);
+      return epee::net_utils::invoke_http_bin(uri, req, res, *m_http_client, timeout, http_method);
     }
     template<class t_request, class t_response>
-    inline bool invoke_http_json_rpc(const boost::string_ref uri, const std::string& method_name, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "GET", const std::string& req_id = "0")
+    inline bool invoke_http_json_rpc(const boost::string_ref uri, const std::string& method_name, const t_request& req, t_response& res, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST", const std::string& req_id = "0")
     {
       if (m_offline) return false;
       boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
-      return epee::net_utils::invoke_http_json_rpc(uri, method_name, req, res, m_http_client, timeout, http_method, req_id);
+      return epee::net_utils::invoke_http_json_rpc(uri, method_name, req, res, *m_http_client, timeout, http_method, req_id);
     }
 
     bool set_ring_database(const std::string &filename);
@@ -1403,11 +1416,18 @@ private:
      */
     bool store_keys(const std::string& keys_file_name, const epee::wipeable_string& password, bool watch_only = false);
     /*!
-     * \brief Load wallet information from wallet file.
+     * \brief Load wallet keys information from wallet file.
      * \param keys_file_name Name of wallet file
      * \param password       Password of wallet file
      */
     bool load_keys(const std::string& keys_file_name, const epee::wipeable_string& password);
+    /*!
+     * \brief Load wallet keys information from a string buffer.
+     * \param keys_buf       Keys buffer to load
+     * \param password       Password of keys buffer
+     */
+    bool load_keys_buf(const std::string& keys_buf, const epee::wipeable_string& password);
+    bool load_keys_buf(const std::string& keys_buf, const epee::wipeable_string& password, boost::optional<crypto::chacha_key>& keys_to_encrypt);
     void process_new_transaction(const crypto::hash &txid, const cryptonote::transaction& tx, const std::vector<uint64_t> &o_indices, uint64_t height, uint8_t block_version, uint64_t ts, bool miner_tx, bool pool, bool double_spend_seen, const tx_cache_data &tx_cache_data, std::map<std::pair<uint64_t, uint64_t>, size_t> *output_tracker_cache = NULL);
     bool should_skip_block(const cryptonote::block &b, uint64_t height) const;
     void process_new_blockchain_entry(const cryptonote::block& b, const cryptonote::block_complete_entry& bche, const parsed_block &parsed_block, const crypto::hash& bl_id, uint64_t height, const std::vector<tx_cache_data> &tx_cache_data, size_t tx_cache_data_offset, std::map<std::pair<uint64_t, uint64_t>, size_t> *output_tracker_cache = NULL);
@@ -1502,7 +1522,7 @@ private:
     std::string m_wallet_file;
     std::string m_keys_file;
     std::string m_mms_file;
-    epee::net_utils::http::http_simple_client m_http_client;
+    const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     hashchain m_blockchain;
     std::unordered_map<crypto::hash, unconfirmed_transfer_details> m_unconfirmed_txs;
     std::unordered_map<crypto::hash, confirmed_transfer_details> m_confirmed_txs;

--- a/src/wallet/wallet_rpc_payments.cpp
+++ b/src/wallet/wallet_rpc_payments.cpp
@@ -85,7 +85,7 @@ bool wallet2::make_rpc_payment(uint32_t nonce, uint32_t cookie, uint64_t &credit
   uint64_t pre_call_credits = m_rpc_payment_state.credits;
   req.client = get_client_signature();
   epee::json_rpc::error error;
-  bool r = epee::net_utils::invoke_http_json_rpc("/json_rpc", "rpc_access_submit_nonce", req, res, error, m_http_client, rpc_timeout);
+  bool r = epee::net_utils::invoke_http_json_rpc("/json_rpc", "rpc_access_submit_nonce", req, res, error, *m_http_client, rpc_timeout);
   m_daemon_rpc_mutex.unlock();
   THROW_ON_RPC_RESPONSE_ERROR_GENERIC(r, error, res, "rpc_access_submit_nonce");
   THROW_WALLET_EXCEPTION_IF(res.credits < pre_call_credits, error::wallet_internal_error, "RPC payment did not increase balance");

--- a/tests/fuzz/http-client.cpp
+++ b/tests/fuzz/http-client.cpp
@@ -29,6 +29,7 @@
 #include "include_base_utils.h"
 #include "file_io_utils.h"
 #include "net/http_client.h"
+#include "net/net_ssl.h"
 #include "fuzzer.h"
 
 class dummy_client
@@ -46,6 +47,10 @@ public:
     data.clear();
     return true;
   }
+  void set_ssl(epee::net_utils::ssl_options_t ssl_options) { }
+  bool is_connected(bool *ssl = NULL) { return true; }
+  uint64_t get_bytes_sent() const  { return 1; }
+  uint64_t get_bytes_received() const { return 1; }
 
   void set_test_data(const std::string &s) { data = s; }
 


### PR DESCRIPTION
- Add contrib/epee/include/net/abstract_http_client.h which
http_client.h extends.
- Replace `simple_http_client` with `abstract_http_client` in wallet2,
message_store, message_transporter, and node_rpc_proxy.
- Skip code incompatible with webassembly using `#if defined
__EMSCRIPTEN__` directives.
- Add ability to import and export wallet file buffers in wallet2
instead of using file system.

Code and collaboration credits: moneromooo, endogenic, mymonero

Feedback is requested on removing the call to `miner::find_nonce_for_given_block` in cryptonote_tx_utils.cpp and changing the default http method from `GET` to `POST` in wallet2.h and http_abstract_invoke.h (otherwise the browser issues `GET` requests which fail).