### PR TITLE
performance_tests: some windows fixes

### DIFF
--- a/tests/performance_tests/equality.h
+++ b/tests/performance_tests/equality.h
@@ -35,7 +35,7 @@
 
 struct memcmp32
 {
-  static const size_t loop_count = 1000000000;
+  static const size_t loop_count = 10000000;
   static int call(const unsigned char *k0, const unsigned char *k1){ return memcmp(k0, k1, 32); }
 };
 

--- a/tests/performance_tests/performance_tests.h
+++ b/tests/performance_tests/performance_tests.h
@@ -195,7 +195,7 @@ void run_test(const std::string &filter, Params &params, const char* test_name)
      scale = 1000;
      time_per_call = runner.time_per_call(1000);
 #ifdef _WIN32
-     unit = "\xb5s";
+     unit = "us";
 #else
      unit = "µs";
 #endif


### PR DESCRIPTION
Too many iterations cause std::bad_alloc for the timings vector,
and the micro prefix displays as some other character, so use u.

Reported by iDunk