### PR TITLE
functional_tests: ensure signed timestamps are fresh

### DIFF
--- a/tests/functional_tests/make_test_signature.cc
+++ b/tests/functional_tests/make_test_signature.cc
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
+#include "misc_language.h"
 #include "string_tools.h"
 #include "rpc/rpc_payment_signature.h"
 
@@ -69,6 +70,7 @@ int main(int argc, const char **argv)
   while (count--)
   {
     std::string signature = cryptonote::make_rpc_payment_signature(skey);
+    epee::misc_utils::sleep_no_w(1);
     printf("%s\n", signature.c_str());
   }
   return 0;

--- a/tests/functional_tests/rpc_payment.py
+++ b/tests/functional_tests/rpc_payment.py
@@ -59,12 +59,14 @@ class RPCPaymentTest():
         return fields
 
     def refill_signatures(self):
+        self.signatures_time = time.time()
+        self.signatures = []
         signatures = subprocess.check_output([self.make_test_signature, self.secret_key, '256']).decode('utf-8')
         for line in signatures.split():
             self.signatures.append(line.rstrip())
 
     def get_signature(self):
-        if len(self.signatures) == 0:
+        if len(self.signatures) == 0 or self.signatures_time + 10 < time.time():
             self.refill_signatures()
         s = self.signatures[0]
         self.signatures = self.signatures[1:]


### PR DESCRIPTION
This fixes a test failure now that timestamps are more constrained