### PR TITLE
BlockchainDB Rework transactions to improve thread safety

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -283,9 +283,9 @@ typedef struct outtx {
     uint64_t local_index;
 } outtx;
 
-const std::string& mdb_databases::name(source database)
+const char* mdb_databases::name(source database)
 {
-  static std::array<std::string, 18> names{
+  constexpr static std::array<const char*, 18> names{
     "blocks",
     "block_heights",
     "block_info",
@@ -325,7 +325,7 @@ MDB_stat mdb_databases::stat(MDB_txn* txn, source database) const
     return stat;
 
   auto error_message =
-    "Failed to query " +
+    std::string{"Failed to query "} +
     mdb_databases::name(database) +
     ": " +
     mdb_strerror(res);
@@ -341,7 +341,7 @@ void mdb_databases::drop(MDB_txn* txn, source database, bool close)
     return;
 
   auto error_message =
-    "Failed to drop " +
+    std::string{"Failed to drop "} +
     mdb_databases::name(database) +
     ": " +
     mdb_strerror(res);
@@ -513,7 +513,7 @@ MDB_cursor* mdb_writer_data::cursor(source database)
     return cursor;
 
   auto error_message =
-    "Failed to open a cursor for " +
+    std::string{"Failed to open a cursor for "} +
     mdb_databases::name(database) +
     ": " +
     mdb_strerror(res);
@@ -717,7 +717,7 @@ MDB_cursor* mdb_read_handle::cursor(source database)
     }
 
     auto error_message =
-      "Failed to open a cursor for " +
+      std::string{"Failed to open a cursor for "} +
       mdb_databases::name(database) +
       ": " +
       mdb_strerror(res);
@@ -735,7 +735,7 @@ MDB_cursor* mdb_read_handle::cursor(source database)
     }
 
     auto error_message =
-      "Failed to renew a cursor for " +
+      std::string{"Failed to renew a cursor for "} +
       mdb_databases::name(database) +
       ": " +
       mdb_strerror(res);
@@ -754,13 +754,13 @@ inline void BlockchainLMDB::check_open() const
 
 void BlockchainLMDB::db_open(MDB_txn* txn, int flags, source database)
 {
-  auto res = mdb_dbi_open(txn, mdb_databases::name(database).data(), flags, &m_databases.get(database));
+  auto res = mdb_dbi_open(txn, mdb_databases::name(database), flags, &m_databases.get(database));
 
   if (res == 0)
     return;
 
   auto error_message =
-    "Failed to open db handle for " +
+    std::string{"Failed to open db handle for "} +
     mdb_databases::name(database) +
     ": " +
     mdb_strerror(res) +

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -500,7 +500,7 @@ mdb_txn_cursors& mdb_writer_data::cursors()
 MDB_cursor* mdb_writer_data::cursor(source database)
 {
   if (current_thread() != boost::this_thread::get_id())
-    throw1(DB_ERROR{"transaction owned by other threayyd"});
+    throw1(DB_ERROR{"transaction owned by other thread"});
 
   auto& cursor = m_cursors->get(database);
 
@@ -556,7 +556,7 @@ MDB_txn* mdb_writer_data::acquire()
 void mdb_writer_data::release(bool error)
 {
   if (current_thread() != boost::this_thread::get_id())
-    throw1(DB_ERROR{"transaction owned by other threayyd"});
+    throw1(DB_ERROR{"transaction owned by other thread"});
 
   if (m_writer_depth == 0)
     throw1(DB_ERROR{"transaction already released"});

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -619,8 +619,15 @@ mdb_write_handle::~mdb_write_handle()
   if (m_data == nullptr || m_txn == nullptr)
     return;
 
-  LOG_PRINT_L3("mdb_write_handle: destructor");
-  m_data->release(static_cast<bool>(std::current_exception()));
+  // note: logging may throw, release may throw if the commit fails
+  try
+  {
+    LOG_PRINT_L3("mdb_write_handle: destructor");
+    m_data->release(static_cast<bool>(std::current_exception()));
+  } catch (...)
+  {
+    // note: don't log here, since it may yield another exception
+  }
 }
 
 mdb_write_handle& mdb_write_handle::operator=(mdb_write_handle&& that) noexcept

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -32,6 +32,7 @@
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
 #include "ringct/rctTypes.h"
 #include <boost/thread/tss.hpp>
+#include <thread>
 
 #include <lmdb.h>
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -154,6 +154,8 @@ struct mdb_txn_safe
   static void prevent_new_txns();
   static void wait_no_active_txns();
   static void allow_new_txns();
+  static void wait_and_register();
+  static void unregister();
 
   static std::atomic<uint64_t> num_active_txns;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -32,7 +32,6 @@
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
 #include "ringct/rctTypes.h"
 #include <boost/thread/tss.hpp>
-#include <boost/atomic/atomic.hpp>
 
 #include <lmdb.h>
 
@@ -177,7 +176,7 @@ class mdb_writer_data
 
     ~mdb_writer_data();
 
-    boost::thread::id current_thread() const noexcept;
+    std::thread::id current_thread() const noexcept;
 
     mdb_databases& databases() noexcept;
     mdb_txn_cursors& cursors();
@@ -193,7 +192,7 @@ class mdb_writer_data
     MDB_txn* m_txn;
     mdb_databases& m_databases;
     boost::optional<mdb_txn_cursors> m_cursors;
-    boost::atomic<boost::thread::id> m_writer_thread;
+    std::atomic<std::thread::id> m_writer_thread;
     size_t m_writer_depth;
     bool m_error;
 };

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -106,7 +106,7 @@ class mdb_databases
         m_databases{{}}
       {}
 
-      const static std::string& name(source database);
+      static const char* name(source database);
 
       const MDB_dbi& get(source database) const
       {


### PR DESCRIPTION
This is a large PR, which fixes a number of issues.

- the mdb_cursors struct was cast to an array, which is technically undefined behaviour
- the m_writer variable was not atomic, nor protected by a lock, resulting in possible race conditions
- some functions called mutliple functions without an overarching transaction (inconsistent view)