### PR TITLE
Ledger: Fix incorrect lenght of command INS_PREFIX_HASH

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1468,8 +1468,8 @@ namespace hw {
         offset = set_command_header(INS_PREFIX_HASH,2,cnt);      
         len = pref_length - pref_offset;
         //options
-        if (len > (BUFFER_SEND_SIZE-7)) {
-          len = BUFFER_SEND_SIZE-7;
+        if (len > (BUFFER_SEND_SIZE-offset-3)) {
+          len = BUFFER_SEND_SIZE-offset-3;
           this->buffer_send[offset] = 0x80;
         } else {
           this->buffer_send[offset] = 0x00;


### PR DESCRIPTION
Using version `0.16.0.0` of the `monero-wallet-cli`, an error appears when trying to `transfer` funds to more than one address on the Ledger Nano S/X:

```
Error: unexpected error: Wrong Device Status: 0x6701 (UNKNOWN), EXPECTED 0x9000 (SW_OK), MASK 0xffff
```

This is the due to an incorrect assignment of `buffer_send[4]` (`unsigned char` representing `LC`) [line 1482](https://github.com/monero-project/monero/blob/release-v0.16/src/device/device_ledger.cpp#L1482) to more than `255` which results to an incorrect lenght command.

```
   1     1    1    1    1     1     var
+-------------------------------------------+
| CLA | INS | P1 | P2 | LC | Opt | Add data |
+-------------------------------------------+
                        ^
                len(Opt + Add data)
```
It's fixed by setting `len` to be at most `254` (`262-5-3`) which the maximum lenght in `Add data` expected.