### PR TITLE
Remove unused macros from cryptonote_config.h

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -37,7 +37,6 @@
 #define CRYPTONOTE_DNS_TIMEOUT_MS                       20000
 
 #define CRYPTONOTE_MAX_BLOCK_NUMBER                     500000000
-#define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE	196608 //size of block (bytes) that is the maximum that miners will produce
 #define CRYPTONOTE_MAX_TX_SIZE                          1000000
 #define CRYPTONOTE_MAX_TX_PER_BLOCK                     0x10000000
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
@@ -155,7 +154,6 @@
 #define RPC_IP_FAILS_BEFORE_BLOCK                       3
 
 #define CRYPTONOTE_NAME                         "bitmonero"
-#define CRYPTONOTE_POOLDATA_FILENAME            "poolstate.bin"
 #define CRYPTONOTE_BLOCKCHAINDATA_FILENAME      "data.mdb"
 #define CRYPTONOTE_BLOCKCHAINDATA_LOCK_FILENAME "lock.mdb"
 #define P2P_NET_DATA_FILENAME                   "p2pstate.bin"


### PR DESCRIPTION
Not sure if these are used by projects including the header to code outside of our source tree. I'd gladly close again, if that is  provably the case.
EDIT:
CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE removed here: https://github.com/monero-project/monero/commit/1607cb7e0c5cc5e1400766f595e723531a97cb7b

CRYPTONOTE_POOLDATA_FILENAME removed here: https://github.com/monero-project/monero/commit/b52abd1370cc21484d64f45504adbab47240debf