### PR TITLE
Avoid -march=native when reproducible builds are wanted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LOWER)
 # when ARCH is not set to an explicit identifier, cmake's builtin is used
 # to identify the target architecture, to direct logic in this cmake script.
 # Since ARCH is a cached variable, it will not be set on first cmake invocation.
+
+if (NOT ARCH AND DEFINED ENV{SOURCE_DATE_EPOCH})
+  set(ARCH "default")
+endif()
 if (NOT ARCH_ID)
 if (NOT ARCH OR ARCH STREQUAL "" OR ARCH STREQUAL "native" OR ARCH STREQUAL "default")
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "")


### PR DESCRIPTION
Distribution builds that intend to have verifiable binaries, set the `SOURCE_DATE_EPOCH` variable.
Those builds should not default to `-march=native` so that verification builds can produce bit-identical results on other CPUs of the same architecture.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).

Note: this is tested a bit, but might have room for improvement.