### PR TITLE
depends: update qt 5.7.1 download link

### DIFF
--- a/contrib/depends/packages/qt.mk
+++ b/contrib/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=https://download.qt.io/archive/qt/5.7/5.7.1/submodules
+$(package)_download_path=http://linorg.usp.br/Qt/archive/qt/5.7/5.7.1/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410


### PR DESCRIPTION
5.7.1 was removed from official qt.io archive, this is one of the few mirrors remaining that keep a copy.
I think it would be better if @TheCharlatan updated to a newer version soon than merging this PR