### PR TITLE
p2p: If remote node has a different net id ban right away

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2323,6 +2323,7 @@ namespace nodetool
       LOG_INFO_CC(context, "WRONG NETWORK AGENT CONNECTED! id=" << arg.node_data.network_id);
       drop_connection(context);
       add_host_fail(context.m_remote_address);
+      block_host(context.m_remote_address);
       return 1;
     }
 


### PR DESCRIPTION
If a remote node has a different network id than the one hardcoded dont wait for the fail attempts to reach the critical number in order to block it. Ban/block it right away on first fail, the network id wont magically change in a few minutes on the next connection attempt. That remote node was compiled on purpose with a different network id and is most likely intentionally (or unintentionally - if it was compiled for testing purposes as such) spamming monero's network