### PR TITLE
Restrict duplicate keys in epee binary format [0.17]

### DIFF
--- a/contrib/epee/include/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/storages/portable_storage_from_bin.h
@@ -295,7 +295,9 @@ namespace epee
         //read section name string
         std::string sec_name;
         read_sec_name(sec_name);
-        sec.m_entries.emplace(std::move(sec_name), load_storage_entry());
+        const auto insert_loc = sec.m_entries.lower_bound(sec_name);
+        CHECK_AND_ASSERT_THROW_MES(insert_loc == sec.m_entries.end() || insert_loc->first != sec_name, "duplicate key: " << sec_name);
+        sec.m_entries.emplace_hint(insert_loc, std::move(sec_name), load_storage_entry());
       }
     }
     inline 


### PR DESCRIPTION
Duplicate keys are no longer silently ignored. The default output/serializer never generates duplicate keys. Unit tests passed locally (several tests use this code).

Eventually I'll add a test specific for this. Looking for responses, etc.