### PR TITLE
Compil time: Remove boost/optional from headers

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #include <string>
-#include <boost/optional/optional.hpp>
-#include "http_auth.h"
+#include "fwd/boost_monero_optional_fwd.h"
 #include "net/net_ssl.h"
+#include "net/http_types.h"
 
 namespace epee
 {
@@ -63,9 +63,9 @@ namespace http
   public:
     abstract_http_client() {}
     virtual ~abstract_http_client() {}
-    bool set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect);
+    bool set_server(const std::string& address, const boost::optional<login> & user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect);
     virtual bool set_proxy(const std::string& address);
-    virtual void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) = 0;
+    virtual void set_server(std::string host, std::string port, const boost::optional<login> & user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) = 0;
     virtual void set_auto_connect(bool auto_connect) = 0;
     virtual bool connect(std::chrono::milliseconds timeout) = 0;
     virtual bool disconnect() = 0;

--- a/contrib/epee/include/net/http_auth.h
+++ b/contrib/epee/include/net/http_auth.h
@@ -27,14 +27,14 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/utility/string_ref.hpp>
 #include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>
 #include "wipeable_string.h"
-#include "http_base.h"
+#include "http_types.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net.http"
@@ -75,12 +75,7 @@ namespace net_utils
       http_server_auth(login credentials, std::function<void(size_t, uint8_t*)> r);
 
       //! \return Auth response, or `boost::none` iff `request` had valid auth.
-      boost::optional<http_response_info> get_response(const http_request_info& request)
-      {
-        if (user)
-          return do_get_response(request);
-        return boost::none;
-      }
+      boost::optional<http_response_info> get_response(const http_request_info& request);
 
     private:
       boost::optional<http_response_info> do_get_response(const http_request_info& request);

--- a/contrib/epee/include/net/http_base.h
+++ b/contrib/epee/include/net/http_base.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <utility>
 #include <list>
+#include "http_types.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net.http"
@@ -44,7 +45,6 @@ namespace net_utils
 {
 	namespace http
 	{
-
 		enum http_method{
 			http_method_options,
 			http_method_get,
@@ -62,8 +62,6 @@ namespace net_utils
 			http_content_type_other,
 			http_content_type_not_set
 		};
-
-		typedef std::list<std::pair<std::string, std::string> > fields_list;
 
 		std::string get_value_from_fields_list(const std::string& param_name, const net_utils::http::fields_list& fields);
 

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -30,7 +30,7 @@
 #include <ctype.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/utility/string_ref.hpp>
 //#include <mbstring.h>
 #include <algorithm>
@@ -173,7 +173,7 @@ namespace net_utils
 
 			using abstract_http_client::set_server;
 
-			void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) override
+			void set_server(std::string host, std::string port, const boost::optional<login> & user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) override
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				disconnect();

--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -30,7 +30,7 @@
 #ifndef _HTTP_SERVER_H_
 #define _HTTP_SERVER_H_
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <string>
 #include "net_utils_base.h"
 #include "to_nonconst_iterator.h"

--- a/contrib/epee/include/net/http_types.h
+++ b/contrib/epee/include/net/http_types.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#pragma once
+
+#include "net/net_fwd.h"
+
+#include <list>
+#include <string>
+#include <utility>
+
+namespace epee
+{
+namespace net_utils
+{
+namespace http
+{
+    using fields_list = std::list<std::pair<std::string, std::string> >; 
+}
+}
+}

--- a/contrib/epee/include/net/net_fwd.h
+++ b/contrib/epee/include/net/net_fwd.h
@@ -34,5 +34,12 @@ namespace epee
   {
     struct ssl_authentication_t;
     class ssl_options_t;
+    
+    namespace http
+    {
+        struct login;
+        struct http_response_info;
+	    struct http_request_info;
+    }
   }
 }

--- a/contrib/epee/include/wipeable_string.h
+++ b/contrib/epee/include/wipeable_string.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <stddef.h>
 #include <vector>
 #include <string>
@@ -37,6 +37,7 @@
 
 namespace epee
 {
+  struct ws_optional;
   class wipeable_string
   {
   public:
@@ -78,6 +79,7 @@ namespace epee
 
   private:
     void grow(size_t sz, size_t reserved = 0);
+    bool parse_hexstr_optional(wipeable_string & str_to_init) const;
 
   private:
     std::vector<char> buffer;
@@ -88,12 +90,12 @@ namespace epee
     static_assert(std::is_pod<T>::value, "expected pod type");
     if (size() != sizeof(T) * 2)
       return false;
-    boost::optional<epee::wipeable_string> blob = parse_hexstr();
-    if (!blob)
+    epee::wipeable_string str;
+    if (! parse_hexstr_optional(str))
       return false;
-    if (blob->size() != sizeof(T))
+    if (str.size() != sizeof(T))
       return false;
-    pod = *(const T*)blob->data();
+    pod = *(const T*)str.data();
     return true;
   }
 }

--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -130,7 +130,7 @@ namespace net_utils
 namespace http
 {
   //----------------------------------------------------------------------------------------------------
-  bool epee::net_utils::http::abstract_http_client::set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options)
+  bool epee::net_utils::http::abstract_http_client::set_server(const std::string& address, const boost::optional<login> & user, ssl_options_t ssl_options)
   {
     http::url_content parsed{};
     const bool r = parse_url(address, parsed);

--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -69,6 +69,7 @@
 #include "hex.h"
 #include "md5_l.h"
 #include "string_coding.h"
+#include "net/http_base.h"
 
 /* This file uses the `u8` prefix and specifies all chars by ASCII numeric
 value. This is for maximum portability - C++ does not actually specify ASCII
@@ -90,7 +91,7 @@ namespace
   {
     return boost::string_ref(arg, N - 1);
   }
-
+  
   constexpr const auto client_auth_field = ceref(u8"Authorization");
   constexpr const auto server_auth_field = ceref(u8"WWW-authenticate");
   constexpr const auto auth_realm = ceref(u8"monero-rpc");
@@ -712,6 +713,13 @@ namespace epee
     {
       http_server_auth::http_server_auth(login credentials, std::function<void(size_t, uint8_t*)> r)
         : user(session{std::move(credentials)}), rng(std::move(r)) {
+      }
+      
+      boost::optional<http_response_info> http_server_auth::get_response(const http_request_info& request)
+      {
+        if (user)
+          return do_get_response(request);
+        return boost::none;
       }
 
       boost::optional<http_response_info> http_server_auth::do_get_response(const http_request_info& request)

--- a/contrib/epee/src/wipeable_string.cpp
+++ b/contrib/epee/src/wipeable_string.cpp
@@ -26,7 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <limits>
 #include <string.h>
 #include "memwipe.h"
@@ -221,6 +221,21 @@ boost::optional<epee::wipeable_string> wipeable_string::parse_hexstr() const
     res->push_back(((ptr0-hex)<<4) | (ptr1-hex));
   }
   return res;
+}
+
+/**
+The only purpose of this method is to encapsulate the boost::optional within this .cpp file,
+in order not to spread the boost/optional/optional.hpp header to files, that don't need it.
+*/
+bool wipeable_string::parse_hexstr_optional(wipeable_string & str_to_init) const
+{
+    boost::optional<epee::wipeable_string> blob = parse_hexstr();
+    if (blob)
+    {
+        str_to_init = std::move(blob.get());
+        return true;
+    }
+    return false;
 }
 
 char wipeable_string::pop_back()

--- a/src/3rd/CMakeLists.txt
+++ b/src/3rd/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) 2014-2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(TGT 3rd)
+set(3rd_sources
+  monero_3rd.cpp
+)
+
+set(3rd_headers
+  boost_monero_optional.h
+)
+
+set(3rd_private_headers
+)
+
+monero_private_headers(${TGT}
+  ${3rd_private_headers})
+  
+monero_add_library(${TGT}
+  ${3rd_sources}
+  ${3rd_headers}
+  ${3rd_private_headers}
+)
+
+#monero_install_headers(common
+#  ${3rd_headers})
+

--- a/src/3rd/boost_monero_optional.h
+++ b/src/3rd/boost_monero_optional.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,14 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+/*
+Only boost::optional wrapper for easier searches in Doxygen
+*/
 
-namespace cryptonote
-{
-class core;
+#include <boost/optional/optional.hpp>
 
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote

--- a/src/3rd/monero_3rd.cpp
+++ b/src/3rd/monero_3rd.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,15 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#pragma once
+/*
+This file serves 3 purposes:
+1) It allows older versions of CMake create an INTERFACE library.
+2) It performs preprocessor checks on the target, before it's distributed to the dependees.
+3) It allows IDEs to list the headers of the target
+*/
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+#include "monero_3rd.h"
 
-namespace cryptonote
-{
-class core;
-
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -36,7 +36,7 @@
 #include "crypto/crypto.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/algorithm/string/join.hpp>
-#include <boost/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/utility/string_ref.hpp>
 using namespace epee;
 

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -30,7 +30,7 @@
 #include <vector>
 #include <string>
 #include <functional>
-#include <boost/optional/optional_fwd.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/utility/string_ref_fwd.hpp>
 
 namespace tools

--- a/src/common/password.cpp
+++ b/src/common/password.cpp
@@ -30,6 +30,7 @@
 
 #include "password.h"
 
+#include "3rd/boost_monero_optional.h"
 #include <iostream>
 #include <stdio.h>
 

--- a/src/common/password.h
+++ b/src/common/password.h
@@ -32,7 +32,8 @@
 
 #include <string>
 #include <atomic>
-#include <boost/optional/optional.hpp>
+#include <functional>
+#include "fwd/boost_monero_optional_fwd.h"
 #include "wipeable_string.h"
 
 namespace tools

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 
 #include "common/http_connection.h"
 #include "common/scoped_message_writer.h"

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -32,7 +32,7 @@
 
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <system_error>
 #include <csignal>
 #include <cstdio>

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -37,6 +37,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/shared_ptr.hpp>
+#include "3rd/boost_monero_optional.h"
 
 #include "common/varint.h"
 #include "warnings.h"

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -32,7 +32,7 @@
 
 #include <cstddef>
 #include <iostream>
-#include <boost/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <type_traits>
 #include <vector>
 #include <random>

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -39,6 +39,7 @@
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
 #include "ringct/rctSigs.h"
+#include "3rd/boost_monero_optional.h"
 
 using namespace epee;
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -41,6 +41,7 @@
 #include <boost/multi_index/global_fun.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <atomic>
 #include <functional>
 #include <unordered_map>

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 
 #include "daemon/rpc_command_executor.h"
 #include "common/common_fwd.h"

--- a/src/daemon/command_server.h
+++ b/src/daemon/command_server.h
@@ -39,7 +39,7 @@ Passing RPC commands:
 
 #pragma once
 
-#include <boost/optional/optional_fwd.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include "common/common_fwd.h"
 #include "console_handler.h"
 #include "daemon/command_parser_executor.h"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -38,7 +38,7 @@
 
 #pragma once
 
-#include <boost/optional/optional_fwd.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 
 #include "common/common_fwd.h"
 #include "common/rpc_client.h"

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -34,6 +34,8 @@
 #endif
 #include "misc_log_ex.h"
 
+#include "3rd/boost_monero_optional.h"
+
 
 namespace hw {
     
@@ -101,5 +103,8 @@ namespace hw {
         device_registry *registry = get_device_registry();
         return registry->register_device(device_name, hw_device);
     }
+    
+    boost::optional<epee::wipeable_string> i_device_callback::on_pin_request() { return boost::none; }
+    boost::optional<epee::wipeable_string> i_device_callback::on_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
 
 }

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -34,6 +34,8 @@
 #include "ringct/rctTypes.h"
 #include "cryptonote_config.h"
 
+#include "fwd/boost_monero_optional_fwd.h"
+
 
 #ifndef USE_DEVICE_LEDGER
 #define USE_DEVICE_LEDGER 1
@@ -78,8 +80,8 @@ namespace hw {
     public:
         virtual void on_button_request(uint64_t code=0) {}
         virtual void on_button_pressed() {}
-        virtual boost::optional<epee::wipeable_string> on_pin_request() { return boost::none; }
-        virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
+        virtual boost::optional<epee::wipeable_string> on_pin_request();
+        virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device);
         virtual void on_progress(const device_progress& event) {}
         virtual ~i_device_callback() = default;
     };

--- a/src/device/device_cold.hpp
+++ b/src/device/device_cold.hpp
@@ -31,7 +31,7 @@
 #define MONERO_DEVICE_COLD_H
 
 #include "wallet/wallet2.h"
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/function.hpp>
 
 

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -38,6 +38,7 @@
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "ringct/rctOps.h"
 #include "cryptonote_config.h"
+#include "3rd/boost_monero_optional.h"
 
 namespace hw {
 

--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -31,6 +31,7 @@
 #include <boost/scope_exit.hpp>
 #include "log.hpp"
 #include "device_io_hid.hpp"
+#include "3rd/boost_monero_optional.h"
 
 namespace hw {
   namespace io {
@@ -112,7 +113,7 @@ namespace hw {
       ASSERT_X(false, "No device found");
     }
 
-    hid_device_info *device_io_hid::find_device(hid_device_info *devices_list, boost::optional<int> interface_number, boost::optional<unsigned short> usage_page) {
+    hid_device_info *device_io_hid::find_device(hid_device_info *devices_list, const boost::optional<int> & interface_number, const boost::optional<unsigned short> & usage_page) {
       bool select_any = !interface_number && !usage_page;
 
       MDEBUG( "Looking for " <<
@@ -148,7 +149,7 @@ namespace hw {
       return result;
     }
 
-    hid_device  *device_io_hid::connect(unsigned int vid, unsigned  int pid, boost::optional<int> interface_number, boost::optional<unsigned short> usage_page) {
+    hid_device  *device_io_hid::connect(unsigned int vid, unsigned  int pid, const boost::optional<int> & interface_number, const boost::optional<unsigned short> & usage_page) {
       hid_device_info *hwdev_info_list;
       hid_device      *hwdev;
 

--- a/src/device/device_io_hid.hpp
+++ b/src/device/device_io_hid.hpp
@@ -29,7 +29,7 @@
 
 #if defined(HAVE_HIDAPI) 
 
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <hidapi/hidapi.h>
 #include "device_io.hpp"
 
@@ -82,7 +82,7 @@ namespace hw {
       unsigned int wrapCommand(const unsigned char *command, size_t command_len, unsigned char *out, size_t out_len);
       unsigned int unwrapReponse(const unsigned char *data, size_t data_len, unsigned char *out, size_t out_len);
  
-      hid_device_info *find_device(hid_device_info *devices_list, boost::optional<int> interface_number, boost::optional<unsigned short> usage_page);
+      hid_device_info *find_device(hid_device_info *devices_list, const boost::optional<int> & interface_number, const boost::optional<unsigned short> & usage_page);
  
     public:
       bool hid_verbose = false;
@@ -99,7 +99,7 @@ namespace hw {
       void init();  
       void connect(void *params);
       void connect(const std::vector<hid_conn_params> &conn);
-      hid_device  *connect(unsigned int vid, unsigned  int pid, boost::optional<int> interface_number, boost::optional<unsigned short> usage_page);
+      hid_device  *connect(unsigned int vid, unsigned  int pid, const boost::optional<int> & interface_number, const boost::optional<unsigned short> & usage_page);
       bool connected() const;
       int  exchange(unsigned char *command, unsigned int cmd_len, unsigned char *response, unsigned int max_resp_len, bool user_input);
       void disconnect();

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -33,8 +33,10 @@
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/subaddress_index.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
+#include "crypto/hash.h"
 
-#include <boost/thread/locks.hpp> 
+#include "3rd/boost_monero_optional.h"
+#include <boost/thread/locks.hpp>
 #include <boost/thread/lock_guard.hpp>
 
 namespace hw {

--- a/src/device_trezor/trezor/exceptions.hpp
+++ b/src/device_trezor/trezor/exceptions.hpp
@@ -32,7 +32,7 @@
 
 #include <exception>
 #include <string>
-#include <boost/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 
 namespace hw {
 namespace trezor {

--- a/src/fwd/CMakeLists.txt
+++ b/src/fwd/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2014-2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(TGT fwd)
+set(fwd_sources
+  monero_fwd.cpp
+)
+
+set(fwd_headers
+  monero_fwd.h
+  boost_monero_fwd.h
+  boost_monero_program_options_fwd.h
+)
+
+set(fwd_private_headers
+)
+
+monero_private_headers(${TGT}
+  ${fwd_private_headers})
+  
+monero_add_library(${TGT}
+  ${fwd_sources}
+  ${fwd_headers}
+  ${fwd_private_headers}
+)
+
+#monero_install_headers(common
+#  ${fwd_headers})
+

--- a/src/fwd/boost_monero_fwd.h
+++ b/src/fwd/boost_monero_fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,13 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+/*
+Only boost forward declarations go here.
+*/
 
-namespace cryptonote
-{
-class core;
-
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote
+#include "fwd/boost_monero_program_options_fwd.h"

--- a/src/fwd/boost_monero_optional_fwd.h
+++ b/src/fwd/boost_monero_optional_fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,14 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+/*
+Only boost::optional fwds go here
+*/
 
-namespace cryptonote
-{
-class core;
+#include <boost/optional/optional_fwd.hpp>
 
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote

--- a/src/fwd/boost_monero_program_options_fwd.h
+++ b/src/fwd/boost_monero_program_options_fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,20 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+/*
+Only boost::program options fwds go here
+*/
 
-namespace cryptonote
-{
-class core;
-
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote
+namespace boost {
+    namespace program_options {
+        class parsers;
+        class variables_map;
+        class options_description;
+        class positional_options_description;
+    }
+}

--- a/src/fwd/monero_fwd.cpp
+++ b/src/fwd/monero_fwd.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,14 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#pragma once
+/*
+This file serves 3 purposes:
+1) It allows older versions of CMake create an INTERFACE library.
+2) It performs preprocessor checks on the target, before it's distributed to the dependees.
+3) It allows IDEs to list the headers of the target
+*/
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
-
-namespace cryptonote
-{
-class core;
-
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote
+#include "monero_fwd.h"

--- a/src/fwd/monero_fwd.h
+++ b/src/fwd/monero_fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020, The Monero Project
+// Copyright (c) 2014-2020, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -25,43 +25,17 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
 
-#include "fwd/boost_monero_optional_fwd.h"
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "byte_slice.h"
-#include "crypto/hash.h"
+/*
+This header could be included globally, as long as it's kept clean of any normal declarations.
+However it would help in better understanding the structure of dependencies,
+if each fwd was still included individually on demand.
+(mj-xmr)
+*/
 
-namespace cryptonote
-{
-class core;
-
-namespace rpc
-{
-
-struct output_distribution_data
-{
-  std::vector<std::uint64_t> distribution;
-  std::uint64_t start_height;
-  std::uint64_t base;
-};
-
-class RpcHandler
-{
-  public:
-    RpcHandler() { }
-    virtual ~RpcHandler() { }
-
-    virtual epee::byte_slice handle(std::string&& request) = 0;
-
-    static boost::optional<output_distribution_data>
-      get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);
-};
-
-
-}  // rpc
-
-}  // cryptonote
+// Include here other monero forward declaration aggregates
+#include "fwd/boost_monero_fwd.h"

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -32,7 +32,7 @@
 #include <boost/algorithm/string/finder.hpp>
 #include <boost/chrono/duration.hpp>
 #include <boost/endian/conversion.hpp>
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/thread/future.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <chrono>

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -34,7 +34,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/thread.hpp>
-#include <boost/optional/optional_fwd.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -34,7 +34,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/thread/thread.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <iterator>
 
+#include "3rd/boost_monero_optional.h"
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/portable_binary_oarchive.hpp>
 #include <boost/archive/portable_binary_iarchive.hpp>

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -39,7 +39,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/member.hpp>
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/range/adaptor/reversed.hpp>
 
 

--- a/src/rpc/bootstrap_daemon.h
+++ b/src/rpc/bootstrap_daemon.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <utility>
 
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/utility/string_ref.hpp>
 

--- a/src/rpc/bootstrap_node_selector.h
+++ b/src/rpc/bootstrap_node_selector.h
@@ -37,7 +37,7 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 
 #include "net/http_client.h"
 

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -28,7 +28,7 @@
 //
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <string>

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -37,7 +37,7 @@
 
 #include <memory>
 
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/program_options/variables_map.hpp>
 
 #include "cryptonote_basic/account.h"

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -35,7 +35,7 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/options_description.hpp>
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include "serialization/serialization.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_basic/account_boost_serialization.h"

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -32,7 +32,7 @@
 #include <tuple>
 #include <queue>
 #include <boost/format.hpp>
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include <boost/optional/optional.hpp>
+#include "fwd/boost_monero_optional_fwd.h"
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/positional_options.hpp>
 #include <boost/program_options/variables_map.hpp>

--- a/src/wallet/wallet_rpc_payments.cpp
+++ b/src/wallet/wallet_rpc_payments.cpp
@@ -26,7 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/utility/value_init.hpp>
 #include "include_base_utils.h"
 #include "cryptonote_config.h"

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -36,7 +36,7 @@
 #include <stdint.h>
 
 #include <boost/program_options.hpp>
-#include <boost/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/variant.hpp>
 #include <boost/serialization/optional.hpp>

--- a/tests/core_tests/transaction_tests.cpp
+++ b/tests/core_tests/transaction_tests.cpp
@@ -33,6 +33,7 @@
 #include "cryptonote_basic/account.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "misc_language.h"
+#include "3rd/boost_monero_optional.h"
 
 using namespace cryptonote;
 

--- a/tests/performance_tests/ge_frombytes_vartime.h
+++ b/tests/performance_tests/ge_frombytes_vartime.h
@@ -32,6 +32,7 @@
 
 #include "crypto/crypto.h"
 #include "cryptonote_basic/cryptonote_basic.h"
+#include "3rd/boost_monero_optional.h"
 
 #include "single_tx_test_base.h"
 

--- a/tests/unit_tests/http.cpp
+++ b/tests/unit_tests/http.cpp
@@ -28,6 +28,7 @@
 
 #include "gtest/gtest.h"
 #include "net/http_auth.h"
+#include "net/http_base.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/join.hpp>

--- a/tests/unit_tests/is_hdd.cpp
+++ b/tests/unit_tests/is_hdd.cpp
@@ -1,4 +1,5 @@
 #include "common/util.h"
+#include "3rd/boost_monero_optional.h"
 #include <string>
 #include <gtest/gtest.h>
 

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -1,5 +1,5 @@
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <boost/range/adaptor/indexed.hpp>
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>

--- a/tests/unit_tests/test_peerlist.cpp
+++ b/tests/unit_tests/test_peerlist.cpp
@@ -33,6 +33,7 @@
 #include "common/util.h"
 #include "p2p/net_peerlist.h"
 #include "net/net_utils_base.h"
+#include "3rd/boost_monero_optional.h"
 
 TEST(peer_list, peer_list_general)
 {

--- a/tests/unit_tests/tx_proof.cpp
+++ b/tests/unit_tests/tx_proof.cpp
@@ -34,6 +34,7 @@ extern "C" {
 }
 #include "crypto/hash.h"
 #include <boost/algorithm/string.hpp>
+#include "3rd/boost_monero_optional.h"
 
 static inline unsigned char *operator &(crypto::ec_point &point) {
     return &reinterpret_cast<unsigned char &>(point);

--- a/tests/unit_tests/wipeable_string.cpp
+++ b/tests/unit_tests/wipeable_string.cpp
@@ -26,7 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/optional/optional.hpp>
+#include "3rd/boost_monero_optional.h"
 #include <string.h>
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Removed almost all occurrences of boost/optional from headers (where it was possible without introducing a new interface), thus limiting the header only to those files, which need it.

Notice, that for the class wipeable_string I had to create a new wrapper method: parse_hexstr_optional(), in order to encapsulate the optional.hpp, as the template hex_to_pod was the only place, where the optional was queried, so I thought it might be worth it.

According to this graph, where I temporarily replaced the inclusion of the original options header with my wrapper for better tracing, boost optional is now included only where it's needed, because all of its direct 1st level dependees use the optional as one of their class members:
![image](https://user-images.githubusercontent.com/63722585/98965620-8b2fd300-250a-11eb-9535-176dc3c0d3ec.png)
while the below graph shows how many unnecessary inclusions of the original header there were, by showing the dependees of just the forward declaration header:
![image](https://user-images.githubusercontent.com/63722585/98965705-a6024780-250a-11eb-9c6f-fb8deddfb737.png)

Speed improvements:
| Previous   |      Current      | Change |
|----------|-------------|-------------|
| Parsing (frontend):         1611.3 s |     Parsing (frontend):         1514.9 s   |  -5.98% | 
| Codegen & opts (backend):   1663.8 s | Codegen & opts (backend):  1571.9  | -5.52% |

Reduction rate of 6% overall. The affected files were not listed in the below report, because they weren't the largest bottlenecks.

[cba-result.txt](https://github.com/monero-project/monero/files/6369404/cba-result.txt)

Work time:
5.5h Active
0.61h Testing
0.4h verification (in parallel with testing time)
2.1h additional 2 verifications for the review