### PR TITLE
Allow AddressBook description edits via wallet/api

### DIFF
--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -70,6 +70,25 @@ bool AddressBookImpl::addRow(const std::string &dst_addr , const std::string &pa
   return r;
 }
 
+bool AddressBookImpl::setDescription(std::size_t index, const std::string &description)
+{
+    clearStatus();
+
+    const auto ab = m_wallet->m_wallet->get_address_book();
+    if (index >= ab.size()){
+        return false;
+    }
+
+    tools::wallet2::address_book_row entry = ab[index];
+    entry.m_description = description;
+    bool r =  m_wallet->m_wallet->set_address_book_row(index, entry.m_address, NULL, entry.m_description, entry.m_is_subaddress);
+    if (r)
+        refresh();
+    else
+        m_errorCode = General_Error;
+    return r;
+}
+
 void AddressBookImpl::refresh() 
 {
   LOG_PRINT_L2("Refreshing addressbook");

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -45,6 +45,7 @@ public:
     void refresh() override;
     std::vector<AddressBookRow*> getAll() const override;
     bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) override;
+    bool setDescription(std::size_t index, const std::string &description) override;
     bool deleteRow(std::size_t rowId) override;
      
     // Error codes. See AddressBook:ErrorCode enum in wallet2_api.h

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -250,6 +250,7 @@ struct AddressBook
     virtual std::vector<AddressBookRow*> getAll() const = 0;
     virtual bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) = 0;  
     virtual bool deleteRow(std::size_t rowId) = 0;
+    virtual bool setDescription(std::size_t index, const std::string &description) = 0;
     virtual void refresh() = 0;  
     virtual std::string errorString() const = 0;
     virtual int errorCode() const = 0;


### PR DESCRIPTION
Apparently in the Monero GUI, in order to edit the description of an address book entry the GUI removes and adds a new entry altogether. This patch adds the possibility to edit an existing item.

https://github.com/monero-project/monero-gui/blob/238b1b777f508c907bcfb4b5186445a12feeffe2/pages/AddressBook.qml#L377-L400

