### PR TITLE
blockchain: return empty chain hashes if the start is pruned

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2662,7 +2662,10 @@ bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qbloc
     if (start_height < tools::get_next_unpruned_block_height(start_height, current_height, pruning_seed))
     {
       MDEBUG("We only have a pruned version of the common ancestor");
-      return false;
+      hashes.push_back(m_db->get_block_hash_from_height(start_height));
+      if (weights)
+        weights->push_back(m_db->get_block_weight(start_height));
+      return true;
     }
     stop_height = tools::get_next_pruned_block_height(start_height, current_height, pruning_seed);
   }


### PR DESCRIPTION
This will still cause the peer to drop us since we're probably
no use to it, but this will happen without the peer having to wait
for a timeout first