### PR TITLE
message_store: don't print an error when there is no mms file

### DIFF
--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -724,7 +724,7 @@ void message_store::read_from_file(const multisig_wallet_state &state, const std
   {
     // Simply do nothing if the file is not there; allows e.g. easy recovery
     // from problems with the MMS by deleting the file
-    MERROR("No message store file found: " << filename);
+    MINFO("No message store file found: " << filename);
     return;
   }
 


### PR DESCRIPTION
It confuses people