### PR TITLE
trezor: add new firmware version support

### DIFF
--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -678,8 +678,10 @@ namespace trezor {
         throw exc::TrezorException("Trezor firmware 2.0.10 and lower are not supported. Please update.");
       }
 
-      // default client version, higher versions check will be added
       unsigned client_version = 1;
+      if (trezor_version >= pack_version(2, 3, 1)){
+        client_version = 3;
+      }
 
 #ifdef WITH_TREZOR_DEBUGGING
       // Override client version for tests


### PR DESCRIPTION
We know that Trezor Firmware 2.3.1 will support the new protocol client version (v3).