### PR TITLE
Allow byte_stream->byte_slice conversion to shrink unused buffer space

### DIFF
--- a/contrib/epee/include/byte_slice.h
+++ b/contrib/epee/include/byte_slice.h
@@ -112,7 +112,7 @@ namespace epee
     explicit byte_slice(std::string&& buffer);
 
     //! Convert `stream` into a slice with zero allocations.
-    explicit byte_slice(byte_stream&& stream) noexcept;
+    explicit byte_slice(byte_stream&& stream, bool shrink = true);
 
     byte_slice(byte_slice&& source) noexcept;
     ~byte_slice() noexcept = default;

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -1090,11 +1090,13 @@ TEST(ByteStream, ToByteSlice)
 
   epee::byte_stream stream;
 
+  stream.reserve(128*1024);
   stream.write(source);
   EXPECT_EQ(sizeof(source), stream.size());
+  EXPECT_EQ(128*1024, stream.capacity());
   EXPECT_TRUE(equal(source, byte_span{stream.data(), stream.size()}));
 
-  const epee::byte_slice slice{std::move(stream)};
+  const epee::byte_slice slice{std::move(stream), true};
   EXPECT_EQ(0u, stream.size());
   EXPECT_EQ(0u, stream.available());
   EXPECT_EQ(0u, stream.capacity());


### PR DESCRIPTION
This allows for the optional shrinkage of the `byte_stream` buffer when converting to an immutable `byte_slice`. This uses `realloc` so in the bulk of calls this can be done without a copy. Larger buffers are likely to be "overcommited" by OSes anyway, so it frequently could be a NOP. Its still beneficial given that Monero supports 32-bit builds, where the address space reclamation can be beneficial.