### PR TITLE
Clean removal of empty statements

### DIFF
--- a/contrib/epee/demo/iface/transport_defs.h
+++ b/contrib/epee/demo/iface/transport_defs.h
@@ -218,7 +218,7 @@ namespace demo
 
     s.m_subobj.m_str = "subszzzzzzzz";
     s.m_list_of_self.push_back(s);
-    s.m_storage_entry_int = epee::serialization::storage_entry(uint64_t(22222));;
+    s.m_storage_entry_int = epee::serialization::storage_entry(uint64_t(22222));
     s.m_storage_entry_string = epee::serialization::storage_entry(std::string("sdsvsdvs"));
     return s;
   }

--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -202,7 +202,7 @@ namespace net_utils
 
 			virtual bool thread_init()
 			{
-				return m_config.m_phandler->init_server_thread();;
+				return m_config.m_phandler->init_server_thread();
 			}
 	
 			virtual bool thread_deinit()

--- a/contrib/epee/include/net/munin_connection_handler.h
+++ b/contrib/epee/include/net/munin_connection_handler.h
@@ -237,7 +237,7 @@ namespace net_utils
 						return send_hook("Unknown command. Try list, nodes, config, fetch, version or quit\n");
 				}
 
-				return send_hook("Unknown command. Try list, nodes, config, fetch, version or quit\n");;
+				return send_hook("Unknown command. Try list, nodes, config, fetch, version or quit\n");
 			}
 
 			bool handle_list_command()

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1986,7 +1986,7 @@ bool BlockchainLMDB::prune_worker(int mode, uint32_t pruning_seed)
   const uint32_t log_stripes = tools::get_pruning_log_stripes(pruning_seed);
   if (log_stripes && log_stripes != CRYPTONOTE_PRUNING_LOG_STRIPES)
     throw0(DB_ERROR("Pruning seed not in range"));
-  pruning_seed = tools::get_pruning_stripe(pruning_seed);;
+  pruning_seed = tools::get_pruning_stripe(pruning_seed);
   if (pruning_seed > (1ul << CRYPTONOTE_PRUNING_LOG_STRIPES))
     throw0(DB_ERROR("Pruning seed not in range"));
   check_open();
@@ -3271,7 +3271,7 @@ output_data_t BlockchainLMDB::get_output_key(const uint64_t& amount, const uint6
   else
   {
     const pre_rct_outkey *okp = (const pre_rct_outkey *)v.mv_data;
-    memcpy(&ret, &okp->data, sizeof(pre_rct_output_data_t));;
+    memcpy(&ret, &okp->data, sizeof(pre_rct_output_data_t));
     if (include_commitmemt)
       ret.commitment = rct::zeroCommit(amount);
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5169,12 +5169,12 @@ bool Blockchain::for_all_transactions(std::function<bool(const crypto::hash&, co
 
 bool Blockchain::for_all_outputs(std::function<bool(uint64_t amount, const crypto::hash &tx_hash, uint64_t height, size_t tx_idx)> f) const
 {
-  return m_db->for_all_outputs(f);;
+  return m_db->for_all_outputs(f);
 }
 
 bool Blockchain::for_all_outputs(uint64_t amount, std::function<bool(uint64_t height)> f) const
 {
-  return m_db->for_all_outputs(amount, f);;
+  return m_db->for_all_outputs(amount, f);
 }
 
 void Blockchain::invalidate_block_template_cache()

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -142,7 +142,7 @@ namespace cryptonote
     uint64_t summary_amounts = 0;
     for (size_t no = 0; no < out_amounts.size(); no++)
     {
-      crypto::key_derivation derivation = AUTO_VAL_INIT(derivation);;
+      crypto::key_derivation derivation = AUTO_VAL_INIT(derivation);
       crypto::public_key out_eph_public_key = AUTO_VAL_INIT(out_eph_public_key);
       bool r = crypto::generate_key_derivation(miner_address.m_view_public_key, txkey.sec, derivation);
       CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to generate_key_derivation(" << miner_address.m_view_public_key << ", " << txkey.sec << ")");

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -69,7 +69,7 @@ uint16_t parse_public_rpc_port(const po::variables_map &vm)
   const auto &restricted_rpc_port = cryptonote::core_rpc_server::arg_rpc_restricted_bind_port;
   if (!command_line::is_arg_defaulted(vm, restricted_rpc_port))
   {
-    rpc_port_str = command_line::get_arg(vm, restricted_rpc_port);;
+    rpc_port_str = command_line::get_arg(vm, restricted_rpc_port);
   }
   else if (command_line::get_arg(vm, cryptonote::core_rpc_server::arg_restricted_rpc))
   {

--- a/src/ringct/bulletproofs.cc
+++ b/src/ringct/bulletproofs.cc
@@ -173,7 +173,7 @@ static rct::key cross_vector_exponent8(size_t size, const std::vector<ge_p3> &A,
   multiexp_data.resize(size*2 + (!!extra_point));
   for (size_t i = 0; i < size; ++i)
   {
-    sc_mul(multiexp_data[i*2].scalar.bytes, a[ao+i].bytes, INV_EIGHT.bytes);;
+    sc_mul(multiexp_data[i*2].scalar.bytes, a[ao+i].bytes, INV_EIGHT.bytes);
     multiexp_data[i*2].point = A[Ao+i];
     sc_mul(multiexp_data[i*2+1].scalar.bytes, b[bo+i].bytes, INV_EIGHT.bytes);
     if (scale)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -108,7 +108,7 @@ typedef cryptonote::simple_wallet sw;
   epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ \
     /* m_idle_mutex is still locked here */ \
     m_auto_refresh_enabled.store(auto_refresh_enabled, std::memory_order_relaxed); \
-    m_suspend_rpc_payment_mining.store(false, std::memory_order_relaxed);; \
+    m_suspend_rpc_payment_mining.store(false, std::memory_order_relaxed); \
     m_rpc_payment_checker.trigger(); \
     m_idle_cond.notify_one(); \
   })
@@ -1963,7 +1963,7 @@ bool simple_wallet::rpc_payment_info(const std::vector<std::string> &args)
       if (expected)
         message_writer() << tr("Credit discrepancy this session: ") << discrepancy << " (" << 100.0f * discrepancy / expected << "%)";
       float cph = credits_per_hash_found / (float)diff;
-      message_writer() << tr("Difficulty: ") << diff << ", " << credits_per_hash_found << " " << tr("credits per hash found, ") << cph << " " << tr("credits/hash");;
+      message_writer() << tr("Difficulty: ") << diff << ", " << credits_per_hash_found << " " << tr("credits per hash found, ") << cph << " " << tr("credits/hash");
       const boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
       bool mining = (now - m_last_rpc_payment_mining_time).total_microseconds() < 1000000;
       if (mining)

--- a/tests/unit_tests/mul_div.cpp
+++ b/tests/unit_tests/mul_div.cpp
@@ -82,7 +82,7 @@ namespace
 
     lo = mul128(0x1111111111111111, 0x1111111111111111, &hi);
     ASSERT_EQ(lo, 0x0fedcba987654321);
-    ASSERT_EQ(hi, 0x0123456789abcdf0);;
+    ASSERT_EQ(hi, 0x0123456789abcdf0);
   }
 
   TEST(mul128_with_carry_1_only, multiplies_correctly)

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -44,7 +44,7 @@ namespace
 
 TEST(parse_tx_extra, handles_empty_extra)
 {
-  std::vector<uint8_t> extra;;
+  std::vector<uint8_t> extra;
   std::vector<cryptonote::tx_extra_field> tx_extra_fields;
   ASSERT_TRUE(cryptonote::parse_tx_extra(extra, tx_extra_fields));
   ASSERT_TRUE(tx_extra_fields.empty());


### PR DESCRIPTION
Cleaning up a little around code base, and I found empty statements on our fork. It is human error, and they are safely removed.