### PR TITLE
Correct key image check in tx_pool

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -422,27 +422,18 @@ namespace cryptonote
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, txin, false);
       std::unordered_set<crypto::hash>& kei_image_set = m_spent_key_images[txin.k_image];
 
-      /* If any existing key-image in the set is publicly visible AND this is
-         not forcibly "kept_by_block", then fail (duplicate key image). If all
-         existing key images are supposed to be hidden, we silently allow so
-         that the node doesn't leak knowledge of a local/stem tx. */
-      bool visible = false;
+      // Only allow multiple txes per key-image if kept-by-block. Only allow
+      // the same txid if going from local/stem->fluff.
+
       if (tx_relay != relay_method::block)
       {
-        for (const crypto::hash& other_id : kei_image_set)
-          visible |= m_blockchain.txpool_tx_matches_category(other_id, relay_category::legacy);
-      }
-
-      CHECK_AND_ASSERT_MES(!visible, false, "internal error: tx_relay=" << unsigned(tx_relay)
+        const bool one_txid =
+          (kei_image_set.empty() || (kei_image_set.size() == 1 && *(kei_image_set.cbegin()) == id));
+        CHECK_AND_ASSERT_MES(one_txid, false, "internal error: tx_relay=" << unsigned(tx_relay)
                                            << ", kei_image_set.size()=" << kei_image_set.size() << ENDL << "txin.k_image=" << txin.k_image << ENDL
                                            << "tx_id=" << id);
+      }
 
-      /* If adding a tx (hash) that already exists, fail only if the tx has
-         been publicly "broadcast" previously. This way, when a private tx is
-         received for the first time from a remote node, "this" node will
-         respond as-if it were seen for the first time. LMDB does the
-         "hard-check"  on key-images, so the effect is overwriting the existing
-         tx_pool metadata and "first seen" time. */
       const bool new_or_previously_private =
         kei_image_set.insert(id).second ||
         !m_blockchain.txpool_tx_matches_category(id, relay_category::legacy);

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -161,6 +161,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(txpool_spend_key_all);
     GENERATE_AND_PLAY(txpool_double_spend_norelay);
     GENERATE_AND_PLAY(txpool_double_spend_local);
+    GENERATE_AND_PLAY(txpool_double_spend_keyimage);
 
     // Double spend
     GENERATE_AND_PLAY(gen_double_spend_in_tx<false>);

--- a/tests/core_tests/tx_pool.h
+++ b/tests/core_tests/tx_pool.h
@@ -77,6 +77,7 @@ class txpool_double_spend_base : public txpool_base
   std::unordered_set<crypto::hash> m_no_relay_hashes;
   std::unordered_map<crypto::hash, uint64_t> m_all_hashes;
   size_t m_no_new_index;
+  size_t m_failed_index;
   size_t m_new_timestamp_index;
   crypto::hash m_last_tx;
 
@@ -86,6 +87,7 @@ public:
   txpool_double_spend_base();
 
   bool mark_no_new(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
+  bool mark_failed(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
   bool mark_timestamp_change(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
 
   //! Pause for 1 second, so that `receive_time` for tx meta changes (tx hidden from public rpc being updated)
@@ -111,6 +113,15 @@ struct txpool_double_spend_norelay : txpool_double_spend_base
 struct txpool_double_spend_local : txpool_double_spend_base
 {
   txpool_double_spend_local()
+    : txpool_double_spend_base()
+  {}
+
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+
+struct txpool_double_spend_keyimage : txpool_double_spend_base
+{
+  txpool_double_spend_keyimage()
     : txpool_double_spend_base()
   {}
 


### PR DESCRIPTION
This makes the check closer [to the original](https://github.com/monero-project/monero/blob/c96b7ee61910ab64e0e0cbd978addfe2ea3e4b27/src/cryptonote_core/tx_pool.cpp#L416). The inline comment should explain enough. This was due to a reddit post, asking about DoS and Dandelion (mentioned in a Bitcoin thread). I also think the check is far more clear now, my original approach was a bit confusing.

The summary is that this allows a txid to go from stem->fluff but does not allow a key-image with two different txid in the stem phase. This can only occur if someone were trying to spam.