### PR TITLE
rpc: on_send_raw_tx (bootstrap) - send to bootstrap daemon and P2P

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1123,6 +1123,11 @@ namespace cryptonote
   {
     RPC_TRACKER(send_raw_tx);
 
+    {
+      bool ok;
+      use_bootstrap_daemon_if_necessary<COMMAND_RPC_SEND_RAW_TX>(invoke_http_mode::JON, "/sendrawtransaction", req, res, ok);
+    }
+
     const bool restricted = m_restricted && ctx;
 
     bool skip_validation = false;
@@ -1137,6 +1142,10 @@ namespace cryptonote
       {
         CHECK_CORE_READY();
       }
+    }
+    else
+    {
+      CHECK_CORE_READY();
     }
 
     CHECK_PAYMENT_MIN1(req, res, COST_PER_TX_RELAY, false);


### PR DESCRIPTION
It will now try to both forward a tx to bootstrap daemon AND broadcast it through P2P.

Apparently sending through P2P is not that reliable at the moment due to "asshole peers".