### PR TITLE
Extend TransactionInfo with coinbase and description attributes in wallet/api

### DIFF
--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -126,10 +126,12 @@ void TransactionHistoryImpl::refresh()
             payment_id = payment_id.substr(0,16);
         TransactionInfoImpl * ti = new TransactionInfoImpl();
         ti->m_paymentid = payment_id;
+        ti->m_coinbase = pd.m_coinbase;
         ti->m_amount    = pd.m_amount;
         ti->m_direction = TransactionInfo::Direction_In;
         ti->m_hash      = string_tools::pod_to_hex(pd.m_tx_hash);
         ti->m_blockheight = pd.m_block_height;
+        ti->m_description = m_wallet->m_wallet->get_tx_note(pd.m_tx_hash);
         ti->m_subaddrIndex = { pd.m_subaddr_index.minor };
         ti->m_subaddrAccount = pd.m_subaddr_index.major;
         ti->m_label     = m_wallet->m_wallet->get_subaddress_label(pd.m_subaddr_index);
@@ -173,6 +175,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_direction = TransactionInfo::Direction_Out;
         ti->m_hash = string_tools::pod_to_hex(hash);
         ti->m_blockheight = pd.m_block_height;
+        ti->m_description = m_wallet->m_wallet->get_tx_note(hash);
         ti->m_subaddrIndex = pd.m_subaddr_indices;
         ti->m_subaddrAccount = pd.m_subaddr_account;
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
@@ -183,6 +186,7 @@ void TransactionHistoryImpl::refresh()
         for (const auto &d: pd.m_dests) {
             ti->m_transfers.push_back({d.amount, d.address(m_wallet->m_wallet->nettype(), pd.m_payment_id)});
         }
+
         m_history.push_back(ti);
     }
 
@@ -207,6 +211,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_failed = is_failed;
         ti->m_pending = true;
         ti->m_hash = string_tools::pod_to_hex(hash);
+        ti->m_description = m_wallet->m_wallet->get_tx_note(hash);
         ti->m_subaddrIndex = pd.m_subaddr_indices;
         ti->m_subaddrAccount = pd.m_subaddr_account;
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
@@ -230,6 +235,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_direction = TransactionInfo::Direction_In;
         ti->m_hash      = string_tools::pod_to_hex(pd.m_tx_hash);
         ti->m_blockheight = pd.m_block_height;
+        ti->m_description = m_wallet->m_wallet->get_tx_note(pd.m_tx_hash);
         ti->m_pending = true;
         ti->m_subaddrIndex = { pd.m_subaddr_index.minor };
         ti->m_subaddrAccount = pd.m_subaddr_index.major;

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -45,6 +45,7 @@ TransactionInfoImpl::TransactionInfoImpl()
     : m_direction(Direction_Out)
       , m_pending(false)
       , m_failed(false)
+      , m_coinbase(false)
       , m_amount(0)
       , m_fee(0)
       , m_blockheight(0)
@@ -77,6 +78,11 @@ bool TransactionInfoImpl::isFailed() const
     return m_failed;
 }
 
+bool TransactionInfoImpl::isCoinbase() const
+{
+    return m_coinbase;
+}
+
 uint64_t TransactionInfoImpl::amount() const
 {
     return m_amount;
@@ -90,6 +96,11 @@ uint64_t TransactionInfoImpl::fee() const
 uint64_t TransactionInfoImpl::blockHeight() const
 {
     return m_blockheight;
+}
+
+std::string TransactionInfoImpl::description() const
+{
+    return m_description;
 }
 
 std::set<uint32_t> TransactionInfoImpl::subaddrIndex() const

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -46,10 +46,12 @@ public:
     //! true if hold
     virtual bool isPending() const override;
     virtual bool isFailed() const override;
+    virtual bool isCoinbase() const override;
     virtual uint64_t amount() const override;
     //! always 0 for incoming txes
     virtual uint64_t fee() const override;
     virtual uint64_t blockHeight() const override;
+    virtual std::string description() const override;
     virtual std::set<uint32_t> subaddrIndex() const override;
     virtual uint32_t subaddrAccount() const override;
     virtual std::string label() const override;
@@ -65,9 +67,11 @@ private:
     int         m_direction;
     bool        m_pending;
     bool        m_failed;
+    bool        m_coinbase;
     uint64_t    m_amount;
     uint64_t    m_fee;
     uint64_t    m_blockheight;
+    std::string m_description;
     std::set<uint32_t> m_subaddrIndex;        // always unique index for incoming transfers; can be multiple indices for outgoing transfers
     uint32_t m_subaddrAccount;
     std::string m_label;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -182,9 +182,11 @@ struct TransactionInfo
     virtual int  direction() const = 0;
     virtual bool isPending() const = 0;
     virtual bool isFailed() const = 0;
+    virtual bool isCoinbase() const = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t fee() const = 0;
     virtual uint64_t blockHeight() const = 0;
+    virtual std::string description() const = 0;
     virtual std::set<uint32_t> subaddrIndex() const = 0;
     virtual uint32_t subaddrAccount() const = 0;
     virtual std::string label() const = 0;


### PR DESCRIPTION
Adds `coinbase` and `description` to the `TransactionInfo` object. This modifies the object. However, Monero GUI should still work ok:

https://github.com/monero-project/monero-gui/blob/2fd3974194d555979e9b960d44d613ffdc67a7c9/src/libwalletqt/TransactionInfo.cpp#L141-L154