### PR TITLE
unit_tests: fix gcc warning

### DIFF
--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -583,7 +583,9 @@ TEST_F(levin_notify, stem_without_padding)
         {
             const std::size_t sent = context->process_send_queue();
             if (sent && is_stem)
+            {
                 EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+            }
             send_count += sent;
         }
 
@@ -653,7 +655,9 @@ TEST_F(levin_notify, local_without_padding)
         {
             const std::size_t sent = context->process_send_queue();
             if (sent && is_stem)
+            {
                 EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+            }
             send_count += sent;
         }
 


### PR DESCRIPTION
fixes gcc warning
```
/home/runner/work/monero/monero/tests/unit_tests/levin.cpp: In member function ‘virtual void levin_notify_stem_without_padding_Test::TestBody()’:
/home/runner/work/monero/monero/tests/unit_tests/levin.cpp:585:16: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
             if (sent && is_stem)
                ^
/home/runner/work/monero/monero/tests/unit_tests/levin.cpp: In member function ‘virtual void levin_notify_local_without_padding_Test::TestBody()’:
/home/runner/work/monero/monero/tests/unit_tests/levin.cpp:655:16: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
             if (sent && is_stem)
                ^
```