### PR TITLE
WIP - protocol: check first new block pow before accepting a new set of hashes

### DIFF
--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -35,6 +35,7 @@
 #include "net/net_utils_base.h"
 #include "copyable_atomic.h"
 #include "crypto/hash.h"
+#include "difficulty.h"
 
 namespace cryptonote
 {
@@ -44,7 +45,7 @@ namespace cryptonote
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
         m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
         m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0), m_anchor(false), m_score(0),
-        m_expect_response(0) {}
+        m_expect_response(0), m_expect_height(0), m_expect_hash(crypto::null_hash), m_expect_difficulty(0) {}
 
     enum state
     {
@@ -69,6 +70,9 @@ namespace cryptonote
     bool m_anchor;
     int32_t m_score;
     int m_expect_response;
+    uint64_t m_expect_height;
+    crypto::hash m_expect_hash;
+    cryptonote::difficulty_type m_expect_difficulty;
   };
 
   inline std::string get_protocol_state_string(cryptonote_connection_context::state s)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -699,13 +699,15 @@ crypto::hash Blockchain::get_tail_id() const
  *   powers of 2 less recent from there, so 13, 17, 25, etc...
  *
  */
-bool Blockchain::get_short_chain_history(std::list<crypto::hash>& ids) const
+bool Blockchain::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   uint64_t i = 0;
   uint64_t current_multiplier = 1;
-  uint64_t sz = m_db->height();
+  height = m_db->height();
+  uint64_t sz = height;
+  next_difficulty = get_difficulty_for_next_block();
 
   if(!sz)
     return true;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -400,10 +400,12 @@ namespace cryptonote
      *   powers of 2 less recent from there, so 13, 17, 25, etc...
      *
      * @param ids return-by-reference list to put the resulting hashes in
+     * @param height return-by-reference blockchain height
+     * @param next_difficulty return-by-reference the PoW difficulty the next block to be added has to meet
      *
      * @return true
      */
-    bool get_short_chain_history(std::list<crypto::hash>& ids) const;
+    bool get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty);
 
     /**
      * @brief get recent block hashes for a foreign chain

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -126,6 +126,10 @@ namespace cryptonote
     "sync-pruned-blocks"
   , "Allow syncing from nodes with only pruned blocks"
   };
+  const command_line::arg_descriptor<bool> arg_early_pow_sanity_check  = {
+    "early-pow-sanity-check"
+  , "Check first block pow when getting new block hashes from peers (requires peer support)"
+  };
 
   static const command_line::arg_descriptor<bool> arg_test_drop_download = {
     "test-drop-download"
@@ -341,6 +345,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_disable_dns_checkpoints);
     command_line::add_arg(desc, arg_block_download_max_size);
     command_line::add_arg(desc, arg_sync_pruned_blocks);
+    command_line::add_arg(desc, arg_early_pow_sanity_check);
     command_line::add_arg(desc, arg_max_txpool_weight);
     command_line::add_arg(desc, arg_block_notify);
     command_line::add_arg(desc, arg_prune_blockchain);
@@ -1678,9 +1683,9 @@ namespace cryptonote
     return m_mempool.get_pool_for_rpc(tx_infos, key_image_infos);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_short_chain_history(std::list<crypto::hash>& ids) const
+  bool core::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty)
   {
-    return m_blockchain_storage.get_short_chain_history(ids);
+    return m_blockchain_storage.get_short_chain_history(ids, height, next_difficulty);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NOTIFY_RESPONSE_GET_OBJECTS::request& rsp, cryptonote_connection_context& context)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -70,6 +70,7 @@ namespace cryptonote
   extern const command_line::arg_descriptor<bool> arg_offline;
   extern const command_line::arg_descriptor<size_t> arg_block_download_max_size;
   extern const command_line::arg_descriptor<bool> arg_sync_pruned_blocks;
+  extern const command_line::arg_descriptor<bool> arg_early_pow_sanity_check;
 
   /************************************************************************/
   /*                                                                      */
@@ -550,7 +551,7 @@ namespace cryptonote
       *
       * @note see Blockchain::get_short_chain_history
       */
-     bool get_short_chain_history(std::list<crypto::hash>& ids) const;
+     bool get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty);
 
      /**
       * @copydoc Blockchain::find_blockchain_supplement(const std::list<crypto::hash>&, NOTIFY_RESPONSE_CHAIN_ENTRY::request&) const

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -174,6 +174,7 @@ namespace cryptonote
     uint64_t m_sync_download_chain_size, m_sync_download_objects_size;
     size_t m_block_download_max_size;
     bool m_sync_pruned_blocks;
+    bool m_early_pow_sanity_check;
 
     // Values for sync time estimates
     boost::posix_time::ptime m_sync_start_time;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -69,7 +69,7 @@
 #define REQUEST_NEXT_SCHEDULED_SPAN_THRESHOLD_STANDBY (5 * 1000000) // microseconds
 #define REQUEST_NEXT_SCHEDULED_SPAN_THRESHOLD (30 * 1000000) // microseconds
 #define IDLE_PEER_KICK_TIME (240 * 1000000) // microseconds
-#define NON_RESPONSIVE_PEER_KICK_TIME (20 * 1000000) // microseconds
+#define NON_RESPONSIVE_PEER_KICK_TIME (60 * 1000000) // microseconds
 #define PASSIVE_PEER_KICK_TIME (60 * 1000000) // microseconds
 #define DROP_ON_SYNC_WEDGE_THRESHOLD (30 * 1000000000ull) // nanoseconds
 #define LAST_ACTIVITY_STALL_THRESHOLD (2.0f) // seconds
@@ -111,6 +111,7 @@ namespace cryptonote
 
     m_block_download_max_size = command_line::get_arg(vm, cryptonote::arg_block_download_max_size);
     m_sync_pruned_blocks = command_line::get_arg(vm, cryptonote::arg_sync_pruned_blocks);
+    m_early_pow_sanity_check = command_line::get_arg(vm, cryptonote::arg_early_pow_sanity_check);
 
     return true;
   }
@@ -141,7 +142,8 @@ namespace cryptonote
     {
       NOTIFY_REQUEST_CHAIN::request r = {};
       context.m_needed_objects.clear();
-      m_core.get_short_chain_history(r.block_ids);
+      m_core.get_short_chain_history(r.block_ids, context.m_expect_height, context.m_expect_difficulty);
+      context.m_expect_hash = r.block_ids.front();
       handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
       r.prune = m_sync_pruned_blocks;
       context.m_last_request_time = boost::posix_time::microsec_clock::universal_time();
@@ -493,7 +495,8 @@ namespace cryptonote
       context.m_needed_objects.clear();
       context.m_state = cryptonote_connection_context::state_synchronizing;
       NOTIFY_REQUEST_CHAIN::request r = {};
-      m_core.get_short_chain_history(r.block_ids);
+      m_core.get_short_chain_history(r.block_ids, context.m_expect_height, context.m_expect_difficulty);
+      context.m_expect_hash = r.block_ids.front();
       r.prune = m_sync_pruned_blocks;
       handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
       context.m_last_request_time = boost::posix_time::microsec_clock::universal_time();
@@ -773,7 +776,8 @@ namespace cryptonote
           context.m_needed_objects.clear();
           context.m_state = cryptonote_connection_context::state_synchronizing;
           NOTIFY_REQUEST_CHAIN::request r = {};
-          m_core.get_short_chain_history(r.block_ids);
+          m_core.get_short_chain_history(r.block_ids, context.m_expect_height, context.m_expect_difficulty);
+          context.m_expect_hash = r.block_ids.front();
           handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
           r.prune = m_sync_pruned_blocks;
           context.m_last_request_time = boost::posix_time::microsec_clock::universal_time();
@@ -2331,14 +2335,20 @@ skip:
     {//we have to fetch more objects ids, request blockchain entry
 
       NOTIFY_REQUEST_CHAIN::request r = {};
-      m_core.get_short_chain_history(r.block_ids);
+      m_core.get_short_chain_history(r.block_ids, context.m_expect_height, context.m_expect_difficulty);
+      context.m_expect_hash = r.block_ids.front();
       CHECK_AND_ASSERT_MES(!r.block_ids.empty(), false, "Short chain history is empty");
 
       if (!start_from_current_chain)
       {
         // we'll want to start off from where we are on that peer, which may not be added yet
         if (context.m_last_known_hash != crypto::null_hash && r.block_ids.front() != context.m_last_known_hash)
+        {
+          context.m_expect_height = std::numeric_limits<uint64_t>::max();
+          context.m_expect_difficulty = 0;
+          context.m_expect_hash = context.m_last_known_hash;
           r.block_ids.push_front(context.m_last_known_hash);
+        }
       }
 
       handler_request_blocks_history( r.block_ids ); // change the limit(?), sleep(?)
@@ -2480,18 +2490,30 @@ skip:
       return 1;
     }
     context.m_expect_response = 0;
+    if (arg.start_height + 1 > context.m_expect_height) // we expect to get one overlapping hash
+    {
+      LOG_ERROR_CCONTEXT("Got NOTIFY_RESPONSE_CHAIN_ENTRY past expected height, dropping connection (expected " << context.m_expect_height << ", got " << arg.start_height + 1 << ")");
+      drop_connection_with_score(context, 5, false);
+      return 1;
+    }
 
     context.m_last_request_time = boost::date_time::not_a_date_time;
 
     m_sync_download_chain_size += arg.m_block_ids.size() * sizeof(crypto::hash);
+    m_sync_download_chain_size += arg.first_block.size();
 
-    if(!arg.m_block_ids.size())
+    if(arg.m_block_ids.empty())
     {
       LOG_ERROR_CCONTEXT("sent empty m_block_ids, dropping connection");
       drop_connection(context, true, false);
       return 1;
     }
-    if (arg.total_height < arg.m_block_ids.size() || arg.start_height > arg.total_height - arg.m_block_ids.size() || arg.start_height >= m_core.get_current_blockchain_height())
+    if(arg.m_block_ids.size() == 1)
+    {
+      MDEBUG(context << "Got 1 element chain, ignored");
+      return 1;
+    }
+    if (arg.total_height < arg.m_block_ids.size() || arg.start_height > arg.total_height - arg.m_block_ids.size())
     {
       LOG_ERROR_CCONTEXT("sent invalid start/nblocks/height, dropping connection");
       drop_connection(context, true, false);
@@ -2504,6 +2526,24 @@ skip:
       return 1;
     }
     MDEBUG(context << "first block hash " << arg.m_block_ids.front() << ", last " << arg.m_block_ids.back());
+
+    if (arg.m_block_ids.front() != context.m_expect_hash)
+    {
+      FAILCONNMSG(context, "Chain entry does not start with the expected hash, dropping connection");
+      drop_connection(context, true, false);
+      return 1;
+    }
+
+    std::unordered_set<crypto::hash> hashes;
+    for (const auto &h: arg.m_block_ids)
+    {
+      if (!hashes.insert(h).second)
+      {
+        FAILCONNMSG(context, "sent duplicate block, dropping connection");
+        drop_connection(context, true, false);
+        return 1;
+      }
+    }
 
     if (arg.total_height >= CRYPTONOTE_MAX_BLOCK_NUMBER || arg.m_block_ids.size() > BLOCKS_IDS_SYNCHRONIZING_MAX_COUNT)
     {
@@ -2552,6 +2592,51 @@ skip:
         break;
     }
     context.m_last_response_height -= arg.m_block_ids.size() - n_use_blocks;
+
+    if (m_early_pow_sanity_check && arg.first_block.empty())
+    {
+      LOG_ERROR_CCONTEXT("First block in chain entry is empty, dropping connection");
+      drop_connection(context, false, false);
+      return 1;
+    }
+
+    if (!arg.first_block.empty() && context.m_expect_difficulty != 0)
+    {
+      cryptonote::block b;
+      if (!cryptonote::parse_and_validate_block_from_blob(arg.first_block, b))
+      {
+        LOG_ERROR_CCONTEXT("Failed to parse first block in chain entry, dropping connection");
+        drop_connection_with_score(context, 5, false);
+        return 1;
+      }
+      const crypto::hash block_hash = cryptonote::get_block_hash(b);
+      if (block_hash != arg.m_block_ids[1])
+      {
+        LOG_ERROR_CCONTEXT("First block hash in chain entry does not match block data, dropping connection");
+        drop_connection_with_score(context, 5, false);
+        return 1;
+      }
+      if (b.prev_id != arg.m_block_ids[0])
+      {
+        LOG_ERROR_CCONTEXT("First block prev id in chain entry does not match first block hash, dropping connection");
+        drop_connection_with_score(context, 5, false);
+        return 1;
+      }
+      crypto::hash pow;
+      // see if we can avoid a blockchain lookup for the seed hash, this can lock for a long time when in sync mode
+      if (!cryptonote::get_block_longhash(&m_core.get_blockchain_storage(), b, pow, arg.start_height, 0))
+      {
+        LOG_ERROR_CCONTEXT("Failed to calculate PoW hash of first block in chain entry, dropping connection");
+        drop_connection(context, true, false);
+        return 1;
+      }
+      if (!cryptonote::check_hash(pow, context.m_expect_difficulty))
+      {
+        LOG_ERROR_CCONTEXT("First block PoW does not meet expected difficulty, dropping connection");
+        drop_connection_with_score(context, 5, false);
+        return 1;
+      }
+    }
 
     if (!request_missing_objects(context, false))
     {

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -228,8 +228,8 @@ bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_
     return true;
 }
 
-bool tests::proxy_core::get_short_chain_history(std::list<crypto::hash>& ids) {
-    build_short_history(ids, m_lastblk);
+bool tests::proxy_core::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty) {
+    build_short_history(ids, m_lastblk, height, next_difficulty);
     return true;
 }
 
@@ -251,8 +251,10 @@ bool tests::proxy_core::have_block(const crypto::hash& id) {
     return true;
 }
 
-void tests::proxy_core::build_short_history(std::list<crypto::hash> &m_history, const crypto::hash &m_start) {
+void tests::proxy_core::build_short_history(std::list<crypto::hash> &m_history, const crypto::hash &m_start, uint64_t &height, cryptonote::difficulty_type &next_difficulty) {
     m_history.push_front(get_block_hash(m_genesis));
+    height = 0;
+    next_difficulty = 1;
     /*std::unordered_map<crypto::hash, tests::block_index>::const_iterator cit = m_hash2blkidx.find(m_lastblk);
 
     do {

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -62,7 +62,7 @@ namespace tests
       std::list<cryptonote::transaction> txes;
 
       bool add_block(const crypto::hash &_id, const crypto::hash &_longhash, const cryptonote::block &_blk, const cryptonote::blobdata &_blob);
-      void build_short_history(std::list<crypto::hash> &m_history, const crypto::hash &m_start);
+      void build_short_history(std::list<crypto::hash> &m_history, const crypto::hash &m_start, uint64_t &height, cryptonote::difficulty_type &next_difficulty);
       
 
   public:
@@ -73,7 +73,7 @@ namespace tests
     void set_target_blockchain_height(uint64_t) {}
     bool init(const boost::program_options::variables_map& vm);
     bool deinit(){return true;}
-    bool get_short_chain_history(std::list<crypto::hash>& ids);
+    bool get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty);
     bool have_block(const crypto::hash& id);
     void get_blockchain_top(uint64_t& height, crypto::hash& top_id);
     bool handle_incoming_tx(const cryptonote::tx_blob_entry& tx_blob, cryptonote::tx_verification_context& tvc, cryptonote::relay_method tx_relay, bool relayed);

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -41,7 +41,7 @@
 #define MAKE_IPV4_SUBNET(a,b,c,d,e) epee::net_utils::ipv4_network_subnet{MAKE_IP(a,b,c,d),e}
 
 namespace cryptonote {
-  class blockchain_storage;
+  class Blockchain;
 }
 
 class test_core : public cryptonote::i_core_events
@@ -54,7 +54,7 @@ public:
   void set_target_blockchain_height(uint64_t) {}
   bool init(const boost::program_options::variables_map& vm) {return true ;}
   bool deinit(){return true;}
-  bool get_short_chain_history(std::list<crypto::hash>& ids) const { return true; }
+  bool get_short_chain_history(std::list<crypto::hash>& ids, uint64_t &height, cryptonote::difficulty_type &next_difficulty) const { height = 1; next_difficulty = 1; return true; }
   bool have_block(const crypto::hash& id) const {return true;}
   void get_blockchain_top(uint64_t& height, crypto::hash& top_id)const{height=0;top_id=crypto::null_hash;}
   bool handle_incoming_tx(const cryptonote::tx_blob_entry& tx_blob, cryptonote::tx_verification_context& tvc, cryptonote::relay_method tx_relay, bool relayed) { return true; }
@@ -65,7 +65,7 @@ public:
   bool on_idle(){return true;}
   bool find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp){return true;}
   bool handle_get_objects(cryptonote::NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote::NOTIFY_RESPONSE_GET_OBJECTS::request& rsp, cryptonote::cryptonote_connection_context& context){return true;}
-  cryptonote::blockchain_storage &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class test_core."); }
+  cryptonote::Blockchain &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class test_core."); }
   bool get_test_drop_download() const {return true;}
   bool get_test_drop_download_height() const {return true;}
   bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks) { return true; }


### PR DESCRIPTION
This means an extra PoW call per peer per ~9k blocks in sync mode.
It also means we can relax the timeout for non responsive peers, since
this should make it a lot harder to lie about new blocks.

NOT READY yet, just here to show how #7130 is meant to be used.