### PR TITLE
[CI] Fix MacOSX ccache by caching the right directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         submodules: recursive
     - uses: actions/cache@v2
       with:
-        path: ~/.ccache
+        path: /Users/runner/Library/Caches/ccache
         key: ccache-macos-build-${{ github.sha }}
         restore-keys: ccache-macos-build-
     - name: install dependencies


### PR DESCRIPTION
For MacOSX the right directory of ccache for storing and restoring is:
`/Users/runner/Library/Caches/ccache`

In the current setup, the directory ~/.ccache does Not default to the above directory.