### PR TITLE
blockchain: only update pruning when the chain changed

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -88,7 +88,7 @@ DISABLE_VS_WARNINGS(4267)
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_reset_timestamps_and_difficulties_height(true), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
-  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
+  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_update_pruning(false), m_bytes_to_sync(0), m_cancel(false),
   m_long_term_block_weights_window(CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE),
   m_long_term_effective_median_block_weight(0),
   m_long_term_block_weights_cache_tip_hash(crypto::null_hash),
@@ -647,6 +647,7 @@ block Blockchain::pop_block_from_blockchain()
   crypto::hash top_block_hash = get_tail_id(top_block_height);
   m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
   invalidate_block_template_cache();
+  m_update_pruning = true;
 
   return popped_block;
 }
@@ -4339,6 +4340,7 @@ leave:
 
   bvc.m_added_to_main_chain = true;
   ++m_sync_counter;
+  m_update_pruning = true;
 
   // appears to be a NOP *and* is called elsewhere.  wat?
   m_tx_pool.on_blockchain_inc(new_height, id);
@@ -4617,7 +4619,7 @@ void Blockchain::block_longhash_worker(uint64_t height, const epee::span<const b
 //------------------------------------------------------------------
 bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
 {
-  bool success = false;
+  bool success = false, update_pruning = false;
 
   MTRACE("Blockchain::" << __func__);
   CRITICAL_REGION_BEGIN(m_blockchain_lock);
@@ -4684,10 +4686,14 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
     m_blocks_hash_check.shrink_to_fit();
   }
 
+  update_pruning = m_update_pruning;
+  m_update_pruning = false;
+
   CRITICAL_REGION_END();
   m_tx_pool.unlock();
 
-  update_blockchain_pruning();
+  if (update_pruning)
+    update_blockchain_pruning();
 
   return success;
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1149,6 +1149,7 @@ namespace cryptonote
 
 
     bool m_batch_success;
+    bool m_update_pruning;
 
     /* `boost::function` is used because the implementation never allocates if
        the callable object has a single `std::shared_ptr` or `std::weap_ptr`


### PR DESCRIPTION
Most of the addition calls will end up adding nothing, since we
expect to receive every block from all peers, and only the first
time we get it leads to actual addition.