### PR TITLE
Switch to Dandelion++ fluff mode if no out connections for stem mode

### DIFF
--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -524,12 +524,7 @@ namespace levin
         if (!zone_ || !core_ || txs_.empty())
           return;
 
-        if (zone_->fluffing)
-        {
-          core_->on_transactions_relayed(epee::to_span(txs_), relay_method::fluff);
-          fluff_notify::run(std::move(zone_), epee::to_span(txs_), source_);
-        }
-        else // forward tx in stem
+        if (!zone_->fluffing)
         {
           core_->on_transactions_relayed(epee::to_span(txs_), relay_method::stem);
           for (int tries = 2; 0 < tries; tries--)
@@ -549,6 +544,9 @@ namespace levin
 
           MERROR("Unable to send transaction(s) via Dandelion++ stem");
         }
+
+        core_->on_transactions_relayed(epee::to_span(txs_), relay_method::fluff);
+        fluff_notify::run(std::move(zone_), epee::to_span(txs_), source_);
       }
     };
 


### PR DESCRIPTION
The paper doesn't state what to do this in situation. This is going to be useful with a couple of the checks for "bad" peers or syncing peers.