### PR TITLE
Fix protocol with Ledger's HW when using CLSAG

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -2126,7 +2126,7 @@ namespace hw {
         AUTO_LOCK_CMD();
         #ifdef DEBUG_HWDEVICE
         const rct::key p_x   = hw::ledger::decrypt(p);
-        const rct::key z_x   = hw::ledger::decrypt(z);
+        const rct::key z_x   = z;
         rct::key       I_x;
         rct::key       D_x;
         const rct::key H_x   = H;
@@ -2146,7 +2146,8 @@ namespace hw {
         //p
         this->send_secret(p.bytes, offset);
         //z
-        this->send_secret(z.bytes, offset);
+        memmove(this->buffer_send+offset, z.bytes, 32);
+        offset += 32;
         //H
         memmove(this->buffer_send+offset, H.bytes, 32);
         offset += 32;
@@ -2225,7 +2226,7 @@ namespace hw {
         const rct::key c_x    = c;
         const rct::key a_x    = hw::ledger::decrypt(a);
         const rct::key p_x    = hw::ledger::decrypt(p);
-        const rct::key z_x    = hw::ledger::decrypt(z);
+        const rct::key z_x    = z;
         const rct::key mu_P_x = mu_P;
         const rct::key mu_C_x = mu_C;
         rct::key       s_x;
@@ -2249,7 +2250,8 @@ namespace hw {
         //p
         this->send_secret(p.bytes, offset);
         //z
-        this->send_secret(z.bytes, offset);
+        memmove(this->buffer_send+offset, z.bytes, 32);
+        offset += 32;
         //mu_P
         memmove(this->buffer_send+offset, mu_P.bytes, 32);
         offset += 32;

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -259,7 +259,7 @@ namespace hw {
 
     static int device_id = 0;
 
-    #define PROTOCOL_VERSION                    3
+    #define PROTOCOL_VERSION                    4
 
     #define INS_NONE                            0x00
     #define INS_RESET                           0x02

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -44,8 +44,8 @@ namespace hw {
 
     /* Minimal supported version */
     #define MINIMAL_APP_VERSION_MAJOR    1
-    #define MINIMAL_APP_VERSION_MINOR    3
-    #define MINIMAL_APP_VERSION_MICRO    1
+    #define MINIMAL_APP_VERSION_MINOR    6
+    #define MINIMAL_APP_VERSION_MICRO    0
 
     #define VERSION(M,m,u)       ((M)<<16|(m)<<8|(u))
     #define VERSION_MAJOR(v)     (((v)>>16)&0xFF)


### PR DESCRIPTION
- Update protocol version to allow MLSAG and CLSAG in Ledger Monero application
- Update minimal version required for Ledger Monero application
- Fix method to send scalar `z` in `clsag_sign()` which can't be encrypted in the Monero client because it hasn't been generated on the HW.