### PR TITLE
protocol: wait till we get blocks to update target height

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2560,9 +2560,6 @@ skip:
       return 1;
     }
 
-    if (arg.total_height > m_core.get_target_blockchain_height())
-      m_core.set_target_blockchain_height(arg.total_height);
-
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Some look-at-me is playing silly buggers and not sending data
after claiming they have that data.
This will only delay the set, but we'll soon have this hidden
behind a PoW check.