### PR TITLE
Allow tx note edits via TransactionHistory object in wallet/api

### DIFF
--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -92,6 +92,17 @@ std::vector<TransactionInfo *> TransactionHistoryImpl::getAll() const
     return m_history;
 }
 
+void TransactionHistoryImpl::setTxNote(const std::string &txid, const std::string &note)
+{
+    cryptonote::blobdata txid_data;
+    if(!epee::string_tools::parse_hexstr_to_binbuff(txid, txid_data) || txid_data.size() != sizeof(crypto::hash))
+        return;
+    const crypto::hash htxid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
+
+    m_wallet->m_wallet->set_tx_note(htxid, note);
+    refresh();
+}
+
 void TransactionHistoryImpl::refresh()
 {
     // multithreaded access:

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -45,6 +45,7 @@ public:
     virtual TransactionInfo * transaction(const std::string &id) const;
     virtual std::vector<TransactionInfo*> getAll() const;
     virtual void refresh();
+    virtual void setTxNote(const std::string &txid, const std::string &note);
 
 private:
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -208,6 +208,7 @@ struct TransactionHistory
     virtual TransactionInfo * transaction(const std::string &id) const = 0;
     virtual std::vector<TransactionInfo*> getAll() const = 0;
     virtual void refresh() = 0;
+    virtual void setTxNote(const std::string &txid, const std::string &note) = 0;
 };
 
 /**


### PR DESCRIPTION
Current transaction note editing is done through the "global" `WalletImpl` class.

https://github.com/monero-project/monero/blob/d27d4526fe89b7cdeb4b296280c4a6cf7efe21f8/src/wallet/api/wallet.cpp#L1750-L1759

This is rather awkward as the callee/user of the concept "transactions" (for display in a table for example) usually deals with the objects (`TransactionHistory`) defined in `api/transaction_history.h` and `api/transaction_info.h` instead - where there is no availability of the `Wallet` instance, unless it is dependency injected.

The same situation can be observed in the current code with setting labels on sub-addresses, which have 2 nearly distinct implementations:

#### api/wallet.cpp

https://github.com/monero-project/monero/blob/d27d4526fe89b7cdeb4b296280c4a6cf7efe21f8/src/wallet/api/wallet.cpp#L1243-L1254

#### api/subaddress.cpp

https://github.com/monero-project/monero/blob/d27d4526fe89b7cdeb4b296280c4a6cf7efe21f8/src/wallet/api/subaddress.cpp#L50-L61

This PR simply adds `setTxNote` on `TransactionHistory` so it's easier to reach and as explained previously this concept already happens in other places currently.