### PR TITLE
[release-v0.17] core_rpc_server: getblocktemplate - fix next_seed_height

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1661,6 +1661,13 @@ namespace cryptonote
       return false;
     }
 
+    uint64_t next_height;
+    crypto::rx_seedheights(height, &seed_height, &next_height);
+    if (next_height != seed_height)
+      next_seed_hash = m_core.get_block_id_by_height(next_height);
+    else
+      next_seed_hash = seed_hash;
+
     if (extra_nonce.empty())
     {
       reserved_offset = 0;


### PR DESCRIPTION
Bugfix for next_seed_height in getblocktemplate rpc