### PR TITLE
wallet2: fix catching reason on fail to verify password on wallet opening

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3975,7 +3975,12 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
   std::string keys_file_buf;
   bool r = load_from_file(keys_file_name, keys_file_buf);
   THROW_WALLET_EXCEPTION_IF(!r, error::file_read_error, keys_file_name);
-
+  if(!verify_password(password))
+  {
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, "invalid password");
+    return false;
+  }
+	
   // Load keys from buffer
   boost::optional<crypto::chacha_key> keys_to_encrypt;
   try {


### PR DESCRIPTION
on wrong password typed on opening an existing wallet
`Error: failed to load wallet: std::exception` was printed on exit
instead of
`Error: failed to load wallet: invalid password`
that's a small bug introduced by vtnerd's load keys restructuring part to make wallet2.h work with web assembly (the original exception with the invalid password reason moved from `wallet2::load_keys` block to `wallet2::load_keys_buf`) .
This is just a patch that fixes it, i bet there are more elegant ways of fixing this but i dont want to mess with the structure,