### PR TITLE
[branch] updates: mac gui .tar.bz2 -> .dmg

### DIFF
--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -102,6 +102,8 @@ namespace tools
     const char *base = user ? "https://downloads.getmonero.org/" : "https://updates.getmonero.org/";
 #ifdef _WIN32
     static const char *extension = strncmp(buildtag.c_str(), "source", 6) ? (strncmp(buildtag.c_str(), "install-", 8) ? ".zip" : ".exe") : ".tar.bz2";
+#elif defined(__APPLE__)
+    static const char *extension = strncmp(software.c_str(), "monero-gui", 10) ? ".tar.bz2" : ".dmg";
 #else
     static const char extension[] = ".tar.bz2";
 #endif


### PR DESCRIPTION
To notarize the macOS GUI we have to distribute it as .dmg