### PR TITLE
Only INFO log for short seed words with ALLOW_SHORT_WORDS active

### DIFF
--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -129,7 +129,7 @@ namespace Language
         if ((*it).size() < unique_prefix_length)
         {
           if (flags & ALLOW_SHORT_WORDS)
-            MWARNING(language_name << " word '" << *it << "' is shorter than its prefix length, " << unique_prefix_length);
+            MINFO(language_name << " word '" << *it << "' is shorter than its prefix length, " << unique_prefix_length);
           else
             throw std::runtime_error("Too short word in " + language_name + " word list: " + *it);
         }


### PR DESCRIPTION
Prevents those unnecessary 30+ log lines about 3-letter seed words for Spanish that are too short because prefix length for Spanish is 4 in general, e.g. when using `monero-wallet-rpc` and creating a new wallet: If a language sets the flag `ALLOW_SHORT_WORDS` this is not worth a warning.