### PR TITLE
Add test for string emptiness before wiping in http_base

### DIFF
--- a/contrib/epee/include/net/http_base.h
+++ b/contrib/epee/include/net/http_base.h
@@ -204,7 +204,8 @@ namespace net_utils
 
 			void wipe()
 			{
-				memwipe(&m_body[0], m_body.size());
+				if (!m_body.empty())
+					memwipe(&m_body[0], m_body.size());
 			}
 		};
 	}


### PR DESCRIPTION
As discussed in issue https://github.com/monero-project/monero-gui/issues/3296 it is safer to check for string emptiness before wiping it. 