### PR TITLE
Compil time: Got rid of boost/program_options from all headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ endfunction ()
 include(Version)
 monero_add_library(version SOURCES ${CMAKE_BINARY_DIR}/version.cpp DEPENDS genversion)
 
+add_subdirectory(fwd)
 add_subdirectory(common)
 add_subdirectory(crypto)
 add_subdirectory(ringct)

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -33,6 +33,7 @@
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "profile_tools.h"
 #include "ringct/rctOps.h"
+#include "common/command_line_functions.h"
 
 #include "lmdb/db_lmdb.h"
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -32,7 +32,7 @@
 
 #include <string>
 #include <exception>
-#include <boost/program_options.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "common/command_line.h"
 #include "crypto/hash.h"
 #include "cryptonote_basic/blobdatatype.h"
@@ -1489,7 +1489,7 @@ public:
    * @param outputs return-by-reference a list of outputs' metadata
    */
   virtual void get_output_key(const epee::span<const uint64_t> &amounts, const std::vector<uint64_t> &offsets, std::vector<output_data_t> &outputs, bool allow_partial = false) const = 0;
-  
+
   /*
    * FIXME: Need to check with git blame and ask what this does to
    * document it

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -34,7 +34,7 @@
 #include <boost/archive/portable_binary_oarchive.hpp>
 #include <boost/filesystem/path.hpp>
 #include "common/unordered_containers_boost_serialization.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/varint.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_core/tx_pool.h"

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -30,7 +30,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include "common/unordered_containers_boost_serialization.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/varint.h"
 #include "serialization/crypto.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -29,7 +29,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/varint.h"
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/cryptonote_core.h"

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -28,7 +28,7 @@
 
 #include "bootstrap_file.h"
 #include "blocksdat_file.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "blockchain_db/blockchain_db.h"

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -43,6 +43,7 @@
 #include "serialization/json_utils.h" // dump_json()
 #include "include_base_utils.h"
 #include "cryptonote_core/cryptonote_core.h"
+#include "common/command_line_functions.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "bcutil"

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -31,7 +31,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/filesystem.hpp>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/pruning.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -28,7 +28,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "serialization/crypto.h"
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/cryptonote_core.h"

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -28,7 +28,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/varint.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_core/tx_pool.h"

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -29,7 +29,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/path.hpp>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/varint.h"
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/cryptonote_core.h"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -63,6 +63,7 @@ set(common_private_headers
   base58.h
   boost_serialization_helper.h
   command_line.h
+  command_line_functions.h
   common_fwd.h
   dns_utils.h
   download.h

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -25,8 +25,6 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "command_line.h"
 #include <boost/algorithm/string/compare.hpp>

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -25,21 +25,15 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include <functional>
-#include <iostream>
-#include <sstream>
-#include <array>
-#include <type_traits>
-
-#include <boost/program_options/parsers.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
 #include "include_base_utils.h"
+
+#include "fwd/boost_monero_program_options_fwd.h"
+
+#include <functional>
+#include <array>
 
 namespace command_line
 {
@@ -114,185 +108,6 @@ namespace command_line
 
     bool not_use_default;
   };
-
-  template<typename T>
-  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, true>& /*arg*/)
-  {
-    return boost::program_options::value<T>()->required();
-  }
-
-  template<typename T>
-  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false>& arg)
-  {
-    auto semantic = boost::program_options::value<T>();
-    if (!arg.not_use_default)
-      semantic->default_value(arg.default_value);
-    return semantic;
-  }
-
-  template<typename T>
-  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false, true>& arg)
-  {
-    auto semantic = boost::program_options::value<T>();
-    if (!arg.not_use_default) {
-      std::ostringstream format;
-      format << arg.depf(false, true, arg.default_value) << ", "
-             << arg.depf(true, true, arg.default_value) << " if '"
-             << arg.ref.name << "'";
-      semantic->default_value(arg.depf(arg.ref.default_value, true, arg.default_value), format.str());
-    }
-    return semantic;
-  }
-
-  template<typename T, int NUM_DEPS>
-  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false, true, NUM_DEPS>& arg)
-  {
-    auto semantic = boost::program_options::value<T>();
-    if (!arg.not_use_default) {
-      std::array<bool, NUM_DEPS> depval;
-      depval.fill(false);
-      std::ostringstream format;
-      format << arg.depf(depval, true, arg.default_value);
-      for (size_t i = 0; i < depval.size(); ++i)
-      {
-        depval.fill(false);
-        depval[i] = true;
-        format << ", " << arg.depf(depval, true, arg.default_value) << " if '" << arg.ref[i]->name << "'";
-      }
-      for (size_t i = 0; i < depval.size(); ++i)
-        depval[i] = arg.ref[i]->default_value;
-      semantic->default_value(arg.depf(depval, true, arg.default_value), format.str());
-    }
-    return semantic;
-  }
-
-  template<typename T>
-  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false>& arg, const T& def)
-  {
-    auto semantic = boost::program_options::value<T>();
-    if (!arg.not_use_default)
-      semantic->default_value(def);
-    return semantic;
-  }
-
-  template<typename T>
-  boost::program_options::typed_value<std::vector<T>, char>* make_semantic(const arg_descriptor<std::vector<T>, false>& /*arg*/)
-  {
-    auto semantic = boost::program_options::value< std::vector<T> >();
-    semantic->default_value(std::vector<T>(), "");
-    return semantic;
-  }
-
-  template<typename T, bool required, bool dependent, int NUM_DEPS>
-  void add_arg(boost::program_options::options_description& description, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg, bool unique = true)
-  {
-    if (0 != description.find_nothrow(arg.name, false))
-    {
-      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
-      return;
-    }
-
-    description.add_options()(arg.name, make_semantic(arg), arg.description);
-  }
-
-  template<typename T>
-  void add_arg(boost::program_options::options_description& description, const arg_descriptor<T, false>& arg, const T& def, bool unique = true)
-  {
-    if (0 != description.find_nothrow(arg.name, false))
-    {
-      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
-      return;
-    }
-
-    description.add_options()(arg.name, make_semantic(arg, def), arg.description);
-  }
-
-  template<>
-  inline void add_arg(boost::program_options::options_description& description, const arg_descriptor<bool, false>& arg, bool unique)
-  {
-    if (0 != description.find_nothrow(arg.name, false))
-    {
-      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
-      return;
-    }
-
-    description.add_options()(arg.name, boost::program_options::bool_switch(), arg.description);
-  }
-
-  template<typename charT>
-  boost::program_options::basic_parsed_options<charT> parse_command_line(int argc, const charT* const argv[],
-    const boost::program_options::options_description& desc, bool allow_unregistered = false)
-  {
-    auto parser = boost::program_options::command_line_parser(argc, argv);
-    parser.options(desc);
-    if (allow_unregistered)
-    {
-      parser.allow_unregistered();
-    }
-    return parser.run();
-  }
-
-  template<typename F>
-  bool handle_error_helper(const boost::program_options::options_description& desc, F parser)
-  {
-    try
-    {
-      return parser();
-    }
-    catch (const std::exception& e)
-    {
-      std::cerr << "Failed to parse arguments: " << e.what() << std::endl;
-      std::cerr << desc << std::endl;
-      return false;
-    }
-    catch (...)
-    {
-      std::cerr << "Failed to parse arguments: unknown exception" << std::endl;
-      std::cerr << desc << std::endl;
-      return false;
-    }
-  }
-
-  template<typename T, bool required, bool dependent, int NUM_DEPS>
-  typename std::enable_if<!std::is_same<T, bool>::value, bool>::type has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg)
-  {
-    auto value = vm[arg.name];
-    return !value.empty();
-  }
-
-  template<typename T, bool required, bool dependent, int NUM_DEPS>
-  bool is_arg_defaulted(const boost::program_options::variables_map& vm, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg)
-  {
-    return vm[arg.name].defaulted();
-  }
-
-  template<typename T>
-  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, false, true>& arg)
-  {
-    return arg.depf(get_arg(vm, arg.ref), is_arg_defaulted(vm, arg), vm[arg.name].template as<T>());
-  }
-
-  template<typename T, int NUM_DEPS>
-  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, false, true, NUM_DEPS>& arg)
-  {
-    std::array<bool, NUM_DEPS> depval;
-    for (size_t i = 0; i < depval.size(); ++i)
-      depval[i] = get_arg(vm, *arg.ref[i]);
-    return arg.depf(depval, is_arg_defaulted(vm, arg), vm[arg.name].template as<T>());
-  }
-
-  template<typename T, bool required>
-  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required>& arg)
-  {
-    return vm[arg.name].template as<T>();
-  }
- 
-  template<bool dependent, int NUM_DEPS>
-  inline bool has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<bool, false, dependent, NUM_DEPS>& arg)
-  {
-    return get_arg(vm, arg);
-  }
-
 
   extern const arg_descriptor<bool> arg_help;
   extern const arg_descriptor<bool> arg_version;

--- a/src/common/command_line_functions.h
+++ b/src/common/command_line_functions.h
@@ -1,0 +1,214 @@
+// Copyright (c) 2014-2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "command_line.h"
+#include "include_base_utils.h"
+
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/variables_map.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <array>
+#include <stdexcept>
+#include <type_traits>
+
+namespace command_line
+{
+  template<typename T>
+  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, true>& /*arg*/)
+  {
+    return boost::program_options::value<T>()->required();
+  }
+
+  template<typename T>
+  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false>& arg)
+  {
+    auto semantic = boost::program_options::value<T>();
+    if (!arg.not_use_default)
+      semantic->default_value(arg.default_value);
+    return semantic;
+  }
+
+  template<typename T>
+  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false, true>& arg)
+  {
+    auto semantic = boost::program_options::value<T>();
+    if (!arg.not_use_default) {
+      std::ostringstream format;
+      format << arg.depf(false, true, arg.default_value) << ", "
+             << arg.depf(true, true, arg.default_value) << " if '"
+             << arg.ref.name << "'";
+      semantic->default_value(arg.depf(arg.ref.default_value, true, arg.default_value), format.str());
+    }
+    return semantic;
+  }
+
+  template<typename T, int NUM_DEPS>
+  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false, true, NUM_DEPS>& arg)
+  {
+    auto semantic = boost::program_options::value<T>();
+    if (!arg.not_use_default) {
+      std::array<bool, NUM_DEPS> depval;
+      depval.fill(false);
+      std::ostringstream format;
+      format << arg.depf(depval, true, arg.default_value);
+      for (size_t i = 0; i < depval.size(); ++i)
+      {
+        depval.fill(false);
+        depval[i] = true;
+        format << ", " << arg.depf(depval, true, arg.default_value) << " if '" << arg.ref[i]->name << "'";
+      }
+      for (size_t i = 0; i < depval.size(); ++i)
+        depval[i] = arg.ref[i]->default_value;
+      semantic->default_value(arg.depf(depval, true, arg.default_value), format.str());
+    }
+    return semantic;
+  }
+
+  template<typename T>
+  boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false>& arg, const T& def)
+  {
+    auto semantic = boost::program_options::value<T>();
+    if (!arg.not_use_default)
+      semantic->default_value(def);
+    return semantic;
+  }
+
+  template<typename T>
+  boost::program_options::typed_value<std::vector<T>, char>* make_semantic(const arg_descriptor<std::vector<T>, false>& /*arg*/)
+  {
+    auto semantic = boost::program_options::value< std::vector<T> >();
+    semantic->default_value(std::vector<T>(), "");
+    return semantic;
+  }
+
+  template<typename T, bool required, bool dependent, int NUM_DEPS>
+  void add_arg(boost::program_options::options_description& description, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg, bool unique = true)
+  {
+    if (0 != description.find_nothrow(arg.name, false))
+    {
+      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
+      return;
+    }
+
+    description.add_options()(arg.name, make_semantic(arg), arg.description);
+  }
+
+  template<typename T>
+  void add_arg(boost::program_options::options_description& description, const arg_descriptor<T, false>& arg, const T& def, bool unique = true)
+  {
+    if (0 != description.find_nothrow(arg.name, false))
+    {
+      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
+      return;
+    }
+
+    description.add_options()(arg.name, make_semantic(arg, def), arg.description);
+  }
+
+  template<>
+  inline void add_arg(boost::program_options::options_description& description, const arg_descriptor<bool, false>& arg, bool unique)
+  {
+    if (0 != description.find_nothrow(arg.name, false))
+    {
+      CHECK_AND_ASSERT_MES(!unique, void(), "Argument already exists: " << arg.name);
+      return;
+    }
+
+    description.add_options()(arg.name, boost::program_options::bool_switch(), arg.description);
+  }
+
+  template<typename F>
+  bool handle_error_helper(const boost::program_options::options_description& desc, F parser)
+  {
+    try
+    {
+      return parser();
+    }
+    catch (const std::exception& e)
+    {
+      std::cerr << "Failed to parse arguments: " << e.what() << std::endl;
+      std::cerr << desc << std::endl;
+      return false;
+    }
+    catch (...)
+    {
+      std::cerr << "Failed to parse arguments: unknown exception" << std::endl;
+      std::cerr << desc << std::endl;
+      return false;
+    }
+  }
+
+  template<typename T, bool required, bool dependent, int NUM_DEPS>
+  typename std::enable_if<!std::is_same<T, bool>::value, bool>::type has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg)
+  {
+    auto value = vm[arg.name];
+    return !value.empty();
+  }
+
+  template<typename T, bool required, bool dependent, int NUM_DEPS>
+  bool is_arg_defaulted(const boost::program_options::variables_map& vm, const arg_descriptor<T, required, dependent, NUM_DEPS>& arg)
+  {
+    return vm[arg.name].defaulted();
+  }
+
+  template<typename T>
+  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, false, true>& arg)
+  {
+    return arg.depf(get_arg(vm, arg.ref), is_arg_defaulted(vm, arg), vm[arg.name].template as<T>());
+  }
+
+  template<typename T, int NUM_DEPS>
+  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, false, true, NUM_DEPS>& arg)
+  {
+    std::array<bool, NUM_DEPS> depval;
+    for (size_t i = 0; i < depval.size(); ++i)
+      depval[i] = get_arg(vm, *arg.ref[i]);
+    return arg.depf(depval, is_arg_defaulted(vm, arg), vm[arg.name].template as<T>());
+  }
+
+  template<typename T, bool required>
+  T get_arg(const boost::program_options::variables_map& vm, const arg_descriptor<T, required>& arg)
+  {
+    return vm[arg.name].template as<T>();
+  }
+
+  template<bool dependent, int NUM_DEPS>
+  inline bool has_arg(const boost::program_options::variables_map& vm, const arg_descriptor<bool, false, dependent, NUM_DEPS>& arg)
+  {
+    return get_arg(vm, arg);
+  }
+
+
+  extern const arg_descriptor<bool> arg_help;
+  extern const arg_descriptor<bool> arg_version;
+}

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -38,7 +38,7 @@
 #include "cryptonote_format_utils.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "file_io_utils.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/util.h"
 #include "string_coding.h"
 #include "string_tools.h"

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -30,7 +30,7 @@
 
 #pragma once 
 
-#include <boost/program_options.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <boost/logic/tribool_fwd.hpp>
 #include <atomic>
 #include "cryptonote_basic.h"

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -40,7 +40,7 @@ using namespace epee;
 #include "common/updates.h"
 #include "common/download.h"
 #include "common/threadpool.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "cryptonote_basic/events.h"
 #include "warnings.h"
 #include "crypto/crypto.h"

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -33,9 +33,7 @@
 #include <ctime>
 
 #include <boost/function.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
-
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "cryptonote_basic/fwd.h"
 #include "cryptonote_core/i_core_events.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler_common.h"

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <string>
 
 #include "byte_slice.h"

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -39,6 +39,7 @@
 
 #include "common/password.h"
 #include "common/util.h"
+#include "common/command_line_functions.h"
 #include "cryptonote_basic/events.h"
 #include "daemon/core.h"
 #include "daemon/p2p.h"

--- a/src/daemon/executor.h
+++ b/src/daemon/executor.h
@@ -28,9 +28,8 @@
 
 #pragma once
 
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "daemon/daemon.h"
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
 #include <string>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -28,7 +28,7 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/scoped_message_writer.h"
 #include "common/password.h"
 #include "common/util.h"

--- a/src/daemonizer/daemonizer.h
+++ b/src/daemonizer/daemonizer.h
@@ -28,9 +28,8 @@
 
 #pragma once
 
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <boost/filesystem/path.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
 
 namespace daemonizer
 {

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -28,8 +28,10 @@
 
 #pragma once
 
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "common/scoped_message_writer.h"
 #include "common/util.h"
+#include "common/command_line_functions.h"
 #include "daemonizer/posix_fork.h"
 
 #include <boost/filesystem/operations.hpp>

--- a/src/daemonizer/windows_daemonizer.inl
+++ b/src/daemonizer/windows_daemonizer.inl
@@ -28,7 +28,9 @@
 
 #pragma once
 
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "common/util.h"
+#include "common/command_line_functions.h"
 #include "daemonizer/windows_service.h"
 #include "daemonizer/windows_service_runner.h"
 #include "cryptonote_core/cryptonote_core.h"

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -33,6 +33,7 @@
 #include "cryptonote_basic/tx_extra.h"
 #include "cryptonote_core/blockchain.h"
 #include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY

--- a/src/debug_utilities/dns_checks.cpp
+++ b/src/debug_utilities/dns_checks.cpp
@@ -34,6 +34,7 @@
 #include "misc_log_ex.h"
 #include "common/util.h"
 #include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/dns_utils.h"
 #include "version.h"
 

--- a/src/fwd/CMakeLists.txt
+++ b/src/fwd/CMakeLists.txt
@@ -26,74 +26,29 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(daemon_sources
-  command_parser_executor.cpp
-  command_server.cpp
-  daemon.cpp
-  executor.cpp
-  main.cpp
-  rpc_command_executor.cpp
+set(TGT fwd)
+set(fwd_sources
+  monero_fwd.cpp
 )
 
-set(daemon_headers)
+set(fwd_headers
+  monero_fwd.h
+  boost_monero_fwd.h
+  boost_monero_program_options_fwd.h
+)
 
-set(daemon_private_headers
-  command_parser_executor.h
-  command_server.h
-  command_line_args.h
-  core.h
-  daemon.h
-  executor.h
-  p2p.h
-  protocol.h
-  rpc.h
-  rpc_command_executor.h
+set(fwd_private_headers
+)
 
-  # cryptonote_protocol
-  ../cryptonote_protocol/cryptonote_protocol_defs.h
-  ../cryptonote_protocol/cryptonote_protocol_handler.h
-  ../cryptonote_protocol/cryptonote_protocol_handler.inl
-  ../cryptonote_protocol/cryptonote_protocol_handler_common.h
+monero_private_headers(${TGT}
+  ${fwd_private_headers})
+  
+monero_add_library(${TGT}
+  ${fwd_sources}
+  ${fwd_headers}
+  ${fwd_private_headers}
+)
 
-  # p2p
-  ../p2p/net_node.h
-  ../p2p/net_node_common.h
-  ../p2p/net_peerlist.h
-  ../p2p/net_peerlist_boost_serialization.h
-  ../p2p/p2p_protocol_defs.h
-  ../p2p/stdafx.h)
+#monero_install_headers(common
+#  ${fwd_headers})
 
-monero_private_headers(daemon
-  ${daemon_private_headers})
-monero_add_executable(daemon
-  ${daemon_sources}
-  ${daemon_headers}
-  ${daemon_private_headers})
-target_link_libraries(daemon
-  PRIVATE
-    rpc
-    blockchain_db
-    cryptonote_core
-    cncrypto
-    common
-    p2p
-    cryptonote_protocol
-    daemonizer
-    serialization
-    daemon_rpc_server
-    ${EPEE_READLINE}
-    version
-    ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_REGEX_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${ZMQ_LIB}
-    ${GNU_READLINE_LIBRARY}
-    ${EXTRA_LIBRARIES}
-    ${Blocks})
-set_property(TARGET daemon
-  PROPERTY
-    OUTPUT_NAME "monerod")
-install(TARGETS daemon DESTINATION bin)

--- a/src/fwd/boost_monero_fwd.h
+++ b/src/fwd/boost_monero_fwd.h
@@ -27,33 +27,9 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
+
+/*
+Only boost forward declarations go here.
+*/
+
 #include "fwd/boost_monero_program_options_fwd.h"
-
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "daemon"
-
-namespace daemonize {
-
-struct t_internals;
-
-class t_daemon final {
-public:
-  static void init_options(boost::program_options::options_description & option_spec);
-private:
-  void stop_p2p();
-private:
-  std::unique_ptr<t_internals> mp_internals;
-  uint16_t public_rpc_port;
-public:
-  t_daemon(
-      boost::program_options::variables_map const & vm,
-      uint16_t public_rpc_port = 0
-    );
-  t_daemon(t_daemon && other);
-  t_daemon & operator=(t_daemon && other);
-  ~t_daemon();
-
-  bool run(bool interactive = false);
-  void stop();
-};
-}

--- a/src/fwd/boost_monero_program_options_fwd.h
+++ b/src/fwd/boost_monero_program_options_fwd.h
@@ -27,33 +27,16 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-#include "fwd/boost_monero_program_options_fwd.h"
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "daemon"
+/*
+Only boost::program options fwds go here
+*/
 
-namespace daemonize {
-
-struct t_internals;
-
-class t_daemon final {
-public:
-  static void init_options(boost::program_options::options_description & option_spec);
-private:
-  void stop_p2p();
-private:
-  std::unique_ptr<t_internals> mp_internals;
-  uint16_t public_rpc_port;
-public:
-  t_daemon(
-      boost::program_options::variables_map const & vm,
-      uint16_t public_rpc_port = 0
-    );
-  t_daemon(t_daemon && other);
-  t_daemon & operator=(t_daemon && other);
-  ~t_daemon();
-
-  bool run(bool interactive = false);
-  void stop();
-};
+namespace boost {
+    namespace program_options {
+        class parsers;
+        class variables_map;
+        class options_description;
+        class positional_options_description;
+    }
 }

--- a/src/fwd/monero_fwd.cpp
+++ b/src/fwd/monero_fwd.cpp
@@ -25,35 +25,13 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#pragma once
-#include "fwd/boost_monero_program_options_fwd.h"
+/*
+This file serves 2 purposes:
+1) It allows older versions of CMake create an INTERFACE library.
+2) It performs preprocessor checks on the target, before it's distributed to the dependees.
+*/
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "daemon"
-
-namespace daemonize {
-
-struct t_internals;
-
-class t_daemon final {
-public:
-  static void init_options(boost::program_options::options_description & option_spec);
-private:
-  void stop_p2p();
-private:
-  std::unique_ptr<t_internals> mp_internals;
-  uint16_t public_rpc_port;
-public:
-  t_daemon(
-      boost::program_options::variables_map const & vm,
-      uint16_t public_rpc_port = 0
-    );
-  t_daemon(t_daemon && other);
-  t_daemon & operator=(t_daemon && other);
-  ~t_daemon();
-
-  bool run(bool interactive = false);
-  void stop();
-};
-}
+#include "monero_fwd.h"

--- a/src/fwd/monero_fwd.h
+++ b/src/fwd/monero_fwd.h
@@ -27,33 +27,12 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-#include "fwd/boost_monero_program_options_fwd.h"
 
-#undef MONERO_DEFAULT_LOG_CATEGORY
-#define MONERO_DEFAULT_LOG_CATEGORY "daemon"
+/*
+This header could be included globally, as long as it's kept clean of any normal declarations.
+However it would help in better understanding the structure of dependencies,
+if each fwd was still included individually on demand.
+*/
 
-namespace daemonize {
-
-struct t_internals;
-
-class t_daemon final {
-public:
-  static void init_options(boost::program_options::options_description & option_spec);
-private:
-  void stop_p2p();
-private:
-  std::unique_ptr<t_internals> mp_internals;
-  uint16_t public_rpc_port;
-public:
-  t_daemon(
-      boost::program_options::variables_map const & vm,
-      uint16_t public_rpc_port = 0
-    );
-  t_daemon(t_daemon && other);
-  t_daemon & operator=(t_daemon && other);
-  ~t_daemon();
-
-  bool run(bool interactive = false);
-  void stop();
-};
-}
+// Include here other monero forward declaration aggregates
+#include "fwd/boost_monero_fwd.h"

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -41,7 +41,7 @@
 #include "include_base_utils.h"
 #include "crypto/crypto.h"  // for crypto::secret_key definition
 #include "common/i18n.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/util.h"
 #include "common/scoped_message_writer.h"
 #include "wallet/wallet_args.h"

--- a/src/gen_ssl_cert/gen_ssl_cert.cpp
+++ b/src/gen_ssl_cert/gen_ssl_cert.cpp
@@ -37,7 +37,7 @@
 #include "crypto/crypto.h"
 #include "common/util.h"
 #include "common/i18n.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/scoped_message_writer.h"
 #include "common/password.h"
 #include "version.h"

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -38,7 +38,7 @@
 #include <chrono>
 #include <utility>
 
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "net_node.h"

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -35,8 +35,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/thread.hpp>
 #include <boost/optional/optional_fwd.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <boost/uuid/uuid.hpp>
 #include <chrono>
 #include <functional>

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -30,6 +30,7 @@
 
 // IP blocking adapted from Boolberry
 
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <algorithm>
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -50,6 +51,7 @@
 #include "common/util.h"
 #include "common/dns_utils.h"
 #include "common/pruning.h"
+#include "common/command_line_functions.h"
 #include "net/error.h"
 #include "net/net_helper.h"
 #include "math_helper.h"

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -36,7 +36,7 @@
 using namespace epee;
 
 #include "core_rpc_server.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/updates.h"
 #include "common/download.h"
 #include "common/util.h"

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -32,9 +32,7 @@
 
 #include <memory>
 
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
-
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "bootstrap_daemon.h"
 #include "net/http_server_impl_base.h"
 #include "net/http_client.h"

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -31,7 +31,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <functional>
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/i18n.h"
 #include "hex.h"
 

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -29,8 +29,7 @@
 #pragma once
 
 #include <boost/optional/optional.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <string>
 
 #include "common/command_line.h"

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -54,7 +54,7 @@
 #include "include_base_utils.h"
 #include "console_handler.h"
 #include "common/i18n.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/util.h"
 #include "common/dns_utils.h"
 #include "common/base58.h"

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -38,8 +38,7 @@
 #include <memory>
 
 #include <boost/optional/optional.hpp>
-#include <boost/program_options/variables_map.hpp>
-
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "wallet/wallet2.h"

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -41,6 +41,7 @@
 #include "common/base58.h"
 #include "common/util.h"
 #include "common/utf8.h"
+#include "common/command_line_functions.h"
 #include "string_tools.h"
 
 

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -33,8 +33,7 @@
 #include <vector>
 #include "crypto/hash.h"
 #include <boost/serialization/vector.hpp>
-#include <boost/program_options/variables_map.hpp>
-#include <boost/program_options/options_description.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <boost/optional/optional.hpp>
 #include "serialization/serialization.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -60,7 +60,7 @@ using namespace epee;
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "multisig/multisig.h"
 #include "common/boost_serialization_helper.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/threadpool.h"
 #include "int-util.h"
 #include "profile_tools.h"

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -32,15 +32,14 @@
 
 #include <memory>
 
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
+#include <boost/thread/lock_guard.hpp>
 #if BOOST_VERSION >= 107400
 #include <boost/serialization/library_version_type.hpp>
 #endif
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/deque.hpp>
-#include <boost/thread/lock_guard.hpp>
 #include <atomic>
 #include <random>
 

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -32,6 +32,7 @@
 #include <boost/format.hpp>
 #include "common/i18n.h"
 #include "common/util.h"
+#include "common/command_line_functions.h"
 #include "misc_log_ex.h"
 #include "string_tools.h"
 #include "version.h"

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -26,10 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/optional/optional.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/positional_options.hpp>
-#include <boost/program_options/variables_map.hpp>
-
+#include "fwd/boost_monero_program_options_fwd.h"
 #include "common/command_line.h"
 
 namespace wallet_args

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -39,7 +39,7 @@ using namespace epee;
 #include "version.h"
 #include "wallet_rpc_server.h"
 #include "wallet/wallet_args.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/i18n.h"
 #include "common/scoped_message_writer.h"
 #include "cryptonote_config.h"

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -30,8 +30,7 @@
 
 #pragma  once
 
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 #include <string>
 #include "common/util.h"
 #include "net/http_server_impl_base.h"

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <boost/program_options/variables_map.hpp>
+#include "fwd/boost_monero_program_options_fwd.h"
 
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/verification_context.h"

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(core_tests_headers
   chain_split_1.h
   chain_switch_1.h
   chaingen.h
+  chaingen_program_options.h
   chaingen_tests_list.h
   double_spend.h
   double_spend.inl

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -28,7 +28,9 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include "common/command_line_functions.h"
 #include "chaingen.h"
+#include "chaingen_program_options.h"
 #include "chaingen_tests_list.h"
 #include "common/util.h"
 #include "common/command_line.h"

--- a/tests/core_tests/chaingen_program_options.h
+++ b/tests/core_tests/chaingen_program_options.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2014-2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include "fwd/boost_monero_program_options_fwd.h"
+#include "chaingen.h"
+#include "common/command_line_functions.h"
+
+template<class t_test_class>
+inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cryptonote::core *core)
+{
+  boost::program_options::options_description desc("Allowed options");
+  cryptonote::core::init_options(desc);
+  boost::program_options::variables_map vm;
+  bool r = command_line::handle_error_helper(desc, [&]()
+  {
+    boost::program_options::store(boost::program_options::basic_parsed_options<char>(&desc), vm);
+    boost::program_options::notify(vm);
+    return true;
+  });
+  if (!r)
+    return false;
+
+  auto & c = *core;
+
+  // FIXME: make sure that vm has arg_testnet_on set to true or false if
+  // this test needs for it to be so.
+  get_test_options<t_test_class> gto;
+
+  // Hardforks can be specified in events.
+  v_hardforks_t hardforks;
+  cryptonote::test_options test_options_tmp{nullptr, 0};
+  const cryptonote::test_options * test_options_ = &gto.test_options;
+  if (extract_hard_forks(events, hardforks)){
+    hardforks.push_back(std::make_pair((uint8_t)0, (uint64_t)0));  // terminator
+    test_options_tmp.hard_forks = hardforks.data();
+    test_options_ = &test_options_tmp;
+  }
+
+  if (!c.init(vm, test_options_))
+  {
+    MERROR("Failed to init core");
+    return false;
+  }
+  c.get_blockchain_storage().get_db().set_batch_transactions(true);
+
+  // start with a clean pool
+  std::vector<crypto::hash> pool_txs;
+  if (!c.get_pool_transaction_hashes(pool_txs))
+  {
+    MERROR("Failed to flush txpool");
+    return false;
+  }
+  c.get_blockchain_storage().flush_txes_from_pool(pool_txs);
+
+  t_test_class validator;
+  bool ret = replay_events_through_core<t_test_class>(c, events, validator);
+  tools::threadpool::getInstance().recycle();
+//  c.deinit();
+  return ret;
+}
+
+//--------------------------------------------------------------------------
+template<class t_test_class>
+inline bool do_replay_events(std::vector<test_event_entry>& events)
+{
+  cryptonote::core core(nullptr);
+  bool ret = do_replay_events_get_core<t_test_class>(events, &core);
+  core.deinit();
+  return ret;
+}
+//--------------------------------------------------------------------------
+template<class t_test_class>
+inline bool do_replay_file(const std::string& filename)
+{
+  std::vector<test_event_entry> events;
+  if (!tools::unserialize_obj_from_file(events, filename))
+  {
+    MERROR("Failed to deserialize data from file: ");
+    return false;
+  }
+  return do_replay_events<t_test_class>(events);
+}
+
+#define PLAY(filename, genclass) \
+    if(!do_replay_file<genclass>(filename)) \
+    { \
+      MERROR("Failed to pass test : " << #genclass); \
+      return 1; \
+    }
+    

--- a/tests/functional_tests/main.cpp
+++ b/tests/functional_tests/main.cpp
@@ -34,7 +34,7 @@
 #include "string_tools.h"
 using namespace epee;
 
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "common/util.h"
 #include "transactions_flow_test.h"
 

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -31,7 +31,7 @@
 #include <boost/regex.hpp>
 
 #include "common/util.h"
-#include "common/command_line.h"
+#include "common/command_line_functions.h"
 #include "performance_tests.h"
 #include "performance_utils.h"
 


### PR DESCRIPTION
Got rid of program_options from headers and limited them in common/command_line_functions.h and tests/core_tests/chaingen_program_options.h, which are included only by .cpp files, thus preventing from spamming the project with program_options, where they are not needed.

The change is transactional: many files were touched, but cutting slow (boost) headers from top level project headers requires that ALL of the occurrences from the sub-headers are moved. If just one is left out, then the entire effort is meaningless, as the slow header will be included by the users of the top level headers anyway.
To satisfy the above requirement and keep the PR as small as possible in the same time, the strategy that I took, is cutting one boost header library at a time (ie. the whole program_options library).

I have introduced a new target: "fwd", where I will store all kind of lightweight forward declarations in a hierarchical manner.
Below are the files including the fwd header now. Directly or indirectly:
![boost__monero__program__options__fwd_8h__dep__incl](https://user-images.githubusercontent.com/63722585/97739295-f7a8dc00-1adf-11eb-808d-3179a1059ab2.png)
Some still have to include the originals, but this is reasonably limited:
![image](https://user-images.githubusercontent.com/63722585/97774482-6c1f6180-1b58-11eb-8b1d-2a0ca04f54b8.png)
Compare with the previous state:
![image](https://user-images.githubusercontent.com/63722585/97774505-b6a0de00-1b58-11eb-82f6-dd2606e57a8b.png)


**Verification of the results**
Touching the files including the thinned down includes and rebuilding with ccache disabled delivered the following results:
before: 37m33,285s
after:    36m17,847s
This is a speed up of 3.3% for the relevant files, which now didn't have to compile the boost/program_options anymore.
Generating the list of files can be done on my branch with: 
egrep -lir  "common/command_line.h" .
To verify whether there's any boost_options header left included in the headers, please execute on my branch (and compare on the original):
egrep -ir --include=*.{h,hpp,cpp,inl} "boost/program_options" .
This is true for every header, except command_line_functions.h, a new header with templates, where it wasn't possible. The scope of command_line_functions.h was limited to as much as it was possible.

Summary:
| Master   |      Patch      | Change |
|----------|-------------|-------------|
| Parsing (frontend):         1611.3 s |     Parsing (frontend):         1565.1 s   |  -2.87% | 
| Codegen & opts (backend):   1663.8 s | Codegen & opts (backend): 1626.5  | -2.24% |

Active work time (including tools preparation):
4.2h
Passive work time (test and verification of results):
0.6h test
0.9h verification
2.1h additional 2 verifications for the review