### PR TITLE
README: Provides safer semaphore privilege to FreeBSD jail; notes port/pkg availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,10 @@ application.
 
 ### On FreeBSD:
 
-The project can be built from scratch by following instructions for Linux above(but use `gmake` instead of `make`). If you are running monero in a jail you need to add the flag: `allow.sysvipc=1` to your jail configuration, otherwise lmdb will throw the error message: `Failed to open lmdb environment: Function not implemented`.
+The project can be built from scratch by following instructions for Linux above(but use `gmake` instead of `make`). 
+If you are running monero in a jail, you need to add `sysvsem="new"` to your jail configuration, otherwise lmdb will throw the error message: `Failed to open lmdb environment: Function not implemented`.
 
-We expect to add Monero into the ports tree in the near future, which will aid in managing installations using ports or packages.
+Monero is also available as a port or package as 'monero-cli`.
 
 ### On OpenBSD:
 


### PR DESCRIPTION
From the FreeBSD architecture handbook (https://www.freebsd.org/doc/en/books/arch-handbook/jail-restrictions.html) as it relates to `allow.sysvipc`, "By default, this sysctl is set to 0. If it were set to 1, it would defeat the whole purpose of having a jail; privileged users from the jail would be able to affect processes outside the jailed environment."  This is undesirable behavior.

Per `man jail`, regarding `allow.sysvipc`, "A process within the jail has access to System V primitives.  This is deprecated in favor of the per-module parameters."

Since FreeBSD 11, the new way to deal with this (the per-module parameters) is with: `sysvshm`, for shared memory, `sysvsem`, for semaphores, and `sysvmsg`, for message queues.  These can be set selectively to either `disable`; `inherit`, for the previous behavior (problematic due to UID collision, apparently); and `new`, for new behavior that avoids the UID collision problem. 

Monero only uses semaphores, therefore we should recommend that jails be run with `sysvsem="new"` in the jail's jail.conf.  Tested on FreeBSD 12.1.

Also, Monero is now able to be downloaded as a package or built from ports as `monero-cli` with a versioned suffix.  It's got `Monero 'Carbon Chamaeleon' (v0.15.0.1-release)` as of right now, and it's been there 2-3 months, meaning it's currently and timely.