### PR TITLE
Fix compatibility with boost < 1.64

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,13 +332,13 @@ If you are using the older Raspbian Jessie image, compiling Monero is a bit more
 
 * Then, install the dependencies for Monero except `libunwind` and `libboost-all-dev`
 
-* Install the latest version of boost (this may first require invoking `apt-get remove --purge libboost*` to remove a previous version if you're not using a clean install):
+* Install the latest version of boost (this may first require invoking `apt-get remove --purge libboost*-dev` to remove a previous version if you're not using a clean install):
 
     ```bash
     cd
-    wget https://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2
-    tar xvfo boost_1_64_0.tar.bz2
-    cd boost_1_64_0
+    wget https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2
+    tar xvfo boost_1_72_0.tar.bz2
+    cd boost_1_72_0
     ./bootstrap.sh
     sudo ./b2
     ```

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -289,7 +289,9 @@ ssl_options_t::ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints
 
 boost::asio::ssl::context ssl_options_t::create_context() const
 {
-  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::tls};
+  // note: this enables a lot of old and insecure protocols, which we
+  // promptly disable below - if the result is actually used
+  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::sslv23};
   if (!bool(*this))
     return ssl_context;
 


### PR DESCRIPTION
The reason for this is that we use `boost::asio::ssl::context::tls`,
which was introduced in version 1.64, the current master will not
compile with an older boost version.

Additionally, the check in CMake for boost version smaller than 1.62 was
removed, since this no longer applies (the configure would have failed
because the required minimum version was not found).

The instructions for building boost from source on debian Jessie have
been slightly changed, with the old instructions we would have tried to
remove all installed boost packages - which are also used by other
packages installed on the system. Instead we now only remove the header
files.

The downloaded version for boost has also been bumped to 1.72. If we are
building boost from source, there is no reason not to use the most
recent version.