### PR TITLE
Add RELINK_TARGETS and monero_add_target_no_relink 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,24 @@ function (add_definition_if_library_exists library function header var)
   endif()
 endfunction()
 
+option(RELINK_TARGETS "Relink targets, when just a dependant .so changed, but not its header?" OFF)
+function (monero_set_target_no_relink target)
+  if (RELINK_TARGETS MATCHES OFF)
+    # Will not relink the target, when just its dependant .so has changed, but not it's interface
+    set_target_properties("${target}" PROPERTIES LINK_DEPENDS_NO_SHARED true)
+  endif()
+endfunction()
+
+function (monero_add_minimal_executable name)
+  source_group("${name}"
+    FILES
+      ${ARGN})
+
+  add_executable("${name}"
+    ${ARGN})
+    monero_set_target_no_relink( ${name} )
+endfunction()
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
   message(STATUS "Setting default build type: ${CMAKE_BUILD_TYPE}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,8 @@ function (monero_add_executable name)
     PROPERTY
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
   enable_stack_trace("${name}")
+  
+  monero_set_target_no_relink("${name}")
 endfunction ()
 
 function (monero_add_library name)
@@ -92,6 +94,7 @@ function (monero_add_library_with_deps)
   set(objlib obj_${MONERO_ADD_LIBRARY_NAME})
   add_library(${objlib} OBJECT ${MONERO_ADD_LIBRARY_SOURCES})
   add_library("${MONERO_ADD_LIBRARY_NAME}" $<TARGET_OBJECTS:${objlib}>)
+  monero_set_target_no_relink("${MONERO_ADD_LIBRARY_NAME}")
   if (MONERO_ADD_LIBRARY_DEPENDS)
     add_dependencies(${objlib} ${MONERO_ADD_LIBRARY_DEPENDS})
   endif()

--- a/src/blocks/CMakeLists.txt
+++ b/src/blocks/CMakeLists.txt
@@ -45,4 +45,4 @@ foreach(BLOB_NAME checkpoints testnet_blocks stagenet_blocks)
     )
 endforeach()
 
-add_library(blocks STATIC blocks.cpp ${GENERATED_SOURCES})
+monero_add_library(blocks blocks.cpp ${GENERATED_SOURCES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,7 +106,7 @@ set(hash_targets_sources
 
 set(hash_targets_headers)
 
-add_executable(hash-target-tests
+monero_add_minimal_executable(hash-target-tests
   ${hash_targets_sources}
   ${hash_targets_headers})
 target_link_libraries(hash-target-tests
@@ -149,7 +149,7 @@ foreach(BENCH IN LISTS MONERO_WALLET_CRYPTO_BENCH)
 endforeach ()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/benchmark.h.in" "${MONERO_GENERATED_HEADERS_DIR}/tests/benchmark.h")
-add_executable(monero-wallet-crypto-bench benchmark.cpp ${BENCH_OBJECTS})
+monero_add_minimal_executable(monero-wallet-crypto-bench benchmark.cpp ${BENCH_OBJECTS})
 target_link_libraries(monero-wallet-crypto-bench cncrypto)
 
 add_test(NAME wallet-crypto-bench COMMAND monero-wallet-crypto-bench)

--- a/tests/block_weight/CMakeLists.txt
+++ b/tests/block_weight/CMakeLists.txt
@@ -31,7 +31,7 @@ set(block_weight_sources
 
 set(block_weight_headers)
 
-add_executable(block_weight
+monero_add_minimal_executable(block_weight
   ${block_weight_sources}
   ${block_weight_headers})
 target_link_libraries(block_weight

--- a/tests/core_proxy/CMakeLists.txt
+++ b/tests/core_proxy/CMakeLists.txt
@@ -32,7 +32,7 @@ set(core_proxy_sources
 set(core_proxy_headers
   core_proxy.h)
 
-add_executable(core_proxy
+monero_add_minimal_executable(core_proxy
   ${core_proxy_sources}
   ${core_proxy_headers})
 target_link_libraries(core_proxy

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -68,7 +68,7 @@ set(core_tests_headers
   rct2.h
   wallet_tools.h)
 
-add_executable(core_tests
+monero_add_minimal_executable(core_tests
   ${core_tests_sources}
   ${core_tests_headers})
 target_link_libraries(core_tests

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -37,7 +37,7 @@ set(crypto_sources
 set(crypto_headers
   crypto-tests.h)
 
-add_executable(cncrypto-tests
+monero_add_minimal_executable(cncrypto-tests
   ${crypto_sources}
   ${crypto_headers})
 target_link_libraries(cncrypto-tests
@@ -53,7 +53,7 @@ add_test(
   NAME    cncrypto
   COMMAND cncrypto-tests "${CMAKE_CURRENT_SOURCE_DIR}/tests.txt")
 
-add_executable(cnv4-jit-tests cnv4-jit.c)
+monero_add_minimal_executable(cnv4-jit-tests cnv4-jit.c)
 target_link_libraries(cnv4-jit-tests
   PRIVATE
     common

--- a/tests/daemon_tests/CMakeLists.txt
+++ b/tests/daemon_tests/CMakeLists.txt
@@ -31,7 +31,7 @@ set(transfers_sources
 
 set(transfers_headers)
 
-add_executable(transfers
+monero_add_minimal_executable(transfers
   ${transfers_sources}
   ${transfers_headers})
 target_link_libraries(transfers

--- a/tests/difficulty/CMakeLists.txt
+++ b/tests/difficulty/CMakeLists.txt
@@ -31,7 +31,7 @@ set(difficulty_sources
 
 set(difficulty_headers)
 
-add_executable(difficulty-tests
+monero_add_minimal_executable(difficulty-tests
   ${difficulty_sources}
   ${difficulty_headers})
 target_link_libraries(difficulty-tests

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -35,7 +35,7 @@ set(functional_tests_headers
   transactions_flow_test.h
   transactions_generation_from_blockchain.h)
 
-add_executable(functional_tests
+monero_add_minimal_executable(functional_tests
   ${functional_tests_sources}
   ${functional_tests_headers})
 target_link_libraries(functional_tests
@@ -53,7 +53,7 @@ target_link_libraries(functional_tests
 set(make_test_signature_sources
   make_test_signature.cc)
 
-add_executable(make_test_signature
+monero_add_minimal_executable(make_test_signature
   ${make_test_signature_sources})
 
 target_link_libraries(make_test_signature

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -26,7 +26,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_executable(block_fuzz_tests block.cpp fuzzer.cpp)
+monero_add_minimal_executable(block_fuzz_tests block.cpp fuzzer.cpp)
 target_link_libraries(block_fuzz_tests
   PRIVATE
     cryptonote_core
@@ -40,7 +40,7 @@ set_property(TARGET block_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(transaction_fuzz_tests transaction.cpp fuzzer.cpp)
+monero_add_minimal_executable(transaction_fuzz_tests transaction.cpp fuzzer.cpp)
 target_link_libraries(transaction_fuzz_tests
   PRIVATE
     cryptonote_core
@@ -54,7 +54,7 @@ set_property(TARGET transaction_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(signature_fuzz_tests signature.cpp fuzzer.cpp)
+monero_add_minimal_executable(signature_fuzz_tests signature.cpp fuzzer.cpp)
 target_link_libraries(signature_fuzz_tests
   PRIVATE
     wallet
@@ -69,7 +69,7 @@ set_property(TARGET signature_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(cold-outputs_fuzz_tests cold-outputs.cpp fuzzer.cpp)
+monero_add_minimal_executable(cold-outputs_fuzz_tests cold-outputs.cpp fuzzer.cpp)
 target_link_libraries(cold-outputs_fuzz_tests
   PRIVATE
     wallet
@@ -84,7 +84,7 @@ set_property(TARGET cold-outputs_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(cold-transaction_fuzz_tests cold-transaction.cpp fuzzer.cpp)
+monero_add_minimal_executable(cold-transaction_fuzz_tests cold-transaction.cpp fuzzer.cpp)
 target_link_libraries(cold-transaction_fuzz_tests
   PRIVATE
     wallet
@@ -99,7 +99,7 @@ set_property(TARGET cold-transaction_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(load-from-binary_fuzz_tests load_from_binary.cpp fuzzer.cpp)
+monero_add_minimal_executable(load-from-binary_fuzz_tests load_from_binary.cpp fuzzer.cpp)
 target_link_libraries(load-from-binary_fuzz_tests
   PRIVATE
     common
@@ -112,7 +112,7 @@ set_property(TARGET load-from-binary_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(load-from-json_fuzz_tests load_from_json.cpp fuzzer.cpp)
+monero_add_minimal_executable(load-from-json_fuzz_tests load_from_json.cpp fuzzer.cpp)
 target_link_libraries(load-from-json_fuzz_tests
   PRIVATE
     common
@@ -125,7 +125,7 @@ set_property(TARGET load-from-json_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(base58_fuzz_tests base58.cpp fuzzer.cpp)
+monero_add_minimal_executable(base58_fuzz_tests base58.cpp fuzzer.cpp)
 target_link_libraries(base58_fuzz_tests
   PRIVATE
     common
@@ -138,7 +138,7 @@ set_property(TARGET base58_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(parse-url_fuzz_tests parse_url.cpp fuzzer.cpp)
+monero_add_minimal_executable(parse-url_fuzz_tests parse_url.cpp fuzzer.cpp)
 target_link_libraries(parse-url_fuzz_tests
   PRIVATE
     epee
@@ -152,7 +152,7 @@ set_property(TARGET parse-url_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(http-client_fuzz_tests http-client.cpp fuzzer.cpp)
+monero_add_minimal_executable(http-client_fuzz_tests http-client.cpp fuzzer.cpp)
 target_link_libraries(http-client_fuzz_tests
   PRIVATE
     epee
@@ -168,7 +168,7 @@ set_property(TARGET http-client_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(levin_fuzz_tests levin.cpp fuzzer.cpp)
+monero_add_minimal_executable(levin_fuzz_tests levin.cpp fuzzer.cpp)
 target_link_libraries(levin_fuzz_tests
   PRIVATE
     common
@@ -184,7 +184,7 @@ set_property(TARGET levin_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(bulletproof_fuzz_tests bulletproof.cpp fuzzer.cpp)
+monero_add_minimal_executable(bulletproof_fuzz_tests bulletproof.cpp fuzzer.cpp)
 target_link_libraries(bulletproof_fuzz_tests
   PRIVATE
     common
@@ -200,7 +200,7 @@ set_property(TARGET bulletproof_fuzz_tests
   PROPERTY
     FOLDER "tests")
 
-add_executable(tx-extra_fuzz_tests tx-extra.cpp fuzzer.cpp)
+monero_add_minimal_executable(tx-extra_fuzz_tests tx-extra.cpp fuzzer.cpp)
 target_link_libraries(tx-extra_fuzz_tests
   PRIVATE
     cryptonote_basic

--- a/tests/hash/CMakeLists.txt
+++ b/tests/hash/CMakeLists.txt
@@ -31,7 +31,7 @@ set(hash_sources
 
 set(hash_headers)
 
-add_executable(hash-tests
+monero_add_minimal_executable(hash-tests
   ${hash_sources}
   ${hash_headers})
 target_link_libraries(hash-tests

--- a/tests/libwallet_api_tests/CMakeLists.txt
+++ b/tests/libwallet_api_tests/CMakeLists.txt
@@ -33,7 +33,7 @@ set(libwallet_api_tests_sources
 set(libwallet_api_tests_headers
   )
 
-add_executable(libwallet_api_tests
+monero_add_minimal_executable(libwallet_api_tests
   ${libwallet_api_tests_sources}
   ${libwallet_api_tests_headers})
 

--- a/tests/net_load_tests/CMakeLists.txt
+++ b/tests/net_load_tests/CMakeLists.txt
@@ -32,7 +32,7 @@ set(clt_sources
 set(clt_headers
   net_load_tests.h)
 
-add_executable(net_load_tests_clt
+monero_add_minimal_executable(net_load_tests_clt
   ${clt_sources}
   ${clt_headers})
 target_link_libraries(net_load_tests_clt
@@ -54,7 +54,7 @@ set(srv_sources
 set(srv_headers
   net_load_tests.h)
 
-add_executable(net_load_tests_srv
+monero_add_minimal_executable(net_load_tests_srv
   ${srv_sources}
   ${srv_headers})
 target_link_libraries(net_load_tests_srv

--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -55,7 +55,7 @@ set(performance_tests_headers
   performance_utils.h
   single_tx_test_base.h)
 
-add_executable(performance_tests
+monero_add_minimal_executable(performance_tests
   ${performance_tests_sources}
   ${performance_tests_headers})
 target_link_libraries(performance_tests

--- a/tests/trezor/CMakeLists.txt
+++ b/tests/trezor/CMakeLists.txt
@@ -40,7 +40,7 @@ set(trezor_tests_headers
         ../core_tests/chaingen.h
         ../core_tests/wallet_tools.h)
 
-add_executable(trezor_tests
+monero_add_minimal_executable(trezor_tests
   ${trezor_tests_sources}
   ${trezor_tests_headers})
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -101,7 +101,7 @@ set(unit_tests_sources
 set(unit_tests_headers
   unit_tests_utils.h)
 
-add_executable(unit_tests
+monero_add_minimal_executable(unit_tests
   ${unit_tests_sources}
   ${unit_tests_headers})
 target_link_libraries(unit_tests
@@ -144,6 +144,6 @@ add_test(
   NAME    unit_tests
   COMMAND unit_tests --data-dir "${TEST_DATA_DIR}")
 
-add_executable(test_notifier test_notifier.cpp)
+monero_add_minimal_executable(test_notifier test_notifier.cpp)
 target_link_libraries(test_notifier ${EXTRA_LIBRARIES})
 set_property(TARGET test_notifier PROPERTY FOLDER "tests")


### PR DESCRIPTION
Fortunately Monero was quite prepared for the change, that I wanted to make, so it went smoothly. I have reused the functions:
- monero_add_executable
- monero_add_library_with_deps

to inject a new function: monero_add_target_no_relink,  and switched many (about 20) targets to use the above two functions.
Also added monero_add_minimal_executable, mostly for tests, since they don't need monero_add_executable and haven't even got its definition.

From now on, for shared library builds, by default the relinkage won't be needed for targets, whose dependent dynamic libraries have been relinked, without having their interface changed. This is perfect for TDD, where you write the unit test first, and only modify the production code, recompiling it quite often.

The behavior can be disabled by setting the RELINK_TARGETS variable to ON with:
```
cmake -DRELINK_TARGETS=ON -DBUILD_SHARED_LIBS=ON (...)
```

**Trigger with:**
```
cmake -DBUILD_SHARED_LIBS=ON ../monero-src
make && touch ../monero-src/src/checkpoints/checkpoints.cpp && touch ../monero-src/src/common/notify.cpp && make
```
and notice how only the checkpoints.so and common.so is generated, but nothing else.

**Verification**
For the ease of verification, I remove the bin/* contents and measure the time of regenerating (linking) the binaries on a magnetic drive. An SSD would be faster of course, but would lead to wear of the drive.
From each measurement a dry run of make has been subtracted, with the value of:
time make > /dev/null
 real	0m4,365s
 
1) Typical use case: Debug shared relink(old) vs Debug shared no-relink(new and default)
cmake ../monero-src -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_CCACHE=OFF -DBUILD_TESTS=OFF
make && rm bin/monero*; sudo sh -c "echo 3 > /proc/sys/vm/drop_caches" && time make
real	0m22,860s-4.3 =18.5s -> time saved for generating the bin directory
2) New reasonable use case: Release shared relink(old) vs Release shared no-relink(new and default, only when -DBUILD_SHARED_LIBS=ON is set specifically)
cmake ../monero-src -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DUSE_CCACHE=OFF -DBUILD_TESTS=OFF
real	0m8,907s-4.3 = 4.6s


Work time:
1.8h
Verification time:
0.3h