### PR TITLE
cmake: CheckTrezor - use ${CMAKE_CURRENT_LIST_DIR} to locate tests

### DIFF
--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -91,7 +91,7 @@ endif()
 
 # Protobuf compilation test
 if(Protobuf_FOUND AND USE_DEVICE_TREZOR AND TREZOR_PYTHON)
-    execute_process(COMMAND ${Protobuf_PROTOC_EXECUTABLE} -I "${CMAKE_SOURCE_DIR}/cmake" -I "${Protobuf_INCLUDE_DIR}" "${CMAKE_SOURCE_DIR}/cmake/test-protobuf.proto" --cpp_out ${CMAKE_BINARY_DIR} RESULT_VARIABLE RET OUTPUT_VARIABLE OUT ERROR_VARIABLE ERR)
+    execute_process(COMMAND ${Protobuf_PROTOC_EXECUTABLE} -I "${CMAKE_CURRENT_LIST_DIR}" -I "${Protobuf_INCLUDE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/test-protobuf.proto" --cpp_out ${CMAKE_BINARY_DIR} RESULT_VARIABLE RET OUTPUT_VARIABLE OUT ERROR_VARIABLE ERR)
     if(RET)
         message(STATUS "Protobuf test generation failed: ${OUT} ${ERR}")
     endif()
@@ -100,7 +100,7 @@ if(Protobuf_FOUND AND USE_DEVICE_TREZOR AND TREZOR_PYTHON)
         "${CMAKE_BINARY_DIR}"
         SOURCES
         "${CMAKE_BINARY_DIR}/test-protobuf.pb.cc"
-        "${CMAKE_SOURCE_DIR}/cmake/test-protobuf.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/test-protobuf.cpp"
         CMAKE_FLAGS
         "-DINCLUDE_DIRECTORIES=${Protobuf_INCLUDE_DIR};${CMAKE_BINARY_DIR}"
         "-DCMAKE_CXX_STANDARD=11"


### PR DESCRIPTION
GUI uses monero as a submodule thus `${CMAKE_SOURCE_DIR}` resolves to the wrong folder.