### PR TITLE
For NetBSD, add instructions to README.md and define to ea_config.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,14 @@ c++: error: unable to execute command: Abort trap (core dumped)
 
 Then you need to increase the data ulimit size to 2GB and try again: `ulimit -d 2000000`
 
+### On NetBSD:
+
+Check that the dependencies are present: `pkg_info -c libexecinfo boost-headers boost-libs protobuf readline libusb1 zeromq git-base pkgconf gmake cmake | more`, and install any that are reported missing, using `pkg_add` or from your pkgsrc tree.  Readline is optional but worth having.
+
+Third-party dependencies are usually under `/usr/pkg/`, but if you have a custom setup, adjust the "/usr/pkg" (below) accordingly.
+
+Clone the monero repository recursively and checkout the most recent release as described above. Then build monero: `gmake BOOST_ROOT=/usr/pkg LDFLAGS="-Wl,-R/usr/pkg/lib" release`.  The resulting executables can be found in `build/NetBSD/[Release version]/Release/bin/`.
+
 ### On Solaris:
 
 The default Solaris linker can't be used, you have to install GNU ld, then run cmake manually with the path to your copy of GNU ld:

--- a/external/easylogging++/ea_config.h
+++ b/external/easylogging++/ea_config.h
@@ -11,7 +11,7 @@
 #define ELPP_UTC_DATETIME
 
 #ifdef EASYLOGGING_CC
-#if !(!defined __GLIBC__ || !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__)
+#if !(!defined __GLIBC__ || !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__ || defined __NetBSD__)
 #define ELPP_FEATURE_CRASH_LOG
 #endif
 #endif


### PR DESCRIPTION
Fixes the easylogging problem in [#6592](https://github.com/monero-project/monero/issues/6592) (the RandomX problem there is fixed by [PR6698](https://github.com/monero-project/monero/pull/6698).