### PR TITLE
Change epee binary output from std::stringstream to byte_stream

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -70,7 +70,7 @@ namespace http
     virtual bool connect(std::chrono::milliseconds timeout) = 0;
     virtual bool disconnect() = 0;
     virtual bool is_connected(bool *ssl = NULL) = 0;
-    virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
+    virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const boost::string_ref body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual uint64_t get_bytes_sent() const = 0;

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -233,7 +233,7 @@ namespace net_utils
 			}
 
 			//---------------------------------------------------------------------------
-			inline bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) override
+			inline bool invoke(const boost::string_ref uri, const boost::string_ref method, const boost::string_ref body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) override
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				if(!is_connected())

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -118,8 +118,10 @@
         return true; \
       } \
       uint64_t ticks2 = misc_utils::get_tick_count(); \
-      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), response_info.m_body); \
+      epee::byte_slice buffer; \
+      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), buffer, 64 * 1024); \
       uint64_t ticks3 = epee::misc_utils::get_tick_count(); \
+      response_info.m_body.assign(reinterpret_cast<const char*>(buffer.data()), buffer.size()); \
       response_info.m_mime_tipe = " application/octet-stream"; \
       response_info.m_header_info.m_content_type = " application/octet-stream"; \
       MDEBUG( s_pattern << "() processed with " << ticks1-ticks << "/"<< ticks2-ticks1 << "/" << ticks3-ticks2 << "ms"); \

--- a/contrib/epee/include/net/levin_base.h
+++ b/contrib/epee/include/net/levin_base.h
@@ -31,7 +31,6 @@
 
 #include <cstdint>
 
-#include "byte_slice.h"
 #include "net_utils_base.h"
 #include "span.h"
 
@@ -39,6 +38,7 @@
 
 namespace epee
 {
+class byte_slice;
 namespace levin
 {
 #pragma pack(push)
@@ -86,7 +86,7 @@ namespace levin
   template<class t_connection_context = net_utils::connection_context_base>
   struct levin_commands_handler
   {
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, t_connection_context& context)=0;
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, byte_slice& buff_out, t_connection_context& context)=0;
     virtual int notify(int command, const epee::span<const uint8_t> in_buff, t_connection_context& context)=0;
     virtual void callback(t_connection_context& context){};
 

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -514,16 +514,15 @@ public:
           {
             if(m_current_head.m_have_to_return_data)
             {
-              std::string return_buff;
+              byte_slice return_buff;
               const uint32_t return_code = m_config.m_pcommands_handler->invoke(
                 m_current_head.m_command, buff_to_invoke, return_buff, m_connection_context
               );
 
               bucket_head2 head = make_header(m_current_head.m_command, return_buff.size(), LEVIN_PACKET_RESPONSE, false);
               head.m_return_code = SWAP32LE(return_code);
-              return_buff.insert(0, reinterpret_cast<const char*>(&head), sizeof(head));
 
-              if(!m_pservice_endpoint->do_send(byte_slice{std::move(return_buff)}))
+              if(!m_pservice_endpoint->do_send(byte_slice{{epee::as_byte_span(head), epee::to_span(return_buff)}}))
                 return false;
 
               MDEBUG(m_connection_context << "LEVIN_PACKET_SENT. [len=" << head.m_cb

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -44,6 +44,7 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/interprocess/detail/atomic.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <functional>
 #include "net/net_utils_base.h"
 #include "net/net_ssl.h"
@@ -280,7 +281,7 @@ namespace net_utils
 
 
 		inline 
-		bool send(const std::string& buff, std::chrono::milliseconds timeout)
+		bool send(const boost::string_ref buff, std::chrono::milliseconds timeout)
 		{
 
 			try
@@ -298,7 +299,7 @@ namespace net_utils
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
 				// can use boost::bind rather than boost::lambda.
-				async_write(buff.c_str(), buff.size(), ec);
+				async_write(buff.data(), buff.size(), ec);
 
 				// Block until the asynchronous operation has completed.
 				while (ec == boost::asio::error::would_block)

--- a/contrib/epee/include/storages/http_abstract_invoke.h
+++ b/contrib/epee/include/storages/http_abstract_invoke.h
@@ -29,6 +29,7 @@
 #include <boost/utility/string_ref.hpp>
 #include <chrono>
 #include <string>
+#include "byte_slice.h"
 #include "portable_storage_template_helper.h"
 #include "net/http_base.h"
 #include "net/http_server_handlers_map2.h"
@@ -74,12 +75,12 @@ namespace epee
     template<class t_request, class t_response, class t_transport>
     bool invoke_http_bin(const boost::string_ref uri, const t_request& out_struct, t_response& result_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref method = "POST")
     {
-      std::string req_param;
-      if(!serialization::store_t_to_binary(out_struct, req_param))
+      byte_slice req_param;
+      if(!serialization::store_t_to_binary(out_struct, req_param, 16 * 1024))
         return false;
 
       const http::http_response_info* pri = NULL;
-      if(!transport.invoke(uri, method, req_param, timeout, std::addressof(pri)))
+      if(!transport.invoke(uri, method, boost::string_ref{reinterpret_cast<const char*>(req_param.data()), req_param.size()}, timeout, std::addressof(pri)))
       {
         LOG_PRINT_L1("Failed to invoke http request to  " << uri);
         return false;

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -32,7 +32,6 @@
 
 #include "misc_language.h"
 #include "portable_storage_base.h"
-#include "portable_storage_to_bin.h"
 #include "portable_storage_from_bin.h"
 #include "portable_storage_to_json.h"
 #include "portable_storage_from_json.h"
@@ -42,6 +41,7 @@
 
 namespace epee
 {
+  class byte_slice;
   namespace serialization
   {
     /************************************************************************/
@@ -83,7 +83,7 @@ namespace epee
       bool        delete_entry(const std::string& pentry_name, hsection hparent_section = nullptr);
 
       //-------------------------------------------------------------------------------
-      bool		store_to_binary(binarybuffer& target);
+      bool		store_to_binary(byte_slice& target, std::size_t initial_buffer_size = 8192);
       bool		load_from_binary(const epee::span<const uint8_t> target);
       bool		load_from_binary(const std::string& target) { return load_from_binary(epee::strspan<uint8_t>(target)); }
       template<class trace_policy>
@@ -132,22 +132,6 @@ namespace epee
     bool portable_storage::dump_as_xml(std::string& targetObj, const std::string& root_name)
     {
       return false;//TODO: don't think i ever again will use xml - ambiguous and "overtagged" format
-    }
-
-    inline
-    bool portable_storage::store_to_binary(binarybuffer& target)
-    {
-      TRY_ENTRY();
-      std::stringstream ss;
-      storage_block_header sbh = AUTO_VAL_INIT(sbh);
-      sbh.m_signature_a = SWAP32LE(PORTABLE_STORAGE_SIGNATUREA);
-      sbh.m_signature_b = SWAP32LE(PORTABLE_STORAGE_SIGNATUREB);
-      sbh.m_ver = PORTABLE_STORAGE_FORMAT_VER;
-      ss.write((const char*)&sbh, sizeof(storage_block_header));
-      pack_entry_to_buff(ss, m_root);
-      target = ss.str();
-      return true;
-      CATCH_ENTRY("portable_storage::store_to_binary", false)
     }
     inline
     bool portable_storage::load_from_binary(const epee::span<const uint8_t> source)

--- a/contrib/epee/include/storages/portable_storage_template_helper.h
+++ b/contrib/epee/include/storages/portable_storage_template_helper.h
@@ -28,6 +28,7 @@
 
 #include <string>
 
+#include "byte_slice.h"
 #include "parserse_base_utils.h"
 #include "portable_storage.h"
 #include "file_io_utils.h"
@@ -111,18 +112,18 @@ namespace epee
     }
     //-----------------------------------------------------------------------------------------------------------
     template<class t_struct>
-    bool store_t_to_binary(t_struct& str_in, std::string& binary_buff, size_t indent = 0)
+    bool store_t_to_binary(t_struct& str_in, byte_slice& binary_buff, size_t initial_buffer_size = 8192)
     {
       portable_storage ps;
       str_in.store(ps);
-      return ps.store_to_binary(binary_buff);
+      return ps.store_to_binary(binary_buff, initial_buffer_size);
     }
     //-----------------------------------------------------------------------------------------------------------
     template<class t_struct>
-    std::string store_t_to_binary(t_struct& str_in, size_t indent = 0)
+    byte_slice store_t_to_binary(t_struct& str_in, size_t initial_buffer_size = 8192)
     {
-      std::string binary_buff;
-      store_t_to_binary(str_in, binary_buff, indent);
+      byte_slice binary_buff;
+      store_t_to_binary(str_in, binary_buff, initial_buffer_size);
       return binary_buff;
     }
   }

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -29,7 +29,7 @@
 
 add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
-    int-util.cpp)
+    int-util.cpp portable_storage.cpp)
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
   add_library(epee_readline STATIC readline_buffer.cpp)

--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -1,0 +1,29 @@
+
+#include "byte_slice.h"
+#include "byte_stream.h"
+#include "misc_log_ex.h"
+#include "span.h"
+#include "storages/portable_storage.h"
+#include "storages/portable_storage_to_bin.h"
+
+namespace epee
+{
+namespace serialization
+{
+  bool portable_storage::store_to_binary(byte_slice& target, const std::size_t initial_buffer_size)
+  {
+    TRY_ENTRY();
+    byte_stream ss;
+    ss.reserve(initial_buffer_size);
+    storage_block_header sbh{};
+    sbh.m_signature_a = SWAP32LE(PORTABLE_STORAGE_SIGNATUREA);
+    sbh.m_signature_b = SWAP32LE(PORTABLE_STORAGE_SIGNATUREB);
+    sbh.m_ver = PORTABLE_STORAGE_FORMAT_VER;
+    ss.write(epee::as_byte_span(sbh));
+    pack_entry_to_buff(ss, m_root);
+    target = epee::byte_slice{std::move(ss)};
+    return true;
+    CATCH_ENTRY("portable_storage::store_to_binary", false)
+  }
+}
+}

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -37,6 +37,7 @@
 #include <boost/program_options/variables_map.hpp>
 #include <string>
 
+#include "byte_slice.h"
 #include "math_helper.h"
 #include "storages/levin_abstract_invoke2.h"
 #include "warnings.h"
@@ -100,7 +101,7 @@ namespace cryptonote
     void set_p2p_endpoint(nodetool::i_p2p_endpoint<connection_context>* p2p);
     //bool process_handshake_data(const blobdata& data, cryptonote_connection_context& context);
     bool process_payload_sync_data(const CORE_SYNC_DATA& hshd, cryptonote_connection_context& context, bool is_inital);
-    bool get_payload_sync_data(blobdata& data);
+    bool get_payload_sync_data(epee::byte_slice& data);
     bool get_payload_sync_data(CORE_SYNC_DATA& hshd);
     bool on_callback(cryptonote_connection_context& context);
     t_core& get_core(){return m_core;}
@@ -191,10 +192,10 @@ namespace cryptonote
       bool post_notify(typename t_parameter::request& arg, cryptonote_connection_context& context)
       {
         LOG_PRINT_L2("[" << epee::net_utils::print_connection_context_short(context) << "] post " << typeid(t_parameter).name() << " -->");
-        std::string blob;
-        epee::serialization::store_t_to_binary(arg, blob);
+        epee::byte_slice blob;
+        epee::serialization::store_t_to_binary(arg, blob, 256 * 1024); // optimize for block responses
         //handler_response_blocks_now(blob.size()); // XXX
-        return m_p2p->invoke_notify_to_peer(t_parameter::ID, epee::strspan<uint8_t>(blob), context);
+        return m_p2p->invoke_notify_to_peer(t_parameter::ID, epee::to_span(blob), context);
       }
   };
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -425,7 +425,7 @@ namespace cryptonote
   }
   //------------------------------------------------------------------------------------------------------------------------
     template<class t_core>
-    bool t_cryptonote_protocol_handler<t_core>::get_payload_sync_data(blobdata& data)
+    bool t_cryptonote_protocol_handler<t_core>::get_payload_sync_data(epee::byte_slice& data)
   {
     CORE_SYNC_DATA hsd = {};
     get_payload_sync_data(hsd);
@@ -2586,15 +2586,15 @@ skip:
     // send fluffy ones first, we want to encourage people to run that
     if (!fluffyConnections.empty())
     {
-      std::string fluffyBlob;
-      epee::serialization::store_t_to_binary(fluffy_arg, fluffyBlob);
-      m_p2p->relay_notify_to_list(NOTIFY_NEW_FLUFFY_BLOCK::ID, epee::strspan<uint8_t>(fluffyBlob), std::move(fluffyConnections));
+      epee::byte_slice fluffyBlob;
+      epee::serialization::store_t_to_binary(fluffy_arg, fluffyBlob, 32 * 1024);
+      m_p2p->relay_notify_to_list(NOTIFY_NEW_FLUFFY_BLOCK::ID, epee::to_span(fluffyBlob), std::move(fluffyConnections));
     }
     if (!fullConnections.empty())
     {
-      std::string fullBlob;
-      epee::serialization::store_t_to_binary(arg, fullBlob);
-      m_p2p->relay_notify_to_list(NOTIFY_NEW_BLOCK::ID, epee::strspan<uint8_t>(fullBlob), std::move(fullConnections));
+      epee::byte_slice fullBlob;
+      epee::serialization::store_t_to_binary(arg, fullBlob, 128 * 1024);
+      m_p2p->relay_notify_to_list(NOTIFY_NEW_BLOCK::ID, epee::to_span(fullBlob), std::move(fullConnections));
     }
 
     return true;

--- a/tests/fuzz/http-client.cpp
+++ b/tests/fuzz/http-client.cpp
@@ -26,6 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <boost/utility/string_ref.hpp>
 #include "include_base_utils.h"
 #include "file_io_utils.h"
 #include "net/http_client.h"
@@ -38,7 +39,7 @@ public:
   bool connect(const std::string& addr, int port, std::chrono::milliseconds timeout, bool ssl = false, const std::string& bind_ip = "0.0.0.0") { return true; }
   bool connect(const std::string& addr, const std::string& port, std::chrono::milliseconds timeout, bool ssl = false, const std::string& bind_ip = "0.0.0.0") { return true; }
   bool disconnect() { return true; }
-  bool send(const std::string& buff, std::chrono::milliseconds timeout) { return true; }
+  bool send(const boost::string_ref buff, std::chrono::milliseconds timeout) { return true; }
   bool send(const void* data, size_t sz) { return true; }
   bool is_connected() { return true; }
   bool recv(std::string& buff, std::chrono::milliseconds timeout)

--- a/tests/fuzz/levin.cpp
+++ b/tests/fuzz/levin.cpp
@@ -65,13 +65,13 @@ namespace
     {
     }
 
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, test_levin_connection_context& context)
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, test_levin_connection_context& context)
     {
       m_invoke_counter.inc();
       boost::unique_lock<boost::mutex> lock(m_mutex);
       m_last_command = command;
       m_last_in_buf = std::string((const char*)in_buff.data(), in_buff.size());
-      buff_out = m_invoke_out_buf;
+      buff_out = m_invoke_out_buf.clone();
       return m_return_code;
     }
 
@@ -111,8 +111,7 @@ namespace
     int return_code() const { return m_return_code; }
     void return_code(int v) { m_return_code = v; }
 
-    const std::string& invoke_out_buf() const { return m_invoke_out_buf; }
-    void invoke_out_buf(const std::string& v) { m_invoke_out_buf = v; }
+    void invoke_out_buf(std::string v) { m_invoke_out_buf = epee::byte_slice{std::move(v)}; }
 
     int last_command() const { return m_last_command; }
     const std::string& last_in_buf() const { return m_last_in_buf; }
@@ -127,7 +126,7 @@ namespace
     boost::mutex m_mutex;
 
     int m_return_code;
-    std::string m_invoke_out_buf;
+    epee::byte_slice m_invoke_out_buf;
 
     int m_last_command;
     std::string m_last_in_buf;

--- a/tests/net_load_tests/net_load_tests.h
+++ b/tests/net_load_tests/net_load_tests.h
@@ -64,7 +64,7 @@ namespace net_load_tests
     {
     }
 
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, test_connection_context& context)
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, test_connection_context& context)
     {
       //m_invoke_counter.inc();
       //std::unique_lock<std::mutex> lock(m_mutex);

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -56,13 +56,13 @@ namespace
     {
     }
 
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, test_levin_connection_context& context)
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, test_levin_connection_context& context)
     {
       m_invoke_counter.inc();
       boost::unique_lock<boost::mutex> lock(m_mutex);
       m_last_command = command;
       m_last_in_buf = std::string((const char*)in_buff.data(), in_buff.size());
-      buff_out = m_invoke_out_buf;
+      buff_out = m_invoke_out_buf.clone();
       return m_return_code;
     }
 
@@ -102,8 +102,7 @@ namespace
     int return_code() const { return m_return_code; }
     void return_code(int v) { m_return_code = v; }
 
-    const std::string& invoke_out_buf() const { return m_invoke_out_buf; }
-    void invoke_out_buf(const std::string& v) { m_invoke_out_buf = v; }
+    void invoke_out_buf(std::string v) { m_invoke_out_buf = epee::byte_slice{std::move(v)}; }
 
     int last_command() const { return m_last_command; }
     const std::string& last_in_buf() const { return m_last_in_buf; }
@@ -118,7 +117,7 @@ namespace
     boost::mutex m_mutex;
 
     int m_return_code;
-    std::string m_invoke_out_buf;
+    epee::byte_slice m_invoke_out_buf;
 
     int m_last_command;
     std::string m_last_in_buf;

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -238,9 +238,9 @@ namespace
             return {connection, std::move(request)};
         }
 
-        virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, cryptonote::levin::detail::p2p_context& context) override final
+        virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, cryptonote::levin::detail::p2p_context& context) override final
         {
-            buff_out.clear();
+            buff_out = nullptr;
             invoked_.push_back(
                 {context.m_connection_id, command, std::string{reinterpret_cast<const char*>(in_buff.data()), in_buff.size()}}
             );

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -245,7 +245,7 @@ namespace
 
 TEST(tor_address, epee_serializev_v2)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{MONERO_UNWRAP(net::tor_address::make(v2_onion, 10))};
         EXPECT_FALSE(command.tor.is_unknown());
@@ -266,7 +266,7 @@ TEST(tor_address, epee_serializev_v2)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.tor.is_unknown());
@@ -277,7 +277,7 @@ TEST(tor_address, epee_serializev_v2)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -296,7 +296,7 @@ TEST(tor_address, epee_serializev_v2)
 
 TEST(tor_address, epee_serializev_v3)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{MONERO_UNWRAP(net::tor_address::make(v3_onion, 10))};
         EXPECT_FALSE(command.tor.is_unknown());
@@ -317,7 +317,7 @@ TEST(tor_address, epee_serializev_v3)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.tor.is_unknown());
@@ -328,7 +328,7 @@ TEST(tor_address, epee_serializev_v3)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -347,7 +347,7 @@ TEST(tor_address, epee_serializev_v3)
 
 TEST(tor_address, epee_serialize_unknown)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{net::tor_address::unknown()};
         EXPECT_TRUE(command.tor.is_unknown());
@@ -368,7 +368,7 @@ TEST(tor_address, epee_serialize_unknown)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_TRUE(command.tor.is_unknown());
@@ -379,7 +379,7 @@ TEST(tor_address, epee_serialize_unknown)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -700,7 +700,7 @@ namespace
 
 TEST(i2p_address, epee_serializev_b32)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_i2p command{MONERO_UNWRAP(net::i2p_address::make(b32_i2p, 10))};
         EXPECT_FALSE(command.i2p.is_unknown());
@@ -721,7 +721,7 @@ TEST(i2p_address, epee_serializev_b32)
         EXPECT_EQ(0u, command.i2p.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.i2p.is_unknown());
@@ -732,7 +732,7 @@ TEST(i2p_address, epee_serializev_b32)
     // make sure that exceeding max buffer doesn't destroy i2p_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("i2p", nullptr, false)));
@@ -751,7 +751,7 @@ TEST(i2p_address, epee_serializev_b32)
 
 TEST(i2p_address, epee_serialize_unknown)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_i2p command{net::i2p_address::unknown()};
         EXPECT_TRUE(command.i2p.is_unknown());
@@ -772,7 +772,7 @@ TEST(i2p_address, epee_serialize_unknown)
         EXPECT_EQ(0u, command.i2p.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_TRUE(command.i2p.is_unknown());
@@ -783,7 +783,7 @@ TEST(i2p_address, epee_serialize_unknown)
     // make sure that exceeding max buffer doesn't destroy i2p_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("i2p", nullptr, false)));

--- a/tests/unit_tests/test_protocol_pack.cpp
+++ b/tests/unit_tests/test_protocol_pack.cpp
@@ -36,7 +36,7 @@
 
 TEST(protocol_pack, protocol_pack_command) 
 {
-  std::string buff;
+  epee::byte_slice buff;
   cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request r;
   r.start_height = 1;
   r.total_height = 3;
@@ -47,7 +47,7 @@ TEST(protocol_pack, protocol_pack_command)
     ASSERT_TRUE(res);
 
     cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request r2;
-    res = epee::serialization::load_t_from_binary(r2, buff);
+    res = epee::serialization::load_t_from_binary(r2, epee::to_span(buff));
     ASSERT_TRUE(res);
     ASSERT_TRUE(r.m_block_ids.size() == i);
     ASSERT_TRUE(r.start_height == 1);


### PR DESCRIPTION
The primary motivation for this patch is to remove the internal copy in `std::stringstream::str()` and switch to a `realloc` call for buffer increases. The former is not possible until C++20, and the latter is not possible (yet) with the allocator design of `std::stringstream`. Construction of the object is also faster, and `write` calls have less overhead (no polymorphism or `sentry` objects). In some cases there's still a copy, but these can hopefully be cleaned up in future edits.

Taking glibc as an example - allocation requests over 128KiB are directly `mmap`ed via the kernel. Increasing this memory chunk with `realloc` can be done via `mremap` (on Linux and some BSDs), which either extends the virtual memory space or shuffles around the page table without copying the memory. This obviously helps with manipulating big chunks of memory, which typically happens when returning blocks via p2p or blocks/transactions via RPC. Even with smaller chunks, heap implementations can extend the buffer size without copy if there is free space behind the buffer. 

This results in ~30-70%+ drop in "DOM->binary" wall clock time on a ryzen 3900x. Although this is in some part due to the new aggressive initial buffer sizes, there's still less copying of the data and less overhead on writes. DOM->binary for block responses via p2p should take around ~1ms (at least if you have a beefy CPU).  I expect the performance impact on slower and smaller cache CPUs to a bit more.

There might be some jumps in CPU time due to the syscalls+aggressive buffer requests. These were less than 1 microsecond in total serialization time, but its something that may need tweaking.

Unfortunately, the bulk of the p2p response time is spent on I/O and some other stuff, but this does show in profiles here and there (depending on whether you are pushing blocks, and which blocks being pushed).