### PR TITLE
trezor: adapt to new passphrase mechanism

### DIFF
--- a/contrib/epee/include/net/http_base.h
+++ b/contrib/epee/include/net/http_base.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <utility>
 
+#include "memwipe.h"
 #include "string_tools.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -199,6 +200,11 @@ namespace net_utils
 			{
 				this->~http_response_info();
 				new(this) http_response_info();
+			}
+
+			void wipe()
+			{
+				memwipe(&m_body[0], m_body.size());
 			}
 		};
 	}

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -466,6 +466,11 @@ namespace net_utils
 				return m_net_client.get_bytes_received();
 			}
 			//---------------------------------------------------------------------------
+			void wipe_response()
+			{
+				m_response_info.wipe();
+			}
+			//---------------------------------------------------------------------------
 		private: 
 			//---------------------------------------------------------------------------
 			inline bool handle_reciev(std::chrono::milliseconds timeout)

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -78,7 +78,7 @@ namespace hw {
         virtual void on_button_request(uint64_t code=0) {}
         virtual void on_button_pressed() {}
         virtual boost::optional<epee::wipeable_string> on_pin_request() { return boost::none; }
-        virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool on_device) { return boost::none; }
+        virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
         virtual void on_progress(const device_progress& event) {}
         virtual ~i_device_callback() = default;
     };

--- a/src/device_trezor/device_trezor.hpp
+++ b/src/device_trezor/device_trezor.hpp
@@ -67,10 +67,11 @@ namespace trezor {
       bool m_live_refresh_enabled;
       size_t m_num_transations_to_sign;
 
+      unsigned client_version();
       void transaction_versions_check(const ::tools::wallet2::unsigned_tx_set & unsigned_tx, hw::tx_aux_data & aux_data);
       void transaction_pre_check(std::shared_ptr<messages::monero::MoneroTransactionInitRequest> init_msg);
       void transaction_check(const protocol::tx::TData & tdata, const hw::tx_aux_data & aux_data);
-      void device_state_reset_unsafe() override;
+      void device_state_initialize_unsafe() override;
       void live_refresh_start_unsafe();
       void live_refresh_finish_unsafe();
       void live_refresh_thread_main();

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -70,7 +70,7 @@ namespace trezor {
 
       void on_button_request(uint64_t code=0) override;
       boost::optional<epee::wipeable_string> on_pin_request() override;
-      boost::optional<epee::wipeable_string> on_passphrase_request(bool on_device) override;
+      boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) override;
       void on_passphrase_state_request(const std::string &state);
       void on_disconnect();
     protected:
@@ -94,7 +94,7 @@ namespace trezor {
 
       std::string m_full_name;
       std::vector<unsigned int> m_wallet_deriv_path;
-      std::string m_device_state;  // returned after passphrase entry, session
+      epee::wipeable_string m_device_session_id;  // returned after passphrase entry, session
       std::shared_ptr<messages::management::Features> m_features;  // features from the last device reset
       boost::optional<epee::wipeable_string> m_pin;
       boost::optional<epee::wipeable_string> m_passphrase;
@@ -117,7 +117,7 @@ namespace trezor {
       void require_initialized() const;
       void call_ping_unsafe();
       void test_ping();
-      virtual void device_state_reset_unsafe();
+      virtual void device_state_initialize_unsafe();
       void ensure_derivation_path() noexcept;
 
       // Communication methods
@@ -315,7 +315,7 @@ namespace trezor {
     void on_button_pressed();
     void on_pin_request(GenericMessage & resp, const messages::common::PinMatrixRequest * msg);
     void on_passphrase_request(GenericMessage & resp, const messages::common::PassphraseRequest * msg);
-    void on_passphrase_state_request(GenericMessage & resp, const messages::common::PassphraseStateRequest * msg);
+    void on_passphrase_state_request(GenericMessage & resp, const messages::common::Deprecated_PassphraseStateRequest * msg);
 
 #ifdef WITH_TREZOR_DEBUGGING
     void set_debug(bool debug){

--- a/src/device_trezor/trezor/debug_link.cpp
+++ b/src/device_trezor/trezor/debug_link.cpp
@@ -71,9 +71,9 @@ namespace trezor{
     call(decision, boost::none, true);
   }
 
-  void DebugLink::input_swipe(bool swipe){
+  void DebugLink::input_swipe(messages::debug::DebugLinkDecision_DebugSwipeDirection direction){
     messages::debug::DebugLinkDecision decision;
-    decision.set_up_down(swipe);
+    decision.set_swipe(direction);
     call(decision, boost::none, true);
   }
 

--- a/src/device_trezor/trezor/debug_link.hpp
+++ b/src/device_trezor/trezor/debug_link.hpp
@@ -49,7 +49,7 @@ namespace trezor {
     std::shared_ptr<messages::debug::DebugLinkState> state();
     void input_word(const std::string & word);
     void input_button(bool button);
-    void input_swipe(bool swipe);
+    void input_swipe(messages::debug::DebugLinkDecision_DebugSwipeDirection direction);
     void press_yes() { input_button(true); }
     void press_no() { input_button(false); }
     void stop();

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -66,10 +66,12 @@ namespace trezor {
 
   // Base HTTP comm serialization.
   bool t_serialize(const std::string & in, std::string & out);
+  bool t_serialize(const epee::wipeable_string & in, std::string & out);
   bool t_serialize(const json_val & in, std::string & out);
   std::string t_serialize(const json_val & in);
 
   bool t_deserialize(const std::string & in, std::string & out);
+  bool t_deserialize(std::string & in, epee::wipeable_string & out);
   bool t_deserialize(const std::string & in, json & out);
 
   // Flexible json serialization. HTTP client tailored for bridge API
@@ -84,6 +86,13 @@ namespace trezor {
     additional_params.push_back(std::make_pair("Content-Type","application/json; charset=utf-8"));
 
     const http::http_response_info* pri = nullptr;
+    const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
+      if (!req_param.empty()) {
+        memwipe(&req_param[0], req_param.size());
+      }
+      transport.wipe_response();
+    });
+
     if(!transport.invoke(uri, method, req_param, timeout, &pri, std::move(additional_params)))
     {
       MERROR("Failed to invoke http request to  " << uri);
@@ -103,7 +112,7 @@ namespace trezor {
       return false;
     }
 
-    return t_deserialize(pri->m_body, result_struct);
+    return t_deserialize(const_cast<http::http_response_info*>(pri)->m_body, result_struct);
   }
 
   // Forward decl
@@ -186,7 +195,7 @@ namespace trezor {
     std::string m_bridge_host;
     boost::optional<std::string> m_device_path;
     boost::optional<std::string> m_session;
-    boost::optional<std::string> m_response;
+    boost::optional<epee::wipeable_string> m_response;
     boost::optional<json> m_device_info;
   };
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5576,14 +5576,19 @@ boost::optional<epee::wipeable_string> simple_wallet::on_device_pin_request()
   return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_request(bool on_device)
+boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_request(bool & on_device)
 {
-  if (on_device){
-    message_writer(console_color_white, true) << tr("Please enter the device passphrase on the device");
-    return boost::none;
+  if (on_device) {
+    std::string accepted = input_line(tr(
+        "Device asks for passphrase. Do you want to enter the passphrase on device (Y) (or on the host (N))?"));
+    if (std::cin.eof() || command_line::is_yes(accepted)) {
+      message_writer(console_color_white, true) << tr("Please enter the device passphrase on the device");
+      return boost::none;
+    }
   }
 
   PAUSE_READLINE();
+  on_device = false;
   std::string msg = tr("Enter device passphrase");
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device passphrase"));

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -348,7 +348,7 @@ namespace cryptonote
     virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason);
     virtual void on_device_button_request(uint64_t code);
     virtual boost::optional<epee::wipeable_string> on_device_pin_request();
-    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device);
+    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device);
     //----------------------------------------------------------
 
     friend class refresh_progress_reporter_t;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -267,13 +267,15 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       return boost::none;
     }
 
-    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device)
+    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device)
     {
       if (m_listener) {
         auto passphrase = m_listener->onDevicePassphraseRequest(on_device);
-        if (!on_device && passphrase) {
+        if (passphrase) {
           return boost::make_optional(epee::wipeable_string((*passphrase).data(), (*passphrase).size()));
         }
+      } else {
+        on_device = true;
       }
       return boost::none;
     }

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -400,8 +400,8 @@ struct WalletListener
     /**
      * @brief called by device when passphrase entry is needed
      */
-    virtual optional<std::string> onDevicePassphraseRequest(bool on_device) {
-        if (!on_device) throw std::runtime_error("Not supported");
+    virtual optional<std::string> onDevicePassphraseRequest(bool & on_device) {
+        on_device = true;
         return optional<std::string>();
     }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1109,10 +1109,12 @@ boost::optional<epee::wipeable_string> wallet_device_callback::on_pin_request()
   return boost::none;
 }
 
-boost::optional<epee::wipeable_string> wallet_device_callback::on_passphrase_request(bool on_device)
+boost::optional<epee::wipeable_string> wallet_device_callback::on_passphrase_request(bool & on_device)
 {
   if (wallet)
     return wallet->on_device_passphrase_request(on_device);
+  else
+    on_device = true;
   return boost::none;
 }
 
@@ -13547,10 +13549,12 @@ boost::optional<epee::wipeable_string> wallet2::on_device_pin_request()
   return boost::none;
 }
 //----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> wallet2::on_device_passphrase_request(bool on_device)
+boost::optional<epee::wipeable_string> wallet2::on_device_passphrase_request(bool & on_device)
 {
   if (nullptr != m_callback)
     return m_callback->on_device_passphrase_request(on_device);
+  else
+    on_device = true;
   return boost::none;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -145,7 +145,7 @@ private:
     virtual void on_device_button_request(uint64_t code) {}
     virtual void on_device_button_pressed() {}
     virtual boost::optional<epee::wipeable_string> on_device_pin_request() { return boost::none; }
-    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device) { return boost::none; }
+    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
     virtual void on_device_progress(const hw::device_progress& event) {};
     // Common callbacks
     virtual void on_pool_tx_removed(const crypto::hash &txid) {}
@@ -159,7 +159,7 @@ private:
     void on_button_request(uint64_t code=0) override;
     void on_button_pressed() override;
     boost::optional<epee::wipeable_string> on_pin_request() override;
-    boost::optional<epee::wipeable_string> on_passphrase_request(bool on_device) override;
+    boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) override;
     void on_progress(const hw::device_progress& event) override;
   private:
     wallet2 * wallet;
@@ -1487,7 +1487,7 @@ private:
     void on_device_button_request(uint64_t code);
     void on_device_button_pressed();
     boost::optional<epee::wipeable_string> on_device_pin_request();
-    boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device);
+    boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device);
     void on_device_progress(const hw::device_progress& event);
 
     std::string get_rpc_status(const std::string &s) const;

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -129,7 +129,7 @@ void mock_daemon::init()
   m_rpc_server.nettype(m_network_type);
 
   CHECK_AND_ASSERT_THROW_MES(m_protocol.init(m_vm), "Failed to initialize cryptonote protocol.");
-  CHECK_AND_ASSERT_THROW_MES(m_rpc_server.init(m_vm, false, main_rpc_port), "Failed to initialize RPC server.");
+  CHECK_AND_ASSERT_THROW_MES(m_rpc_server.init(m_vm, false, main_rpc_port, false), "Failed to initialize RPC server.");
 
   if (m_start_p2p)
     CHECK_AND_ASSERT_THROW_MES(m_server.init(m_vm), "Failed to initialize p2p server.");
@@ -313,7 +313,7 @@ void mock_daemon::mine_blocks(size_t num_blocks, const std::string &miner_addres
 {
   bool blocks_mined = false;
   const uint64_t start_height = get_height();
-  const auto mining_timeout = std::chrono::seconds(30);
+  const auto mining_timeout = std::chrono::seconds(120);
   MDEBUG("Current height before mining: " << start_height);
 
   start_mining(miner_address);

--- a/tests/trezor/daemon.h
+++ b/tests/trezor/daemon.h
@@ -76,7 +76,7 @@ public:
   typedef cryptonote::t_cryptonote_protocol_handler<cryptonote::core> t_protocol_raw;
   typedef nodetool::node_server<t_protocol_raw> t_node_server;
 
-  static constexpr const std::chrono::seconds rpc_timeout = std::chrono::seconds(60);
+  static constexpr const std::chrono::seconds rpc_timeout = std::chrono::seconds(120);
 
   cryptonote::core * m_core;
   t_protocol_raw m_protocol;

--- a/tests/trezor/trezor_tests.h
+++ b/tests/trezor/trezor_tests.h
@@ -264,12 +264,6 @@ public:
   bool generate(std::vector<test_event_entry>& events) override;
 };
 
-class gen_trezor_1utxo_paymentid_long : public gen_trezor_base
-{
-public:
-  bool generate(std::vector<test_event_entry>& events) override;
-};
-
 class gen_trezor_4utxo : public gen_trezor_base
 {
 public:


### PR DESCRIPTION
- choice where to enter the passphrase is now made on the host (Trezor changed this in new firmwares)
- use wipeable string in the Trezor communication stack
- wipe passphrase memory after use
- protocol optimizations, prepare for new firmware version which scales better with subaddresses
  - subaddresses are not pre-computed but each UTXO carries also subaddr index so all key are computed on the fly, constant memory w.r.t. number of subaddresses
  - same for key image refresh
  - sending only required info to the Trezor for each step, saves Trezor CPU & RAM, faster protocol
  - optimizations detailed in https://github.com/trezor/trezor-firmware/pull/786
- minor fixes and improvements
- tests: fix and update Trezor tests, HF12, disable long payment ID test
- wallet API update for passphrases, GUI related PR: https://github.com/monero-project/monero-gui/pull/2829
- Trezor related PR: https://github.com/trezor/trezor-firmware/pull/942
- Trezor CLSAG PR: https://github.com/trezor/trezor-firmware/pull/943 
- more on passphrase redesign: https://docs.trezor.io/trezor-firmware/common/communication/passphrase-redesign-migration.html