### PR TITLE
build: omit '-pie' linker flag in native non static WIN32 GCC builds 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,9 +714,10 @@ else()
   endif()
 
   # linker
-  if (NOT SANITIZE AND NOT OSSFUZZ AND NOT (WIN32 AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1)))
+  if (NOT SANITIZE AND NOT OSSFUZZ AND NOT (WIN32 AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1 OR NOT STATIC))))
     # PIE executables randomly crash at startup with ASAN
     # Windows binaries die on startup with PIE when compiled with GCC <9.x
+    # Windows dynamically-linked binaries die on startup with PIE regardless of GCC version
     add_linker_flag_if_supported(-pie LD_SECURITY_FLAGS)
   endif()
   add_linker_flag_if_supported(-Wl,-z,relro LD_SECURITY_FLAGS)


### PR DESCRIPTION
Even tested GCC 10.2, Windows binaries still die on startup with PIE enabled.