### PR TITLE
Used legacy category to match insert_key_images behavior

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1121,7 +1121,7 @@ namespace cryptonote
       // See `insert_key_images`.
       if (1 < found->second.size() || *(found->second.cbegin()) != txid)
         return true;
-      return m_blockchain.txpool_tx_matches_category(txid, relay_category::broadcasted);
+      return m_blockchain.txpool_tx_matches_category(txid, relay_category::legacy);
     }
     return false;
   }


### PR DESCRIPTION
The core tests don't need updating because `insert_key_images` already filter this out (there are actually two different tests when adding a transaction).