### PR TITLE
protocol: prefer cycling low score peers

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1691,6 +1691,7 @@ skip:
     MTRACE("Checking for outgoing syncing peers...");
     unsigned n_syncing = 0, n_synced = 0;
     boost::uuids::uuid last_synced_peer_id(boost::uuids::nil_uuid());
+    int64_t lowest_score = std::numeric_limits<int64_t>::max();
     m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
     {
       if (!peer_id || context.m_is_income) // only consider connected outgoing peers
@@ -1700,8 +1701,14 @@ skip:
       if (context.m_state == cryptonote_connection_context::state_normal)
       {
         ++n_synced;
-        if (!context.m_anchor)
-          last_synced_peer_id = context.m_connection_id;
+        if (!context.m_anchor || context.m_score < 0)
+        {
+          if (context.m_score <= lowest_score)
+          {
+            last_synced_peer_id = context.m_connection_id;
+            lowest_score = context.m_score;
+          }
+        }
       }
       return true;
     });


### PR DESCRIPTION
Cycling is meant to opportunistically connecting to a new peer
in case we're connected to a malicious subset of the network.
We now prefer dropping a low score peer, since those will be
either ones which already failed newly at least one test, or
newly connected ones at the same height. In particular, they
can't be a newly connected one that's found another chain, or
they'd be in synchronizing state, not normal state.