### PR TITLE
Fix byte_stream::put_n [0.17]

### DIFF
--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -188,7 +188,7 @@ namespace epee
     void put_n(const std::uint8_t ch, const std::size_t count)
     {
       check(count);
-      std::memset(tellp(), count, ch);
+      std::memset(tellp(), ch, count);
       next_write_ += count;
     }
 

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -972,6 +972,23 @@ TEST(ByteStream, Put)
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 }
 
+TEST(ByteStream, PutN)
+{
+  using boost::range::equal;
+  using byte_span = epee::span<const std::uint8_t>;
+
+  std::vector<std::uint8_t> bytes;
+  bytes.resize(1000, 'f');
+
+  epee::byte_stream stream;
+  stream.put_n('f', 1000);
+
+  EXPECT_EQ(1000u, stream.size());
+  EXPECT_LE(1000u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+}
+
 TEST(ByteStream, Reserve)
 {
   using boost::range::equal;


### PR DESCRIPTION
Same as #7151 but on release branch. This shouldn't affect any release code, but the change is simple and prevents mistakes from possible future modifications to release branch.