### PR TITLE
bump the number of out connections in sync mode

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -130,6 +130,7 @@
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000
 
 #define P2P_DEFAULT_CONNECTIONS_COUNT                   12
+#define P2P_DEFAULT_SYNCING_CONNECTIONS_COUNT_BOOST     36
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //secondes
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
 #define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -111,7 +111,7 @@ namespace cryptonote
     const block_queue &get_block_queue() const { return m_block_queue; }
     void stop();
     void on_connection_close(cryptonote_connection_context &context);
-    void set_max_out_peers(unsigned int max) { m_max_out_peers = max; }
+    void set_max_out_peers(unsigned int max, unsigned int sync_boost) { m_max_out_peers = max; m_out_peers_sync_boost = sync_boost; }
     bool no_sync() const { return m_no_sync; }
     void set_no_sync(bool value) { m_no_sync = value; }
     std::string get_peers_overview() const;
@@ -168,6 +168,7 @@ namespace cryptonote
     epee::math_helper::once_a_time_seconds<101> m_sync_search_checker;
     epee::math_helper::once_a_time_seconds<43> m_bad_peer_checker;
     std::atomic<unsigned int> m_max_out_peers;
+    std::atomic<unsigned int> m_out_peers_sync_boost;
     tools::PerformanceTimer m_sync_timer, m_add_timer;
     uint64_t m_last_add_end_time;
     uint64_t m_sync_spans_downloaded, m_sync_old_spans_downloaded, m_sync_bad_spans_downloaded;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -88,7 +88,9 @@ namespace cryptonote
                                                                                                               m_synchronized(offline),
                                                                                                               m_ask_for_txpool_complement(true),
                                                                                                               m_stopping(false),
-                                                                                                              m_no_sync(false)
+                                                                                                              m_no_sync(false),
+                                                                                                              m_max_out_peers(P2P_DEFAULT_CONNECTIONS_COUNT),
+                                                                                                              m_out_peers_sync_boost(P2P_DEFAULT_SYNCING_CONNECTIONS_COUNT_BOOST)
 
   {
     if(!m_p2p)
@@ -1768,7 +1770,8 @@ skip:
     MTRACE(n_syncing << " syncing, " << n_synced << " synced");
 
     // if we're at max out peers, and not enough are syncing
-    if (n_synced + n_syncing >= m_max_out_peers && n_syncing < P2P_DEFAULT_SYNC_SEARCH_CONNECTIONS_COUNT && last_synced_peer_id != boost::uuids::nil_uuid())
+    const auto target_conns = m_max_out_peers + (is_synchronized() ? 0u : m_out_peers_sync_boost.load());
+    if (n_synced + n_syncing >= target_conns && n_syncing < P2P_DEFAULT_SYNC_SEARCH_CONNECTIONS_COUNT && last_synced_peer_id != boost::uuids::nil_uuid())
     {
       if (!m_p2p->for_connection(last_synced_peer_id, [&](cryptonote_connection_context& ctx, nodetool::peerid_type peer_id, uint32_t f)->bool{
         MINFO(ctx << "dropping synced peer, " << n_syncing << " syncing, " << n_synced << " synced");
@@ -1954,10 +1957,11 @@ skip:
         return true;
       });
       const uint32_t distance = (peer_stripe + (1<<CRYPTONOTE_PRUNING_LOG_STRIPES) - next_stripe) % (1<<CRYPTONOTE_PRUNING_LOG_STRIPES);
-      if ((n_out_peers >= m_max_out_peers && n_peers_on_next_stripe == 0) || (distance > 1 && n_peers_on_next_stripe <= 2) || distance > 2)
+      const auto target_conns = m_max_out_peers + (is_synchronized() ? 0u : m_out_peers_sync_boost.load());
+      if ((n_out_peers >= target_conns && n_peers_on_next_stripe == 0) || (distance > 1 && n_peers_on_next_stripe <= 2) || distance > 2)
       {
         MDEBUG(context << "we want seed " << next_stripe << ", and either " << n_out_peers << " is at max out peers ("
-            << m_max_out_peers << ") or distance " << distance << " from " << next_stripe << " to " << peer_stripe <<
+            << target_conns << ") or distance " << distance << " from " << next_stripe << " to " << peer_stripe <<
             " is too large and we have only " << n_peers_on_next_stripe << " peers on next seed, dropping connection to make space");
         return true;
       }
@@ -2696,11 +2700,12 @@ skip:
       }
       return true;
     });
-    const bool use_next = (n_next > m_max_out_peers / 2 && n_subsequent <= 1) || (n_next > 2 && n_subsequent == 0);
+    const auto target_conns = m_max_out_peers + (is_synchronized() ? 0u : m_out_peers_sync_boost.load());
+    const bool use_next = (n_next > target_conns / 2 && n_subsequent <= 1) || (n_next > 2 && n_subsequent == 0);
     const uint32_t ret_stripe = use_next ? subsequent_pruning_stripe: next_pruning_stripe;
     MIDEBUG(const std::string po = get_peers_overview(), "get_next_needed_pruning_stripe: want height " << want_height << " (" <<
         want_height_from_blockchain << " from blockchain, " << want_height_from_block_queue << " from block queue), stripe " <<
-        next_pruning_stripe << " (" << n_next << "/" << m_max_out_peers << " on it and " << n_subsequent << " on " <<
+        next_pruning_stripe << " (" << n_next << "/" << target_conns << " on it and " << n_subsequent << " on " <<
         subsequent_pruning_stripe << ", " << n_others << " others) -> " << ret_stripe << " (+" <<
         (ret_stripe - next_pruning_stripe + (1 << CRYPTONOTE_PRUNING_LOG_STRIPES)) % (1 << CRYPTONOTE_PRUNING_LOG_STRIPES) <<
         "), current peers " << po);
@@ -2720,7 +2725,7 @@ skip:
         ++n_out_peers;
       return true;
     });
-    if (n_out_peers >= m_max_out_peers)
+    if (n_out_peers >= m_max_out_peers + (is_synchronized() ? 0u : m_out_peers_sync_boost.load()))
       return false;
     return true;
   }

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -155,6 +155,7 @@ namespace nodetool
     const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
     const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4  = {"p2p-ignore-ipv4", "Ignore unsuccessful IPv4 bind for p2p", false};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
+    const command_line::arg_descriptor<uint32_t>    arg_out_peers_sync_boost = {"out-peers-sync-boost", "Extra peers when in sync mode", P2P_DEFAULT_SYNCING_CONNECTIONS_COUNT_BOOST};
     const command_line::arg_descriptor<int64_t>     arg_in_peers = {"in-peers", "set max number of in peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -257,7 +257,8 @@ namespace nodetool
         m_igd(no_igd),
         m_offline(false),
         is_closing(false),
-        m_network_id()
+        m_network_id(),
+        m_out_peers_sync_boost(P2P_DEFAULT_SYNCING_CONNECTIONS_COUNT_BOOST)
     {}
     virtual ~node_server();
 
@@ -512,6 +513,8 @@ namespace nodetool
     cryptonote::network_type m_nettype;
 
     epee::net_utils::ssl_support_t m_ssl_support;
+
+    uint32_t m_out_peers_sync_boost;
   };
 
     const int64_t default_limit_up = P2P_DEFAULT_LIMIT_RATE_UP;      // kB/s
@@ -538,6 +541,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<std::string> arg_igd;
     extern const command_line::arg_descriptor<bool>        arg_offline;
     extern const command_line::arg_descriptor<int64_t>     arg_out_peers;
+    extern const command_line::arg_descriptor<uint32_t>    arg_out_peers_sync_boost;
     extern const command_line::arg_descriptor<int64_t>     arg_in_peers;
     extern const command_line::arg_descriptor<int> arg_tos_flag;
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -123,6 +123,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_no_igd);
     command_line::add_arg(desc, arg_igd);
     command_line::add_arg(desc, arg_out_peers);
+    command_line::add_arg(desc, arg_out_peers_sync_boost);
     command_line::add_arg(desc, arg_in_peers);
     command_line::add_arg(desc, arg_tos_flag);
     command_line::add_arg(desc, arg_limit_rate_up);
@@ -499,9 +500,8 @@ namespace nodetool
 
     if ( !set_max_out_peers(public_zone, command_line::get_arg(vm, arg_out_peers) ) )
       return false;
-    else
-      m_payload_handler.set_max_out_peers(public_zone.m_config.m_net_config.max_out_connection_count);
-
+    m_out_peers_sync_boost = command_line::get_arg(vm, arg_out_peers_sync_boost);
+    m_payload_handler.set_max_out_peers(public_zone.m_config.m_net_config.max_out_connection_count, m_out_peers_sync_boost);
 
     if ( !set_max_in_peers(public_zone, command_line::get_arg(vm, arg_in_peers) ) )
       return false;
@@ -1325,7 +1325,7 @@ namespace nodetool
     {
       return false;
     }
-    else if (zone.m_current_number_of_out_peers > zone.m_config.m_net_config.max_out_connection_count)
+    else if (zone.m_current_number_of_out_peers > (zone.m_config.m_net_config.max_out_connection_count + ((m_payload_handler.get_core().is_synchronized() ? 0 : m_out_peers_sync_boost))))
     {
       zone.m_net_server.get_config_object().del_out_connections(1);
       --(zone.m_current_number_of_out_peers); // atomic variable, update time = 1s
@@ -1776,9 +1776,18 @@ namespace nodetool
       // carefully avoid `continue` in nested loop
       
       size_t conn_count = get_outgoing_connections_count(zone.second);
-      while(conn_count < zone.second.m_config.m_net_config.max_out_connection_count)
+      while (1)
       {
-        const size_t expected_white_connections = m_payload_handler.get_next_needed_pruning_stripe().second ? zone.second.m_config.m_net_config.max_out_connection_count : base_expected_white_connections;
+        const bool sync_boost = zone.first == zone_type::public_ && !m_payload_handler.get_core().is_synchronized();
+        const size_t conn_target = zone.second.m_config.m_net_config.max_out_connection_count + (sync_boost ? m_out_peers_sync_boost : 0);
+        if (conn_count >= conn_target)
+        {
+          if (conn_count > conn_target)
+            zone.second.m_net_server.get_config_object().del_out_connections(conn_count - conn_target);
+          break;
+        }
+
+        const size_t expected_white_connections = m_payload_handler.get_next_needed_pruning_stripe().second ? conn_target : base_expected_white_connections;
         if(conn_count < expected_white_connections)
         {
           //start from anchor list
@@ -1788,16 +1797,16 @@ namespace nodetool
           while (get_outgoing_connections_count(zone.second) < expected_white_connections
             && make_expected_connections_count(zone.second, white, expected_white_connections));
           //then do grey list
-          while (get_outgoing_connections_count(zone.second) < zone.second.m_config.m_net_config.max_out_connection_count
-            && make_expected_connections_count(zone.second, gray, zone.second.m_config.m_net_config.max_out_connection_count));
+          while (get_outgoing_connections_count(zone.second) < conn_target
+            && make_expected_connections_count(zone.second, gray, conn_target));
         }else
         {
           //start from grey list
-          while (get_outgoing_connections_count(zone.second) < zone.second.m_config.m_net_config.max_out_connection_count
-            && make_expected_connections_count(zone.second, gray, zone.second.m_config.m_net_config.max_out_connection_count));
+          while (get_outgoing_connections_count(zone.second) < conn_target
+            && make_expected_connections_count(zone.second, gray, conn_target));
           //and then do white list
-          while (get_outgoing_connections_count(zone.second) < zone.second.m_config.m_net_config.max_out_connection_count
-            && make_expected_connections_count(zone.second, white, zone.second.m_config.m_net_config.max_out_connection_count));
+          while (get_outgoing_connections_count(zone.second) < conn_target
+            && make_expected_connections_count(zone.second, white, conn_target));
         }
         if(zone.second.m_net_server.is_stop_signal_sent())
           return false;
@@ -1812,7 +1821,9 @@ namespace nodetool
         conn_count = new_conn_count;
       }
 
-      if (start_conn_count == get_outgoing_connections_count(zone.second) && start_conn_count < zone.second.m_config.m_net_config.max_out_connection_count)
+      const bool sync_boost = zone.first == zone_type::public_ && !m_payload_handler.get_core().is_synchronized();
+      const size_t conn_target = zone.second.m_config.m_net_config.max_out_connection_count + (sync_boost ? m_out_peers_sync_boost : 0);
+      if (start_conn_count == get_outgoing_connections_count(zone.second) && start_conn_count < conn_target)
       {
         MINFO("Failed to connect to any, trying seeds");
         if (!connect_to_seed(zone.first))
@@ -2663,7 +2674,7 @@ namespace nodetool
       public_zone->second.m_config.m_net_config.max_out_connection_count = count;
       if(current > count)
         public_zone->second.m_net_server.get_config_object().del_out_connections(current - count);
-      m_payload_handler.set_max_out_peers(count);
+      m_payload_handler.set_max_out_peers(count, m_out_peers_sync_boost);
     }
   }
 


### PR DESCRIPTION
Defaults to 4 times the default number, can be overridden
with --out-peers-sync-boost