### PR TITLE
[depends] Upgrade boost to 1.68

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,8 +1,8 @@
-package=boost                                                                                                                                                                                                                      
-$(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
+package=boost
+$(package)_version=1_68_0
+$(package)_download_path=https://dl.bintray.com/boostorg/release/1.68.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_sha256_hash=7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
 $(package)_dependencies=libiconv
 $(package)_patches=fix_aroptions.patch
 


### PR DESCRIPTION
- Higher versions apparently append '-x64' to the library names, which breaks things
- As a result, upgrading to 1.69+ will require futher modifications.

Please also note: I had tried updating OpenSSL to a version above 1.0, as everything below 1.1 has reached EOL.  

However, openssl has overhauled their build process such that `Makefile.org` is no longer included in the repo.  They have transitioned to a 'Configure-first' build.  As such, build scripts appear to require some heavy modifications prior to upgrading to 1.1+.