### PR TITLE
Provide last error from http client to UI

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <string>
+#include <system_error>
 #include <boost/optional/optional.hpp>
 #include "http_auth.h"
 #include "net/net_ssl.h"
@@ -70,6 +71,7 @@ namespace http
     virtual bool connect(std::chrono::milliseconds timeout) = 0;
     virtual bool disconnect() = 0;
     virtual bool is_connected(bool *ssl = NULL) = 0;
+    virtual std::error_code last_error();
     virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -135,7 +135,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		bool handshake(boost::asio::ssl::stream_base::handshake_type type)
 		{
 			//m_state != nullptr verified in constructor
-			return m_state->ssl_options().handshake(socket_, type);
+			return !bool(m_state->ssl_options().handshake(socket_, type));
 		}
 
 		template<typename MutableBufferSequence, typename ReadHandler>

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -213,6 +213,12 @@ namespace net_utils
 				return m_net_client.is_connected(ssl);
 			}
 			//---------------------------------------------------------------------------
+			std::error_code last_error() override final
+			{
+				CRITICAL_REGION_LOCAL(m_lock);
+				return m_net_client.last_error();
+			}
+			//---------------------------------------------------------------------------
 			virtual bool handle_target_data(std::string& piece_of_transfer) override
 			{
 				CRITICAL_REGION_LOCAL(m_lock);

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -127,9 +127,8 @@ namespace net_utils
           `verification == system_ca` the client also does a rfc2818 check to
           ensure that the server certificate is to the provided hostname.
 
-        \return True if the SSL handshake completes with peer verification
-          settings. */
-    bool handshake(
+        \return Non-empty error_code on failure. */
+    boost::system::error_code handshake(
       boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket,
       boost::asio::ssl::stream_base::handshake_type type,
       const std::string& host = {},

--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -142,6 +142,13 @@ namespace http
   {
     return false;
   }
+
+  std::error_code epee::net_utils::http::abstract_http_client::last_error()
+  {
+    if (is_connected())
+      return std::error_code{};
+    return make_error_code(std::errc::not_connected);
+  }
 }
 }
 }

--- a/contrib/epee/src/net_helper.cpp
+++ b/contrib/epee/src/net_helper.cpp
@@ -1,7 +1,47 @@
+// Copyright (c) 2019-2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "net/net_helper.h"
+#include <boost/version.hpp>
 
 namespace epee
 {
+std::error_code convert_error_code(boost::system::error_code error)
+{
+#if BOOST_VERSION >= 106500
+	return error; // builtin conversion from boost in 1.65+
+#else
+	if (error)
+		return make_error_code(std::errc::not_connected);
+	return std::error_code{};
+#endif
+}
+
 namespace net_utils
 {
 	boost::unique_future<boost::asio::ip::tcp::socket>
@@ -77,6 +117,85 @@ namespace net_utils
 			}
 		});
 		return shared->result_.get_future();
+	}
+
+	boost::system::error_code blocked_mode_client::try_connect(const std::string& addr, const std::string& port, std::chrono::milliseconds timeout)
+	{
+		m_deadline.expires_from_now(timeout);
+		boost::unique_future<boost::asio::ip::tcp::socket> connection = m_connector(addr, port, m_deadline);
+		for (;;)
+		{
+			m_io_service.reset();
+			m_io_service.run_one();
+
+			if (connection.is_ready())
+				break;
+		}
+
+		m_ssl_socket->next_layer() = connection.get();
+		m_deadline.cancel();
+		if (m_ssl_socket->next_layer().is_open())
+		{
+			boost::system::error_code error{};
+			m_deadline.expires_at(std::chrono::steady_clock::time_point::max());
+			// SSL Options
+			if (m_ssl_options.support == ssl_support_t::e_ssl_support_enabled || m_ssl_options.support == ssl_support_t::e_ssl_support_autodetect)
+			{
+				if ((error = m_ssl_options.handshake(*m_ssl_socket, boost::asio::ssl::stream_base::client, addr, timeout)))
+				{
+					MWARNING("Failed to establish SSL connection");
+					boost::system::error_code ignored_ec;
+					m_ssl_socket->next_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
+					m_ssl_socket->next_layer().close();
+				}
+			}
+			return error;
+		}
+
+		MWARNING("Some problems at connect, expected open socket");
+		return boost::asio::error::not_connected;
+	}
+
+	bool blocked_mode_client::connect(const std::string& addr, const std::string& port, std::chrono::milliseconds timeout)
+	{
+		try
+		{
+			disconnect();
+
+			// Set SSL options
+			// disable sslv2
+			m_ssl_socket.reset(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(m_io_service, m_ctx));
+
+			boost::system::error_code error = try_connect(addr, port, timeout);
+			if (error && error != boost::asio::error::not_connected && m_ssl_options.support == ssl_support_t::e_ssl_support_autodetect)
+			{
+				MERROR("SSL handshake failed on an autodetect connection, reconnecting without SSL");
+				m_ssl_options.support = ssl_support_t::e_ssl_support_disabled;
+				error = try_connect(addr, port, timeout);
+			}
+			m_stream_error = convert_error_code(error);
+		}
+		catch (const std::system_error& er)
+		{
+			if (er.code())
+				m_stream_error = er.code();
+			MDEBUG("Some problems at connect, message: " << er.what());
+		}
+		catch (const boost::system::system_error& er)
+		{
+			if (er.code())
+				m_stream_error = convert_error_code(er.code());
+			MDEBUG("Some problems at connect, message: " << er.what());
+		}
+		catch(const std::exception& er)
+		{
+			MDEBUG("Some problems at connect, message: " << er.what());
+		}
+		catch(...)
+		{
+			MDEBUG("Some fatal problems.");
+		}
+		return !m_stream_error;
 	}
 }
 }

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -470,7 +470,7 @@ bool ssl_options_t::has_fingerprint(boost::asio::ssl::verify_context &ctx) const
   return false;
 }
 
-bool ssl_options_t::handshake(
+boost::system::error_code ssl_options_t::handshake(
   boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket,
   boost::asio::ssl::stream_base::handshake_type type,
   const std::string& host,
@@ -545,12 +545,10 @@ bool ssl_options_t::handshake(
   }
 
   if (ec)
-  {
     MERROR("SSL handshake failed, connection dropped: " << ec.message());
-    return false;
-  }
-  MDEBUG("SSL handshake success");
-  return true;
+  else
+    MDEBUG("SSL handshake success");
+  return ec;
 }
 
 bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4760,10 +4760,11 @@ bool simple_wallet::try_connect_to_daemon(bool silent, uint32_t* version)
   uint32_t version_ = 0;
   if (!version)
     version = &version_;
-  if (!m_wallet->check_connection(version))
+  expect<void> status{};
+  if (!(status = m_wallet->check_connection(version)))
   {
     if (!silent)
-      fail_msg_writer() << tr("wallet failed to connect to daemon: ") << m_wallet->get_daemon_address() << ". " <<
+      fail_msg_writer() << tr("wallet failed to connect to daemon ") << m_wallet->get_daemon_address() << " : " << status.error().message() << ". " <<
         tr("Daemon either is not started or wrong port was passed. "
         "Please make sure daemon is running or change the daemon address using the 'set_daemon' command.");
     return false;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2062,20 +2062,20 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
 
 bool WalletImpl::connectToDaemon()
 {
-    bool result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    const expect<void> result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
     if (!result) {
-        setStatusError("Error connecting to daemon at " + m_wallet->get_daemon_address());
+        setStatusError("Error connecting to daemon at " + m_wallet->get_daemon_address() + " : " + result.error().message());
     } else {
         clearStatus();
         // start refreshing here
     }
-    return result;
+    return bool(result);
 }
 
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
     uint32_t version = 0;
-    m_is_connected = m_wallet->check_connection(&version, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    m_is_connected = bool(m_wallet->check_connection(&version, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS));
     if (!m_is_connected)
         return Wallet::ConnectionStatus_Disconnected;
     // Version check is not implemented in light wallets nodes/wallets

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -53,6 +53,7 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
+#include "common/expect.h"
 #include "common/unordered_containers_boost_serialization.h"
 #include "common/util.h"
 #include "crypto/chacha.h"
@@ -996,7 +997,7 @@ private:
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);
     std::vector<pending_tx> create_unmixable_sweep_transactions();
     void discard_unmixable_outputs();
-    bool check_connection(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 200000);
+    expect<void> check_connection(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 200000);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
     void get_payments(const crypto::hash& payment_id, std::list<wallet2::payment_details>& payments, uint64_t min_height = 0, const boost::optional<uint32_t>& subaddr_account = boost::none, const std::set<uint32_t>& subaddr_indices = {}) const;
     void get_payments(std::list<std::pair<crypto::hash,wallet2::payment_details>>& payments, uint64_t min_height, uint64_t max_height = (uint64_t)-1, const boost::optional<uint32_t>& subaddr_account = boost::none, const std::set<uint32_t>& subaddr_indices = {}) const;

--- a/tests/fuzz/http-client.cpp
+++ b/tests/fuzz/http-client.cpp
@@ -41,6 +41,7 @@ public:
   bool send(const std::string& buff, std::chrono::milliseconds timeout) { return true; }
   bool send(const void* data, size_t sz) { return true; }
   bool is_connected() { return true; }
+  static std::error_code last_error() noexcept { return {}; }
   bool recv(std::string& buff, std::chrono::milliseconds timeout)
   {
     buff = data;


### PR DESCRIPTION
This stores the last `std::error_code` while doing HTTP client I/O to make it available to UIs. With Boost 1.65+ this provides more useful messages with the CLI wallet, and hopefully GUI wallet too. The primary purpose is for an (shortly) upcoming DANE/TLSA patch that uses DNSSEC for the "autodetect" SSL mode with wallets. I broke this into its own patch because its useful even if the DANE/TLSA patch is rejected or reverted.

