### PR TITLE
rolling_median_t: fix wraparound case

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -106,6 +106,14 @@ namespace misc_utils
 		return true;
 	}
 
+  template <typename T>
+  T get_mid(const T &a, const T &b)
+  {
+    //returns the average of two numbers; overflow safe and works with at least all integral and floating point types
+    //(a+b)/2 = (a/2) + (b/2) + ((a - 2*(a/2)) + (b - 2*(b/2)))/2
+    return (a/2) + (b/2) + ((a - 2*(a/2)) + (b - 2*(b/2)))/2;
+  }
+
   template<class type_vec_type>
   type_vec_type median(std::vector<type_vec_type> &v)
   {
@@ -122,7 +130,7 @@ namespace misc_utils
       return v[n];
     }else 
     {//2, 4, 6...
-      return (v[n-1] + v[n])/2;
+      return get_mid<type_vec_type>(v[n-1],v[n]);
     }
 
   }

--- a/contrib/epee/include/rolling_median.h
+++ b/contrib/epee/include/rolling_median.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "misc_language.h"
+
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -226,7 +228,7 @@ public:
     Item v = data[heap[0]];
     if (minCt < maxCt)
     {
-      v = (v + data[heap[-1]]) / 2;
+      v = get_mid<Item>(v, data[heap[-1]]);
     }
     return v;
   }

--- a/tests/unit_tests/rolling_median.cpp
+++ b/tests/unit_tests/rolling_median.cpp
@@ -170,6 +170,17 @@ TEST(rolling_median, history_blind)
   }
 }
 
+TEST(rolling_median, overflow)
+{
+  epee::misc_utils::rolling_median_t<uint64_t> m(2);
+
+  uint64_t over_half = static_cast<uint64_t>(3) << static_cast<uint64_t>(62);
+  m.insert(over_half);
+  m.insert(over_half);
+  ASSERT_EQ((over_half + over_half) < over_half, true);
+  ASSERT_EQ(over_half, m.median());
+}
+
 TEST(rolling_median, size)
 {
   epee::misc_utils::rolling_median_t<uint64_t> m(10);


### PR DESCRIPTION
Originally when the rolling median has an even number of elements stored, it returns the average of the middle two elements like this:
`return (a+b)/2`
However, if `(a + b)` is greater than the size of the type of `a` and `b`, the result might wrap around (e.g. if it's an integral type, etc.).

While it is unlikely wraparound will ever occur based on how Monero uses the rolling median, it's better to have safe code in case this template gets reused elsewhere. The new equation is
`(a+b)/2 = (a/2) + (b/2) + ((a - 2*(a/2)) + (b - 2*(b/2)))/2`

This is intended to play nice with integral division, however floating point types may have more rounding errors due to the additional operations.