### PR TITLE
Header row for peer list in sync_info

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2275,6 +2275,7 @@ bool t_rpc_command_executor::sync_info()
       tools::success_msg_writer() << "Next needed pruning seed: " << res.next_needed_pruning_seed;
 
     tools::success_msg_writer() << std::to_string(res.peers.size()) << " peers";
+    tools::success_msg_writer() << "Remote Host                        Peer_ID   State   Prune_Seed          Height  DL kB/s, Queued Blocks / MB";
     for (const auto &p: res.peers)
     {
       std::string address = epee::string_tools::pad_string(p.info.address, 24);


### PR DESCRIPTION

I could never remember what exactly all the columns in `sync_info` were, so I added a header row to the banner.
There it is, the most trivial PR you'll see all day.
Happy New Year!

![sync-info-header](https://user-images.githubusercontent.com/19517339/103403044-da62af00-4b1c-11eb-9e99-5e97da92a705.png)
