### PR TITLE
Reduce compilation time of epee/portable_storage.h

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -28,9 +28,11 @@
 
 #pragma once
 
-#include <limits>
-#include <boost/thread.hpp>
 #include <boost/utility/value_init.hpp>
+#include <boost/shared_ptr.hpp>
+#include <limits>
+#include <functional>
+#include <vector>
 namespace epee
 {
 #define STD_TRY_BEGIN() try {
@@ -95,16 +97,7 @@ namespace misc_utils
       return memcmp(&_Left, &_Right, sizeof(_Left)) < 0;
   }
 	
-
-	inline
-	bool sleep_no_w(long ms )
-	{
-		boost::this_thread::sleep( 
-			boost::get_system_time() + 
-			boost::posix_time::milliseconds( std::max<long>(ms,0) ) );
-		
-		return true;
-	}
+	bool sleep_no_w(long ms );
 
   template <typename T>
   T get_mid(const T &a, const T &b)

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -40,6 +40,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp> // TODO
 #include <boost/thread/condition_variable.hpp> // TODO
 #include <boost/make_shared.hpp>
+#include <boost/thread.hpp>
 #include "warnings.h"
 #include "string_tools.h"
 #include "misc_language.h"

--- a/contrib/epee/include/storages/portable_storage_base.h
+++ b/contrib/epee/include/storages/portable_storage_base.h
@@ -29,10 +29,10 @@
 #pragma once 
 
 #include <boost/variant.hpp>
-#include <boost/any.hpp>
 #include <string>
 #include <vector>
 #include <deque>
+#include <map>
 
 #define PORTABLE_STORAGE_SIGNATUREA 0x01011101
 #define PORTABLE_STORAGE_SIGNATUREB 0x01020101 // bender's nightmare 

--- a/contrib/epee/include/storages/portable_storage_from_json.h
+++ b/contrib/epee/include/storages/portable_storage_from_json.h
@@ -26,6 +26,7 @@
 
 #pragma once
 #include <boost/lexical_cast.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include "parserse_base_utils.h"
 #include "file_io_utils.h"

--- a/contrib/epee/include/storages/portable_storage_template_helper.h
+++ b/contrib/epee/include/storages/portable_storage_template_helper.h
@@ -32,6 +32,7 @@
 #include "parserse_base_utils.h"
 #include "portable_storage.h"
 #include "file_io_utils.h"
+#include "span.h"
 
 namespace epee
 {

--- a/contrib/epee/include/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/storages/portable_storage_to_bin.h
@@ -32,6 +32,7 @@
 #include "misc_language.h"
 #include "portable_storage_base.h"
 #include "portable_storage_bin_utils.h"
+#include "misc_log_ex.h"
 
 namespace epee
 {

--- a/contrib/epee/include/storages/portable_storage_val_converters.h
+++ b/contrib/epee/include/storages/portable_storage_val_converters.h
@@ -28,12 +28,17 @@
 
 #pragma once
 
-#include <time.h>
 #include <boost/regex.hpp>
 
 #include "misc_language.h"
 #include "portable_storage_base.h"
+#include "parserse_base_utils.h"
 #include "warnings.h"
+#include "misc_log_ex.h"
+
+#include <boost/lexical_cast.hpp>
+#include <typeinfo>
+#include <iomanip>
 
 namespace epee
 {

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -29,7 +29,9 @@
 
 add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
-    int-util.cpp portable_storage.cpp)
+    int-util.cpp portable_storage.cpp
+    misc_language.cpp
+    )
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
   add_library(epee_readline STATIC readline_buffer.cpp)
@@ -71,3 +73,6 @@ if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
     PRIVATE
     ${GNU_READLINE_LIBRARY})
 endif()
+
+target_include_directories(epee PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+

--- a/contrib/epee/src/misc_language.cpp
+++ b/contrib/epee/src/misc_language.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#include "misc_language.h"
+
+#include <boost/thread.hpp>
+
+namespace epee
+{
+namespace misc_utils
+{
+	bool sleep_no_w(long ms )
+	{
+		boost::this_thread::sleep( 
+			boost::get_system_time() + 
+			boost::posix_time::milliseconds( std::max<long>(ms,0) ) );
+		
+		return true;
+	}
+}
+}

--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -1,10 +1,43 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
 
 #include "byte_slice.h"
 #include "byte_stream.h"
 #include "misc_log_ex.h"
 #include "span.h"
 #include "storages/portable_storage.h"
+#include "storages/portable_storage_to_json.h"
+#include "storages/portable_storage_from_json.h"
 #include "storages/portable_storage_to_bin.h"
+#include "storages/portable_storage_from_bin.h"
+
+#include <boost/utility/string_ref.hpp>
+
+#include <string>
+#include <sstream>
 
 namespace epee
 {
@@ -25,5 +58,187 @@ namespace serialization
     return true;
     CATCH_ENTRY("portable_storage::store_to_binary", false)
   }
+
+    bool portable_storage::dump_as_json(std::string& buff, size_t indent, bool insert_newlines)
+    {
+      TRY_ENTRY();
+      std::stringstream ss;
+      epee::serialization::dump_as_json(ss, m_root, indent, insert_newlines);
+      buff = ss.str();
+      return true;
+      CATCH_ENTRY("portable_storage::dump_as_json", false)
+    }
+
+    bool portable_storage::load_from_json(const std::string& source)
+    {
+      TRY_ENTRY();
+      return json::load_from_json(source, *this);
+      CATCH_ENTRY("portable_storage::load_from_json", false)
+    }
+
+    bool portable_storage::load_from_binary(const std::string& target, const limits_t *limits)
+    {
+         return load_from_binary(epee::strspan<uint8_t>(target), limits);
+    }
+
+    bool portable_storage::load_from_binary(const epee::span<const uint8_t> source, const limits_t *limits)
+    {
+      m_root.m_entries.clear();
+      if(source.size() < sizeof(storage_block_header))
+      {
+        LOG_ERROR("portable_storage: wrong binary format, packet size = " << source.size() << " less than expected sizeof(storage_block_header)=" << sizeof(storage_block_header));
+        return false;
+      }
+      storage_block_header* pbuff = (storage_block_header*)source.data();
+      if(pbuff->m_signature_a != SWAP32LE(PORTABLE_STORAGE_SIGNATUREA) ||
+        pbuff->m_signature_b != SWAP32LE(PORTABLE_STORAGE_SIGNATUREB)
+        )
+      {
+        LOG_ERROR("portable_storage: wrong binary format - signature mismatch");
+        return false;
+      }
+      if(pbuff->m_ver != PORTABLE_STORAGE_FORMAT_VER)
+      {
+        LOG_ERROR("portable_storage: wrong binary format - unknown format ver = " << pbuff->m_ver);
+        return false;
+      }
+      TRY_ENTRY();
+      throwable_buffer_reader buf_reader(source.data()+sizeof(storage_block_header), source.size()-sizeof(storage_block_header));
+      if (limits)
+        buf_reader.set_limits(limits->n_objects, limits->n_fields, limits->n_strings);
+      buf_reader.read(m_root);
+      return true;//TODO:
+      CATCH_ENTRY("portable_storage::load_from_binary", false);
+    }
+    
+    hsection portable_storage::open_section(const std::string& section_name,  hsection hparent_section, bool create_if_notexist)
+    {
+      TRY_ENTRY();
+      hparent_section = hparent_section ? hparent_section:&m_root;
+      storage_entry* pentry = find_storage_entry(section_name, hparent_section);
+      if(!pentry)
+      {
+        if(!create_if_notexist)
+          return nullptr;
+        return insert_new_section(section_name, hparent_section);
+      }
+      CHECK_AND_ASSERT(pentry , nullptr);
+      //check that section_entry we find is real "CSSection"
+      if(pentry->type() != typeid(section))
+      {
+        if(create_if_notexist)
+          *pentry = storage_entry(section());//replace
+        else
+          return nullptr;
+      }
+      return &boost::get<section>(*pentry);
+      CATCH_ENTRY("portable_storage::open_section", nullptr);
+    }
+    
+    bool portable_storage::get_value(const std::string& value_name, storage_entry& val, hsection hparent_section)
+    {
+      //TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(value_name, hparent_section);
+      if(!pentry)
+        return false;
+
+      val = *pentry;
+      return true;
+      //CATCH_ENTRY("portable_storage::template<>get_value", false);
+    }
+    
+    storage_entry* portable_storage::find_storage_entry(const std::string& pentry_name, hsection psection)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(psection, nullptr);
+      auto it = psection->m_entries.find(pentry_name);
+      if(it == psection->m_entries.end())
+        return nullptr;
+
+      return &it->second;
+      CATCH_ENTRY("portable_storage::find_storage_entry", nullptr);
+    }
+    
+    hsection portable_storage::insert_new_section(const std::string& pentry_name, hsection psection)
+    {
+      TRY_ENTRY();
+      storage_entry* pse = insert_new_entry_get_storage_entry(pentry_name, psection, section());
+      if(!pse) return nullptr;
+      return &boost::get<section>(*pse);
+      CATCH_ENTRY("portable_storage::insert_new_section", nullptr);
+    }
+    
+    harray portable_storage::get_first_section(const std::string& sec_name, hsection& h_child_section, hsection hparent_section)
+    {
+      TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
+      if(!pentry)
+        return nullptr;
+      if(pentry->type() != typeid(array_entry))
+        return nullptr;
+      array_entry& ar_entry = boost::get<array_entry>(*pentry);
+      if(ar_entry.type() != typeid(array_entry_t<section>))
+        return nullptr;
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
+      section* psec = sec_array.get_first_val();
+      if(!psec)
+        return nullptr;
+      h_child_section = psec;
+      return &ar_entry;
+      CATCH_ENTRY("portable_storage::get_first_section", nullptr);
+    }
+    
+    bool portable_storage::get_next_section(harray hsec_array, hsection& h_child_section)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(hsec_array, false);
+      if(hsec_array->type() != typeid(array_entry_t<section>))
+        return false;
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
+      h_child_section = sec_array.get_next_val();
+      if(!h_child_section)
+        return false;
+      return true;
+      CATCH_ENTRY("portable_storage::get_next_section", false);
+    }
+    
+    harray portable_storage::insert_first_section(const std::string& sec_name, hsection& hinserted_childsection, hsection hparent_section)
+    {
+      TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
+      if(!pentry)
+      {
+        pentry = insert_new_entry_get_storage_entry(sec_name, hparent_section, array_entry(array_entry_t<section>()));
+        if(!pentry)
+          return nullptr;
+      }
+      if(pentry->type() != typeid(array_entry))
+        *pentry = storage_entry(array_entry(array_entry_t<section>()));
+
+      array_entry& ar_entry = boost::get<array_entry>(*pentry);
+      if(ar_entry.type() != typeid(array_entry_t<section>))
+        ar_entry = array_entry(array_entry_t<section>());
+
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
+      hinserted_childsection = &sec_array.insert_first_val(section());
+      return &ar_entry;
+      CATCH_ENTRY("portable_storage::insert_first_section", nullptr);
+    }
+    
+    bool portable_storage::insert_next_section(harray hsec_array, hsection& hinserted_childsection)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(hsec_array, false);
+      CHECK_AND_ASSERT_MES(hsec_array->type() == typeid(array_entry_t<section>), 
+        false, "unexpected type(not 'section') in insert_next_section, type: " << hsec_array->type().name());
+
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
+      hinserted_childsection = &sec_array.insert_next_value(section());
+      return true;
+      CATCH_ENTRY("portable_storage::insert_next_section", false);
+    }
 }
 }

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -32,6 +32,8 @@
 #include "rpc/rpc_payment_costs.h"
 #include "storages/http_abstract_invoke.h"
 
+#include <boost/thread.hpp>
+
 #define RETURN_ON_RPC_RESPONSE_ERROR(r, error, res, method) \
   do { \
     CHECK_AND_ASSERT_MES(error.code == 0, error.message, error.message); \

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 #include "include_base_utils.h"
 #include "net/abstract_http_client.h"
 #include "rpc/core_rpc_server_commands_defs.h"

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "storages/portable_storage.h"
+#include "span.h"
 
 TEST(epee_binary, two_keys)
 {


### PR DESCRIPTION
I have touched here the header, that cumulatively was taking the longest time, as reported by ClangBuildAnalyser.
The change involves mainly moving inline functions into .cpp files, so that their dependencies can be hidden within.

portable_storage.h now
![portable_storage.h now](https://user-images.githubusercontent.com/63722585/98635455-4e56b700-2325-11eb-8711-e824c8556ed7.png)

portable_storage.h now (outdated - see review):
![portable_storage.h now](https://user-images.githubusercontent.com/63722585/98589307-5e42ac80-22cd-11eb-8d61-e97a20180a15.png)

portable_storage.h before:
![portable_storage.h before](https://user-images.githubusercontent.com/63722585/98589408-84684c80-22cd-11eb-9e55-f4139bf18b66.png)

Speed improvements:
| Prevous   |      Current      |
|----------|-------------|
|Compilation (798 times): |  Compilation (802 times): |
| Parsing (frontend):         1728.2 s |     Parsing (frontend):         1488.6 s   | 
| Codegen & opts (backend):   1739.0 s | Codegen & opts (backend):   1587.8  |
| 168138 ms: portable_storage.h (included 82 times, avg 2050 ms) | 136062 ms: portable_storage.h (included 83 times, avg 1639 ms) |

Reduction by 14 or by 19%, depending on how you calculate it.

[Full report](https://github.com/monero-project/monero/files/5517820/cba-result.txt)
[Reference report available here](https://github.com/monero-project/monero/pull/6956)
 
  

Active work time so far: 3.5 h
