### PR TITLE
Fixed string_ref usage bug in epee::from_hex::vector

### DIFF
--- a/contrib/epee/src/hex.cpp
+++ b/contrib/epee/src/hex.cpp
@@ -84,7 +84,7 @@ namespace epee
     return write_hex(out, src);
   }
 
-  std::vector<uint8_t> from_hex::vector(boost::string_ref src)
+  std::vector<uint8_t> from_hex::vector(const boost::string_ref src)
   {
     // should we include a specific character
     auto include = [](char input) {
@@ -104,7 +104,7 @@ namespace epee
     result.reserve(count / 2);
 
     // the data to work with (std::string is always null-terminated)
-    auto data = src.data();
+    auto data = src.begin();
 
     // convert a single hex character to an unsigned integer
     auto char_to_int = [](const char *input) {
@@ -130,9 +130,9 @@ namespace epee
     };
 
     // keep going until we reach the end
-    while (data[0] != '\0') {
+    while (data != src.end()) {
       // skip unwanted characters
-      if (!include(data[0])) {
+      if (!include(*data)) {
         ++data;
         continue;
       }

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -840,6 +840,9 @@ TEST(FromHex, String)
     // decoding it this way also, ignoring spaces and colons between the numbers
     hex.assign("00:ff 0f:f0");
     EXPECT_EQ(source, epee::from_hex::vector(hex));
+
+    hex.append("f0");
+    EXPECT_EQ(source, epee::from_hex::vector(boost::string_ref{hex.data(), hex.size() - 2}));
 }
 
 TEST(ToHex, Array)


### PR DESCRIPTION
Identical to PR #6359 except on 0.15 branch. There shouldn't be any issues with current usage, so this is mainly a protection against potential modifications to this branch.