### PR TITLE
systemd: Make sure required folders exist

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -7,6 +7,8 @@ User=monero
 Group=monero
 WorkingDirectory=~
 RuntimeDirectory=monero
+StateDirectory=monero
+LogsDirectory=monero
 
 # Clearnet config
 #


### PR DESCRIPTION
The default monero.conf file depends on the existence of the folders `/var/log/monero/` and `/var/lib/monero/`.
This change makes sure systemd will create them, together with the proper permissions, if they don't exist.
`StateDirectory` can be considered an extra safety in case the user `monero` happens to have been created with specifying `/var/lib/monero/` as a home folder but without actually creating it.