### PR TITLE
Let stagenet hardfork happen before mainnet.

### DIFF
--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -115,7 +115,7 @@ const hardfork_t stagenet_hard_forks[] = {
   { 10, 269000, 0, 1550153694 },
   { 11, 269720, 0, 1550225678 },
   { 12, 454721, 0, 1571419280 },
-  { 13, 699045, 0, 1598180817 },
-  { 14, 699765, 0, 1598180818 },
+  { 13, 675405, 0, 1598180817 },
+  { 14, 676125, 0, 1598180818 },
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);


### PR DESCRIPTION
This PR decreases the `stagenet` hardfork heights for `v13` and `v14`, so the `stagenet` hardfork will take place before the `mainnet` hardfork, hopefully.

Right now, according to https://community.xmr.to/xmr-countdown/ and https://community.xmr.to/xmr-countdown/stagenet/ the `mainnet` hardfork comes first.

I chose (assuming 2 minutes per block):
* `v13`: 675405. (ca. 2020-09-28 at 11:52).
* `v14`: 676125. (ca. 2020-09-28 at 08:32).


This is open for discussion.