### PR TITLE
rpc: Add check for too old timestamps in payment signatures.

### DIFF
--- a/src/rpc/rpc_payment_signature.cpp
+++ b/src/rpc/rpc_payment_signature.cpp
@@ -102,6 +102,11 @@ namespace cryptonote
       MDEBUG("Timestamp is in the future");
       return false;
     }
+    if (ts < now - TIMESTAMP_LEEWAY)
+    {
+      MDEBUG("Timestamp is too old");
+      return false;
+    }
     return true;
   }
 }


### PR DESCRIPTION
Or is there a reason to allow old timestamps?
