### PR TITLE
Reduce compilation time of epee/portable_storage_template_helper.h

### DIFF
--- a/contrib/epee/include/file_io_utils.h
+++ b/contrib/epee/include/file_io_utils.h
@@ -24,211 +24,23 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 
-
 #ifndef _FILE_IO_UTILS_H_
 #define _FILE_IO_UTILS_H_
 
-#include <fstream>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#ifdef WIN32
-#include <windows.h>
-#include "string_tools.h"
-#endif
-
-// On Windows there is a problem with non-ASCII characters in path and file names
-// as far as support by the standard components used is concerned:
-
-// The various file stream classes, e.g. std::ifstream and std::ofstream, are
-// part of the GNU C++ Library / libstdc++. On the most basic level they use the
-// fopen() call as defined / made accessible to programs compiled within MSYS2
-// by the stdio.h header file maintained by the MinGW project.
-
-// The critical point: The implementation of fopen() is part of MSVCRT, the
-// Microsoft Visual C/C++ Runtime Library, and this method does NOT offer any
-// Unicode support.
-
-// Monero code that would want to continue to use the normal file stream classes
-// but WITH Unicode support could therefore not solve this problem on its own,
-// but 2 different projects from 2 different maintaining groups would need changes
-// in this particular direction - something probably difficult to achieve and
-// with a long time to wait until all new versions / releases arrive.
-
-// Implemented solution approach: Circumvent the problem by stopping to use std
-// file stream classes on Windows and directly use Unicode-capable WIN32 API
-// calls. Most of the code doing so is concentrated in this header file here.
+#include <string>
+#include <ctime>
 
 namespace epee
 {
 namespace file_io_utils
 {
-	inline 
-		bool is_file_exist(const std::string& path)
-	{
-		boost::filesystem::path p(path);
-		return boost::filesystem::exists(p);
-	}
-
-	inline
-		bool save_string_to_file(const std::string& path_to_file, const std::string& str)
-	{
-#ifdef WIN32
-                std::wstring wide_path;
-                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-                if (file_handle == INVALID_HANDLE_VALUE)
-                    return false;
-                DWORD bytes_written;
-                DWORD bytes_to_write = (DWORD)str.size();
-                BOOL result = WriteFile(file_handle, str.data(), bytes_to_write, &bytes_written, NULL);
-                CloseHandle(file_handle);
-                if (bytes_written != bytes_to_write)
-                    result = FALSE;
-                return result;
-#else
-		try
-		{
-			std::ofstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
-			fstream << str;
-			fstream.close();
-			return true;
-		}
-
-		catch(...)
-		{
-			return false;
-		}
-#endif
-	}
-
-	inline
-	bool get_file_time(const std::string& path_to_file, time_t& ft)
-	{
-		boost::system::error_code ec;
-		ft = boost::filesystem::last_write_time(boost::filesystem::path(path_to_file), ec);
-		if(!ec)
-			return true;
-		else
-			return false;
-	}
-
-	inline
-		bool set_file_time(const std::string& path_to_file, const time_t& ft)
-	{
-		boost::system::error_code ec;
-		boost::filesystem::last_write_time(boost::filesystem::path(path_to_file), ft, ec);
-		if(!ec)
-			return true;
-		else
-			return false;
-	}
-
-
-	inline
-		bool load_file_to_string(const std::string& path_to_file, std::string& target_str, size_t max_size = 1000000000)
-	{
-#ifdef WIN32
-                std::wstring wide_path;
-                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-                if (file_handle == INVALID_HANDLE_VALUE)
-                    return false;
-                DWORD file_size = GetFileSize(file_handle, NULL);
-                if ((file_size == INVALID_FILE_SIZE) || (uint64_t)file_size > (uint64_t)max_size) {
-                    CloseHandle(file_handle);
-                    return false;
-                }
-                target_str.resize(file_size);
-                DWORD bytes_read;
-                BOOL result = ReadFile(file_handle, &target_str[0], file_size, &bytes_read, NULL);
-                CloseHandle(file_handle);
-                if (bytes_read != file_size)
-                    result = FALSE;
-                return result;
-#else
-		try
-		{
-			std::ifstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::in | std::ios::ate);
-
-			std::ifstream::pos_type file_size = fstream.tellg();
-			
-			if((uint64_t)file_size > (uint64_t)max_size) // ensure a large domain for comparison, and negative -> too large
-				return false;//don't go crazy
-			size_t file_size_t = static_cast<size_t>(file_size);
-
-			target_str.resize(file_size_t);
-
-			fstream.seekg (0, std::ios::beg);
-			fstream.read((char*)target_str.data(), target_str.size());
-			fstream.close();
-			return true;
-		}
-
-		catch(...)
-		{
-			return false;
-		}
-#endif
-	}
-
-	inline
-		bool append_string_to_file(const std::string& path_to_file, const std::string& str)
-	{
-                // No special Windows implementation because so far not used in Monero code
-		try
-		{
-			std::ofstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file.c_str(), std::ios_base::binary | std::ios_base::out | std::ios_base::app);
-			fstream << str;
-			fstream.close();
-			return true;
-		}
-
-		catch(...)
-		{
-			return false;
-		}
-	}
-
-	inline
-		bool get_file_size(const std::string& path_to_file, uint64_t &size)
-	{
-#ifdef WIN32
-                std::wstring wide_path;
-                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-                if (file_handle == INVALID_HANDLE_VALUE)
-                    return false;
-                LARGE_INTEGER file_size;
-                BOOL result = GetFileSizeEx(file_handle, &file_size);
-                CloseHandle(file_handle);
-                if (result) {
-                    size = file_size.QuadPart;
-                }
-                return size;
-#else
-		try
-		{
-			std::ifstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::in | std::ios::ate);
-			size = fstream.tellg();
-			fstream.close();
-			return true;
-		}
-
-		catch(...)
-		{
-			return false;
-		}
-#endif
-	}
-
+    bool is_file_exist(const std::string& path);
+    bool save_string_to_file(const std::string& path_to_file, const std::string& str);
+    bool get_file_time(const std::string& path_to_file, time_t& ft);
+    bool set_file_time(const std::string& path_to_file, const time_t& ft);
+    bool load_file_to_string(const std::string& path_to_file, std::string& target_str, size_t max_size = 1000000000);
+    bool append_string_to_file(const std::string& path_to_file, const std::string& str);
+    bool get_file_size(const std::string& path_to_file, uint64_t &size);
 }
 }
 

--- a/contrib/epee/include/storages/portable_storage_template_helper.h
+++ b/contrib/epee/include/storages/portable_storage_template_helper.h
@@ -29,7 +29,7 @@
 #include <string>
 
 #include "byte_slice.h"
-#include "parserse_base_utils.h"
+#include "parserse_base_utils.h" /// TODO: (mj-xmr) This will be reduced in an another PR
 #include "portable_storage.h"
 #include "file_io_utils.h"
 #include "span.h"

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_cli
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
     int-util.cpp portable_storage.cpp
     misc_language.cpp
-
+    file_io_utils.cpp
     ${EPEE_HEADERS_PUBLIC}
     )
 

--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+
+#include "file_io_utils.h"
+
+#include <fstream>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+#ifdef WIN32
+#include <windows.h>
+#include "string_tools.h"
+#endif
+
+// On Windows there is a problem with non-ASCII characters in path and file names
+// as far as support by the standard components used is concerned:
+
+// The various file stream classes, e.g. std::ifstream and std::ofstream, are
+// part of the GNU C++ Library / libstdc++. On the most basic level they use the
+// fopen() call as defined / made accessible to programs compiled within MSYS2
+// by the stdio.h header file maintained by the MinGW project.
+
+// The critical point: The implementation of fopen() is part of MSVCRT, the
+// Microsoft Visual C/C++ Runtime Library, and this method does NOT offer any
+// Unicode support.
+
+// Monero code that would want to continue to use the normal file stream classes
+// but WITH Unicode support could therefore not solve this problem on its own,
+// but 2 different projects from 2 different maintaining groups would need changes
+// in this particular direction - something probably difficult to achieve and
+// with a long time to wait until all new versions / releases arrive.
+
+// Implemented solution approach: Circumvent the problem by stopping to use std
+// file stream classes on Windows and directly use Unicode-capable WIN32 API
+// calls. Most of the code doing so is concentrated in this header file here.
+
+namespace epee
+{
+namespace file_io_utils
+{
+ 
+	bool is_file_exist(const std::string& path)
+	{
+		boost::filesystem::path p(path);
+		return boost::filesystem::exists(p);
+	}
+
+
+	bool save_string_to_file(const std::string& path_to_file, const std::string& str)
+	{
+#ifdef WIN32
+                std::wstring wide_path;
+                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
+                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+                if (file_handle == INVALID_HANDLE_VALUE)
+                    return false;
+                DWORD bytes_written;
+                DWORD bytes_to_write = (DWORD)str.size();
+                BOOL result = WriteFile(file_handle, str.data(), bytes_to_write, &bytes_written, NULL);
+                CloseHandle(file_handle);
+                if (bytes_written != bytes_to_write)
+                    result = FALSE;
+                return result;
+#else
+		try
+		{
+			std::ofstream fstream;
+			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+			fstream << str;
+			fstream.close();
+			return true;
+		}
+
+		catch(...)
+		{
+			return false;
+		}
+#endif
+	}
+
+
+	bool get_file_time(const std::string& path_to_file, time_t& ft)
+	{
+		boost::system::error_code ec;
+		ft = boost::filesystem::last_write_time(boost::filesystem::path(path_to_file), ec);
+		if(!ec)
+			return true;
+		else
+			return false;
+	}
+
+
+	bool set_file_time(const std::string& path_to_file, const time_t& ft)
+	{
+		boost::system::error_code ec;
+		boost::filesystem::last_write_time(boost::filesystem::path(path_to_file), ft, ec);
+		if(!ec)
+			return true;
+		else
+			return false;
+	}
+
+
+
+	bool load_file_to_string(const std::string& path_to_file, std::string& target_str, size_t max_size)
+	{
+#ifdef WIN32
+                std::wstring wide_path;
+                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
+                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                if (file_handle == INVALID_HANDLE_VALUE)
+                    return false;
+                DWORD file_size = GetFileSize(file_handle, NULL);
+                if ((file_size == INVALID_FILE_SIZE) || (uint64_t)file_size > (uint64_t)max_size) {
+                    CloseHandle(file_handle);
+                    return false;
+                }
+                target_str.resize(file_size);
+                DWORD bytes_read;
+                BOOL result = ReadFile(file_handle, &target_str[0], file_size, &bytes_read, NULL);
+                CloseHandle(file_handle);
+                if (bytes_read != file_size)
+                    result = FALSE;
+                return result;
+#else
+		try
+		{
+			std::ifstream fstream;
+			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::in | std::ios::ate);
+
+			std::ifstream::pos_type file_size = fstream.tellg();
+			
+			if((uint64_t)file_size > (uint64_t)max_size) // ensure a large domain for comparison, and negative -> too large
+				return false;//don't go crazy
+			size_t file_size_t = static_cast<size_t>(file_size);
+
+			target_str.resize(file_size_t);
+
+			fstream.seekg (0, std::ios::beg);
+			fstream.read((char*)target_str.data(), target_str.size());
+			fstream.close();
+			return true;
+		}
+
+		catch(...)
+		{
+			return false;
+		}
+#endif
+	}
+
+
+	bool append_string_to_file(const std::string& path_to_file, const std::string& str)
+	{
+                // No special Windows implementation because so far not used in Monero code
+		try
+		{
+			std::ofstream fstream;
+			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+			fstream.open(path_to_file.c_str(), std::ios_base::binary | std::ios_base::out | std::ios_base::app);
+			fstream << str;
+			fstream.close();
+			return true;
+		}
+
+		catch(...)
+		{
+			return false;
+		}
+	}
+
+
+	bool get_file_size(const std::string& path_to_file, uint64_t &size)
+	{
+#ifdef WIN32
+                std::wstring wide_path;
+                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
+                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                if (file_handle == INVALID_HANDLE_VALUE)
+                    return false;
+                LARGE_INTEGER file_size;
+                BOOL result = GetFileSizeEx(file_handle, &file_size);
+                CloseHandle(file_handle);
+                if (result) {
+                    size = file_size.QuadPart;
+                }
+                return size;
+#else
+		try
+		{
+			std::ifstream fstream;
+			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::in | std::ios::ate);
+			size = fstream.tellg();
+			fstream.close();
+			return true;
+		}
+
+		catch(...)
+		{
+			return false;
+		}
+#endif
+	}
+
+}
+}

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -32,6 +32,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/archive/portable_binary_iarchive.hpp>
 #include <boost/archive/portable_binary_oarchive.hpp>
+#include <boost/filesystem/path.hpp>
 #include "common/unordered_containers_boost_serialization.h"
 #include "common/command_line.h"
 #include "common/varint.h"

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include "common/unordered_containers_boost_serialization.h"
 #include "common/command_line.h"
 #include "common/varint.h"

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>
 #include "common/command_line.h"
 #include "common/varint.h"

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -29,6 +29,8 @@
 #include <array>
 #include <lmdb.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
 #include "common/command_line.h"
 #include "common/pruning.h"
 #include "cryptonote_core/cryptonote_core.h"

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include "common/command_line.h"
 #include "serialization/crypto.h"
 #include "cryptonote_core/tx_pool.h"

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include "common/command_line.h"
 #include "common/varint.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem/path.hpp>
 #include "common/command_line.h"
 #include "common/varint.h"
 #include "cryptonote_core/tx_pool.h"

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -34,6 +34,8 @@
 #include "string_tools.h"
 #include "storages/portable_storage_template_helper.h" // epee json include
 #include "serialization/keyvalue_serialization.h"
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
 #include <functional>
 #include <vector>
 

--- a/src/common/i18n.cpp
+++ b/src/common/i18n.cpp
@@ -35,6 +35,10 @@
 #include "common/i18n.h"
 #include "translation_files.h"
 
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
+#include <algorithm>
+
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "i18n"
 

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -44,6 +44,7 @@
 #include "string_tools.h"
 #include "storages/portable_storage_template_helper.h"
 #include "boost/logic/tribool.hpp"
+#include <boost/filesystem.hpp>
 
 #ifdef __APPLE__
   #include <sys/times.h>

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -57,6 +57,8 @@ using namespace epee;
 #include "hardforks/hardforks.h"
 #include "version.h"
 
+#include <boost/filesystem.hpp>
+
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "cn"
 

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -30,6 +30,7 @@
 #include "common/command_line.h"
 #include "net/parse.h"
 #include "daemon/command_parser_executor.h"
+#include <boost/filesystem.hpp>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "daemon"

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -30,6 +30,7 @@
 
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/uuid/nil_generator.hpp>
+#include <boost/filesystem.hpp>
 #include "include_base_utils.h"
 #include "string_tools.h"
 using namespace epee;

--- a/src/rpc/rpc_payment.cpp
+++ b/src/rpc/rpc_payment.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/archive/portable_binary_iarchive.hpp>
+#include <boost/filesystem.hpp>
 #include "cryptonote_config.h"
 #include "include_base_utils.h"
 #include "string_tools.h"

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -50,6 +50,7 @@
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/filesystem.hpp>
 #include "include_base_utils.h"
 #include "console_handler.h"
 #include "common/i18n.h"

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 #include <sstream>
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -45,10 +45,8 @@
 #include <sstream>
 #include <unordered_map>
 
-#ifdef WIN32
 #include <boost/locale.hpp>
 #include <boost/filesystem.hpp>
-#endif
 
 using namespace std;
 using namespace cryptonote;

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -30,6 +30,8 @@
 #include <boost/archive/portable_binary_iarchive.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
 #include <fstream>
 #include <sstream>
 #include "file_io_utils.h"


### PR DESCRIPTION
The header consists of:

- parserse_base_utils.h: This will be reduced in an another PR. For now it would create too many conflicts 
- portable_storage.h: has to stay here
- file_io_utils.h: this is the one, where I could make meaningful changes for now, by encapsulating boost::filesystem and boost::system

Speed improvements:
| Prevous   |      Current      |
|----------|-------------|
|Compilation (798 times): |  Compilation (802 times): |
| Parsing (frontend):         1728.2 s |     Parsing (frontend):         1660.9 s   | 
| Codegen & opts (backend):   1739.0 s | Codegen & opts (backend):   1670.6  |
| 155623 ms: portable_storage_template_helper.h (included 79 times, avg 1969 ms) | 143785 ms: portable_storage_template_helper.h (included 79 times, avg 1820 ms) |

Reduction rate of 4% overall or 7.5% for the file alone.

[Report](https://github.com/monero-project/monero/files/5520317/cba-result.txt)


Active work time: 1.8h