### PR TITLE
Multihost parallel compilation via USE_ICECC=ON or release-all-icecc …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,14 @@ endif()
 cmake_minimum_required(VERSION 3.5)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
+option (USE_ICECC "Use icecc/icecream if a usable instance is found" OFF) # Off by default, since it influences the CPU architecture
+if (USE_ICECC)
+	include(FindIcecream) # Has to be called before project() macro to preset the C and CXX vars.
+	set(ARCH "default") # The top condition for icecream to work is to compile a generic binary.
+else()
+	message(STATUS "icecc deselected")
+endif()
+
 project(monero)
 
 option (USE_CCACHE "Use ccache if a usable instance is found" ON)
@@ -54,6 +62,7 @@ if (USE_CCACHE)
 else()
 	message(STATUS "ccache deselected")
 endif()
+
 option (USE_COMPILATION_TIME_PROFILER "Use compilation time profiler (for CLang >= 9 only)" OFF)
 if (USE_COMPILATION_TIME_PROFILER)
 	if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ debug-all:
 	mkdir -p $(builddir)/debug
 	cd $(builddir)/debug && cmake -D BUILD_TESTS=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Debug $(topdir) && $(MAKE)
 
+debug-all-icecc:
+	mkdir -p $(builddir)/debug
+	cd $(builddir)/debug && cmake -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=debug -D USE_ICECC=ON -D BUILD_SHARED_LIBS=ON $(topdir) && $(MAKE) -j25
+
 debug-static-all:
 	mkdir -p $(builddir)/debug
 	cd $(builddir)/debug && cmake -D BUILD_TESTS=ON -D STATIC=ON -D CMAKE_BUILD_TYPE=Debug $(topdir) && $(MAKE)
@@ -101,6 +105,11 @@ release-test:
 release-all:
 	mkdir -p $(builddir)/release
 	cd $(builddir)/release && cmake -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release $(topdir) && $(MAKE)
+
+release-all-icecc:
+	mkdir -p $(builddir)/release
+	cd $(builddir)/release && cmake -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release -D USE_ICECC=ON -D BUILD_SHARED_LIBS=ON $(topdir) && $(MAKE) -j25
+
 
 release-static:
 	mkdir -p $(builddir)/release

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ library archives (`.a`).
 | expat        | 1.1           | NO       | `libexpat1-dev`      | `expat`      | `expat-devel`      | `expat-devel`       | YES      | XML parsing     |
 | GTest        | 1.5           | YES      | `libgtest-dev`[1]    | `gtest`      | `gtest-devel`      | `gtest-devel`       | YES      | Test suite      |
 | ccache       | any           | NO       | `ccache`             | `ccache`     | `ccache`           | `ccache`            | YES      | Compil. cache   |
+| icecc        | any           | NO       | `icecc`              | `icecream`   |                    | `icecream`          | YES      | Distrib. compil. |
+| icemon       | any           | NO       | `icecc-monitor`      | `icemon`     |                    | `icemon`            | YES      | Distrib. compil. GUI |
 | Doxygen      | any           | NO       | `doxygen`            | `doxygen`    | `doxygen`          | `doxygen`           | YES      | Documentation   |
 | Graphviz     | any           | NO       | `graphviz`           | `graphviz`   | `graphviz`         | `graphviz`          | YES      | Documentation   |
 | lrelease     | ?             | NO       | `qttools5-dev-tools` | `qt5-tools`  | `qt5-tools`        | `qt5-linguist`      | YES      | Translations    |
@@ -284,6 +286,40 @@ Dependencies need to be built with -fPIC. Static libraries usually aren't, so yo
     ```bash
     sudo apt install ccache
     ```
+
+* **Optional**: use icecream/icecc to spread compilation across as many hosts as are avaliable in your LAN (only), with icecream daemon running. On all your slave hosts install:
+
+    ```bash
+    sudo apt install icecc
+    ```
+
+    On your GUI machine additionally install an optional monitor and execute it:
+
+    ```bash
+    sudo apt install icecc icecc-monitor
+    icemon &
+    ```
+
+    On one of the slaves, which acts as a server, start the scheduler (Debian example):
+
+    ```bash
+    sudo /etc/init.d/icecc-scheduler start
+    ```
+
+    Your monitor should soon discover the hosts in your LAN. Please consult your distro's manual how to start a service (icecc-scheduler) at startup. It's recommended to adjust the number of accepted jobs on each slave to the amount of RAM, and to the heat tolerance. For instance to make a low-end laptop accept just one job at a time, please alter the variable `ICECC_MAX_JOBS` to `"1"` in `/etc/icecc/icecc.conf`. The below command will automatically find and use icecream. Note however, that it's only possible to build a generic binary this way.
+
+    ```bash
+    make release-all-icecc
+    ```
+
+    If you require more customisation via cmake, the following flags need to be set, in order to use iceccream (Monero specific):
+
+    ```bash
+    cmake -DUSE_ICECC=ON -DARCH="default" (...)
+    make -j25
+    ```
+
+    More icecream documentation on [Github](https://github.com/icecc/icecream), and [Mozilla.org](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Using_Icecream).
 
 #### On the Raspberry Pi
 

--- a/cmake/FindIcecream.cmake
+++ b/cmake/FindIcecream.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2014-2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Automatically uses icecream network compiler, if it's found, else aborts.
+#
+# Usage of this module as follows:
+#
+#     include(FindIcecream) # Include before project() macro to preset the C and CXX vars
+#     project(monero)
+#
+# Properties modified by this module:
+#
+#  CMAKE_C_COMPILER     set to ICECC_C_COMPILER,   if compilation with icecc succeeds
+#  CMAKE_CXX_COMPILER   set to ICECC_CXX_COMPILER, if compilation with icecc succeeds
+
+find_program(ICECC_FOUND icecc)
+if (ICECC_FOUND)
+	set(ICECC_C_COMPILER   /usr/lib/icecc/bin/cc  ) # Typical installation dir
+	set(ICECC_CXX_COMPILER /usr/lib/icecc/bin/c++ )
+	# Try to compile a test program with icecc, in order to verify if it really works.
+	# Create a temporary file with a simple program.
+	set(TEMP_CPP_FILE "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/CMakeTmp/test-program.cpp")
+	file(WRITE "${TEMP_CPP_FILE}" "int main() { return 0; }")
+	# And run the found ccache on it.
+	execute_process(COMMAND "${ICECC_CXX_COMPILER}" "${TEMP_CPP_FILE}"  RESULT_VARIABLE RET)
+	if (${RET} EQUAL 0)
+		# Success
+		message(STATUS "Found usable icecc: ${ICECC_CXX_COMPILER}")
+		set(CMAKE_C_COMPILER   "${ICECC_C_COMPILER}")
+		set(CMAKE_CXX_COMPILER "${ICECC_CXX_COMPILER}")
+	else()
+		message(FATAL_ERROR "Found icecc ${ICECC_CXX_COMPILER}, but is UNUSABLE! Return code: ${RET}")
+	endif()
+else()
+	message(FATAL_ERROR "icecc NOT found! Please install it for parallel builds. sudo apt install icecc icecc-monitor")
+endif()
+


### PR DESCRIPTION
…or debug-all-icecc

Build time without icecream: real	27m10s
Build time with icecream     : real	8m35s
Almost 70% decrease of build time on my network.

YMMV depending on how many hosts you have in your network.
Distributing the compilation across many nodes gives an additional benefit of distributing the heat evenly. Your CPU will live longer.

To use icecream please install on the host machine the icecc and icecc-monitor (for fun), and on all nodes in your LAN, only the icecc package.
One of the nodes has to have a scheduler running. Please put into your `/etc/rc.local` the line : `icecc-scheduler -d` and `sudo chmod +x /etc/rc.local` All the nodes in your LAN should be able to automatically find the scheduler.
The command which starts the icecream monitor (as on the picture below) is:
```
icemon
```

![icecc](https://user-images.githubusercontent.com/63722585/102454192-e723d500-403d-11eb-98b5-f780a3122e44.png)


The official docu is here:
https://github.com/icecc/icecream
This documentation is also a prominent one:
https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Using_Icecream

In short, this is a LAN-distributed (dynamically) compilation scheduler. It plays nicely with ccache.
I will write more documentation of my new stuff this Christmas, taking into account Monero's specifics.

This PR doesn't affect the CI in its current setup, as the only 2 (new) targets, which preset the icecream are: release-all-icecc and debug-all-icecc. They are not called by the CI.