### PR TITLE
ringct: fix CLSAG serialization after boost/epee changes

### DIFF
--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1599,7 +1599,7 @@ namespace rct {
     bool signMultisigCLSAG(rctSig &rv, const std::vector<unsigned int> &indices, const keyV &k, const multisig_out &msout, const key &secret_key) {
         CHECK_AND_ASSERT_MES(rv.type == RCTTypeCLSAG, false, "unsupported rct type");
         CHECK_AND_ASSERT_MES(indices.size() == k.size(), false, "Mismatched k/indices sizes");
-        CHECK_AND_ASSERT_MES(k.size() == rv.p.CLSAGs.size(), false, "Mismatched k/MGs size");
+        CHECK_AND_ASSERT_MES(k.size() == rv.p.CLSAGs.size(), false, "Mismatched k/CLSAGs size");
         CHECK_AND_ASSERT_MES(k.size() == msout.c.size(), false, "Mismatched k/msout.c size");
         CHECK_AND_ASSERT_MES(rv.p.MGs.empty(), false, "MGs not empty for CLSAGs");
         CHECK_AND_ASSERT_MES(msout.c.size() == msout.mu_p.size(), false, "Bad mu_p size");

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -523,6 +523,7 @@ namespace rct {
           FIELD(rangeSigs)
           FIELD(bulletproofs)
           FIELD(MGs)
+          FIELD(CLSAGs)
           FIELD(pseudoOuts)
         END_SERIALIZE()
     };


### PR DESCRIPTION
also fix a an assert message refering t MLSAG