### PR TITLE
rpc: allow an unused second parameter in submitblock

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1793,7 +1793,7 @@ namespace cryptonote
       }
     }
     CHECK_CORE_READY();
-    if(req.size()!=1)
+    if(req.size()!=1 && req.size()!=2)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
       error_resp.message = "Wrong param";


### PR DESCRIPTION
This allows an upstream merge mining proxy to use this parameter
and passing around to us (because we might be a proxy too, it
doesn't know). The proxies can use this parameter to store the
difficulty of a given PoW hash, so proxies can route the block
to whichever daemon will accept that difficulty without having
to calculate the hash, saving some work.