### PR TITLE
Doxy - scan whole repo, create subdirs, don't generate LaTeX - mj-xmr

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -68,7 +68,7 @@ OUTPUT_DIRECTORY       = doc
 # performance problems for the file system.
 # The default value is: NO.
 
-CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS         = YES
 
 # If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
 # characters to appear in the names of generated files. If set to NO, non-ASCII
@@ -754,7 +754,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src
+INPUT                  = .
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1552,7 +1552,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
The changes are the following:
- create subdirs: As the Doxy docs say, putting everything into one directory might create performance problems, and with such an amount of data, it does create these problems on my machine. After the change, the user notices no drawbacks.
- scan whole repo: This allows for including the contrib directories, which add a reasonable amount of dependencies. I need it for my purposes for sure, while you might not, if you just want to distribute Monero's source documentation. However, notice, that by including the **src** dir only, you omit the **include** directory of Monero, which is equally important (or will be in the future)
- don't generate LaTeX: arguable, but if nobody needs it, and the HTML report is what we care about, then LaTeX generation is just a waste of time and disk space.

If you disagree with my changes, I will have to put this version into my own "utils/health" directory, as I will need it this way anyway for my compilation time reduction tasks. Please decide.
@xiphon : Pinging you, as the Doxyfile's maintainer.