### PR TITLE
cmake: Use job pool feature to limit concurrent jobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,20 @@ else()
 	message(STATUS "ccache deselected")
 endif()
 
+if (${CMAKE_VERSION} VERSION_GREATER "3.0.0" AND CMAKE_MAKE_PROGRAM MATCHES "ninja")
+  set(MONERO_PARALLEL_COMPILE_JOBS "" CACHE STRING "The maximum number of concurrent compilation jobs.")
+  if (MONERO_PARALLEL_COMPILE_JOBS)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS compile_job_pool=${MONERO_PARALLEL_COMPILE_JOBS})
+    set(CMAKE_JOB_POOL_COMPILE compile_job_pool)
+  endif ()
+
+  set(MONERO_PARALLEL_LINK_JOBS "" CACHE STRING "The maximum number of concurrent link jobs.")
+  if (MONERO_PARALLEL_LINK_JOBS)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS link_job_pool=${MONERO_PARALLEL_LINK_JOBS})
+    set(CMAKE_JOB_POOL_LINK link_job_pool)
+  endif ()
+endif()
+
 enable_language(C ASM)
 
 function (die msg)


### PR DESCRIPTION
Add two new options, MONERO_PARALLEL_COMPILE_JOBS and MONERO_PARALLEL_LINK_JOBS to try and prevent running out of memory when building everything.

Requires >= cmake 3.0.0, and the use of the Ninja generator.

If the values are unset, or if Ninja is not used, it behaves as before.

##### Useful links

* https://cmake.org/cmake/help/latest/prop_gbl/JOB_POOLS.html
* https://reviews.llvm.org/D6304

##### Example

```bash
cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DMONERO_PARALLEL_LINK_JOBS=1
cd build
ninja
```