### PR TITLE
depends: libsodium disable getrandom()/getentropy() (glibc < 2.25)

### DIFF
--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -3,7 +3,7 @@ $(package)_version=1.0.18
 $(package)_download_path=https://download.libsodium.org/libsodium/releases/
 $(package)_file_name=libsodium-$($(package)_version).tar.gz
 $(package)_sha256_hash=6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
-$(package)_patches=fix-whitespace.patch
+$(package)_patches=disable-glibc-getrandom-getentropy.patch fix-whitespace.patch
 
 define $(package)_set_vars
 $(package)_config_opts=--enable-static --disable-shared
@@ -13,6 +13,7 @@ $(package)_config_opts_darwin=RANLIB="$(host_prefix)/native/bin/x86_64-apple-dar
 endef
 
 define $(package)_config_cmds
+  patch -p1 < $($(package)_patch_dir)/disable-glibc-getrandom-getentropy.patch &&\
   ./autogen.sh &&\
   patch -p1 < $($(package)_patch_dir)/fix-whitespace.patch &&\
   $($(package)_autoconf) $($(package)_config_opts) AR_FLAGS=$($(package)_arflags)

--- a/contrib/depends/patches/sodium/disable-glibc-getrandom-getentropy.patch
+++ b/contrib/depends/patches/sodium/disable-glibc-getrandom-getentropy.patch
@@ -1,0 +1,25 @@
+diff --git a/configure.ac b/configure.ac
+index 9e2de27c..0fa85c2d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -807,6 +807,10 @@ AS_IF([test "x$EMSCRIPTEN" = "x"],[
+ # include <sys/random.h>
+ #endif
+ ]], [[
++#ifdef __linux__
++# error getrandom() is currently disabled on Linux to support glibc < 2.25
++#endif
++
+ unsigned char buf;
+ (void) getrandom((void *) &buf, 1U, 0U);
+   ]])],
+@@ -825,6 +829,9 @@ unsigned char buf;
+ # include <sys/random.h>
+ #endif
+ ]], [[
++#ifdef __linux__
++# error getentropy() is currently disabled on Linux to support glibc < 2.25
++#endif
+ #ifdef __APPLE__
+ # error getentropy() is currently disabled on Apple operating systems
+ #endif


### PR DESCRIPTION
Resolves https://github.com/monero-project/monero/issues/6396