### PR TITLE
README: update list of third party monero packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,10 @@ The produced binaries still link libc dynamically. If the binary is compiled on 
 
 Packages are available for
 
+* Debian Buster
+
+    See the [instructions in the whonix/monero-gui repository](https://gitlab.com/whonix/monero-gui#how-to-install-monero-using-apt-get)
+
 * Debian Bullseye and Sid
 
     ```bash
@@ -550,9 +554,9 @@ Packages are available for
     ```
 More info and versions in the [Debian package tracker](https://tracker.debian.org/pkg/monero).
 
-* Arch Linux (via [AUR](https://aur.archlinux.org/)):
-  - Stable release: [`monero`](https://aur.archlinux.org/packages/monero)
-  - Bleeding edge: [`monero-git`](https://aur.archlinux.org/packages/monero-git)
+
+* Arch Linux (via Community packages):
+    [`monero`](https://www.archlinux.org/packages/community/x86_64/monero/)
 
 * Void Linux:
 
@@ -564,6 +568,21 @@ More info and versions in the [Debian package tracker](https://tracker.debian.or
 
     ```bash
     guix package -i monero
+    ```
+
+* Gentoo [Monero overlay](https://github.com/gentoo-monero/gentoo-monero)
+
+    ```bash
+    emerge --noreplace eselect-repository
+    eselect repository enable monero
+    emaint sync -r monero
+    echo '*/*::monero ~amd64' >> /etc/portage/package.accept_keywords
+    emerge net-p2p/monero
+    ```
+
+* macOS (homebrew)
+    ```bash
+    brew install monero
     ```
 
 * Docker


### PR DESCRIPTION
Removed AUR package, since doesn't seem to exist anymore and added Debian package (the CCS-funded one).

We will link to this list from the website: https://github.com/monero-project/monero-site/pull/1135