### PR TITLE
p2p: ignore empty IP from DNS block list

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2014,6 +2014,8 @@ namespace nodetool
       boost::split(ips, record, boost::is_any_of(";"));
       for (const auto &ip: ips)
       {
+        if (ip.empty())
+          continue;
         const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(ip, 0);
         if (!parsed_addr)
         {


### PR DESCRIPTION
ie, if the list ends in ;