### PR TITLE
Improve hex->bin Conversion

### DIFF
--- a/contrib/epee/include/hex.h
+++ b/contrib/epee/include/hex.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, The Monero Project
+// Copyright (c) 2017-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -80,9 +80,20 @@ namespace epee
     static void buffer_unchecked(char* out, const span<const std::uint8_t> src) noexcept;
   };
 
+  //! Convert hex in UTF8 encoding to binary
   struct from_hex
   {
-      //! \return An std::vector of unsigned integers from the `src`
-      static std::vector<uint8_t> vector(boost::string_ref src);
+    static bool to_string(std::string& out, boost::string_ref src);
+
+    static bool to_buffer(span<std::uint8_t> out, boost::string_ref src) noexcept;
+
+  private:
+    static bool to_buffer_unchecked(std::uint8_t* out, boost::string_ref src) noexcept;
+  };
+
+  //! Convert hex in current C locale encoding to binary
+  struct from_hex_locale
+  {
+      static std::vector<uint8_t> to_vector(boost::string_ref src);
   };
 }

--- a/contrib/epee/include/storages/parserse_base_utils.h
+++ b/contrib/epee/include/storages/parserse_base_utils.h
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <boost/utility/string_ref.hpp>
 
+#include "misc_log_ex.h"
+
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "serialization"
 

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -42,6 +42,7 @@
 #include <type_traits>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/utility/string_ref.hpp>
 #include "misc_log_ex.h"
 #include "storages/parserse_base_utils.h"
 #include "hex.h"
@@ -69,7 +70,7 @@ namespace string_tools
     return to_hex::string(to_byte_span(to_span(src)));
   }
   //----------------------------------------------------------------------------
-  inline bool parse_hexstr_to_binbuff(const epee::span<const char> s, epee::span<char>& res)
+  inline bool parse_hexstr_to_binbuff(const boost::string_ref s, epee::span<char> res)
   {
       if (s.size() != res.size() * 2)
         return false;
@@ -90,7 +91,7 @@ namespace string_tools
       return true;
   }
   //----------------------------------------------------------------------------
-  inline bool parse_hexstr_to_binbuff(const std::string& s, std::string& res)
+  inline bool parse_hexstr_to_binbuff(const boost::string_ref s, std::string& res)
   {
     if (s.size() & 1)
       return false;
@@ -303,7 +304,7 @@ POP_WARNINGS
   }
   //----------------------------------------------------------------------------
   template<class t_pod_type>
-  bool hex_to_pod(const std::string& hex_str, t_pod_type& s)
+  bool hex_to_pod(const boost::string_ref hex_str, t_pod_type& s)
   {
     static_assert(std::is_pod<t_pod_type>::value, "expected pod type");
     if(sizeof(s)*2 != hex_str.size())
@@ -313,13 +314,13 @@ POP_WARNINGS
   }
   //----------------------------------------------------------------------------
   template<class t_pod_type>
-  bool hex_to_pod(const std::string& hex_str, tools::scrubbed<t_pod_type>& s)
+  bool hex_to_pod(const boost::string_ref hex_str, tools::scrubbed<t_pod_type>& s)
   {
     return hex_to_pod(hex_str, unwrap(s));
   }
   //----------------------------------------------------------------------------
   template<class t_pod_type>
-  bool hex_to_pod(const std::string& hex_str, epee::mlocked<t_pod_type>& s)
+  bool hex_to_pod(const boost::string_ref hex_str, epee::mlocked<t_pod_type>& s)
   {
     return hex_to_pod(hex_str, unwrap(s));
   }

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -70,34 +70,9 @@ namespace string_tools
     return to_hex::string(to_byte_span(to_span(src)));
   }
   //----------------------------------------------------------------------------
-  inline bool parse_hexstr_to_binbuff(const boost::string_ref s, epee::span<char> res)
-  {
-      if (s.size() != res.size() * 2)
-        return false;
-
-      unsigned char *dst = (unsigned char *)&res[0];
-      const unsigned char *src = (const unsigned char *)s.data();
-      for(size_t i = 0; i < s.size(); i += 2)
-      {
-        int tmp = *src++;
-        tmp = epee::misc_utils::parse::isx[tmp];
-        if (tmp == 0xff) return false;
-        int t2 = *src++;
-        t2 = epee::misc_utils::parse::isx[t2];
-        if (t2 == 0xff) return false;
-        *dst++ = (tmp << 4) | t2;
-      }
-
-      return true;
-  }
-  //----------------------------------------------------------------------------
   inline bool parse_hexstr_to_binbuff(const boost::string_ref s, std::string& res)
   {
-    if (s.size() & 1)
-      return false;
-    res.resize(s.size() / 2);
-    epee::span<char> rspan((char*)&res[0], res.size());
-    return parse_hexstr_to_binbuff(epee::to_span(s), rspan);
+    return from_hex::to_string(res, s);
   }
   //----------------------------------------------------------------------------
 PUSH_WARNINGS
@@ -306,11 +281,8 @@ POP_WARNINGS
   template<class t_pod_type>
   bool hex_to_pod(const boost::string_ref hex_str, t_pod_type& s)
   {
-    static_assert(std::is_pod<t_pod_type>::value, "expected pod type");
-    if(sizeof(s)*2 != hex_str.size())
-      return false;
-    epee::span<char> rspan((char*)&s, sizeof(s));
-    return parse_hexstr_to_binbuff(epee::to_span(hex_str), rspan);
+    static_assert(std::is_standard_layout<t_pod_type>(), "expected standard layout type");
+    return from_hex::to_buffer(as_mut_byte_span(s), hex_str);
   }
   //----------------------------------------------------------------------------
   template<class t_pod_type>

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -51,7 +51,7 @@ namespace cryptonote
         const std::vector<std::string> ssl_allowed_fingerprints = command_line::get_arg(vm, arg.rpc_ssl_allowed_fingerprints);
 
         std::vector<std::vector<uint8_t>> allowed_fingerprints{ ssl_allowed_fingerprints.size() };
-        std::transform(ssl_allowed_fingerprints.begin(), ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex::vector);
+        std::transform(ssl_allowed_fingerprints.begin(), ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex_locale::to_vector);
         for (const auto &fpr: allowed_fingerprints)
         {
           if (fpr.size() != SSL_FINGERPRINT_SIZE)

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019, The Monero Project
+// Copyright (c) 2016-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -32,7 +32,11 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <limits>
 #include <type_traits>
-#include "string_tools.h"
+
+// drop macro from windows.h
+#ifdef GetObject
+  #undef GetObject
+#endif
 
 namespace cryptonote
 {
@@ -106,6 +110,19 @@ namespace
       throw WRONG_TYPE{"unsigned integer"};
     }
     convert_numeric(val.GetUint64(), i);
+  }
+}
+
+void read_hex(const rapidjson::Value& val, epee::span<std::uint8_t> dest)
+{
+  if (!val.IsString())
+  {
+    throw WRONG_TYPE("string");
+  }
+
+  if (!epee::from_hex::to_buffer(dest, {val.GetString(), val.Size()}))
+  {
+    throw BAD_INPUT();
   }
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -357,7 +357,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   else if (!daemon_ssl_ca_file.empty() || !daemon_ssl_allowed_fingerprints.empty())
   {
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ daemon_ssl_allowed_fingerprints.size() };
-    std::transform(daemon_ssl_allowed_fingerprints.begin(), daemon_ssl_allowed_fingerprints.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
+    std::transform(daemon_ssl_allowed_fingerprints.begin(), daemon_ssl_allowed_fingerprints.end(), ssl_allowed_fingerprints.begin(), epee::from_hex_locale::to_vector);
     for (const auto &fpr: ssl_allowed_fingerprints)
     {
       THROW_WALLET_EXCEPTION_IF(fpr.size() != SSL_FINGERPRINT_SIZE, tools::error::wallet_internal_error,


### PR DESCRIPTION
The initial reason for the change was hex->bin conversion in the ZMQ JSON-RPC server required a temporary `std::string` for each attempt. The individual commits should explain the other changes.

@hyc and @moneromooo-monero should have copyrights, allowing the move into the monero copyrighted file. This move isn't strictly necessary to improve performance, but does it make easier on the compiler (less code in the header AND declared in a header with less overhead). The latter is useful because the ZMQ JSON code can (eventually) just include `hex.h` instead of the more expensive `string_tools.h`.