### PR TITLE
protocol: don't drop a connection if we can't get a compatible chain

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1721,7 +1721,6 @@ skip:
     if(!m_core.find_blockchain_supplement(arg.block_ids, !arg.prune, r))
     {
       LOG_ERROR_CCONTEXT("Failed to handle NOTIFY_REQUEST_CHAIN.");
-      drop_connection(context, false, false);
       return 1;
     }
     MLOG_P2P_MESSAGE("-->>NOTIFY_RESPONSE_CHAIN_ENTRY: m_start_height=" << r.start_height << ", m_total_height=" << r.total_height << ", m_block_ids.size()=" << r.m_block_ids.size());


### PR DESCRIPTION
This can now happen if:
- we have a pruned db
- we have not connected to the monero network for a while
- we connect to a node
- that node asks us for history
- we only have a pruned version of the most recent common block

In that case, it's better to not reply but keep the connection alive,
so we can sync off it.