### PR TITLE
simplewallet: fix smart mining not starting after first setup

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5199,8 +5199,11 @@ void simple_wallet::check_background_mining(const epee::wipeable_string &passwor
   if (is_background_mining_enabled)
   {
     // already active, nice
-    m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningYes);
-    m_wallet->rewrite(m_wallet_file, password);
+    if (setup == tools::wallet2::BackgroundMiningMaybe)
+    {
+      m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningYes);
+      m_wallet->rewrite(m_wallet_file, password);
+    }
     start_background_mining();
     return;
   }
@@ -5221,6 +5224,11 @@ void simple_wallet::check_background_mining(const epee::wipeable_string &passwor
     }
     m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningYes);
     m_wallet->rewrite(m_wallet_file, password);
+    start_background_mining();
+  }
+  else
+  {
+    // the setting is already enabled, and the daemon is not mining yet, so start it
     start_background_mining();
   }
 }


### PR DESCRIPTION
Also avoid rewriting the wallet if the setting is already was we need