### PR TITLE
Fix conditional __AFL_LOOP function definition

### DIFF
--- a/tests/fuzz/fuzzer.cpp
+++ b/tests/fuzz/fuzzer.cpp
@@ -35,7 +35,7 @@
 
 #ifndef OSSFUZZ
 
-#if (!defined(__clang__) || (__clang__ < 5))
+#ifndef __AFL_LOOP
 static int __AFL_LOOP(int)
 {
   static int once = 0;


### PR DESCRIPTION
`__AFL_LOOP` function name conflicts with macro definition in `AFL`/`AFLPlusPlus`.

Resolves #7230