### PR TITLE
db_lmdb: test for mmap support at init time

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -356,6 +356,7 @@ public:
   static int compare_string(const MDB_val *a, const MDB_val *b);
 
 private:
+  void check_mmap_support();
   void do_resize(uint64_t size_increase=0);
 
   bool need_resize(uint64_t threshold_size=0) const;


### PR DESCRIPTION
It'll make it clearer when a DB init failure is due to being
on a filesystem which does not support mmap