### PR TITLE
mingw: fix warnings (util.cpp)

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -152,7 +152,7 @@ namespace tools
     if (!GetTokenInformation(process.get(), TokenOwner, sid.get(), sid_size, std::addressof(sid_size)))
       return {};
 
-    const PSID psid = reinterpret_cast<const PTOKEN_OWNER>(sid.get())->Owner;
+    const PSID psid = reinterpret_cast<PTOKEN_OWNER>(sid.get())->Owner;
     const DWORD daclSize =
       sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) + GetLengthSid(psid) - sizeof(DWORD);
 
@@ -328,9 +328,16 @@ namespace tools
 
     // Call GetNativeSystemInfo if supported or GetSystemInfo otherwise.
 
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
     pGNSI = (PGNSI) GetProcAddress(
       GetModuleHandle(TEXT("kernel32.dll")), 
       "GetNativeSystemInfo");
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic pop
+#endif
     if(NULL != pGNSI)
       pGNSI(&si);
     else GetSystemInfo(&si);
@@ -381,9 +388,16 @@ namespace tools
           else StringCchCat(pszOS, BUFSIZE, TEXT("Windows Server 2012 R2 " ));
         }
 
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
         pGPI = (PGPI) GetProcAddress(
           GetModuleHandle(TEXT("kernel32.dll")), 
           "GetProductInfo");
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#pragma GCC diagnostic pop
+#endif
 
         pGPI( osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &dwType);
 


### PR DESCRIPTION
I ll spam a bit by pushing a couple of prs fixing warnings on mingw building. I wanted to push all in one but it is better if i do it separately for you to check their validity better

Warnings from util.cpp file code

1st warning line 155 - GCC is warning that declaring const to PTOKEN_OWNER on that static cast doesn't do anything. True. Remove it.
```
D:/a/monero/monero/src/common/util.cpp: In static member function 'static tools::private_file tools::private_file::create(std::string)':
D:/a/monero/monero/src/common/util.cpp:155:69: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  155 |     const PSID psid = reinterpret_cast<const PTOKEN_OWNER>(sid.get())->Owner;
      |                                                                     ^
```
2nd - 3rd two same warnings on lines 333, 386 - GetProcAddress returns a pointer to some function. It can return pointers to different functions, so it has to return something that is suitable to store any pointer to function. Microsoft chose FARPROC, which is int (WINAPI *)() on 32-bit Windows. The user is supposed to know the signature of the function he requests and perform a cast (which is a nop on this platform). The result is a pointer to function with the required signature, which is bitwise equal to what GetProcAddress returned. However, gcc >= 8 warns about that and it shouldnt. There is nothing to fix here so silence the warning explicitly.
Copied from this related boost bug report:
https://github.com/boostorg/thread/issues/225
```
D:/a/monero/monero/src/common/util.cpp: In function 'std::string tools::get_windows_version_display_string()':
D:/a/monero/monero/src/common/util.cpp:333:28: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'PGNSI' {aka 'void (*)(_SYSTEM_INFO*)'} [-Wcast-function-type]
  333 |       "GetNativeSystemInfo");
      |                            ^
D:/a/monero/monero/src/common/util.cpp:386:27: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'PGPI' {aka 'int (*)(long unsigned int, long unsigned int, long unsigned int, long unsigned int, long unsigned int*)'} [-Wcast-function-type]
  386 |           "GetProductInfo");
      |                           ^
```