### PR TITLE
change language around Electrum-style seeds

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -732,8 +732,8 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
     clearStatus();
     m_errorString.clear();
     if (seed.empty()) {
-        LOG_ERROR("Electrum seed is empty");
-        setStatusError(tr("Electrum seed is empty"));
+        LOG_ERROR("Mnemonic seed is empty");
+        setStatusError(tr("Mnemonic seed is empty"));
         return false;
     }
 
@@ -742,7 +742,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
     crypto::secret_key recovery_key;
     std::string old_language;
     if (!crypto::ElectrumWords::words_to_bytes(seed, recovery_key, old_language)) {
-        setStatusError(tr("Electrum-style word list failed verification"));
+        setStatusError(tr("Mnemonic word list failed verification"));
         return false;
     }
     if (!seed_offset.empty())

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -632,7 +632,7 @@ std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> generate_f
     {
       if (!crypto::ElectrumWords::words_to_bytes(field_seed, recovery_key, old_language))
       {
-        THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("Electrum-style word list failed verification"));
+        THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("Mnemonic word list failed verification"));
       }
       restore_deterministic_wallet = true;
 
@@ -652,11 +652,11 @@ std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> generate_f
     // compatibility checks
     if (!field_seed_found && !field_viewkey_found && !field_spendkey_found)
     {
-      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("At least one of either an Electrum-style word list, private view key, or private spend key must be specified"));
+      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("At least one of either an mnemonic word list, private view key, or private spend key must be specified"));
     }
     if (field_seed_found && (field_viewkey_found || field_spendkey_found))
     {
-      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("Both Electrum-style word list and private key(s) specified"));
+      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet2::tr("Both mnemonic word list and private key(s) specified"));
     }
 
     // if an address was given, we check keys against it, and deduce the spend

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3572,7 +3572,7 @@ namespace tools
       if (!crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, old_language))
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "Electrum-style word list failed verification";
+        er.message = "Mnemonic word list failed verification";
         return false;
       }
     }


### PR DESCRIPTION
I think "Electrum-style", or any reference to Electrum, is confusing to newcomers. Whilst we can and should keep Electrum references in the underlying code, since we use their seed derivation mechanism and even some of their word lists, I think it's ok to change the language around error and interface messages.

I've additionally renamed ```--electrum-seed``` to ```--mnemonic-seed```, and then created an aliased CLI flag for ```--electrum-seed``` to retain backwards compatibility.