### PR TITLE
cmake: fix "release" version string on tagged releases

### DIFF
--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -48,29 +48,21 @@ function (get_version_tag_from_git GIT)
         message(STATUS "You are currently on commit ${COMMIT}")
 
         # Get all the tags
-        execute_process(COMMAND "${GIT}" rev-list --tags --max-count=1 --abbrev-commit 
+        execute_process(COMMAND "${GIT}" tag -l --points-at HEAD
                         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                         RESULT_VARIABLE RET
-                        OUTPUT_VARIABLE TAGGEDCOMMIT
+                        OUTPUT_VARIABLE TAG
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-        if(NOT TAGGEDCOMMIT)
-            message(WARNING "Cannot determine most recent tag. Make sure that you are building either from a Git working tree or from a source archive.")
+        # Check if we're building that tagged commit or a different one
+        if(TAG)
+            message(STATUS "You are building a tagged release")
+            set(VERSIONTAG "release")
+            set(VERSION_IS_RELEASE "true")
+        else()
+            message(STATUS "You are ahead of or behind a tagged release")
             set(VERSIONTAG "${COMMIT}")
             set(VERSION_IS_RELEASE "false")
-        else()
-            message(STATUS "The most recent tag was at ${TAGGEDCOMMIT}")
-
-            # Check if we're building that tagged commit or a different one
-            if(COMMIT STREQUAL TAGGEDCOMMIT)
-                message(STATUS "You are building a tagged release")
-                set(VERSIONTAG "release")
-                set(VERSION_IS_RELEASE "true")
-            else()
-                message(STATUS "You are ahead of or behind a tagged release")
-                set(VERSIONTAG "${COMMIT}")
-                set(VERSION_IS_RELEASE "false")
-            endif()
         endif()	    
     endif()
 


### PR DESCRIPTION
It would not say "release" if we're on a previous tag