### PR TITLE
epee: also limit number of strings in portable_storage

### DIFF
--- a/contrib/epee/include/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/storages/portable_storage_from_bin.h
@@ -38,7 +38,8 @@
 #define EPEE_PORTABLE_STORAGE_RECURSION_LIMIT_INTERNAL 100
 #endif
 #define EPEE_PORTABLE_STORAGE_OBJECT_LIMIT_INTERNAL 65536
-#define EPEE_PORTABLE_STORAGE_OBJECT_FIELD_LIMIT_INTERNAL 262144
+#define EPEE_PORTABLE_STORAGE_OBJECT_FIELD_LIMIT_INTERNAL 65536
+#define EPEE_PORTABLE_STORAGE_STRING_LIMIT_INTERNAL 65536 // does not include field names
 
 namespace epee
 {
@@ -106,6 +107,7 @@ namespace epee
       size_t m_recursion_count;
       size_t m_objects;
       size_t m_fields;
+      size_t m_strings;
     };
 
     inline throwable_buffer_reader::throwable_buffer_reader(const void* ptr, size_t sz)
@@ -119,6 +121,7 @@ namespace epee
       m_recursion_count = 0;
       m_objects = 0;
       m_fields = 0;
+      m_strings = 0;
     }
     inline 
     void throwable_buffer_reader::read(void* target, size_t count)
@@ -171,6 +174,11 @@ namespace epee
       {
         CHECK_AND_ASSERT_THROW_MES(size <= EPEE_PORTABLE_STORAGE_OBJECT_LIMIT_INTERNAL - m_objects, "Too many objects");
         m_objects += size;
+      }
+      else if (std::is_same<type_name, std::string>())
+      {
+        CHECK_AND_ASSERT_THROW_MES(size <= EPEE_PORTABLE_STORAGE_STRING_LIMIT_INTERNAL - m_strings, "Too many strings");
+        m_strings += size;
       }
 
       sa.reserve(size);
@@ -238,6 +246,8 @@ namespace epee
     inline storage_entry throwable_buffer_reader::read_se<std::string>()
     {
       RECURSION_LIMITATION();
+      CHECK_AND_ASSERT_THROW_MES(m_strings + 1 <= EPEE_PORTABLE_STORAGE_STRING_LIMIT_INTERNAL, "Too many strings");
+      m_strings += 1;
       return storage_entry(read<std::string>());
     }
 


### PR DESCRIPTION
They require at least 24 bytes