### PR TITLE
systemd: Don't use Type=forking

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -6,16 +6,15 @@ After=network.target
 User=monero
 Group=monero
 WorkingDirectory=~
-RuntimeDirectory=monero
 StateDirectory=monero
 LogsDirectory=monero
 
 # Clearnet config
 #
-Type=forking
-PIDFile=/run/monero/monerod.pid
-ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf \
-    --detach --pidfile /run/monero/monerod.pid
+Type=simple
+ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf --non-interactive
+StandardOutput=null
+StandardError=null
 
 # Tor config
 #


### PR DESCRIPTION
Per the systemd.service(5) man page, "It is generally recommended to use Type=simple for long-running services whenever possible."

It's better than Type=forking because the service (monerod) will be a direct child of systemd, which can then directly monitor it with the wait() family of syscalls.

AFAIK, the only reason to fork is to disassociate the controlling terminal and login session from the process. This isn't needed under systemd which already handles all of that.

Without the --detach option, monerod will send log messages to stdout/err, in addition to its own log file. By default, these duplicate messages would end up in the journal (and/or syslog). The two `Standard*=null` directives fix that.