### PR TITLE
Create apparmor profiles for monerod and monero-wallet-cli

### DIFF
--- a/contrib/apparmor/tunables/monero
+++ b/contrib/apparmor/tunables/monero
@@ -1,0 +1,54 @@
+#----------------------------------------------------------------------------------------
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#----------------------------------------------------------------------------------------
+# vim:ft=apparmor
+
+# @{MONEROD_DATA_DIR} is a list of directories where the Monero daemon is allowed to
+# store its blockchain data, configuration files, and logs.
+#
+# Change this value if you launch monerod with a parameter like --data-dir.
+
+@{MONEROD_DATA_DIR}=@{HOME}/.bitmonero/ /var/lib/monero/
+
+# @{MONERO_WALLET_DIR} is a list of directories where the Monero wallet is allowed to
+# store its private keys, wallet cache, and log files.
+#
+# You should start monero-wallet-cli from this directory, and store your wallet files
+# here.
+#
+# Change this value if you don't like it.
+
+@{MONERO_WALLET_DIR}=@{HOME}/{,Documents/,Desktop/}{m,M}onero/
+
+# @{MONERO_WALLET_RINGDB_DIR} is a list of directories where the Monero wallet is
+# allowed to store its shared ring database.
+#
+# Change this value if you launch monero-wallet-cli with --shared-ringdb-dir.
+
+@{MONERO_WALLET_RINGDB_DIR}=@{HOME}/.shared-ringdb/

--- a/contrib/apparmor/usr.bin.monero-wallet-cli
+++ b/contrib/apparmor/usr.bin.monero-wallet-cli
@@ -1,0 +1,60 @@
+#----------------------------------------------------------------------------------------
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#----------------------------------------------------------------------------------------
+# vim: ft=apparmor
+
+abi <abi/3.0>,
+
+include <tunables/global>
+include <tunables/monero>
+
+@{MONERO_WALLET_RINGDB_DIRS}=@{MONERO_WALLET_RINGDB_DIR}/{,stagenet/,testnet/}
+
+profile monero-wallet-cli /usr/{,local/}bin/monero-wallet-cli {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+
+  /etc/inputrc r,
+  /etc/terminfo/** r,
+
+  /etc/tor/torsocks.conf r,
+
+  owner @{MONERO_WALLET_RINGDB_DIRS}/ w,
+  owner @{MONERO_WALLET_RINGDB_DIRS}/data.mdb rwk,
+  owner @{MONERO_WALLET_RINGDB_DIRS}/lock.mdb rwk,
+
+  owner @{MONERO_WALLET_DIR}/** rwk,
+
+  # Allow config files to be read, but not modified.
+  audit deny ${MONERO_WALLET_DIR}/**.conf wklx,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.monero-wallet-cli>
+}

--- a/contrib/apparmor/usr.bin.monero-wallet-rpc
+++ b/contrib/apparmor/usr.bin.monero-wallet-rpc
@@ -1,0 +1,60 @@
+#----------------------------------------------------------------------------------------
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#----------------------------------------------------------------------------------------
+# vim: ft=apparmor
+
+abi <abi/3.0>,
+
+include <tunables/global>
+include <tunables/monero>
+
+@{MONERO_WALLET_RINGDB_DIRS}=@{MONERO_WALLET_RINGDB_DIR}/{,stagenet/,testnet/}
+
+profile monero-wallet-rpc /usr/{,local/}bin/monero-wallet-rpc {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+
+  /etc/inputrc r,
+  /etc/terminfo/** r,
+
+  /etc/tor/torsocks.conf r,
+
+  owner @{MONERO_WALLET_RINGDB_DIRS}/ w,
+  owner @{MONERO_WALLET_RINGDB_DIRS}/data.mdb rwk,
+  owner @{MONERO_WALLET_RINGDB_DIRS}/lock.mdb rwk,
+
+  owner @{MONERO_WALLET_DIR}/** rwk,
+
+  # Allow config files to be read, but not modified.
+  audit deny ${MONERO_WALLET_DIR}/**.conf wklx,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.monero-wallet-rpc>
+}

--- a/contrib/apparmor/usr.bin.monerod
+++ b/contrib/apparmor/usr.bin.monerod
@@ -1,0 +1,76 @@
+#----------------------------------------------------------------------------------------
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#----------------------------------------------------------------------------------------
+# vim: ft=apparmor
+
+abi <abi/3.0>,
+
+include <tunables/global>
+include <tunables/monero>
+
+@{MONEROD_DATA_DIRS}=@{MONEROD_DATA_DIR}/{,stagenet/,testnet/,fake/}
+
+# Add `flags=(attach_disconnected)` before the opening curly bracket if you
+# have audit log messages like "Failed name lookup - disconnected path". This
+# reduces the effectiveness of AppArmor.
+#
+# See: https://lists.ubuntu.com/archives/apparmor/2018-July/011718.html
+# See: https://github.com/monero-project/monero/pull/6758#issuecomment-699275306
+profile monerod /usr/{,local/}bin/monerod {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+
+  capability sys_nice,
+
+  /etc/inputrc r,
+  /etc/terminfo/** r,
+
+  /sys/devices/**/rotational r,
+
+  /etc/tor/torsocks.conf r,
+
+  # Allow another apparmored program to start monerod.
+  /usr/{,local/}bin/monerod mr,
+
+  /etc/monerod.conf r,
+
+  owner @{MONEROD_DATA_DIRS}/ rw,
+  owner @{MONEROD_DATA_DIRS}/lmdb/ w,
+  owner @{MONEROD_DATA_DIRS}/lmdb/data.mdb rwk,
+  owner @{MONEROD_DATA_DIRS}/lmdb/lock.mdb rwk,
+  owner @{MONEROD_DATA_DIRS}/ssl/* r,
+  owner @{MONEROD_DATA_DIRS}/bitmonero.conf r,
+  owner @{MONEROD_DATA_DIRS}/bitmonero.log* w,
+  owner @{MONEROD_DATA_DIRS}/p2pstate.bin rw,
+  owner @{MONEROD_DATA_DIRS}/monerod.pid w,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.monerod>
+}


### PR DESCRIPTION
Closes #6705

Draft. Looking for feedback, and testing for use with hardware wallets like the Ledger and Trezor.

To install and use:

```bash
# as root
cp -r contrib/apparmor/* /etc/apparmor.d/
aa-complain monerod monero-wallet-cli # or aa-enforce
tail -f /var/log/syslog # and start daemon/wallet in another window and watch for audit events
```