### PR TITLE
remove std::move() on temporary http_client object to resolve warning

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1125,7 +1125,7 @@ void wallet_device_callback::on_progress(const hw::device_progress& event)
 }
 
 wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory):
-  m_http_client(std::move(http_client_factory->create())),
+  m_http_client(http_client_factory->create()),
   m_multisig_rescan_info(NULL),
   m_multisig_rescan_k(NULL),
   m_upper_transaction_weight_limit(0),


### PR DESCRIPTION
This PR fixes the following compiler warning:

monero-core/src/wallet/wallet2.cpp:1128:17: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
  m_http_client(std::move(http_client_factory->create())),
                ^
monero-core/src/wallet/wallet2.cpp:1128:17: note: remove std::move call here
  m_http_client(std::move(http_client_factory->create())),