### PR TITLE
Improve ZMQ GetBlocksFast (Pruned Txes)

### DIFF
--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -182,6 +182,7 @@ namespace rpc
       for (const auto& blob : it->second)
       {
         bwt.transactions.emplace_back();
+        bwt.transactions.back().pruned = req.prune;
         if (!parse_and_validate_tx_from_blob(blob.second, bwt.transactions.back()))
         {
           res.blocks.clear();

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -906,13 +906,13 @@ namespace rpc
     return true;
   }
 
-  epee::byte_slice DaemonHandler::handle(const std::string& request)
+  epee::byte_slice DaemonHandler::handle(std::string&& request)
   {
     MDEBUG("Handling RPC request: " << request);
 
     try
     {
-      FullMessage req_full(request, true);
+      FullMessage req_full(std::move(request), true);
 
       const std::string request_type = req_full.getRequestType();
       const auto matched_handler = std::lower_bound(std::begin(handlers), std::end(handlers), request_type);

--- a/src/rpc/daemon_handler.h
+++ b/src/rpc/daemon_handler.h
@@ -133,7 +133,7 @@ class DaemonHandler : public RpcHandler
 
     void handle(const GetOutputDistribution::Request& req, GetOutputDistribution::Response& res);
 
-    epee::byte_slice handle(const std::string& request) override final;
+    epee::byte_slice handle(std::string&& request) override final;
 
   private:
 

--- a/src/rpc/message.cpp
+++ b/src/rpc/message.cpp
@@ -79,9 +79,12 @@ void Message::fromJson(const rapidjson::Value& val)
   GET_FROM_JSON_OBJECT(val, rpc_version, rpc_version);
 }
 
-FullMessage::FullMessage(const std::string& json_string, bool request)
+FullMessage::FullMessage(std::string&& json_string, bool request)
+  : contents(std::move(json_string)), doc()
 {
-  doc.Parse(json_string.c_str());
+  /* Insitu parsing does not copy data from `contents` to DOM,
+     accelerating string heavy content. */
+  doc.ParseInsitu(std::addressof(contents[0]));
   if (doc.HasParseError() || !doc.IsObject())
   {
     throw cryptonote::json::PARSE_FAIL();

--- a/src/rpc/message.h
+++ b/src/rpc/message.h
@@ -72,9 +72,7 @@ namespace rpc
     public:
       ~FullMessage() { }
 
-      FullMessage(FullMessage&& rhs) noexcept : doc(std::move(rhs.doc)) { }
-
-      FullMessage(const std::string& json_string, bool request=false);
+      FullMessage(std::string&& json_string, bool request=false);
 
       std::string getRequestType() const;
 
@@ -91,10 +89,13 @@ namespace rpc
     private:
 
       FullMessage() = default;
+      FullMessage(const FullMessage&) = delete;
+      FullMessage& operator=(const FullMessage&) = delete;
 
       FullMessage(const std::string& request, Message* message);
       FullMessage(Message* message);
 
+      std::string contents;
       rapidjson::Document doc;
   };
 

--- a/src/rpc/rpc_handler.h
+++ b/src/rpc/rpc_handler.h
@@ -55,7 +55,7 @@ class RpcHandler
     RpcHandler() { }
     virtual ~RpcHandler() { }
 
-    virtual epee::byte_slice handle(const std::string& request) = 0;
+    virtual epee::byte_slice handle(std::string&& request) = 0;
 
     static boost::optional<output_distribution_data>
       get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);

--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -158,9 +158,9 @@ void ZmqServer::serve()
 
       if (!pub || sockets[2].revents)
       {
-        const std::string message = MONERO_UNWRAP(net::zmq::receive(rep.get(), read_flags));
+        std::string message = MONERO_UNWRAP(net::zmq::receive(rep.get(), read_flags));
         MDEBUG("Received RPC request: \"" << message << "\"");
-        epee::byte_slice response = handler.handle(message);
+        epee::byte_slice response = handler.handle(std::move(message));
 
         const boost::string_ref response_view{reinterpret_cast<const char*>(response.data()), response.size()};
         MDEBUG("Sending RPC reply: \"" << response_view << "\"");

--- a/src/serialization/CMakeLists.txt
+++ b/src/serialization/CMakeLists.txt
@@ -42,6 +42,7 @@ monero_add_library(serialization
   ${serialization_private_headers})
 target_link_libraries(serialization
   LINK_PRIVATE
+    cryptonote_basic
     cryptonote_core
     cryptonote_protocol
     epee

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
+#include <vector>
 
 #include "byte_stream.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -341,6 +342,7 @@ inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type from
 
   auto itr = val.MemberBegin();
 
+  map.clear();
   while (itr != val.MemberEnd())
   {
     typename Map::key_type k;
@@ -361,6 +363,19 @@ inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type t
   dest.EndArray();
 }
 
+namespace traits
+{
+  template<typename T>
+  void reserve(const T&, std::size_t)
+  {}
+
+  template<typename T>
+  void reserve(std::vector<T>& vec, const std::size_t count)
+  {
+    vec.reserve(count);
+  }
+}
+
 template <typename Vec>
 inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec)
 {
@@ -369,11 +384,12 @@ inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type f
     throw WRONG_TYPE("json array");
   }
 
+  vec.clear();
+  traits::reserve(vec, val.Size());
   for (rapidjson::SizeType i=0; i < val.Size(); i++)
   {
-    typename Vec::value_type v;
-    fromJsonValue(val[i], v);
-    vec.push_back(v);
+    vec.emplace_back();
+    fromJsonValue(val[i], vec.back());
   }
 }
 

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -277,6 +277,8 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResp
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& i);
 void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig);
 
+void fromJsonValue(const rapidjson::Value& val, rct::ctkey& key);
+
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::ecdhTuple& tuple);
 void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple);
 

--- a/tests/unit_tests/zmq_rpc.cpp
+++ b/tests/unit_tests/zmq_rpc.cpp
@@ -304,7 +304,7 @@ namespace
       : cryptonote::rpc::RpcHandler()
     {}
 
-    virtual epee::byte_slice handle(const std::string& request) override final
+    virtual epee::byte_slice handle(std::string&& request) override final
     {
       throw std::logic_error{"not implemented"};
     }


### PR DESCRIPTION
Reading a chunk of transactions (via ZMQ `GetBlocksFast`) in larger blocks takes 0.5 seconds (yes seconds!), which makes for a bad time when re-scanning older viewkeys with light wallet server.

Fixing pruned txes with `GetBlocksFast` has a ~73% speedup on a ryzen 3 testbox. This is specifically for large borromean blocks, but has good speedups overall considering the newer transaction volume. The other two patches have a combined ~31% speedup for pruned blocks, and ~36% speed for unpruned blocks.

Overall reading `GetBlocksFast` went from ~0.55 seconds to ~0.11 seconds (~82% faster), which is still somewhat poor (but better). I have other optimizations to push (a schema breaking change in particular), but even the DOMless I-know-where-hex-data-is mode still tops out at 75 milliseconds; text protocols have their limitation for this sort of content.