### PR TITLE
Revert functional test changes in babf25d2e and 571546067

### DIFF
--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -34,8 +34,8 @@ try:
 except:
   tests = DEFAULT_TESTS
 
-N_MONERODS = 3
-N_WALLETS = 7
+N_MONERODS = 2
+N_WALLETS = 4
 WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 DIFFICULTY = 10
 
@@ -43,17 +43,9 @@ monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", st
 monerod_extra = [
   [],
   ["--rpc-payment-address", "44SKxxLQw929wRF6BA9paQ1EWFshNnKhXM3qz6Mo3JGDE2YG3xyzVutMStEicxbQGRfrYvAAYxH6Fe8rnD56EaNwUiqhcwR", "--rpc-payment-difficulty", str(DIFFICULTY), "--rpc-payment-credits", "5000", "--data-dir", builddir + "/functional-tests-directory/monerod1"],
-  ["--rpc-restricted-bind-port", "18482", "--data-dir", builddir + "/functional-tests-directory/monerod2"]
 ]
-wallet_base = [builddir + "/bin/monero-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--log-level", "1"]
+wallet_base = [builddir + "/bin/monero-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--daemon-port", "18180", "--log-level", "1"]
 wallet_extra = [
-  ["--daemon-port", "18180"],
-  ["--daemon-port", "18180"],
-  ["--daemon-port", "18180"],
-  ["--daemon-port", "18180"],
-  ["--daemon-port", "18182"],
-  ["--daemon-port", "18182"],
-  ["--daemon-port", "18182"]
 ]
 
 command_lines = []

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -55,7 +55,7 @@ class TransferTest():
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
@@ -69,7 +69,7 @@ class TransferTest():
         ]
         self.wallet = [None] * len(seeds)
         for i in range(len(seeds)):
-            self.wallet[i] = Wallet(idx = i + 4)
+            self.wallet[i] = Wallet(idx = i)
             # close the wallet if any, will throw if none is loaded
             try: self.wallet[i].close_wallet()
             except: pass
@@ -77,7 +77,7 @@ class TransferTest():
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         res = daemon.get_info()
         height = res.height
@@ -89,7 +89,7 @@ class TransferTest():
             assert res.height == height + 80
 
     def transfer(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Creating transfer to self")
 
@@ -508,7 +508,7 @@ class TransferTest():
     def check_get_bulk_payments(self):
         print('Checking get_bulk_payments')
 
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_info()
         height = res.height
 
@@ -544,7 +544,7 @@ class TransferTest():
     def check_get_payments(self):
         print('Checking get_payments')
 
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_info()
         height = res.height
 
@@ -587,8 +587,7 @@ class TransferTest():
             assert len(res.tx_blob_list) == 1
             txes[i][1] = res.tx_blob_list[0]
 
-        daemon = Daemon(idx = 2)
-        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
+        daemon = Daemon()
         res = daemon.send_raw_transaction(txes[0][1])
         assert res.not_relayed == False
         assert res.low_mixin == False
@@ -599,18 +598,6 @@ class TransferTest():
         assert res.overspend == False
         assert res.fee_too_low == False
 
-        res = restricted_daemon.send_raw_transaction(txes[0][1])
-        assert res.not_relayed == False
-        assert res.low_mixin == False
-        assert res.double_spend == False
-        assert res.invalid_input == False
-        assert res.invalid_output == False
-        assert res.too_big == False
-        assert res.overspend == False
-        assert res.fee_too_low == False
-
-        res = restricted_daemon.get_transactions([txes[0][0]])
-        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -628,19 +615,6 @@ class TransferTest():
         assert res.fee_too_low == False
         assert res.too_few_outputs == False
 
-        res = restricted_daemon.send_raw_transaction(txes[1][1])
-        assert res.not_relayed == False
-        assert res.low_mixin == False
-        assert res.double_spend == True
-        assert res.invalid_input == False
-        assert res.invalid_output == False
-        assert res.too_big == False
-        assert res.overspend == False
-        assert res.fee_too_low == False
-        assert res.too_few_outputs == False
-
-        res = restricted_daemon.get_transactions([txes[0][0]])
-        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -649,13 +623,13 @@ class TransferTest():
 
     def sweep_dust(self):
         print("Sweeping dust")
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         self.wallet[0].refresh()
         res = self.wallet[0].sweep_dust()
         assert not 'tx_hash_list' in res or len(res.tx_hash_list) == 0 # there's just one, but it cannot meet the fee
 
     def sweep_single(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Sending single output")
 
@@ -711,7 +685,7 @@ class TransferTest():
         assert len([t for t in res.transfers if t.key_image == ki]) == 1
 
     def check_destinations(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Checking transaction destinations")
 
@@ -767,7 +741,7 @@ class TransferTest():
                 self.wallet[0].refresh()
 
     def check_tx_notes(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing tx notes')
         res = self.wallet[0].get_transfers()
@@ -784,7 +758,7 @@ class TransferTest():
         assert res.notes == ['out txid', 'in txid']
 
     def check_rescan(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing rescan_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')
@@ -824,7 +798,7 @@ class TransferTest():
             assert sorted(old_t_out, key = lambda k: k['txid']) == sorted(new_t_out, key = lambda k: k['txid'])
 
     def check_is_key_image_spent(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing is_key_image_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')

--- a/tests/functional_tests/txpool.py
+++ b/tests/functional_tests/txpool.py
@@ -45,14 +45,14 @@ class TransferTest():
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon(idx=2)
+        daemon = Daemon()
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
 
     def create(self):
         print('Creating wallet')
-        wallet = Wallet(idx = 4)
+        wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
         except: pass
@@ -61,8 +61,8 @@ class TransferTest():
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon(idx = 2)
-        wallet = Wallet(idx = 4)
+        daemon = Daemon()
+        wallet = Wallet()
 
         daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 80)
         wallet.refresh()
@@ -70,8 +70,8 @@ class TransferTest():
     def create_txes(self, address, ntxes):
         print('Creating ' + str(ntxes) + ' transactions')
 
-        daemon = Daemon(idx = 2)
-        wallet = Wallet(idx = 4)
+        daemon = Daemon()
+        wallet = Wallet()
 
         dst = {'address': address, 'amount': 1000000000000}
 
@@ -83,10 +83,8 @@ class TransferTest():
         return txes
 
     def check_empty_pool(self):
-        self.check_empty_rpc_pool(Daemon(idx = 2))
-        self.check_empty_rpc_pool(Daemon(idx = 2, restricted_rpc = True))
+        daemon = Daemon()
 
-    def check_empty_rpc_pool(self, daemon):
         res = daemon.get_transaction_pool_hashes()
         assert not 'tx_hashes' in res or len(res.tx_hashes) == 0
         res = daemon.get_transaction_pool_stats()
@@ -105,9 +103,8 @@ class TransferTest():
         assert res.pool_stats.num_double_spends == 0
 
     def check_txpool(self):
-        daemon = Daemon(idx = 2)
-        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
-        wallet = Wallet(idx = 4)
+        daemon = Daemon()
+        wallet = Wallet()
 
         res = daemon.get_info()
         height = res.height
@@ -120,7 +117,6 @@ class TransferTest():
         res = daemon.get_info()
         assert res.tx_pool_size == txpool_size + 5
         txpool_size = res.tx_pool_size
-        self.check_empty_rpc_pool(restricted_daemon)
 
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size
@@ -164,7 +160,6 @@ class TransferTest():
         print('Flushing 2 transactions')
         txes_keys = list(txes.keys())
         daemon.flush_txpool([txes_keys[1], txes_keys[3]])
-        self.check_empty_rpc_pool(restricted_daemon)
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size - 2
         assert len([x for x in res.transactions if x.id_hash == txes_keys[1]]) == 0
@@ -215,7 +210,6 @@ class TransferTest():
         print('Flushing unknown transactions')
         unknown_txids = ['1'*64, '2'*64, '3'*64]
         daemon.flush_txpool(unknown_txids)
-        self.check_empty_rpc_pool(restricted_daemon)
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size - 2
 


### PR DESCRIPTION
Testing behavior of Dandelion++ via the restricted port is not possible currently - the stem/fluff mode changes the behavior of the node and is selected randomly.