### PR TITLE
Fix receive order leakage with tx fluffing

### DIFF
--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -358,7 +358,10 @@ namespace levin
         });
 
         for (auto& connection : connections)
+        {
+          std::sort(connection.first.begin(), connection.first.end()); // don't leak receive order
           make_payload_send_txs(*zone_->p2p, std::move(connection.first), connection.second, zone_->pad_txs);
+        }
 
         if (next_flush != std::chrono::steady_clock::time_point::max())
           fluff_flush::queue(std::move(zone_), next_flush);

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -462,8 +462,8 @@ TEST_F(levin_notify, fluff_without_padding)
     }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'e');
-    txs[1].resize(200, 'f');
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
 
     ASSERT_EQ(10u, contexts_.size());
     {
@@ -479,6 +479,7 @@ TEST_F(levin_notify, fluff_without_padding)
         for (++context; context != contexts_.end(); ++context)
             EXPECT_EQ(1u, context->process_send_queue());
 
+        std::sort(txs.begin(), txs.end());
         ASSERT_EQ(9u, receiver_.notified_size());
         for (unsigned count = 0; count < 9; ++count)
         {
@@ -510,8 +511,8 @@ TEST_F(levin_notify, fluff_with_padding)
     }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'e');
-    txs[1].resize(200, 'f');
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
 
     ASSERT_EQ(10u, contexts_.size());
     {
@@ -527,6 +528,7 @@ TEST_F(levin_notify, fluff_with_padding)
         for (++context; context != contexts_.end(); ++context)
             EXPECT_EQ(1u, context->process_send_queue());
 
+        std::sort(txs.begin(), txs.end());
         ASSERT_EQ(9u, receiver_.notified_size());
         for (unsigned count = 0; count < 9; ++count)
         {
@@ -558,8 +560,8 @@ TEST_F(levin_notify, private_fluff_without_padding)
     }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'e');
-    txs[1].resize(200, 'f');
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
 
     ASSERT_EQ(10u, contexts_.size());
     {
@@ -572,6 +574,7 @@ TEST_F(levin_notify, private_fluff_without_padding)
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
 
+        std::sort(txs.begin(), txs.end());
         EXPECT_EQ(0u, context->process_send_queue());
         for (++context; context != contexts_.end(); ++context)
         {
@@ -610,8 +613,8 @@ TEST_F(levin_notify, private_fluff_with_padding)
     }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'e');
-    txs[1].resize(200, 'f');
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
 
     ASSERT_EQ(10u, contexts_.size());
     {
@@ -624,6 +627,7 @@ TEST_F(levin_notify, private_fluff_with_padding)
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
 
+        std::sort(txs.begin(), txs.end());
         EXPECT_EQ(0u, context->process_send_queue());
         for (++context; context != contexts_.end(); ++context)
         {


### PR DESCRIPTION
Transactions are temporarily queued per connection for diffusion, which can leak receive/processing order of two different connections.