### PR TITLE
libzmq should be libzmq4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ Install all dependencies at once on Debian/Ubuntu:
 Install all dependencies at once on macOS with the provided Brewfile:
 ``` brew update && brew bundle --file=contrib/brew/Brewfile ```
 
-FreeBSD one liner for required to build dependencies
-```pkg install git gmake cmake pkgconf boost-libs libzmq libsodium```
+FreeBSD 12.1 one-liner required to build dependencies:
+```pkg install git gmake cmake pkgconf boost-libs libzmq4 libsodium```
 
 ### Cloning the repository
 


### PR DESCRIPTION
I'm not sure if libzmq was the name of the package in previous releases, but for 12.1 libzmq doesn't exist.  It should be libzmq4.

https://www.freshports.org/search.php?query=libzmq&search=go&num=10&stype=name&method=match&deleted=excludedeleted&start=1&casesensitivity=caseinsensitive