### PR TITLE
protocol: detect and drop asshole peers

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -43,7 +43,8 @@ namespace cryptonote
   {
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
         m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
-        m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0),  m_anchor(false) {}
+        m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0), m_anchor(false),
+        m_waiting_for_block_deadline(std::numeric_limits<time_t>::max()), m_score(0) {}
 
     enum state
     {
@@ -66,7 +67,15 @@ namespace cryptonote
     uint16_t m_rpc_port;
     uint32_t m_rpc_credits_per_hash;
     bool m_anchor;
-    //size_t m_score;  TODO: add score calculations
+
+    // when we first get a block from a peer, we pick a random other peer,
+    // and we will not relay the block to it, but instead wait to see if we
+    // do get it from that peer. If we do not get this block after a set
+    // time delay, we subtract 1 to its score. If we do, we add 1.
+    // We ban peers with a score less than a threshold
+    cryptonote::blobdata m_waiting_for_block;
+    time_t m_waiting_for_block_deadline;
+    int64_t m_score;
   };
 
   inline std::string get_protocol_state_string(cryptonote_connection_context::state s)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1505,7 +1505,7 @@ namespace cryptonote
       for(auto& tx:  txs)
         arg.b.txs.push_back({tx, crypto::null_hash});
 
-      m_pprotocol->relay_block(arg, exclude_context);
+      m_pprotocol->relay_block(arg, exclude_context, std::vector<boost::uuids::uuid>());
     }
     return true;
   }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -40,7 +40,7 @@ namespace cryptonote
   /************************************************************************/
   struct i_cryptonote_protocol
   {
-    virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context)=0;
+    virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context, std::vector<boost::uuids::uuid> exclude_id)=0;
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, const boost::uuids::uuid& source, epee::net_utils::zone zone, relay_method tx_relay)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
   };
@@ -50,7 +50,7 @@ namespace cryptonote
   /************************************************************************/
   struct cryptonote_protocol_stub: public i_cryptonote_protocol
   {
-    virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context)
+    virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context, std::vector<boost::uuids::uuid> exclude_id)
     {
       return false;
     }

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -38,6 +38,7 @@
 
 #include "byte_slice.h"
 #include "crypto/crypto.h"
+#include "cryptonote_basic/blobdatatype.h"
 #include "cryptonote_basic/connection_context.h"
 #include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_core.h"


### PR DESCRIPTION
defined as those who don't relay blocks for now.

Using transactions would be much faster, but more error prone,
as well as exploit prone.

The score can be reused later to store in the peer list to
affect selection probability.