### PR TITLE
p2p: add seed node.

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -629,6 +629,7 @@ namespace nodetool
       full_addrs.insert("212.83.172.165:18080");
       full_addrs.insert("192.110.160.146:18080");
       full_addrs.insert("88.198.163.90:18080");
+      full_addrs.insert("95.217.25.101:18080");
     }
     return full_addrs;
   }


### PR DESCRIPTION
This is a new PR to replace the closed [https://github.com/monero-project/monero/pull/6417](https://github.com/monero-project/monero/pull/6417)

In summary:
I am running a mainnet node in the cloud and I would like to volunteer it as a seed node.

Of note:

1. It has a fixed IP address
2. I will be promptly updating it as required (currently running v0.15.0.5)
3. I intend to keep running it for the long term
4. Having followed the discussion at the last monero-dev meeting (29/03/20), I have added my node's IP address to the list in this PR.

The provider is `Hetzner` and it is located in `Helsinki, Finland`.

I think that @binaryFate will be able to vouch for me in terms of trust.

If you need further details, let me know.
