### PR TITLE
Update Readme Copyright; 2019 -> 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero
 
-Copyright (c) 2014-2019 The Monero Project.   
+Copyright (c) 2014-2020 The Monero Project.   
 Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Table of Contents


### PR DESCRIPTION
Not sure if it was left intentionally that way, if so just close. 