### PR TITLE
epee: use memwipe rather than memset for md5 secrets

### DIFF
--- a/contrib/epee/include/md5_l.inl
+++ b/contrib/epee/include/md5_l.inl
@@ -277,7 +277,7 @@ namespace md5
 		/* Zeroize sensitive information.
 
 		*/
-		MD5_memset ((POINTER)context, 0, sizeof (*context)); 
+		memwipe ((POINTER)context, sizeof (*context));
 	}
 
 	/* MD5 basic transformation. Transforms state based on block.
@@ -369,7 +369,7 @@ namespace md5
 
 		/* Zeroize sensitive information.
 		*/
-		MD5_memset ((POINTER)x, 0, sizeof (x)); 
+		memwipe ((POINTER)x, sizeof (x));
 	}
 
 	/* Note: Replace "for loop" with standard memcpy if possible.
@@ -431,9 +431,9 @@ namespace md5
 		MD5Update(&hmac->octx, k_opad, 64);     /* apply outer pad */
 
 		/* scrub the pads and key context (if used) */
-		MD5_memset( (POINTER)&k_ipad, 0, sizeof(k_ipad));
-		MD5_memset( (POINTER)&k_opad, 0, sizeof(k_opad));
-		MD5_memset( (POINTER)&tk, 0, sizeof(tk));
+		memwipe( (POINTER)&k_ipad, sizeof(k_ipad));
+		memwipe( (POINTER)&k_opad, sizeof(k_opad));
+		memwipe( (POINTER)&tk, sizeof(tk));
 
 		/* and we're done. */
 	}
@@ -459,7 +459,7 @@ namespace md5
 			state->istate[lupe] = htonl(hmac.ictx.state[lupe]);
 			state->ostate[lupe] = htonl(hmac.octx.state[lupe]);
 		}
-		MD5_memset( (POINTER)&hmac, 0, sizeof(hmac));
+		memwipe( (POINTER)&hmac, sizeof(hmac));
 	}
 
 


### PR DESCRIPTION
That's used by HTTP auth now