### PR TITLE
Change ZMQ-JSON txextra to hex and remove unnecessary base fields

### DIFF
--- a/src/rpc/daemon_rpc_version.h
+++ b/src/rpc/daemon_rpc_version.h
@@ -35,7 +35,7 @@ namespace rpc
 {
 
 static const uint32_t DAEMON_RPC_VERSION_ZMQ_MINOR = 0;
-static const uint32_t DAEMON_RPC_VERSION_ZMQ_MAJOR = 1;
+static const uint32_t DAEMON_RPC_VERSION_ZMQ_MAJOR = 2;
 
 static const uint32_t DAEMON_RPC_VERSION_ZMQ = DAEMON_RPC_VERSION_ZMQ_MINOR + (DAEMON_RPC_VERSION_ZMQ_MAJOR << 16);
 

--- a/src/rpc/message.cpp
+++ b/src/rpc/message.cpp
@@ -65,8 +65,6 @@ const rapidjson::Value& get_method_field(const rapidjson::Value& src)
 void Message::toJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
   dest.StartObject();
-  INSERT_INTO_JSON_OBJECT(dest, status, status);
-  INSERT_INTO_JSON_OBJECT(dest, error_details, error_details);
   INSERT_INTO_JSON_OBJECT(dest, rpc_version, DAEMON_RPC_VERSION_ZMQ);
   doToJson(dest);
   dest.EndObject();
@@ -74,8 +72,6 @@ void Message::toJson(rapidjson::Writer<epee::byte_stream>& dest) const
 
 void Message::fromJson(const rapidjson::Value& val)
 {
-  GET_FROM_JSON_OBJECT(val, status, status);
-  GET_FROM_JSON_OBJECT(val, error_details, error_details);
   GET_FROM_JSON_OBJECT(val, rpc_version, rpc_version);
 }
 

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -146,6 +146,26 @@ void fromJsonValue(const rapidjson::Value& val, std::string& str)
   str = val.GetString();
 }
 
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const std::vector<std::uint8_t>& src)
+{
+  const std::string hex = epee::to_hex::string(epee::to_span(src));
+  dest.String(hex.data(), hex.size());
+}
+
+void fromJsonValue(const rapidjson::Value& val, std::vector<std::uint8_t>& dest)
+{
+  if (!val.IsString())
+  {
+    throw WRONG_TYPE("string");
+  }
+
+  dest.resize(val.GetStringLength() / 2);
+  if ((val.GetStringLength() % 2) != 0 || !epee::from_hex::to_buffer(epee::to_mut_span(dest), {val.GetString(), val.GetStringLength()}))
+  {
+    throw BAD_INPUT();
+  }
+}
+
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, bool i)
 {
   dest.Bool(i);

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -153,6 +153,9 @@ inline void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const std::s
 }
 void fromJsonValue(const rapidjson::Value& val, std::string& str);
 
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const std::vector<std::uint8_t>&);
+void fromJsonValue(const rapidjson::Value& src, std::vector<std::uint8_t>& i);
+
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, bool i);
 void fromJsonValue(const rapidjson::Value& val, bool& b);
 
@@ -353,6 +356,10 @@ inline typename std::enable_if<sfinae::is_map_like<Map>::value, void>::type from
 template <typename Vec>
 inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const Vec &vec)
 {
+  using value_type = typename Vec::value_type;
+  static_assert(!std::is_same<value_type, char>::value, "encoding an array of chars is faster as hex");
+  static_assert(!std::is_same<value_type, unsigned char>::value, "encoding an array of unsigned char is faster as hex");
+
   dest.StartArray();
   for (const auto& t : vec)
     toJsonValue(dest, t);
@@ -362,6 +369,10 @@ inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type t
 template <typename Vec>
 inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type fromJsonValue(const rapidjson::Value& val, Vec& vec)
 {
+  using value_type = typename Vec::value_type;
+  static_assert(!std::is_same<value_type, char>::value, "encoding a vector of chars is faster as hex");
+  static_assert(!std::is_same<value_type, unsigned char>::value, "encoding a vector of unsigned char is faster as hex");
+
   if (!val.IsArray())
   {
     throw WRONG_TYPE("json array");

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -94,7 +94,7 @@ namespace
 
       rapidjson::Document doc;
       doc.Parse(reinterpret_cast<const char*>(buffer.data()), buffer.size());
-      if (doc.HasParseError() || !doc.IsObject())
+      if (doc.HasParseError())
       {
         throw cryptonote::json::PARSE_FAIL();
       }
@@ -104,6 +104,21 @@ namespace
       return out;
     }
 } // anonymous
+
+TEST(JsonSerialization, VectorBytes)
+{
+    EXPECT_EQ(std::vector<std::uint8_t>{}, test_json(std::vector<std::uint8_t>{}));
+    EXPECT_EQ(std::vector<std::uint8_t>{0x00}, test_json(std::vector<std::uint8_t>{0x00}));
+}
+
+TEST(JsonSerialization, InvalidVectorBytes)
+{
+    rapidjson::Document doc;
+    doc.SetString("1");
+
+    std::vector<std::uint8_t> out;
+    EXPECT_THROW(cryptonote::json::fromJsonValue(doc, out), cryptonote::json::BAD_INPUT);
+}
 
 TEST(JsonSerialization, MinerTransaction)
 {


### PR DESCRIPTION
This changes the `txextra` field from an array of integers to a hex string.  This results in a ~12% speedup on pruned txes and a ~2% speed up non-pruned txes. The mythical (but real) DOMless mode has a ~17% speedup with this change (the mode primarily accelerates hex processing).

Since this is a breaking change, I changed the major version number of the server. I decided to simultaneously drop two fields which are superfluous - the same values are always written. If the status is not `OK`, then the JSON-RPC error field is used instead.