### PR TITLE
actions: Upload binaries after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
       run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf
     - name: build
       run: make -j3
+    - name: upload binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos
+        path: build/**/bin/
 
   build-windows:
     runs-on: windows-latest
@@ -29,6 +34,11 @@ jobs:
         install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
     - name: build
       run: make release-static-win64 -j2
+    - name: upload binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows
+        path: build/**/bin/
 
   build-ubuntu:
     runs-on: ubuntu-latest
@@ -49,6 +59,11 @@ jobs:
       run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler
     - name: build
       run: make -j3
+    - name: upload binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: ubuntu
+        path: build/**/bin/
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add an extra step to the GitHub CI build workflow to upload the build artefacts. It puts them on a page like this for each push or pull request:

![Screenshot of GitHub actions run page](https://i.imgur.com/US3b5Hs.png)

The contents of the zip look like this:

```
$ bsdtar tf ubuntu.zip
Linux/
Linux/_HEAD_detached_at_95ad4ce64_/
Linux/_HEAD_detached_at_95ad4ce64_/release/
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-ancestry
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-depth
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-export
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-import
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-mark-spent-outputs
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-prune-known-spent-data
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-prune
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-stats
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-blockchain-usage
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-gen-ssl-cert
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-gen-trusted-multisig
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-wallet-cli
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monero-wallet-rpc
Linux/_HEAD_detached_at_95ad4ce64_/release/bin/monerod
```

It is nice because it allows people to participate in the latest testnet without compiling from source, or download binaries from a developer's branch.

The downside is that these builds are not signed like the regular releases, but I think that they are sufficiently hidden away so that a normal user won't grab them by accident.