### PR TITLE
epee: Remove unused functions in local_ip.h

### DIFF
--- a/contrib/epee/include/net/local_ip.h
+++ b/contrib/epee/include/net/local_ip.h
@@ -28,8 +28,6 @@
 #pragma once
 
 #include <string>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/asio/ip/address_v6.hpp>
 #include "int-util.h"
 
 // IP addresses are kept in network byte order
@@ -40,30 +38,6 @@ namespace epee
 {
   namespace net_utils
   {
-
-    inline
-    bool is_ipv6_local(const std::string& ip)
-    {
-      auto addr = boost::asio::ip::address_v6::from_string(ip);
-
-      // ipv6 link-local unicast addresses are fe80::/10
-      bool is_link_local = addr.is_link_local();
-
-      auto addr_bytes = addr.to_bytes();
-
-      // ipv6 unique local unicast addresses start with fc00::/7 -- (fcXX or fdXX)
-      bool is_unique_local_unicast = (addr_bytes[0] == 0xfc || addr_bytes[0] == 0xfd);
-
-      return is_link_local || is_unique_local_unicast;
-    }
-
-    inline
-    bool is_ipv6_loopback(const std::string& ip)
-    {
-      // ipv6 loopback is ::1
-      return boost::asio::ip::address_v6::from_string(ip).is_loopback();
-    }
-
     inline
     bool is_ip_local(uint32_t ip)
     {


### PR DESCRIPTION
These functions are unused, and don't have any tests. Does no harm to remove them IMHO, and reduces code to maintain.

Also it considered unique local addresses (`fc00::/7`) as link local addresses which is not true, ULA addresses are still global, but they aren't routed on the public internet and intended only for private networks.