### PR TITLE
cmake: Version - use CMAKE_CURRENT_LIST_DIR

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -28,7 +28,7 @@
 
 function (write_version tag)
   set(VERSIONTAG "${tag}" CACHE STRING "The tag portion of the Monero software version" FORCE)
-  configure_file("${CMAKE_SOURCE_DIR}/src/version.cpp.in" "${CMAKE_BINARY_DIR}/version.cpp")
+  configure_file("${CMAKE_CURRENT_LIST_DIR}/../src/version.cpp.in" "${CMAKE_BINARY_DIR}/version.cpp")
 endfunction ()
 
 find_package(Git QUIET)


### PR DESCRIPTION
GUI uses monero as a submodule thus ${CMAKE_SOURCE_DIR} resolves to the wrong folder.