### PR TITLE
cmake: allow custom openssl path on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ endif ()
 
 if (APPLE AND NOT IOS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -fvisibility=default -std=c++11")
-  if (NOT OpenSSL_DIR)
+  if (NOT OPENSSL_ROOT_DIR)
       EXECUTE_PROCESS(COMMAND brew --prefix openssl
         OUTPUT_VARIABLE OPENSSL_ROOT_DIR
         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -55,7 +55,7 @@ SET(Boost_NO_SYSTEM_PATHS ON)
 SET(Boost_USE_STATIC_LIBS ON)
 SET(Boost_USE_STATIC_RUNTIME ON)
 
-SET(OpenSSL_DIR @prefix@/lib)
+SET(OPENSSL_ROOT_DIR @prefix@)
 SET(ARCHITECTURE @arch@)
 
 # for libraries and headers in the target directories


### PR DESCRIPTION
It is now possible to specify a custom openssl dir by using `-DOPENSSL_ROOT_DIR` on macOS.

Tested with gitian, works as expected now. The old `OpenSSL_DIR` was probably a typo.