### PR TITLE
Add TLSA support to DNSSEC fetching

### DIFF
--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -31,15 +31,17 @@
 #include <string>
 #include <functional>
 #include <boost/optional/optional_fwd.hpp>
+#include <boost/utility/string_ref_fwd.hpp>
 
 namespace tools
 {
 
 // RFC defines for record types and classes for DNS, gleaned from ldns source
-const static int DNS_CLASS_IN  = 1;
-const static int DNS_TYPE_A    = 1;
-const static int DNS_TYPE_TXT  = 16;
-const static int DNS_TYPE_AAAA = 8;
+constexpr const int DNS_CLASS_IN  = 1;
+constexpr const int DNS_TYPE_A    = 1;
+constexpr const int DNS_TYPE_TXT  = 16;
+constexpr const int DNS_TYPE_AAAA = 8;
+constexpr const int DNS_TYPE_TLSA = 52;
 
 struct DNSResolverData;
 
@@ -104,6 +106,17 @@ public:
    */
   // TODO: modify this to accommodate DNSSEC
    std::vector<std::string> get_txt_record(const std::string& url, bool& dnssec_available, bool& dnssec_valid);
+
+  /**
+   * @brief gets all TLSA TCP records from a DNS query for the supplied URL;
+   * if no TLSA record present returns an empty vector.
+   *
+   * @param url A string containing a URL to query for
+   * @param port The service port number (as string) to query
+   *
+   * @return A vector of strings containing all TLSA records; or an empty vector
+   */
+  std::vector<std::string> get_tlsa_tcp_record(boost::string_ref url, boost::string_ref port, bool& dnssec_available, bool& dnssec_valid);
 
   /**
    * @brief Gets a DNS address from OpenAlias format

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -26,10 +26,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(net_sources dandelionpp.cpp error.cpp http.cpp i2p_address.cpp parse.cpp socks.cpp
-    socks_connect.cpp tor_address.cpp zmq.cpp)
-set(net_headers dandelionpp.h error.h http.cpp i2p_address.h parse.h socks.h socks_connect.h
-    tor_address.h zmq.h)
+set(net_sources dandelionpp.cpp error.cpp http.cpp i2p_address.cpp parse.cpp resolve.cpp
+    socks.cpp socks_connect.cpp tor_address.cpp zmq.cpp)
+set(net_headers dandelionpp.h error.h http.cpp i2p_address.h parse.h socks.h resolve.h
+    socks_connect.h tor_address.h zmq.h)
 
 monero_add_library(net ${net_sources} ${net_headers})
 target_link_libraries(net common epee ${ZMQ_LIB} ${Boost_ASIO_LIBRARY})

--- a/src/net/error.cpp
+++ b/src/net/error.cpp
@@ -47,12 +47,18 @@ namespace
         {
             switch (net::error(value))
             {
+            case net::error::bogus_dnssec:
+                return "Invalid response signature from DNSSEC enabled domain";
+            case net::error::dns_query_failure:
+                return "Failed to retrieve desired DNS record";
             case net::error::expected_tld:
                 return "Expected top-level domain";
             case net::error::invalid_host:
                 return "Host value is not valid";
             case net::error::invalid_i2p_address:
                 return "Invalid I2P address";
+            case net::error::invalid_mask:
+                return "CIDR netmask outside of 0-32 range";
             case net::error::invalid_port:
                 return "Invalid port value (expected 0-65535)";
             case net::error::invalid_tor_address:
@@ -71,6 +77,7 @@ namespace
             switch (net::error(value))
             {
             case net::error::invalid_port:
+            case net::error::invalid_mask:
                 return std::errc::result_out_of_range;
             case net::error::expected_tld:
             case net::error::invalid_tor_address:

--- a/src/net/resolve.h
+++ b/src/net/resolve.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Monero Project
+// Copyright (c) 2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -26,43 +26,22 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#include <string>
+#include <vector>
 
-#include <system_error>
-#include <type_traits>
+template<typename> class expect;
 
 namespace net
 {
-    //! General net errors
-    enum class error : int
-    {
-        // 0 reserved for success (as per expect<T>)
-        bogus_dnssec = 1,   //!< Invalid response signature from DNSSEC enabled domain
-        dns_query_failure,  //!< Failed to retrieve desired DNS record
-        expected_tld,       //!< Expected a tld
-        invalid_host,       //!< Hostname is not valid
-        invalid_i2p_address,
-        invalid_mask,       //!< Outside of 0-32 range
-        invalid_port,       //!< Outside of 0-65535 range
-        invalid_tor_address,//!< Invalid base32 or length
-        unsupported_address,//!< Type not supported by `get_network_address`
-
-    };
-
-    //! \return `std::error_category` for `net` namespace.
-    std::error_category const& error_category() noexcept;
-
-    //! \return `net::error` as a `std::error_code` value.
-    inline std::error_code make_error_code(error value) noexcept
-    {
-        return std::error_code{int(value), error_category()};
-    }
-}
-
-namespace std
+namespace dnssec
 {
-    template<>
-    struct is_error_code_enum<::net::error>
-      : true_type
-    {};
-}
+  struct service_response
+  {
+    std::vector<std::string> ip;   //!< IPv4/6 records in dotted or semicolon notation
+    std::vector<std::string> tlsa; //!< DANE/TLSA records
+  };
+
+  //! \return IP + (optionally) DANE/TLSA records, failing if DNSSEC signature is "bogus"
+  expect<service_response> resolve_hostname(const std::string& addr, const std::string& tlsa_port = {});
+} // dnssec
+} // net


### PR DESCRIPTION
This adds a function to retrieve IPv4 or IPv6 records, along with TLSA records if the domain has DNSSEC enabled. These functions are unused in this patch. They will potentially be used by p2p encryption (#7078 ) to DNS seed nodes (wth TLS or noise encryption), or by `wallet2` SSL autodetect mode. If both features are rejected by the community, this PR will be closed or reverted.

This has been tested by SSL autodetect mode with the wallet. The associated OpenSSL code is not in this patch.

EDIT: From the OpenSSL description on DANE/TLSA, which helps explain:

> It is expected that the majority of clients employing DANE TLS will be doing "opportunistic DANE TLS" in the sense of RFC7672 and RFC7435. That is, they will use DANE authentication when DNSSEC-validated TLSA records are published for a given peer, and otherwise will use unauthenticated TLS or even cleartext.

The p2p mode would be for publishing pubkeys for DNS seeds, but only if they cannot be included directly in the codebase. Given the context of not hard-coding IP addresses for these seeds, it seems possible that this will be needed.