### PR TITLE
keccak: remove aligned check

### DIFF
--- a/src/crypto/keccak.c
+++ b/src/crypto/keccak.c
@@ -146,7 +146,6 @@ void keccak1600(const uint8_t *in, size_t inlen, uint8_t *md)
 #define KECCAK_BLOCKLEN 136
 #define KECCAK_WORDS 17
 #define KECCAK_DIGESTSIZE 32
-#define IS_ALIGNED_64(p) (0 == (7 & ((const char*)(p) - (const char*)0)))
 #define KECCAK_PROCESS_BLOCK(st, block) { \
     for (int i_ = 0; i_ < KECCAK_WORDS; i_++){ \
         ((st))[i_] ^= swap64le(((block))[i_]); \
@@ -178,17 +177,10 @@ void keccak_update(KECCAK_CTX * ctx, const uint8_t *in, size_t inlen){
         inlen -= left;
     }
 
-    const bool is_aligned = IS_ALIGNED_64(in);
     while (inlen >= KECCAK_BLOCKLEN) {
-        const uint64_t* aligned_message_block;
-        if (is_aligned) {
-            aligned_message_block = (uint64_t*)in;
-        } else {
-            memcpy(ctx->message, in, KECCAK_BLOCKLEN);
-            aligned_message_block = ctx->message;
-        }
+        memcpy(ctx->message, in, KECCAK_BLOCKLEN);
 
-        KECCAK_PROCESS_BLOCK(ctx->hash, aligned_message_block);
+        KECCAK_PROCESS_BLOCK(ctx->hash, ctx->message);
         in  += KECCAK_BLOCKLEN;
         inlen -= KECCAK_BLOCKLEN;
     }


### PR DESCRIPTION
Some tools report the alignment check as UB, which seems a bit
dubious, but since the performance difference between the two
versions is minimal, I'll go with the safe version