### PR TITLE
Improve/zmq json zero copy

### DIFF
--- a/contrib/epee/include/byte_slice.h
+++ b/contrib/epee/include/byte_slice.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, The Monero Project
+// Copyright (c) 2019-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -39,6 +39,7 @@
 namespace epee
 {
   struct byte_slice_data;
+  class byte_stream;
 
   struct release_byte_slice
   {
@@ -48,6 +49,12 @@ namespace epee
     {
       call(nullptr, ptr);
     }
+  };
+
+  //! Frees ref count + buffer allocated internally by `byte_buffer`.
+  struct release_byte_buffer
+  {
+    void operator()(std::uint8_t* buf) const noexcept;
   };
 
   /*! Inspired by slices in golang. Storage is thread-safe reference counted,
@@ -104,6 +111,9 @@ namespace epee
     //! Convert `buffer` into a slice using one allocation for shared count.
     explicit byte_slice(std::string&& buffer);
 
+    //! Convert `stream` into a slice with zero allocations.
+    explicit byte_slice(byte_stream&& stream) noexcept;
+
     byte_slice(byte_slice&& source) noexcept;
     ~byte_slice() noexcept = default;
 
@@ -149,5 +159,19 @@ namespace epee
     //! \post `empty()` \return Ownership of ref-counted buffer.
     std::unique_ptr<byte_slice_data, release_byte_slice> take_buffer() noexcept;
   };
+
+  //! Alias for a buffer that has space for a `byte_slice` ref count.
+  using byte_buffer = std::unique_ptr<std::uint8_t, release_byte_buffer>;
+
+  /*! \return `buf` with a new size of exactly `length`. New bytes not
+        initialized. A `nullptr` is returned on allocation failure. */
+  byte_buffer byte_buffer_resize(byte_buffer buf, std::size_t length) noexcept;
+
+  /*! Increase `buf` of size `current` by `more` bytes.
+
+    \throw std::range_error if `current + more` exceeds `size_t` bounds.
+    \return Buffer of `current + more` bytes. A `nullptr` is returned on
+      allocation failure. */
+  byte_buffer byte_buffer_increase(byte_buffer buf, std::size_t current, std::size_t more);
 } // epee
 

--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -1,0 +1,224 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include "byte_slice.h"
+#include "span.h"
+
+namespace epee
+{
+  /*! \brief A partial drop-in replacement for `std::ostream`.
+
+      Only a few base `std::ostream` functions are implemented - enough for
+      rapidjson output currently.
+
+      Advantages over `std::stringstream` or `rapidjson::StringBuffer`:
+        - The internal buffer can be taken without a copy.
+        - The internal buffer can be given to `byte_slice` with zero
+          allocations for reference count.
+        - The internal buffer can be given to `zmq_msg_data_init` without a
+          copy or extra allocation.
+      an additional advantage over `std::stringstream`:
+        - Construction is significantly faster - the global `std::locale`
+          does not have to be acquired (global thread synchronization), and
+          an extra allocation for `std::stringbuf` is not needed (which is an
+          addition to the buffer inside of that object). */
+  class byte_stream
+  {
+    byte_buffer buffer_;        //! Beginning of buffer
+    std::uint8_t* next_write_;  //! Current write position
+    const std::uint8_t* end_;   //! End of buffer
+    std::size_t increase_size_; //! Minimum buffer size increase
+
+    //! \post `requested <= available()`
+    void overflow(const std::size_t requested);
+
+    //! Ensures that at least `requested` bytes are available.
+    void check(const std::size_t requested)
+    {
+      const std::size_t remaining = available();
+      if (remaining < requested)
+        overflow(requested);
+    }
+
+  public:
+    using char_type = std::uint8_t;
+    using Ch = char_type;
+
+    //! \return Default minimum size increase on buffer overflow
+    static constexpr std::size_t default_increase() noexcept { return 4096; }
+
+    //! Increase internal buffer by at least `byte_stream_increase` bytes.
+    byte_stream() noexcept
+      : byte_stream(default_increase())
+    {}
+
+    //! Increase internal buffer by at least `increase` bytes.
+    explicit byte_stream(const std::size_t increase) noexcept
+      : buffer_(nullptr),
+        next_write_(nullptr),
+        end_(nullptr),
+        increase_size_(increase)
+    {}
+
+    byte_stream(byte_stream&& rhs) noexcept;
+    ~byte_stream() noexcept = default;
+    byte_stream& operator=(byte_stream&& rhs) noexcept;
+
+    //! \return The minimum increase size on buffer overflow
+    std::size_t increase_size() const noexcept { return increase_size_; }
+
+    const std::uint8_t* data() const noexcept { return buffer_.get(); }
+    std::uint8_t* tellp() const noexcept { return next_write_; }
+    std::size_t available() const noexcept { return end_ - next_write_; }
+    std::size_t size() const noexcept { return next_write_ - buffer_.get(); }
+    std::size_t capacity() const noexcept { return end_ - buffer_.get(); }
+
+    //! Compatibility with rapidjson.
+    void Flush() const noexcept
+    {}
+
+    /*! Reserve at least `more` bytes.
+        \post `size() + more <= available()`.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void reserve(const std::size_t more)
+    {
+      check(more);
+    }
+
+    /*! Copy `length` bytes starting at `ptr` to end of stream.
+        \throw std::range_error If exceeding max size_t value.
+        \throw std::bad_alloc If allocation fails. */
+    void write(const std::uint8_t* ptr, const std::size_t length)
+    {
+      check(length);
+      std::memcpy(tellp(), ptr, length);
+      next_write_ += length;
+    }
+
+    /*! Copy `length` bytes starting at `ptr` to end of stream.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void write(const char* ptr, const std::size_t length)
+    {
+      write(reinterpret_cast<const std::uint8_t*>(ptr), length);
+    }
+
+    /*! Copy `source` to end of stream.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void write(const epee::span<const std::uint8_t> source)
+    {
+      write(source.data(), source.size());
+    }
+
+    /*! Copy `source` to end of stream.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void write(const epee::span<const char> source)
+    {
+      write(source.data(), source.size());
+    }
+
+    /*! Copy `ch` to end of stream.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void put(const std::uint8_t ch)
+    {
+      check(1);
+      put_unsafe(ch);
+    }
+
+    /*! Copy `ch` to end of stream. Provides rapidjson compatability.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void Put(const std::uint8_t ch)
+    {
+      put(ch);
+    }
+
+    /*! Writes `ch` to end of stream without runtime capacity checks. Must use
+        `reserve` before calling this function. Primarily for use with
+        rapidjson, which writes characters at a time but reserves memory in
+        blocks. Most applications want to use `put` or `write`. */
+    void put_unsafe(const std::uint8_t ch) noexcept
+    {
+      assert(1 <= available());
+      *(tellp()) = ch;
+      ++next_write_;
+    }
+
+    /*! Write `ch` to end of stream `count` times.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void put_n(const std::uint8_t ch, const std::size_t count)
+    {
+      check(count);
+      std::memset(tellp(), count, ch);
+      next_write_ += count;
+    }
+
+    /*! Copy `ch` to end of stream.
+        \throw std::range_error if exceeding max `size_t` value.
+        \throw std::bad_alloc if allocation fails. */
+    void push_back(const std::uint8_t ch)
+    {
+      put(ch);
+    }
+
+    //! \return The internal buffer. \post `size() == capacity() == 0`.
+    byte_buffer take_buffer() noexcept;
+  };
+
+  //! Compatability/optimization for rapidjson.
+
+  inline void PutReserve(byte_stream& dest, const std::size_t length)
+  {
+    dest.reserve(length);
+  }
+
+  //! Compatability/optimization for rapidjson.
+
+  inline void PutUnsafe(byte_stream& dest, const std::uint8_t ch)
+  {
+    dest.put_unsafe(ch);
+  }
+
+  //! Compability/optimization for rapidjson.
+  inline void PutN(byte_stream& dest, const std::uint8_t ch, const std::size_t count)
+  {
+    dest.put_n(ch, count);
+  }
+} // epee
+

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -26,8 +26,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(epee STATIC byte_slice.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp
-    levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
+
+add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
+    wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
     int-util.cpp)
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))

--- a/contrib/epee/src/byte_slice.cpp
+++ b/contrib/epee/src/byte_slice.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, The Monero Project
+// Copyright (c) 2019-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -34,6 +34,7 @@
 #include <utility>
 
 #include "byte_slice.h"
+#include "byte_stream.h"
 
 namespace epee
 {
@@ -117,6 +118,12 @@ namespace epee
     }
   } // anonymous
 
+  void release_byte_buffer::operator()(std::uint8_t* buf) const noexcept
+  {
+    if (buf)
+      std::free(buf - sizeof(raw_byte_slice));
+  }
+
   byte_slice::byte_slice(byte_slice_data* storage, span<const std::uint8_t> portion) noexcept
     : storage_(storage), portion_(portion)
   {
@@ -162,6 +169,14 @@ namespace epee
   byte_slice::byte_slice(std::vector<std::uint8_t>&& buffer)
     : byte_slice(adapt_buffer{}, std::move(buffer))
   {}
+
+  byte_slice::byte_slice(byte_stream&& stream) noexcept
+    : storage_(nullptr), portion_(stream.data(), stream.size())
+  {
+    std::uint8_t* const data = stream.take_buffer().release() - sizeof(raw_byte_slice);
+    new (data) raw_byte_slice{};
+    storage_.reset(reinterpret_cast<raw_byte_slice*>(data));
+  }
 
   byte_slice::byte_slice(byte_slice&& source) noexcept
     : storage_(std::move(source.storage_)), portion_(source.portion_)
@@ -216,5 +231,30 @@ namespace epee
     std::unique_ptr<byte_slice_data, release_byte_slice> out{std::move(storage_)};
     portion_ = nullptr;
     return out;
+  }
+
+  byte_buffer byte_buffer_resize(byte_buffer buf, const std::size_t length) noexcept
+  {
+    if (std::numeric_limits<std::size_t>::max() - sizeof(raw_byte_slice) < length)
+      return nullptr;
+
+    std::uint8_t* data = buf.get();
+    if (data != nullptr)
+      data -= sizeof(raw_byte_slice);
+
+    data = static_cast<std::uint8_t*>(std::realloc(data, sizeof(raw_byte_slice) + length));
+    if (data == nullptr)
+      return nullptr;
+
+    buf.release();
+    buf.reset(data + sizeof(raw_byte_slice));
+    return buf;
+  }
+
+  byte_buffer byte_buffer_increase(byte_buffer buf, const std::size_t current, const std::size_t more)
+  {
+    if (std::numeric_limits<std::size_t>::max() - current < more)
+      throw std::range_error{"byte_buffer_increase size_t overflow"};
+    return byte_buffer_resize(std::move(buf), current + more);
   }
 } // epee

--- a/contrib/epee/src/byte_stream.cpp
+++ b/contrib/epee/src/byte_stream.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "byte_stream.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <iostream>
+
+namespace epee
+{
+  void byte_stream::overflow(const std::size_t requested)
+  {
+    // Recalculating `need` bytes removes at least one instruction from every
+    // inlined `put` call in header
+
+    assert(available() < requested);
+    const std::size_t need = requested - available();
+
+    const std::size_t len = size();
+    const std::size_t cap = capacity();
+    const std::size_t increase = std::max(need, increase_size());
+
+    next_write_ = nullptr;
+    end_ = nullptr;
+
+    buffer_ = byte_buffer_increase(std::move(buffer_), cap, increase);
+    if (!buffer_)
+      throw std::bad_alloc{};
+
+    next_write_ = buffer_.get() + len;
+    end_ = buffer_.get() + cap + increase;
+  }
+
+  byte_stream::byte_stream(byte_stream&& rhs) noexcept
+    : buffer_(std::move(rhs.buffer_)),
+      next_write_(rhs.next_write_),
+      end_(rhs.end_),
+      increase_size_(rhs.increase_size_)
+  {
+    rhs.next_write_ = nullptr;
+    rhs.end_ = nullptr;
+  }
+
+  byte_stream& byte_stream::operator=(byte_stream&& rhs) noexcept
+  {
+    if (this != std::addressof(rhs))
+    {
+      buffer_ = std::move(rhs.buffer_);
+      next_write_ = rhs.next_write_;
+      end_ = rhs.end_;
+      increase_size_ = rhs.increase_size_;
+      rhs.next_write_ = nullptr;
+      rhs.end_ = nullptr;
+    }
+    return *this;
+  }
+
+  byte_buffer byte_stream::take_buffer() noexcept
+  {
+    byte_buffer out{std::move(buffer_)};
+    next_write_ = nullptr;
+    end_ = nullptr;
+    return out;
+  }
+}

--- a/src/rpc/daemon_messages.cpp
+++ b/src/rpc/daemon_messages.cpp
@@ -34,14 +34,14 @@ namespace cryptonote
 
 namespace rpc
 {
-void GetHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetHeight::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetHeight::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetHeight::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
@@ -52,7 +52,7 @@ void GetHeight::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetBlocksFast::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlocksFast::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, block_ids, block_ids);
   INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
@@ -66,7 +66,7 @@ void GetBlocksFast::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, prune, prune);
 }
 
-void GetBlocksFast::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlocksFast::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, blocks, blocks);
   INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
@@ -83,7 +83,7 @@ void GetBlocksFast::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetHashesFast::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetHashesFast::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, known_hashes, known_hashes);
   INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
@@ -95,7 +95,7 @@ void GetHashesFast::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, start_height, start_height);
 }
 
-void GetHashesFast::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetHashesFast::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, hashes, hashes);
   INSERT_INTO_JSON_OBJECT(dest, start_height, start_height);
@@ -110,7 +110,7 @@ void GetHashesFast::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetTransactions::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTransactions::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, tx_hashes, tx_hashes);
 }
@@ -120,7 +120,7 @@ void GetTransactions::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, tx_hashes, tx_hashes);
 }
 
-void GetTransactions::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTransactions::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, txs, txs);
   INSERT_INTO_JSON_OBJECT(dest, missed_hashes, missed_hashes);
@@ -133,7 +133,7 @@ void GetTransactions::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void KeyImagesSpent::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void KeyImagesSpent::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, key_images, key_images);
 }
@@ -143,7 +143,7 @@ void KeyImagesSpent::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, key_images, key_images);
 }
 
-void KeyImagesSpent::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void KeyImagesSpent::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, spent_status, spent_status);
 }
@@ -154,7 +154,7 @@ void KeyImagesSpent::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetTxGlobalOutputIndices::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTxGlobalOutputIndices::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, tx_hash, tx_hash);
 }
@@ -164,7 +164,7 @@ void GetTxGlobalOutputIndices::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, tx_hash, tx_hash);
 }
 
-void GetTxGlobalOutputIndices::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTxGlobalOutputIndices::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, output_indices, output_indices);
 }
@@ -174,7 +174,7 @@ void GetTxGlobalOutputIndices::Response::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, output_indices, output_indices);
 }
 
-void SendRawTx::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SendRawTx::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, tx, tx);
   INSERT_INTO_JSON_OBJECT(dest, relay, relay);
@@ -186,7 +186,7 @@ void SendRawTx::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, relay, relay);
 }
 
-void SendRawTx::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SendRawTx::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, relayed, relayed);
 }
@@ -197,7 +197,7 @@ void SendRawTx::Response::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, relayed, relayed);
 }
 
-void SendRawTxHex::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SendRawTxHex::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, tx_as_hex, tx_as_hex);
   INSERT_INTO_JSON_OBJECT(dest, relay, relay);
@@ -209,7 +209,7 @@ void SendRawTxHex::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, relay, relay);
 }
 
-void StartMining::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void StartMining::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, miner_address, miner_address);
   INSERT_INTO_JSON_OBJECT(dest, threads_count, threads_count);
@@ -225,7 +225,7 @@ void StartMining::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, ignore_battery, ignore_battery);
 }
 
-void StartMining::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void StartMining::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void StartMining::Response::fromJson(const rapidjson::Value& val)
@@ -233,14 +233,14 @@ void StartMining::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void StopMining::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void StopMining::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void StopMining::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void StopMining::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void StopMining::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void StopMining::Response::fromJson(const rapidjson::Value& val)
@@ -248,14 +248,14 @@ void StopMining::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void MiningStatus::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void MiningStatus::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void MiningStatus::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void MiningStatus::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void MiningStatus::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, active, active);
   INSERT_INTO_JSON_OBJECT(dest, speed, speed);
@@ -274,14 +274,14 @@ void MiningStatus::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetInfo::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetInfo::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetInfo::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetInfo::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetInfo::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, info, info);
 }
@@ -292,14 +292,14 @@ void GetInfo::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void SaveBC::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SaveBC::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void SaveBC::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void SaveBC::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SaveBC::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void SaveBC::Response::fromJson(const rapidjson::Value& val)
@@ -307,7 +307,7 @@ void SaveBC::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetBlockHash::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHash::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
@@ -317,7 +317,7 @@ void GetBlockHash::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, height, height);
 }
 
-void GetBlockHash::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHash::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, hash, hash);
 }
@@ -328,14 +328,14 @@ void GetBlockHash::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetLastBlockHeader::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetLastBlockHeader::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetLastBlockHeader::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetLastBlockHeader::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetLastBlockHeader::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
@@ -346,7 +346,7 @@ void GetLastBlockHeader::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetBlockHeaderByHash::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeaderByHash::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, hash, hash);
 }
@@ -356,7 +356,7 @@ void GetBlockHeaderByHash::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, hash, hash);
 }
 
-void GetBlockHeaderByHash::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeaderByHash::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
@@ -367,7 +367,7 @@ void GetBlockHeaderByHash::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetBlockHeaderByHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeaderByHeight::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, height, height);
 }
@@ -377,7 +377,7 @@ void GetBlockHeaderByHeight::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, height, height);
 }
 
-void GetBlockHeaderByHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeaderByHeight::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, header, header);
 }
@@ -388,7 +388,7 @@ void GetBlockHeaderByHeight::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetBlockHeadersByHeight::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeadersByHeight::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, heights, heights);
 }
@@ -398,7 +398,7 @@ void GetBlockHeadersByHeight::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, heights, heights);
 }
 
-void GetBlockHeadersByHeight::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetBlockHeadersByHeight::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, headers, headers);
 }
@@ -409,14 +409,14 @@ void GetBlockHeadersByHeight::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetPeerList::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetPeerList::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetPeerList::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetPeerList::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetPeerList::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, white_list, white_list);
   INSERT_INTO_JSON_OBJECT(dest, gray_list, gray_list);
@@ -429,7 +429,7 @@ void GetPeerList::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void SetLogLevel::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SetLogLevel::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, level, level);
 }
@@ -439,7 +439,7 @@ void SetLogLevel::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, level, level);
 }
 
-void SetLogLevel::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void SetLogLevel::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void SetLogLevel::Response::fromJson(const rapidjson::Value& val)
@@ -447,14 +447,14 @@ void SetLogLevel::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetTransactionPool::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTransactionPool::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetTransactionPool::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetTransactionPool::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetTransactionPool::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, transactions, transactions);
   INSERT_INTO_JSON_OBJECT(dest, key_images, key_images);
@@ -467,7 +467,7 @@ void GetTransactionPool::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void HardForkInfo::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void HardForkInfo::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, version, version);
 }
@@ -477,7 +477,7 @@ void HardForkInfo::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, version, version);
 }
 
-void HardForkInfo::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void HardForkInfo::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, info, info);
 }
@@ -488,7 +488,7 @@ void HardForkInfo::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetOutputHistogram::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputHistogram::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, amounts, amounts);
   INSERT_INTO_JSON_OBJECT(dest, min_count, min_count);
@@ -506,7 +506,7 @@ void GetOutputHistogram::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, recent_cutoff, recent_cutoff);
 }
 
-void GetOutputHistogram::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputHistogram::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, histogram, histogram);
 }
@@ -517,7 +517,7 @@ void GetOutputHistogram::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetOutputKeys::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputKeys::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, outputs, outputs);
 }
@@ -527,7 +527,7 @@ void GetOutputKeys::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, outputs, outputs);
 }
 
-void GetOutputKeys::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputKeys::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, keys, keys);
 }
@@ -538,14 +538,14 @@ void GetOutputKeys::Response::fromJson(const rapidjson::Value& val)
 }
 
 
-void GetRPCVersion::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetRPCVersion::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {}
 
 void GetRPCVersion::Request::fromJson(const rapidjson::Value& val)
 {
 }
 
-void GetRPCVersion::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetRPCVersion::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, version, version);
 }
@@ -555,7 +555,7 @@ void GetRPCVersion::Response::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, version, version);
 }
 
-void GetFeeEstimate::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetFeeEstimate::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, num_grace_blocks, num_grace_blocks);
 }
@@ -565,7 +565,7 @@ void GetFeeEstimate::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, num_grace_blocks, num_grace_blocks);
 }
 
-void GetFeeEstimate::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetFeeEstimate::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, estimated_base_fee, estimated_base_fee);
   INSERT_INTO_JSON_OBJECT(dest, fee_mask, fee_mask);
@@ -581,7 +581,7 @@ void GetFeeEstimate::Response::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, hard_fork_version, hard_fork_version);
 }
 
-void GetOutputDistribution::Request::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputDistribution::Request::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, amounts, amounts);
   INSERT_INTO_JSON_OBJECT(dest, from_height, from_height);
@@ -597,7 +597,7 @@ void GetOutputDistribution::Request::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, cumulative, cumulative);
 }
 
-void GetOutputDistribution::Response::doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void GetOutputDistribution::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   INSERT_INTO_JSON_OBJECT(dest, status, status);
   INSERT_INTO_JSON_OBJECT(dest, distributions, distributions);

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -28,11 +28,11 @@
 
 #pragma once
 
-#include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <unordered_map>
 #include <vector>
 
+#include "byte_stream.h"
 #include "message.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "rpc/message_data_structs.h"
@@ -50,7 +50,7 @@ class classname \
       public: \
         Request() { } \
         ~Request() { } \
-        void doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const override final; \
+        void doToJson(rapidjson::Writer<epee::byte_stream>& dest) const override final; \
         void fromJson(const rapidjson::Value& val) override final;
 
 #define BEGIN_RPC_MESSAGE_RESPONSE \
@@ -59,7 +59,7 @@ class classname \
       public: \
         Response() { } \
         ~Response() { } \
-        void doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const override final; \
+        void doToJson(rapidjson::Writer<epee::byte_stream>& dest) const override final; \
         void fromJson(const rapidjson::Value& val) override final;
 
 #define END_RPC_MESSAGE_REQUEST };

--- a/src/rpc/message.cpp
+++ b/src/rpc/message.cpp
@@ -62,7 +62,7 @@ const rapidjson::Value& get_method_field(const rapidjson::Value& src)
 }
 }
 
-void Message::toJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+void Message::toJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   dest.StartObject();
   INSERT_INTO_JSON_OBJECT(dest, status, status);
@@ -151,9 +151,9 @@ cryptonote::rpc::error FullMessage::getError()
 
 epee::byte_slice FullMessage::getRequest(const std::string& request, const Message& message, const unsigned id)
 {
-  rapidjson::StringBuffer buffer;
+  epee::byte_stream buffer;
   {
-    rapidjson::Writer<rapidjson::StringBuffer> dest{buffer};
+    rapidjson::Writer<epee::byte_stream> dest{buffer};
 
     dest.StartObject();
     INSERT_INTO_JSON_OBJECT(dest, jsonrpc, (boost::string_ref{"2.0", 3}));
@@ -172,15 +172,15 @@ epee::byte_slice FullMessage::getRequest(const std::string& request, const Messa
     if (!dest.IsComplete())
       throw std::logic_error{"Invalid JSON tree generated"};
   }
-  return epee::byte_slice{{buffer.GetString(), buffer.GetSize()}};
+  return epee::byte_slice{std::move(buffer)};
 }
 
 
 epee::byte_slice FullMessage::getResponse(const Message& message, const rapidjson::Value& id)
 {
-  rapidjson::StringBuffer buffer;
+  epee::byte_stream buffer;
   {
-    rapidjson::Writer<rapidjson::StringBuffer> dest{buffer};
+    rapidjson::Writer<epee::byte_stream> dest{buffer};
 
     dest.StartObject();
     INSERT_INTO_JSON_OBJECT(dest, jsonrpc, (boost::string_ref{"2.0", 3}));
@@ -207,7 +207,7 @@ epee::byte_slice FullMessage::getResponse(const Message& message, const rapidjso
     if (!dest.IsComplete())
       throw std::logic_error{"Invalid JSON tree generated"};
   }
-  return epee::byte_slice{{buffer.GetString(), buffer.GetSize()}};
+  return epee::byte_slice{std::move(buffer)};
 }
 
 // convenience functions for bad input

--- a/src/rpc/message.h
+++ b/src/rpc/message.h
@@ -29,11 +29,11 @@
 #pragma once
 
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <string>
 
 #include "byte_slice.h"
+#include "byte_stream.h"
 #include "rpc/message_data_structs.h"
 
 namespace cryptonote
@@ -44,7 +44,7 @@ namespace rpc
 
   class Message
   {
-      virtual void doToJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const
+      virtual void doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
       {}
 
     public:
@@ -58,7 +58,7 @@ namespace rpc
 
       virtual ~Message() { }
 
-      void toJson(rapidjson::Writer<rapidjson::StringBuffer>& dest) const;
+      void toJson(rapidjson::Writer<epee::byte_stream>& dest) const;
 
       virtual void fromJson(const rapidjson::Value& val);
 

--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -28,7 +28,6 @@
 
 #include "zmq_server.h"
 
-#include <boost/utility/string_ref.hpp>
 #include <chrono>
 #include <cstdint>
 #include <system_error>

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -126,12 +126,12 @@ void read_hex(const rapidjson::Value& val, epee::span<std::uint8_t> dest)
   }
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rapidjson::Value& src)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rapidjson::Value& src)
 {
   src.Accept(dest);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const boost::string_ref i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const boost::string_ref i)
 {
   dest.String(i.data(), i.size());
 }
@@ -146,7 +146,7 @@ void fromJsonValue(const rapidjson::Value& val, std::string& str)
   str = val.GetString();
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, bool i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, bool i)
 {
   dest.Bool(i);
 }
@@ -185,7 +185,7 @@ void fromJsonValue(const rapidjson::Value& val, short& i)
   to_int(val, i);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned int i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const unsigned int i)
 {
   dest.Uint(i);
 }
@@ -195,7 +195,7 @@ void fromJsonValue(const rapidjson::Value& val, unsigned int& i)
   to_uint(val, i);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const int i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const int i)
 {
   dest.Int(i);
 }
@@ -205,7 +205,7 @@ void fromJsonValue(const rapidjson::Value& val, int& i)
   to_int(val, i);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned long long i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const unsigned long long i)
 {
   static_assert(!precision_loss<unsigned long long, std::uint64_t>(), "bad uint64 conversion");
   dest.Uint64(i);
@@ -216,7 +216,7 @@ void fromJsonValue(const rapidjson::Value& val, unsigned long long& i)
   to_uint64(val, i);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const long long i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const long long i)
 {
   static_assert(!precision_loss<long long, std::int64_t>(), "bad int64 conversion");
   dest.Int64(i);
@@ -237,7 +237,7 @@ void fromJsonValue(const rapidjson::Value& val, long& i)
   to_int64(val, i);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::transaction& tx)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::transaction& tx)
 {
   dest.StartObject();
 
@@ -269,7 +269,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::transaction& tx)
   GET_FROM_JSON_OBJECT(val, tx.rct_signatures, ringct);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block& b)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::block& b)
 {
   dest.StartObject();
 
@@ -301,14 +301,14 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::block& b)
   GET_FROM_JSON_OBJECT(val, b.tx_hashes, tx_hashes);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_v& txin)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_v& txin)
 {
   dest.StartObject();
   struct add_input
   {
     using result_type = void;
 
-    rapidjson::Writer<rapidjson::StringBuffer>& dest;
+    rapidjson::Writer<epee::byte_stream>& dest;
 
     void operator()(cryptonote::txin_to_key const& input) const
     {
@@ -373,7 +373,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin)
   }
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_gen& txin)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_gen& txin)
 {
   dest.StartObject();
 
@@ -392,7 +392,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_gen& txin)
   GET_FROM_JSON_OBJECT(val, txin.height, height);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_script& txin)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_script& txin)
 {
   dest.StartObject();
 
@@ -417,7 +417,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin
 }
 
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_scripthash& txin)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_scripthash& txin)
 {
   dest.StartObject();
 
@@ -443,7 +443,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& 
   GET_FROM_JSON_OBJECT(val, txin.sigset, sigset);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_key& txin)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_key& txin)
 {
   dest.StartObject();
 
@@ -467,7 +467,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin)
 }
 
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_script& txout)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout)
 {
   dest.StartObject();
 
@@ -489,7 +489,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txo
 }
 
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_scripthash& txout)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout)
 {
   dest.StartObject();
 
@@ -509,7 +509,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash&
 }
 
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_key& txout)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_key& txout)
 {
   dest.StartObject();
 
@@ -528,7 +528,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_key& txout)
   GET_FROM_JSON_OBJECT(val, txout.key, key);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_out& txout)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::tx_out& txout)
 {
   dest.StartObject();
   INSERT_INTO_JSON_OBJECT(dest, amount, txout.amount);
@@ -537,7 +537,7 @@ void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const crypton
   {
     using result_type = void;
 
-    rapidjson::Writer<rapidjson::StringBuffer>& dest;
+    rapidjson::Writer<epee::byte_stream>& dest;
 
     void operator()(cryptonote::txout_to_key const& output) const
     {
@@ -596,7 +596,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout)
   }
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::connection_info& info)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::connection_info& info)
 {
   dest.StartObject();
 
@@ -668,7 +668,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::connection_info& inf
   GET_FROM_JSON_OBJECT(val, info.current_upload, current_upload);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_blob_entry& tx)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::tx_blob_entry& tx)
 {
   dest.StartObject();
 
@@ -689,7 +689,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_blob_entry& tx)
   GET_FROM_JSON_OBJECT(val, tx.prunable_hash, prunable_hash);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block_complete_entry& blk)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::block_complete_entry& blk)
 {
   dest.StartObject();
 
@@ -711,7 +711,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::block_complete_entry
   GET_FROM_JSON_OBJECT(val, blk.txs, transactions);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::block_with_transactions& blk)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::block_with_transactions& blk)
 {
   dest.StartObject();
 
@@ -733,7 +733,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::block_with_tran
   GET_FROM_JSON_OBJECT(val, blk.transactions, transactions);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::transaction_info& tx_info)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::transaction_info& tx_info)
 {
   dest.StartObject();
 
@@ -757,7 +757,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::transaction_inf
   GET_FROM_JSON_OBJECT(val, tx_info.transaction, transaction);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_and_amount_index& out)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_key_and_amount_index& out)
 {
   dest.StartObject();
 
@@ -779,7 +779,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_and_
   GET_FROM_JSON_OBJECT(val, out.key, key);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::amount_with_random_outputs& out)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::amount_with_random_outputs& out)
 {
   dest.StartObject();
 
@@ -801,7 +801,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::amount_with_ran
   GET_FROM_JSON_OBJECT(val, out.outputs, outputs);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::peer& peer)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::peer& peer)
 {
   dest.StartObject();
 
@@ -833,7 +833,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::peer& peer)
   GET_FROM_JSON_OBJECT(val, peer.pruning_seed, pruning_seed);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::tx_in_pool& tx)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::tx_in_pool& tx)
 {
   dest.StartObject();
 
@@ -880,7 +880,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::tx_in_pool& tx)
   GET_FROM_JSON_OBJECT(val, tx.double_spend_seen, double_spend_seen);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::hard_fork_info& info)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::hard_fork_info& info)
 {
   dest.StartObject();
 
@@ -914,7 +914,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::hard_fork_info&
   GET_FROM_JSON_OBJECT(val, info.earliest_height, earliest_height);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_count& out)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_amount_count& out)
 {
   dest.StartObject();
 
@@ -940,7 +940,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_c
   GET_FROM_JSON_OBJECT(val, out.recent_count, recent_count);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_and_index& out)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_amount_and_index& out)
 {
   dest.StartObject();
 
@@ -962,7 +962,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_a
   GET_FROM_JSON_OBJECT(val, out.index, index);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_mask_unlocked& out)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_key_mask_unlocked& out)
 {
   dest.StartObject();
 
@@ -985,7 +985,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_mask
   GET_FROM_JSON_OBJECT(val, out.unlocked, unlocked);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::error& err)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::error& err)
 {
   dest.StartObject();
 
@@ -1008,7 +1008,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::error& error)
   GET_FROM_JSON_OBJECT(val, error.message, message);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::BlockHeaderResponse& response)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::BlockHeaderResponse& response)
 {
   dest.StartObject();
 
@@ -1045,7 +1045,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResp
   GET_FROM_JSON_OBJECT(val, response.reward, reward);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rctSig& sig)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& sig)
 {
   using boost::adaptors::transform;
 
@@ -1115,7 +1115,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig)
   }
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::ecdhTuple& tuple)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::ecdhTuple& tuple)
 {
   dest.StartObject();
   INSERT_INTO_JSON_OBJECT(dest, mask, tuple.mask);
@@ -1134,7 +1134,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple)
   GET_FROM_JSON_OBJECT(val, tuple.amount, amount);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rangeSig& sig)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rangeSig& sig)
 {
   dest.StartObject();
 
@@ -1171,7 +1171,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::rangeSig& sig)
   }
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::Bulletproof& p)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::Bulletproof& p)
 {
   dest.StartObject();
 
@@ -1212,7 +1212,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::Bulletproof& p)
   GET_FROM_JSON_OBJECT(val, p.t, t);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::boroSig& sig)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::boroSig& sig)
 {
   dest.StartObject();
 
@@ -1257,7 +1257,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::boroSig& sig)
   GET_FROM_JSON_OBJECT(val, sig.ee, ee);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::mgSig& sig)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::mgSig& sig)
 {
   dest.StartObject();
 
@@ -1278,7 +1278,7 @@ void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig)
   GET_FROM_JSON_OBJECT(val, sig.cc, cc);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::DaemonInfo& info)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::DaemonInfo& info)
 {
   dest.StartObject();
 
@@ -1339,7 +1339,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& inf
   GET_FROM_JSON_OBJECT(val, info.start_time, start_time);
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_distribution& dist)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_distribution& dist)
 {
   dest.StartObject();
 

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -31,9 +31,9 @@
 #include <boost/utility/string_ref.hpp>
 #include <cstring>
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include "byte_stream.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "rpc/message_data_structs.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
@@ -123,7 +123,7 @@ void read_hex(const rapidjson::Value& val, epee::span<std::uint8_t> dest);
 
 // POD to json key
 template <class Type>
-inline typename std::enable_if<is_to_hex<Type>()>::type toJsonKey(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Type& pod)
+inline typename std::enable_if<is_to_hex<Type>()>::type toJsonKey(rapidjson::Writer<epee::byte_stream>& dest, const Type& pod)
 {
   const auto hex = epee::to_hex::array(pod);
   dest.Key(hex.data(), hex.size());
@@ -131,7 +131,7 @@ inline typename std::enable_if<is_to_hex<Type>()>::type toJsonKey(rapidjson::Wri
 
 // POD to json value
 template <class Type>
-inline typename std::enable_if<is_to_hex<Type>()>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Type& pod)
+inline typename std::enable_if<is_to_hex<Type>()>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Type& pod)
 {
   const auto hex = epee::to_hex::array(pod);
   dest.String(hex.data(), hex.size());
@@ -144,16 +144,16 @@ inline typename std::enable_if<is_to_hex<Type>()>::type fromJsonValue(const rapi
   json::read_hex(val, epee::as_mut_byte_span(t));
 }
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rapidjson::Value& src);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rapidjson::Value& src);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, boost::string_ref i);
-inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const std::string& i)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, boost::string_ref i);
+inline void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const std::string& i)
 {
   toJsonValue(dest, boost::string_ref{i});
 }
 void fromJsonValue(const rapidjson::Value& val, std::string& str);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, bool i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, bool i);
 void fromJsonValue(const rapidjson::Value& val, bool& b);
 
 // integers overloads for toJsonValue are not needed for standard promotions
@@ -168,144 +168,144 @@ void fromJsonValue(const rapidjson::Value& val, unsigned short& i);
 
 void fromJsonValue(const rapidjson::Value& val, short& i);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const unsigned i);
 void fromJsonValue(const rapidjson::Value& val, unsigned& i);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const int);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const int);
 void fromJsonValue(const rapidjson::Value& val, int& i);
 
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned long long i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const unsigned long long i);
 void fromJsonValue(const rapidjson::Value& val, unsigned long long& i);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const long long i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const long long i);
 void fromJsonValue(const rapidjson::Value& val, long long& i);
 
-inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const unsigned long i) {
+inline void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const unsigned long i) {
     toJsonValue(dest, static_cast<unsigned long long>(i));
 }
 void fromJsonValue(const rapidjson::Value& val, unsigned long& i);
 
-inline void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const long i) {
+inline void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const long i) {
     toJsonValue(dest, static_cast<long long>(i));
 }
 void fromJsonValue(const rapidjson::Value& val, long& i);
 
 // end integers
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::transaction& tx);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::transaction& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::transaction& tx);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block& b);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::block& b);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::block& b);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_v& txin);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_v& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_gen& txin);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_gen& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_gen& txin);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_script& txin);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_script& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_scripthash& txin);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_scripthash& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& txin);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txin_to_key& txin);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_key& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_target_v& txout);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_target_v& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_target_v& txout);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_script& txout);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_scripthash& txout);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::txout_to_key& txout);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_key& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_key& txout);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_out& txout);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::tx_out& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::connection_info& info);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::connection_info& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::connection_info& info);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::tx_blob_entry& tx);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::tx_blob_entry& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_blob_entry& tx);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::block_complete_entry& blk);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::block_complete_entry& blk);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::block_complete_entry& blk);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::block_with_transactions& blk);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::block_with_transactions& blk);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::block_with_transactions& blk);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::transaction_info& tx_info);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::transaction_info& tx_info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::transaction_info& tx_info);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_and_amount_index& out);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_key_and_amount_index& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_and_amount_index& out);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::amount_with_random_outputs& out);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::amount_with_random_outputs& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::amount_with_random_outputs& out);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::peer& peer);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::peer& peer);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::peer& peer);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::tx_in_pool& tx);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::tx_in_pool& tx);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::tx_in_pool& tx);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::hard_fork_info& info);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::hard_fork_info& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::hard_fork_info& info);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_count& out);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_amount_count& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_count& out);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_amount_and_index& out);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_amount_and_index& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_amount_and_index& out);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_key_mask_unlocked& out);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_key_mask_unlocked& out);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_key_mask_unlocked& out);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::error& err);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::error& err);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::error& error);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::BlockHeaderResponse& response);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::BlockHeaderResponse& response);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResponse& response);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rctSig& i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& i);
 void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::ecdhTuple& tuple);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::ecdhTuple& tuple);
 void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::rangeSig& sig);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rangeSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::rangeSig& sig);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::Bulletproof& p);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::Bulletproof& p);
 void fromJsonValue(const rapidjson::Value& val, rct::Bulletproof& p);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::boroSig& sig);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::boroSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::boroSig& sig);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const rct::mgSig& sig);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::mgSig& sig);
 void fromJsonValue(const rapidjson::Value& val, rct::mgSig& sig);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::DaemonInfo& info);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::DaemonInfo& info);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& info);
 
-void toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const cryptonote::rpc::output_distribution& dist);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_distribution& dist);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::output_distribution& dist);
 
 template <typename Map>
-typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Map& map);
+typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Map& map);
 
 template <typename Map>
 typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type fromJsonValue(const rapidjson::Value& val, Map& map);
 
 template <typename Vec>
-typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Vec &vec);
+typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Vec &vec);
 
 template <typename Vec>
 typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec);
@@ -315,7 +315,7 @@ typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJson
 // unfortunately because of how templates work they have to be here.
 
 template <typename Map>
-inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Map& map)
+inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Map& map)
 {
   using key_type = typename Map::key_type;
   static_assert(std::is_same<std::string, key_type>() || is_to_hex<key_type>(), "invalid map key type");
@@ -351,7 +351,7 @@ inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type from
 }
 
 template <typename Vec>
-inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<rapidjson::StringBuffer>& dest, const Vec &vec)
+inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Vec &vec)
 {
   dest.StartArray();
   for (const auto& t : vec)

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -45,6 +45,7 @@
 #include "boost/archive/portable_binary_iarchive.hpp"
 #include "boost/archive/portable_binary_oarchive.hpp"
 #include "byte_slice.h"
+#include "byte_stream.h"
 #include "crypto/crypto.h"
 #include "hex.h"
 #include "net/net_utils_base.h"
@@ -807,6 +808,259 @@ TEST(ByteSlice, GetSlice)
 
   // touch original pointers to check "free" status
   EXPECT_TRUE(boost::range::equal(base_string, original));
+}
+
+TEST(ByteStream, Construction)
+{
+  EXPECT_TRUE(std::is_default_constructible<epee::byte_stream>());
+  EXPECT_TRUE(std::is_move_constructible<epee::byte_stream>());
+  EXPECT_FALSE(std::is_copy_constructible<epee::byte_stream>());
+  EXPECT_TRUE(std::is_move_assignable<epee::byte_stream>());
+  EXPECT_FALSE(std::is_copy_assignable<epee::byte_stream>());
+}
+
+TEST(ByteStream, Noexcept)
+{
+  EXPECT_TRUE(std::is_nothrow_default_constructible<epee::byte_stream>());
+  EXPECT_TRUE(std::is_nothrow_move_constructible<epee::byte_stream>());
+  EXPECT_TRUE(std::is_nothrow_move_assignable<epee::byte_stream>());
+
+  epee::byte_stream lvalue;
+  const epee::byte_stream clvalue;
+
+  EXPECT_TRUE(noexcept(lvalue.data()));
+  EXPECT_TRUE(noexcept(clvalue.data()));
+  EXPECT_TRUE(noexcept(lvalue.tellp()));
+  EXPECT_TRUE(noexcept(clvalue.tellp()));
+  EXPECT_TRUE(noexcept(lvalue.available()));
+  EXPECT_TRUE(noexcept(clvalue.available()));
+  EXPECT_TRUE(noexcept(lvalue.size()));
+  EXPECT_TRUE(noexcept(clvalue.size()));
+  EXPECT_TRUE(noexcept(lvalue.capacity()));
+  EXPECT_TRUE(noexcept(clvalue.capacity()));
+  EXPECT_TRUE(noexcept(lvalue.put_unsafe(4)));
+  EXPECT_TRUE(noexcept(lvalue.take_buffer()));
+}
+
+TEST(ByteStream, Empty)
+{
+  epee::byte_stream stream;
+
+  EXPECT_EQ(epee::byte_stream::default_increase(), stream.increase_size());
+
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.capacity());
+
+  const auto buf = stream.take_buffer();
+  EXPECT_EQ(nullptr, buf.get());
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.capacity());
+}
+
+TEST(ByteStream, Write)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  std::vector<std::uint8_t> bytes;
+  epee::byte_stream stream{4};
+
+  EXPECT_EQ(4u, stream.increase_size());
+
+  stream.write({source, 3});
+  bytes.insert(bytes.end(), source, source + 3);
+  EXPECT_EQ(3u, stream.size());
+  EXPECT_EQ(1u, stream.available());
+  EXPECT_EQ(4u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  stream.write({source, 2});
+  bytes.insert(bytes.end(), source, source + 2);
+  EXPECT_EQ(5u, stream.size());
+  EXPECT_EQ(3u, stream.available());
+  EXPECT_EQ(8u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  stream.write({source, 5});
+  bytes.insert(bytes.end(), source, source + 5);
+  EXPECT_EQ(10u, stream.size());
+  EXPECT_EQ(2u, stream.available());
+  EXPECT_EQ(12u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  stream.write({source, 2});
+  bytes.insert(bytes.end(), source, source + 2);
+  EXPECT_EQ(12u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(12u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  stream.write({source, 5});
+  bytes.insert(bytes.end(), source, source + 5);
+  EXPECT_EQ(17u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(17u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+}
+
+TEST(ByteStream, Put)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  std::vector<std::uint8_t> bytes;
+  epee::byte_stream stream;
+
+  for (std::uint8_t i = 0; i < 200; ++i)
+  {
+    bytes.push_back(i);
+    stream.put(i);
+  }
+
+  EXPECT_EQ(200u, stream.size());
+  EXPECT_EQ(epee::byte_stream::default_increase() - 200, stream.available());
+  EXPECT_EQ(epee::byte_stream::default_increase(), stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+}
+
+TEST(ByteStream, Reserve)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  std::vector<std::uint8_t> bytes;
+  epee::byte_stream stream{4};
+
+  EXPECT_EQ(4u, stream.increase_size());
+
+  stream.reserve(100);
+  EXPECT_EQ(100u, stream.capacity());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(100u, stream.available());
+
+  for (std::size_t i = 0; i < 100 / sizeof(source); ++i)
+  {
+    stream.write(source);
+    bytes.insert(bytes.end(), source, source + sizeof(source));
+  }
+
+  EXPECT_EQ(100u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(100u, stream.capacity());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+}
+
+TEST(ByteStream, TakeBuffer)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  epee::byte_stream stream;
+
+  stream.write(source);
+  ASSERT_EQ(sizeof(source), stream.size());
+  EXPECT_TRUE(equal(source, byte_span{stream.data(), stream.size()}));
+
+  const auto buffer = stream.take_buffer();
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_TRUE(equal(source, byte_span{buffer.get(), sizeof(source)}));
+}
+
+TEST(ByteStream, Move)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  epee::byte_stream stream{10};
+  stream.write(source);
+
+  epee::byte_stream stream2{std::move(stream)};
+
+  EXPECT_EQ(10u, stream.increase_size());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+
+  EXPECT_EQ(10u, stream2.increase_size());
+  EXPECT_EQ(5u, stream2.size());
+  EXPECT_EQ(5u, stream2.available());
+  EXPECT_EQ(10u, stream2.capacity());
+  EXPECT_NE(nullptr, stream2.data());
+  EXPECT_NE(nullptr, stream2.tellp());
+  EXPECT_TRUE(equal(source, byte_span{stream2.data(), stream2.size()}));
+
+  stream = epee::byte_stream{};
+
+  EXPECT_EQ(epee::byte_stream::default_increase(), stream.increase_size());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+
+  stream = std::move(stream2);
+
+  EXPECT_EQ(10u, stream.increase_size());
+  EXPECT_EQ(5u, stream.size());
+  EXPECT_EQ(5u, stream.available());
+  EXPECT_EQ(10u, stream.capacity());
+  EXPECT_NE(nullptr, stream.data());
+  EXPECT_NE(nullptr, stream.tellp());
+  EXPECT_TRUE(equal(source, byte_span{stream.data(), stream.size()}));
+
+  EXPECT_EQ(10u, stream2.increase_size());
+  EXPECT_EQ(0u, stream2.size());
+  EXPECT_EQ(0u, stream2.available());
+  EXPECT_EQ(0u, stream2.capacity());
+  EXPECT_EQ(nullptr, stream2.data());
+  EXPECT_EQ(nullptr, stream2.tellp());
+}
+
+TEST(ByteStream, ToByteSlice)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  epee::byte_stream stream;
+
+  stream.write(source);
+  EXPECT_EQ(sizeof(source), stream.size());
+  EXPECT_TRUE(equal(source, byte_span{stream.data(), stream.size()}));
+
+  const epee::byte_slice slice{std::move(stream)};
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_TRUE(equal(source, slice));
 }
 
 TEST(ToHex, String)

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -3,10 +3,10 @@
 #include <boost/range/adaptor/indexed.hpp>
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <vector>
 
+#include "byte_stream.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -86,14 +86,14 @@ namespace
     template<typename T>
     T test_json(const T& value)
     {
-      rapidjson::StringBuffer buffer;
+      epee::byte_stream buffer;
       {
-        rapidjson::Writer<rapidjson::StringBuffer> dest{buffer};
+        rapidjson::Writer<epee::byte_stream> dest{buffer};
         cryptonote::json::toJsonValue(dest, value);
       }
 
       rapidjson::Document doc;
-      doc.Parse(buffer.GetString());
+      doc.Parse(reinterpret_cast<const char*>(buffer.data()), buffer.size());
       if (doc.HasParseError() || !doc.IsObject())
       {
         throw cryptonote::json::PARSE_FAIL();


### PR DESCRIPTION
Sorry for the churn. I intended to hoard this until the [code in my recent issue](https://github.com/monero-project/monero/issues/6406) was PR'ed, but its probably a better idea to push this concept out now inside of letting it rot. The first commit is from PR 6350, with the second commit being the new code.

This creates a class that rapidjson can use to write directly to a buffer that can be passed into ZMQ without any copy. This same class can be used by the epee binary output code (with nearly zero changes), but code expecting `std::string`s need to change. Epee JSON output can also be replaced, but that requires a few `operator<<` functions. See comments in `byte_stream.h` for why this is an improvement over `rapidjson::StringBuffer` and `std::ostringstream`.