### PR TITLE
wallet2: set propagation timeout to current max timeout

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2962,7 +2962,8 @@ void wallet2::update_pool_state(std::vector<std::tuple<cryptonote::transaction, 
   MTRACE("update_pool_state got pool");
 
   // remove any pending tx that's not in the pool
-  constexpr const std::chrono::seconds tx_propagation_timeout{CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE * 3 / 2};
+  // TODO: set tx_propagation_timeout to CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE * 3 / 2 after v15 hardfork
+  constexpr const std::chrono::seconds tx_propagation_timeout{500};
   const auto now = std::chrono::system_clock::now();
   std::unordered_map<crypto::hash, wallet2::unconfirmed_transfer_details>::iterator it = m_unconfirmed_txs.begin();
   while (it != m_unconfirmed_txs.end())


### PR DESCRIPTION
Due to outdated nodes still running the old Dandelion++ parameter (and the bug fixed in #7021) it can take up to

```
(173 * 3 / 2 + 120 + 120) = 499.5 seconds
```

before a transaction ends up in the public mempool. I added half a second for network latency.

After the v15 hardfork every node will run the same Dandelion++ parameters so we can set it back to the current value.