### PR TITLE
Unit Tests: Remove block reward upper bound size checks

### DIFF
--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -138,24 +138,6 @@ namespace
     ASSERT_FALSE(m_block_not_too_big);
   }
 
-#ifdef __x86_64__ // For 64-bit systems only, because block size is limited to size_t.
-  TEST_F(block_reward_and_current_block_weight, fails_on_huge_median_size)
-  {
-#if !defined(NDEBUG)
-    size_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
-    ASSERT_DEATH(do_test(huge_size, huge_size + 1), "");
-#endif
-  }
-
-  TEST_F(block_reward_and_current_block_weight, fails_on_huge_block_weight)
-  {
-#if !defined(NDEBUG)
-    size_t huge_size = std::numeric_limits<uint32_t>::max() + UINT64_C(2);
-    ASSERT_DEATH(do_test(huge_size - 2, huge_size), "");
-#endif
-  }
-#endif // __x86_64__
-
   //--------------------------------------------------------------------------------------------------------------------
   class block_reward_and_last_block_weights : public ::testing::Test
   {


### PR DESCRIPTION
Tests running after being compiled with `make debug-test` failed with
```
[  FAILED  ] block_reward_and_current_block_weight.fails_on_huge_median_size
[  FAILED  ] block_reward_and_current_block_weight.fails_on_huge_block_weight
```

With the introduction of the patch in https://github.com/monero-project/monero/commit/be82c40703d267184ee07bf7be71002122c86656#diff-1a57d4e6013984c420da98d1adde0eafL113 the assertions checking the weight of the median and current block against a size limit were removed. Since the limit is now enforced by a long divisor and a uint64_t type, checking in a separate test makes little sense, so they are removed here.