### PR TITLE
epee: Add locale-independent version of `std::to_string`

### DIFF
--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -39,6 +39,7 @@
 #include <locale>
 #include <cstdlib>
 #include <string>
+#include <sstream>
 #include <type_traits>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -162,6 +163,23 @@ POP_WARNINGS
 		i64toa_s(val, buff, sizeof(buff)-1, 10);
 		return buff;*/
 		return boost::lexical_cast<std::string>(val);
+	}
+	/*!
+	 \brief Locale-independent version of `std::to_string`.
+
+	 Using `std::to_string` can lead to different results when a different
+	 locale is used on the target computer.
+
+	 \param[in] t The value to convert to string.
+
+	 \return `std::string` the value as a string.
+	 */
+	template <typename T>
+	inline std::string to_string(const T t) {
+		std::ostringstream oss;
+		oss.imbue(std::locale::classic());
+		oss << t;
+		return oss.str();
 	}
 	//----------------------------------------------------------------------------
 	template<typename T>

--- a/contrib/epee/src/net_utils_base.cpp
+++ b/contrib/epee/src/net_utils_base.cpp
@@ -15,7 +15,7 @@ namespace epee { namespace net_utils
 	{ return is_same_host(other) ? port() < other.port() : ip() < other.ip(); }
 
 	std::string ipv4_network_address::str() const
-	{ return string_tools::get_ip_string_from_int32(ip()) + ":" + std::to_string(port()); }
+	{ return string_tools::get_ip_string_from_int32(ip()) + ":" + string_tools::to_string(port()); }
 
 	std::string ipv4_network_address::host_str() const { return string_tools::get_ip_string_from_int32(ip()); }
 	bool ipv4_network_address::is_loopback() const { return net_utils::is_ip_loopback(ip()); }
@@ -28,7 +28,7 @@ namespace epee { namespace net_utils
 	{ return is_same_host(other) ? port() < other.port() : m_address < other.m_address; }
 
 	std::string ipv6_network_address::str() const
-	{ return std::string("[") + host_str() + "]:" + std::to_string(port()); }
+	{ return std::string("[") + host_str() + "]:" + string_tools::to_string(port()); }
 
 	std::string ipv6_network_address::host_str() const { return m_address.to_string(); }
 	bool ipv6_network_address::is_loopback() const { return m_address.is_loopback(); }
@@ -42,9 +42,9 @@ namespace epee { namespace net_utils
 	{ return subnet() < other.subnet() ? true : (other.subnet() < subnet() ? false : (m_mask < other.m_mask)); }
 
 	std::string ipv4_network_subnet::str() const
-	{ return string_tools::get_ip_string_from_int32(subnet()) + "/" + std::to_string(m_mask); }
+	{ return string_tools::get_ip_string_from_int32(subnet()) + "/" + string_tools::to_string(m_mask); }
 
-	std::string ipv4_network_subnet::host_str() const { return string_tools::get_ip_string_from_int32(subnet()) + "/" + std::to_string(m_mask); }
+	std::string ipv4_network_subnet::host_str() const { return string_tools::get_ip_string_from_int32(subnet()) + "/" + string_tools::to_string(m_mask); }
 	bool ipv4_network_subnet::is_loopback() const { return net_utils::is_ip_loopback(subnet()); }
 	bool ipv4_network_subnet::is_local() const { return net_utils::is_ip_local(subnet()); }
 	bool ipv4_network_subnet::matches(const ipv4_network_address &address) const


### PR DESCRIPTION
Makes `to_string` behaviour deterministic (doesn't change depending on the computers locale setting).

Here's a brief list of functions that _might_ be needed to change to use `epee::string_tools::to_string` to avoid this problem.

<details>
<summary>
Results of git grep -E "std::to_string\(([^\)]+)\)" > to_sting.txt
</summary>

```
contrib/epee/include/net/http_client.h:				add_field(req_buff, "Content-Length", std::to_string(body.size()));
contrib/epee/include/net/net_helper.h:      return connect(addr, std::to_string(port), timeout);
contrib/epee/src/abstract_http_client.cpp:    set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), std::move(ssl_options));
contrib/epee/src/mlog.cpp:  c.setGlobally(el::ConfigurationType::MaxLogFileSize, std::to_string(max_log_file_size));
src/blockchain_db/lmdb/db_lmdb.cpp:      throw0(BLOCK_DNE(std::string("Attempt to get rct distribution from height " + std::to_string(heights[i]) + " failed -- block size not in db").c_str()));
src/blockchain_db/lmdb/db_lmdb.cpp:          throw0(DB_ERROR(("Height " + std::to_string(height) + " not included in multuple record range: " + std::to_string(range_begin) + "-" + std::to_string(range_end)).c_str()));
src/blockchain_db/lmdb/db_lmdb.cpp:    throw0(DB_ERROR(("Height " + std::to_string(start_height) + " not in blockchain").c_str()));
src/blockchain_db/lmdb/db_lmdb.cpp:          throw0(DB_ERROR(("Height " + std::to_string(height) + " not included in multiple record range: " + std::to_string(range_begin) + "-" + std::to_string(range_end)).c_str()));
src/blockchain_db/lmdb/db_lmdb.cpp:        std::to_string(amount) + ", index " + std::to_string(index)).c_str()));
src/blockchain_utilities/blockchain_ancestry.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_ancestry.cpp:  MINFO("cache: txes " << std::to_string(cached_txes*100./total_txes)
src/blockchain_utilities/blockchain_ancestry.cpp:        << "%, blocks " << std::to_string(cached_blocks*100./total_blocks)
src/blockchain_utilities/blockchain_ancestry.cpp:        << "%, outputs " << std::to_string(cached_outputs*100./total_outputs)
src/blockchain_utilities/blockchain_blackball.cpp:        boost::join(v | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/blockchain_utilities/blockchain_blackball.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_blackball.cpp:        CHECK_AND_ASSERT_THROW_MES(out.target.type() == typeid(txout_to_key), "Out target type is not txout_to_key: height=" + std::to_string(height));
src/blockchain_utilities/blockchain_blackball.cpp:              boost::join(relative_ring | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " ") <<
src/blockchain_utilities/blockchain_blackball.cpp:              ", " << boost::join(txin.key_offsets | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/blockchain_utilities/blockchain_blackball.cpp:  LOG_PRINT_L0(std::to_string(diff) << " new outputs marked as spent, " << get_num_spent_outputs() << " total outputs marked as spent");
src/blockchain_utilities/blockchain_depth.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_export.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_import.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_prune.cpp:    throw std::runtime_error("Failed to set new mapsize to " + std::to_string(new_mapsize) + ": " + std::string(mdb_strerror(result)));
src/blockchain_utilities/blockchain_prune.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_prune_known_spent_data.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_stats.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_usage.cpp:    mlog_set_log(std::string(std::to_string(log_level) + ",bcutil:INFO").c_str());
src/blockchain_utilities/blockchain_usage.cpp:      MINFO(std::to_string(c.second) << " outputs used " << c.first << " times (" << percent << "%)");
src/common/download.cpp:    MLOG_SET_THREAD_NAME("DL" + std::to_string(thread_id++));
src/common/download.cpp:            const std::string prefix = "bytes=" + std::to_string(offset) + "-";
src/common/download.cpp:      client.set_server(u_c.host, std::to_string(port), boost::none, ssl);
src/common/download.cpp:        const std::string range = "bytes=" + std::to_string(existing_size) + "-";
src/common/expect.cpp:                error_msg.append(std::to_string(line));
src/common/rpc_client.h:        epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user), std::move(ssl_options)
src/common/util.cpp:    tools::log_stack_trace(("crashing with fatal signal " + std::to_string(signal)).c_str());
src/common/util.cpp:      return std::to_string(seconds) + " seconds";
src/cryptonote_basic/cryptonote_format_utils.cpp:    CHECK_AND_ASSERT_THROW_MES_L1(n_outputs <= BULLETPROOF_MAX_OUTPUTS, "maximum number of outputs is " + std::to_string(BULLETPROOF_MAX_OUTPUTS) + " per transaction");
src/cryptonote_basic/cryptonote_format_utils.cpp:    CHECK_AND_ASSERT_THROW_MES_L1(bp_base * n_padded_outputs >= bp_size, "Invalid bulletproof clawback: bp_base " + std::to_string(bp_base) + ", n_padded_outputs "
src/cryptonote_basic/cryptonote_format_utils.cpp:        + std::to_string(n_padded_outputs) + ", bp_size " + std::to_string(bp_size));
src/cryptonote_basic/cryptonote_format_utils.cpp:    std::string s = std::to_string(amount);
src/cryptonote_basic/miner.cpp:    MLOG_SET_THREAD_NAME(std::string("[miner ") + std::to_string(th_local_index) + "]");
src/cryptonote_core/blockchain.cpp:    reorg_notify->notify("%s", std::to_string(split_height).c_str(), "%h", std::to_string(m_db->height()).c_str(),
src/cryptonote_core/blockchain.cpp:        "%n", std::to_string(m_db->height() - split_height).c_str(), "%d", std::to_string(discarded_blocks).c_str(), NULL);
src/cryptonote_core/cryptonote_core.cpp:          MCDEBUG("updates", "Downloaded " << length << "/" << (content_length ? std::to_string(content_length) : "unknown"));
src/cryptonote_core/cryptonote_core.cpp:          block_rate_notify->notify("%t", std::to_string(seconds[n] / 60).c_str(), "%b", std::to_string(b).c_str(), "%e", std::to_string(expected).c_str(), NULL);
src/cryptonote_core/tx_pool.cpp:      ss << "blob_size: " << (short_format ? "-" : std::to_string(txblob->size())) << std::endl
src/cryptonote_protocol/cryptonote_protocol_handler.inl:        << std::setw(30) << std::to_string(cntxt.m_recv_cnt)+ "(" + std::to_string(time(NULL) - cntxt.m_last_recv) + ")" + "/" + std::to_string(cntxt.m_send_cnt) + "(" + std::to_string(time(NULL) - cntxt.m_last_send) + ")"
src/cryptonote_protocol/cryptonote_protocol_handler.inl:        << std::setw(20) << std::to_string(time(NULL) - cntxt.m_started)
src/cryptonote_protocol/cryptonote_protocol_handler.inl:        cnx.port = std::to_string(cntxt.m_remote_address.as<epee::net_utils::ipv4_network_address>().port());
src/cryptonote_protocol/cryptonote_protocol_handler.inl:              progress_message = " (" + std::to_string(completion_percent) + "%, "
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                  + std::to_string(target_blockchain_height - current_blockchain_height) + " left";
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                progress_message += ", " + std::to_string(total_blocks_synced * 100 / total_blocks_to_sync) + "% of total synced";
src/cryptonote_protocol/cryptonote_protocol_handler.inl:              timing_message = std::string(" (") + std::to_string(dt.total_microseconds()/1e6) + " sec, "
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                + std::to_string((current_blockchain_height - previous_height) * 1e6 / dt.total_microseconds())
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                + " blocks/sec), " + std::to_string(m_block_queue.get_data_size() / 1048576.f) + " MB queued in "
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                + std::to_string(m_block_queue.get_num_filled_spans()) + " spans, stripe "
src/cryptonote_protocol/cryptonote_protocol_handler.inl:                + std::to_string(previous_stripe) + " -> " + std::to_string(current_stripe);
src/daemon/command_line_args.h:  , std::to_string(config::ZMQ_RPC_DEFAULT_PORT)
src/daemon/command_line_args.h:        return std::to_string(config::testnet::ZMQ_RPC_DEFAULT_PORT);
src/daemon/command_line_args.h:        return std::to_string(config::stagenet::ZMQ_RPC_DEFAULT_PORT);
src/daemon/rpc_command_executor.cpp:    std::string rpc_port = peer.rpc_port ? std::to_string(peer.rpc_port) : "-";
src/daemon/rpc_command_executor.cpp:     << std::setw(30) << std::to_string(info.recv_count) + "("  + std::to_string(info.recv_idle_time) + ")/" + std::to_string(info.send_count) + "(" + std::to_string(info.send_idle_time) + ")"
src/daemon/rpc_command_executor.cpp:  tools::success_msg_writer() << "Log level is now " << std::to_string(level);
src/daemon/rpc_command_executor.cpp:	const std::string s = res.out_peers == (uint32_t)-1 ? "unlimited" : std::to_string(res.out_peers);
src/daemon/rpc_command_executor.cpp:	const std::string s = res.in_peers == (uint32_t)-1 ? "unlimited" : std::to_string(res.in_peers);
src/daemon/rpc_command_executor.cpp:    tools::success_msg_writer() << std::to_string(res.peers.size()) << " peers";
src/daemon/rpc_command_executor.cpp:    tools::success_msg_writer() << std::to_string(res.spans.size()) << " spans, " << total_size/1e6 << " MB";
src/debug_utilities/object_sizes.cpp:      std::cout << std::to_string(i.first) << "\t" << i.second << std::endl;
src/device/device.hpp:                                    std::string(" (device.hpp line ")+std::to_string(__LINE__)+std::string(").")); \
src/device/device_io_hid.cpp:      ASSERT_X(r>=0, "Unable to init hidapi library. Error "+std::to_string(r)+": "+safe_hid_error(this->usb_device));
src/device/device_io_hid.cpp:              (interface_number ? (" interface_number " + std::to_string(interface_number.value())) : "") <<
src/device/device_io_hid.cpp:              (usage_page ? (" usage_page " + std::to_string(usage_page.value())) : ""));
src/device/device_io_hid.cpp:        MDEBUG("Unable to enumerate device "+std::to_string(vid)+":"+std::to_string(vid)+  ": "+ safe_hid_error(this->usb_device));
src/device/device_io_hid.cpp:      ASSERT_X(hwdev, "Unable to open device "+std::to_string(pid)+":"+std::to_string(vid));
src/device/device_io_hid.cpp:        ASSERT_X(hid_ret>=0, "Unable to send hidapi command. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
src/device/device_io_hid.cpp:      ASSERT_X(hid_ret>=0, "Unable to read hidapi response. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
src/device/device_io_hid.cpp:        ASSERT_X(hid_ret>=0, "Unable to receive hidapi response. Error "+std::to_string(result)+": "+ safe_hid_error(this->usb_device));
src/device/device_io_hid.cpp:      ASSERT_X(this->packet_size >= 3, "Invalid Packet size: "+std::to_string(this->packet_size)) ;
src/device/device_io_hid.cpp:      ASSERT_X(out_len >= 7,  "out_len too short: "+std::to_string(out_len));
src/device/device_io_hid.cpp:      ASSERT_X(out_len >= block_size,  "out_len too short: "+std::to_string(out_len));
src/device/device_io_hid.cpp:        ASSERT_X(out_len >= 5,  "out_len too short: "+std::to_string(out_len));
src/device/device_io_hid.cpp:        ASSERT_X(out_len >= block_size,  "out_len too short: "+std::to_string(out_len));
src/device/device_io_hid.cpp:        ASSERT_X(out_len >= 1,  "out_len too short: "+std::to_string(out_len));
src/device/device_ledger.cpp:        log_message("  keymap", std::to_string(i));
src/device/device_ledger.cpp:        log_message  ("  is_sub", std::to_string(ABP[i].is_subaddress));
src/device/device_ledger.cpp:        log_message  ("   index", std::to_string(ABP[i].index));
src/device/device_ledger.cpp:        log_message  ("derive_subaddress_public_key: [[IN]]  index     ", std::to_string((int)output_index_x));
src/device/device_ledger.cpp:        log_message  ("get_subaddress_spend_public_key: [[IN]]  index               ", std::to_string(index_x.major)+"."+std::to_string(index_x.minor));
src/device/device_ledger.cpp:        log_message  ("get_subaddress: [[IN]]  index                                ", std::to_string(index_x.major)+"."+std::to_string(index_x.minor));
src/device/device_ledger.cpp:        log_message  ("get_subaddress_secret_key: [[IN]]  index  ", std::to_string(index.major)+"."+std::to_string(index.minor));
src/device/device_ledger.cpp:        log_message  ("derivation_to_scalar: [[IN]]  output_index  ", std::to_string(output_index_x));
src/device/device_ledger.cpp:        log_message  ("derive_secret_key: [[IN]]  index      ", std::to_string(output_index_x));
src/device/device_ledger.cpp:        log_message  ("derive_public_key: [[IN]]  output_index", std::to_string(output_index_x));
src/device/device_ledger.cpp:      log_message  ("generate_output_ephemeral_keys: [[IN]] tx_version", std::to_string(tx_version_x));
src/device/device_ledger.cpp:      log_message  ("generate_output_ephemeral_keys: [[IN]] output_index",  std::to_string(output_index_x));
src/device/device_ledger.cpp:      log_message  ("generate_output_ephemeral_keys: [[IN]] need_additional_txkeys",  std::to_string(need_additional_txkeys_x));
src/device/device_ledger.cpp:          log_message("mlsag_prehash", (std::string("inputs_size not null: ") +  std::to_string(inputs_size)).c_str());
src/device/device_ledger.cpp:           hw::ledger::check32("mlsag_sign", "ss["+std::to_string(j)+"]", (char*)ss_x[j].bytes, (char*)ss[j].bytes);
src/device_trezor/trezor/exceptions.hpp:               + (code ? std::to_string(code.get()) : "")
src/device_trezor/trezor/messages_map.cpp:      throw exc::EncodingException(std::string("Message descriptor not found: ") + std::to_string(wire_number));
src/device_trezor/trezor/protocol.cpp:      throw std::invalid_argument(std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
src/device_trezor/trezor/protocol.cpp:      throw std::invalid_argument(std::string("Key has to have ") + std::to_string(sizeof(key.data)) + " B");
src/device_trezor/trezor/protocol.cpp:      throw std::invalid_argument(std::string("Key has to have ") + std::to_string(sizeof(key.bytes)) + " B");
src/device_trezor/trezor/transport.cpp:    return path + m_device_host + ":" + std::to_string(m_device_port);
src/device_trezor/trezor/transport.cpp:    udp::resolver::query query(udp::v4(), m_device_host, std::to_string(m_device_port));
src/device_trezor/trezor/transport.cpp:             << ", vendorId=" << (m_usb_device_desc ? std::to_string(m_usb_device_desc->idVendor) : "?")
src/device_trezor/trezor/transport.cpp:             << ", productId=" << (m_usb_device_desc ? std::to_string(m_usb_device_desc->idProduct) : "?")
src/device_trezor/trezor/transport.hpp:        reason = std::string("Trezor returned unexpected message: ") + std::to_string(recvType);
src/gen_multisig/gen_multisig.cpp:      std::string name = basename + "-" + std::to_string(n + 1);
src/gen_multisig/gen_multisig.cpp:      std::string name = basename + "-" + std::to_string(n + 1);
src/p2p/net_node.cpp:      , std::to_string(config::P2P_DEFAULT_PORT)
src/p2p/net_node.cpp:            return std::to_string(config::testnet::P2P_DEFAULT_PORT);
src/p2p/net_node.cpp:            return std::to_string(config::stagenet::P2P_DEFAULT_PORT);
src/p2p/net_node.cpp:      , std::to_string(config::P2P_DEFAULT_PORT)
src/p2p/net_node.cpp:            return std::to_string(config::testnet::P2P_DEFAULT_PORT);
src/p2p/net_node.cpp:            return std::to_string(config::stagenet::P2P_DEFAULT_PORT);
src/p2p/net_node.inl:    std::string port = std::to_string(default_port);
src/p2p/net_node.inl:          full_addrs.insert(addr_string + ":" + std::to_string(cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT));
src/p2p/net_node.inl:    if ((m_nettype == cryptonote::MAINNET && public_zone.m_port != std::to_string(::config::P2P_DEFAULT_PORT))
src/p2p/net_node.inl:        || (m_nettype == cryptonote::TESTNET && public_zone.m_port != std::to_string(::config::testnet::P2P_DEFAULT_PORT))
src/p2p/net_node.inl:        || (m_nettype == cryptonote::STAGENET && public_zone.m_port != std::to_string(::config::stagenet::P2P_DEFAULT_PORT))) {
src/p2p/p2p_protocol_defs.h:        << " \trpc port " << (pe.rpc_port > 0 ? std::to_string(pe.rpc_port) : "-")
src/p2p/p2p_protocol_defs.h:        << " \trpc credits per hash " << (pe.rpc_credits_per_hash > 0 ? std::to_string(pe.rpc_credits_per_hash) : "-")
src/rpc/core_rpc_server.cpp:          result.insert(std::make_pair(node.host + ":" + std::to_string(node.rpc_port), white));
src/rpc/core_rpc_server.cpp:        res.status = "Error retrieving block at height " + std::to_string(height);
src/rpc/core_rpc_server.cpp:      error_resp.message = std::string("Requested block height: ") + std::to_string(h) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
src/rpc/core_rpc_server.cpp:      error_resp.message = std::string("Requested block height: ") + std::to_string(req.height) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
src/rpc/core_rpc_server.cpp:      error_resp.message = "Internal error: can't get block by height. Height = " + std::to_string(req.height) + '.';
src/rpc/core_rpc_server.cpp:        error_resp.message = std::string("Requested block height: ") + std::to_string(req.height) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
src/rpc/core_rpc_server.cpp:    , std::to_string(config::RPC_DEFAULT_PORT)
src/rpc/core_rpc_server.cpp:          return std::to_string(config::testnet::RPC_DEFAULT_PORT);
src/rpc/core_rpc_server.cpp:          return std::to_string(config::stagenet::RPC_DEFAULT_PORT);
src/simplewallet/simplewallet.cpp:  success_msg_writer() << std::to_string(threshold) << "/" << total << tr(" multisig address: ")
src/simplewallet/simplewallet.cpp:  message_writer() << std::to_string(m_wallet->get_bytes_sent()) + tr(" bytes sent");
src/simplewallet/simplewallet.cpp:  message_writer() << std::to_string(m_wallet->get_bytes_received()) + tr(" bytes received");
src/simplewallet/simplewallet.cpp:      std::string host = node.host + ":" + std::to_string(node.rpc_port);
src/simplewallet/simplewallet.cpp:      daemon_url = match[1] + match[2] + std::string(":") + std::to_string(daemon_port);
src/simplewallet/simplewallet.cpp:    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
src/simplewallet/simplewallet.cpp:      rawfiles_as_text += "signed_monero_tx_raw" + (ptx.size() == 1 ? "" : ("_" + std::to_string(i)));
src/simplewallet/simplewallet.cpp:    return std::to_string(ts) + sw::tr(" seconds");
src/simplewallet/simplewallet.cpp:    return std::to_string((uint64_t)(ts / 60)) + sw::tr(" minutes");
src/simplewallet/simplewallet.cpp:    return std::to_string((uint64_t)(ts / 3600)) + sw::tr(" hours");
src/simplewallet/simplewallet.cpp:    return std::to_string((uint64_t)(ts / (3600 * 24))) + sw::tr(" days");
src/simplewallet/simplewallet.cpp:    return std::to_string((uint64_t)(ts / (3600 * 24 * 30.5))) + sw::tr(" months");
src/simplewallet/simplewallet.cpp:            locked_msg = std::to_string(bh - last_block_height) + " blks";
src/simplewallet/simplewallet.cpp:      % boost::algorithm::join(transfer.index | boost::adaptors::transformed([](uint32_t i) { return std::to_string(i); }), ", ")
src/simplewallet/simplewallet.cpp:      % boost::algorithm::join(transfer.index | boost::adaptors::transformed([](uint32_t i) { return std::to_string(i); }), ", ")
src/simplewallet/simplewallet.cpp:        MINFO(std::to_string(cph) << " credits per hash is >= our threshold (" << m_wallet->auto_mine_for_rpc_payment_threshold() << "), starting mining");
src/simplewallet/simplewallet.cpp:          success_msg_writer() << std::to_string(last_block_height - bh) << " confirmations (" << suggested_threshold << " suggested threshold)";
src/simplewallet/simplewallet.cpp:          success_msg_writer() << std::to_string(last_block_height - bh) << " confirmations";
src/simplewallet/simplewallet.cpp:      const std::string filename = "raw_monero_tx" + (ptx_vector.size() == 1 ? "" : ("_" + std::to_string(i++)));
src/simplewallet/simplewallet.cpp:    text = std::to_string(i+1) + ": ";
src/simplewallet/simplewallet.cpp:      sig_args[0] = std::to_string(ms.get_num_required_signers());
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(index >= m_num_authorized_signers, tools::error::wallet_internal_error, "Invalid signer index " + std::to_string(index));
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(index >= m_num_authorized_signers, tools::error::wallet_internal_error, "Invalid signer index " + std::to_string(index));
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(num_signers != m_num_authorized_signers, tools::error::wallet_internal_error, "Wrong number of signers in config: " + std::to_string(num_signers));
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(index >= m_num_authorized_signers, tools::error::wallet_internal_error, "Invalid signer index " + std::to_string(index));
src/wallet/message_store.cpp:    THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, "Illegal message type " + std::to_string((uint32_t)type));
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(!found, tools::error::wallet_internal_error, "Invalid message id " + std::to_string(id));
src/wallet/message_store.cpp:  THROW_WALLET_EXCEPTION_IF(!found, tools::error::wallet_internal_error, "Invalid message id " + std::to_string(id));
src/wallet/message_transporter.cpp:  m_http_client->set_server(address_parts.host, std::to_string(address_parts.port), boost::none);
src/wallet/ringdb.cpp:  MDEBUG("Relative: " << boost::join(outs | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/wallet/ringdb.cpp:  MDEBUG("Absolute: " << boost::join(outs | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/wallet/wallet2.cpp:  return std::to_string(weight) + " weight";
src/wallet/wallet2.cpp:    daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
src/wallet/wallet2.cpp:    ss << std::to_string(v);
src/wallet/wallet2.cpp:            "transactions outputs size=" + std::to_string(tx.vout.size()) +
src/wallet/wallet2.cpp:            " not match with daemon response size=" + std::to_string(o_indices.size()));
src/wallet/wallet2.cpp:				  std::to_string(o) + ", total_outs=" + std::to_string(tx.vout.size()));
src/wallet/wallet2.cpp:      "block transactions=" + std::to_string(bche.txs.size()) +
src/wallet/wallet2.cpp:      " not match with daemon response size=" + std::to_string(parsed_block.o_indices.indices.size()));
src/wallet/wallet2.cpp:        " (height " + std::to_string(start_height) + "), local block id at this height: " +
src/wallet/wallet2.cpp:    THROW_WALLET_EXCEPTION_IF(it_ki == m_key_images.end(), error::wallet_internal_error, "key image not found: index " + std::to_string(i) + ", ki " + epee::string_tools::pod_to_hex(m_transfers[i].m_key_image) + ", " + std::to_string(m_key_images.size()) + " key images known");
src/wallet/wallet2.cpp:        std::to_string(daemon_resp.spent_status.size()) + ", expected " +  std::to_string(n_outputs));
src/wallet/wallet2.cpp:      std::string raw_filename = signed_filename + "_raw" + (signed_txes.ptx.size() == 1 ? "" : ("_" + std::to_string(i)));
src/wallet/wallet2.cpp:  MDEBUG("Found " << std::to_string(txs_hashes.size()) << " transactions");
src/wallet/wallet2.cpp:        std::to_string(res.txs.size()) + ", expected " + std::to_string(req.txs_hashes.size()));
src/wallet/wallet2.cpp:              std::to_string(ring.size()) + ", it cannot be spent now with ring size " +
src/wallet/wallet2.cpp:              std::to_string(fake_outputs_count + 1) + " as it is smaller: use a higher ring size");
src/wallet/wallet2.cpp:              "Known ring does not include the spent output: " + std::to_string(td.m_global_output_index));
src/wallet/wallet2.cpp:              boost::join(pick.second | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/wallet/wallet2.cpp:            boost::join(o.second | boost::adaptors::transformed([](uint64_t out){return std::to_string(out);}), " "));
src/wallet/wallet2.cpp:        std::to_string(daemon_resp.outs.size()) + ", expected " +  std::to_string(req.outputs.size()));
src/wallet/wallet2.cpp:      std::to_string(d.amount) + ", dust_threshold = " + std::to_string(dust_policy.dust_threshold));
src/wallet/wallet2.cpp:            std::string("original_output_index too large: ") + std::to_string(original_output_index) + " > " + std::to_string(dsts.size()));
src/wallet/wallet2.cpp:      std::to_string(res.txs.size()) + ", expected 1");
src/wallet/wallet2.cpp:      std::to_string(res.txs.size()) + ", expected 1");
src/wallet/wallet2.cpp:        std::to_string(res.outs.size()) + ", expected " +  std::to_string(ring_size));
src/wallet/wallet2.cpp:      std::to_string(res.txs.size()) + ", expected 1");
src/wallet/wallet2.cpp:        std::to_string(res.outs.size()) + ", expected " +  std::to_string(req.outputs.size()));
src/wallet/wallet2.cpp:        std::to_string(daemon_resp.spent_status.size()) + ", expected " +  std::to_string(signed_key_images.size()));
src/wallet/wallet2.cpp:        "daemon returned wrong response for gettransactions, wrong count = " + std::to_string(gettxs_res.txs.size()) + ", expected " + std::to_string(spent_txids.size()));
src/wallet/wallet2.cpp:          THROW_WALLET_EXCEPTION_IF(it->second >= m_transfers.size(), error::wallet_internal_error, std::string("Key images cache contains illegal transfer offset: ") + std::to_string(it->second) + std::string(" m_transfers.size() = ") + std::to_string(m_transfers.size()));
src/wallet/wallet2.cpp:    if (!parse_and_validate_block_from_blob(res.blocks[0].block, blk_min)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_min));
src/wallet/wallet2.cpp:    if (!parse_and_validate_block_from_blob(res.blocks[1].block, blk_mid)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_mid));
src/wallet/wallet2.cpp:    if (!parse_and_validate_block_from_blob(res.blocks[2].block, blk_max)) throw std::runtime_error("failed to parse blob at height " + std::to_string(height_max));
src/wallet/wallet_errors.h:        : wallet_rpc_error(std::move(loc), std::string("error ") + std::to_string(code) + (" in ") + request + " RPC: " + status, request),
src/wallet/wallet_rpc_payments.cpp:          errorfunc("Found nonce, but daemon errored out with error " + std::to_string(e.code()) + ": " + e.status() + ", continuing");
src/wallet/wallet_rpc_server.cpp:          er.message = "Index out of range: " + std::to_string(idx);
src/wallet/wallet_rpc_server.cpp:      er.message = "Index out of range: " + std::to_string(req.index);
src/wallet/wallet_rpc_server.cpp:      er.message = "Index out of range: " + std::to_string(req.index);
src/wallet/wallet_rpc_server.cpp:      MINFO("Auto refresh now " << (m_auto_refresh_period ? std::to_string(m_auto_refresh_period) + " seconds" : std::string("disabled")));
tests/performance_tests/performance_tests.h:          cmp = ", " + std::to_string(pc) + "% " + (mean > prev_instance.mean ? "slower" : "faster");
tests/performance_tests/performance_tests.h:cmp += "  -- " + std::to_string(prev_instance.mean);
tests/trezor/daemon.cpp:  tools::options::set_option(vm, nodetool::arg_p2p_bind_port, po::variable_value(std::to_string(initial_port), false));
tests/trezor/daemon.cpp:  tools::options::set_option(vm, cryptonote::core_rpc_server::arg_rpc_bind_port, po::variable_value(std::to_string(initial_port + 1), false));
tests/trezor/daemon.cpp:  tools::options::set_option(vm, daemon_args::arg_zmq_rpc_bind_port, po::variable_value(std::to_string(initial_port + 2), false));
tests/trezor/trezor_tests.cpp:      TREZOR_SETUP_CHAIN(std::string("HF") + std::to_string((int)hf));
tests/unit_tests/http.cpp:    request.m_http_method_str += std::to_string(i);
```
</details>

Some of the `std::to_string` calls are used in consensus code (AFAIK mostly for logging) and might be good to make that code use locale-indenpendent `std::to_string`. This PR is to see if it's (N)ACKed and extend it properly by replacing all usages of `std::to_string`.