### PR TITLE
Convert expect<T> to boost::system::error_code

### DIFF
--- a/src/common/error.h
+++ b/src/common/error.h
@@ -26,27 +26,37 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <system_error>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 #include <type_traits>
 
-enum class common_error : int
-{
-    // 0 is reserved for no error, as per expect<T>
-    kInvalidArgument = 1, //!< A function argument is invalid
-    kInvalidErrorCode     //!< Default `std::error_code` given to `expect<T>`
-};
+#define MONERO_DECLARE_ERROR_ENUM(name)         \
+    namespace boost {                           \
+        namespace system {                      \
+            template<>                          \
+            struct is_error_code_enum< name >   \
+                : std::true_type                \
+            {};                                 \
+        }                                       \
+    }
 
-std::error_category const& common_category() noexcept;
-
-inline std::error_code make_error_code(::common_error value) noexcept
+namespace monero
 {
-    return std::error_code{int(value), common_category()};
+    namespace errc = boost::system::errc;
+    using error_category = boost::system::error_category;
+    using error_code = boost::system::error_code;
+    using error_condition = boost::system::error_condition;
+    using system_error = boost::system::system_error;
+
+    enum class error : int
+    {
+        none = 0,
+        invalid_argument,  //!< A function argument is invalid
+        invalid_error_code //!< Default `monero::error_code` given to `expect<T>`
+    };
+
+    error_category const& default_category() noexcept;
+    error_code make_error_code(monero::error value) noexcept;
 }
 
-namespace std
-{
-    template<>
-    struct is_error_code_enum<::common_error>
-      : true_type
-    {};
-}
+MONERO_DECLARE_ERROR_ENUM(monero::error)

--- a/src/common/expect.cpp
+++ b/src/common/expect.cpp
@@ -61,10 +61,10 @@ namespace detail
         }
     }
 
-    void expect::throw_(std::error_code ec, const char* msg, const char* file, unsigned line)
+    void expect::throw_(monero::error_code ec, const char* msg, const char* file, unsigned line)
     {
         if (msg || file)
-            throw std::system_error{ec, generate_error(msg, file, line)};
-        throw std::system_error{ec};
+            throw monero::system_error{ec, generate_error(msg, file, line)};
+        throw monero::system_error{ec};
     }
 } // detail

--- a/src/lmdb/error.h
+++ b/src/lmdb/error.h
@@ -26,8 +26,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <system_error>
-#include <type_traits>
+#include "common/error.h"
 
 //! Executes a LMDB command, and returns errors via `lmdb::error` enum.
 #define MONERO_LMDB_CHECK(...)         \
@@ -47,18 +46,8 @@ namespace lmdb
         // All other errors are the values reported by LMDB
     };
 
-    std::error_category const& error_category() noexcept;
-
-    inline std::error_code make_error_code(error value) noexcept
-    {
-        return std::error_code{int(value), error_category()};
-    }
+    monero::error_category const& error_category() noexcept;
+    monero::error_code make_error_code(error value) noexcept;
 }
 
-namespace std
-{
-    template<>
-    struct is_error_code_enum<::lmdb::error>
-      : true_type
-    {};
-}
+MONERO_DECLARE_ERROR_ENUM(lmdb::error)

--- a/src/lmdb/key_stream.h
+++ b/src/lmdb/key_stream.h
@@ -80,7 +80,7 @@ namespace lmdb
 
         /*!
             \param cur Iterate over keys starting at this cursor position.
-            \throw std::system_error if unexpected LMDB error. This can happen
+            \throw monero::system_error if unexpected LMDB error. This can happen
                 if `cur` is invalid.
         */
         key_iterator(MDB_cursor* cur)
@@ -148,7 +148,7 @@ namespace lmdb
             object - the other fields in the struct `account` are never copied
             from the database.
 
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return C++ iterator starting at current cursor position.
         */
         template<typename T = V, typename F = T, std::size_t offset = 0>
@@ -166,7 +166,7 @@ namespace lmdb
             will return a range of `decltype(account.id)` objects - the other
             fields in the struct `account` are never copied from the database.
 
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return An InputIterator range over values at cursor position.
         */
         template<typename T = V, typename F = T, std::size_t offset = 0>
@@ -227,7 +227,7 @@ namespace lmdb
         }
 
         /*!
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return C++ iterator over database keys from current cursor
                 position that will reach `.is_end()` after the last key.
         */
@@ -237,7 +237,7 @@ namespace lmdb
         }
 
         /*!
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return Range from current cursor position until last key record.
                 Useful in for-each range loops or in templated code
         */

--- a/src/lmdb/value_stream.h
+++ b/src/lmdb/value_stream.h
@@ -40,7 +40,7 @@ namespace lmdb
     namespace stream
     {
         /*
-            \throw std::system_error if unexpected LMDB error.
+            \throw monero::system_error if unexpected LMDB error.
             \return 0 if `cur == nullptr`, otherwise count of values at current key.
         */
         mdb_size_t count(MDB_cursor* cur);
@@ -53,9 +53,9 @@ namespace lmdb
             \param key expected key size or 0 to skip key size check.
             \param value expected value size or 0 to skip value size check.
 
-            \throw std::system_error if `key != 0` and `key_.mv_size != key`.
-            \throw std::system_error if `value != 0` and `value_.mv_size != value`.
-            \throw std::system_error if `mdb_cursor_get` returns any error
+            \throw monero::system_error if `key != 0` and `key_.mv_size != key`.
+            \throw monero::system_error if `value != 0` and `value_.mv_size != value`.
+            \throw monero::system_error if `mdb_cursor_get` returns any error
                 other than `MDB_NOTFOUND`.
 
             \return {key bytes, value bytes} or two empty spans if `MDB_NOTFOUND`.
@@ -105,7 +105,7 @@ namespace lmdb
 
         /*!
             \param cur Iterate over values starting at this cursor position.
-            \throw std::system_error if unexpected LMDB error. This can happen
+            \throw monero::system_error if unexpected LMDB error. This can happen
                 if `cur` is invalid.
         */
         value_iterator(MDB_cursor* cur)
@@ -224,7 +224,7 @@ namespace lmdb
         }
 
         /*!
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return Number of values at this key.
         */
         std::size_t count() const
@@ -242,7 +242,7 @@ namespace lmdb
             object - the other fields in the struct `account` are never copied
             from the database.
 
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return C++ iterator starting at current cursor position.
         */
         template<typename U = T, typename F = U, std::size_t offset = 0>
@@ -260,7 +260,7 @@ namespace lmdb
             will return a range of `decltype(account.id)` objects - the other
             fields in the struct `account` are never copied from the database.
 
-            \throw std::system_error if LMDB has unexpected errors.
+            \throw monero::system_error if LMDB has unexpected errors.
             \return An InputIterator range over values at cursor position.
         */
         template<typename U = T, typename F = U, std::size_t offset = 0>

--- a/src/net/dandelionpp.cpp
+++ b/src/net/dandelionpp.cpp
@@ -107,7 +107,7 @@ namespace dandelionpp
     {
         // max value is used by `select_stem` as error case
         if (stems == std::numeric_limits<std::size_t>::max())
-            MONERO_THROW(common_error::kInvalidArgument, "stems value cannot be max size_t");
+            MONERO_THROW(monero::error::invalid_argument, "stems value cannot be max size_t");
 
         usage_count_.resize(stems);
         if (stems < out_mapping_.size())

--- a/src/net/error.h
+++ b/src/net/error.h
@@ -28,8 +28,7 @@
 
 #pragma once
 
-#include <system_error>
-#include <type_traits>
+#include "common/error.h"
 
 namespace net
 {
@@ -49,20 +48,11 @@ namespace net
 
     };
 
-    //! \return `std::error_category` for `net` namespace.
-    std::error_category const& error_category() noexcept;
+    //! \return `monero::error_category` for `net` namespace.
+    monero::error_category const& error_category() noexcept;
 
     //! \return `net::error` as a `std::error_code` value.
-    inline std::error_code make_error_code(error value) noexcept
-    {
-        return std::error_code{int(value), error_category()};
-    }
+    monero::error_code make_error_code(error value) noexcept;
 }
 
-namespace std
-{
-    template<>
-    struct is_error_code_enum<::net::error>
-      : true_type
-    {};
-}
+MONERO_DECLARE_ERROR_ENUM(net::error)

--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -137,12 +137,22 @@ namespace socks
                 return boost::system::error_condition{value, *this};
             }
         };
+        //! function in anonymous namespace allows compiler to optimize `error_category::failed` call
+        const socks_category& category_instance() noexcept
+        {
+            static const socks_category instance;
+            return instance;
+        }
     }
 
     const boost::system::error_category& error_category() noexcept
     {
-        static const socks_category instance{};
-        return instance;
+        return category_instance();
+    }
+
+    boost::system::error_code make_error_code(error value) noexcept
+    {
+        return {int(value), category_instance()};
     }
 
     struct client::completed

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -76,18 +76,15 @@ namespace socks
     };
 
     /* boost::system::error_code is extended for easier compatibility with
-       boost::asio errors. If std::error_code is needed (with expect<T> for
-       instance), then upgrade to boost 1.65+ or use conversion code in
-       develop branch at boost/system/detail/std_interoperability.hpp */
+       boost::asio errors. If std::error_code is needed, then upgrade to boost
+       1.65+ or use conversion code in develop branch at
+       boost/system/detail/std_interoperability.hpp */
 
     //! \return boost::system::error_category for net::socks namespace
     const boost::system::error_category& error_category() noexcept;
 
     //! \return net::socks::error as a boost::system::error_code.
-    inline boost::system::error_code make_error_code(error value) noexcept
-    {
-        return boost::system::error_code{int(value), socks::error_category()};
-    }
+    boost::system::error_code make_error_code(error value) noexcept;
 
     //! Client support for socks connect and resolve commands.
     class client

--- a/src/net/socks_connect.cpp
+++ b/src/net/socks_connect.cpp
@@ -64,7 +64,7 @@ namespace socks
         {
             std::uint16_t port = 0;
             if (!epee::string_tools::get_xtype_from_string(port, remote_port))
-                throw std::system_error{net::error::invalid_port, "Remote port for socks proxy"};
+                throw monero::system_error{net::error::invalid_port, "Remote port for socks proxy"};
 
             bool is_set = false;
             std::uint32_t ip_address = 0;
@@ -80,7 +80,7 @@ namespace socks
                 is_set = proxy->set_connect_command(remote_host, port);
 
             if (!is_set || !net::socks::client::connect_and_send(proxy, proxy_address))
-                throw std::system_error{net::error::invalid_host, "Address for socks proxy"};
+                throw monero::system_error{net::error::invalid_host, "Address for socks proxy"};
 
             timeout.async_wait(net::socks::client::async_close{std::move(proxy)});
         }

--- a/src/net/zmq.h
+++ b/src/net/zmq.h
@@ -65,16 +65,13 @@ namespace net
 namespace zmq
 {
     //! \return Category for ZMQ errors.
-    const std::error_category& error_category() noexcept;
+    const monero::error_category& error_category() noexcept;
 
     //! \return `code` (usally from zmq_errno()`) using `net::zmq::error_category()`.
-    inline std::error_code make_error_code(int code) noexcept
-    {
-        return std::error_code{code, error_category()};
-    }
+    monero::error_code make_error_code(int code) noexcept;
 
     //! \return Error from `zmq_errno()` using `net::zmq::error_category()`.
-    inline std::error_code get_error_code() noexcept
+    inline monero::error_code get_error_code() noexcept
     {
         return make_error_code(zmq_errno());
     }

--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -168,7 +168,7 @@ void ZmqServer::serve()
       }
     }
   }
-  catch (const std::system_error& e)
+  catch (const boost::system::system_error& e)
   {
     if (e.code() != net::zmq::make_error_code(ETERM))
       MERROR("ZMQ RPC Server Error: " << e.what());

--- a/tests/unit_tests/expect.cpp
+++ b/tests/unit_tests/expect.cpp
@@ -118,15 +118,15 @@ namespace
     template<typename T>
     void conversion_bench()
     {
-        EXPECT_TRUE((std::is_convertible<std::error_code, expect<T>>()));
-        EXPECT_TRUE((std::is_convertible<std::error_code&&, expect<T>>()));
-        EXPECT_TRUE((std::is_convertible<std::error_code&, expect<T>>()));
-        EXPECT_TRUE((std::is_convertible<std::error_code const&, expect<T>>()));
+        EXPECT_TRUE((std::is_convertible<monero::error_code, expect<T>>()));
+        EXPECT_TRUE((std::is_convertible<monero::error_code&&, expect<T>>()));
+        EXPECT_TRUE((std::is_convertible<monero::error_code&, expect<T>>()));
+        EXPECT_TRUE((std::is_convertible<monero::error_code const&, expect<T>>()));
 
-        EXPECT_TRUE((std::is_constructible<expect<T>, std::error_code>()));
-        EXPECT_TRUE((std::is_constructible<expect<T>, std::error_code&&>()));
-        EXPECT_TRUE((std::is_constructible<expect<T>, std::error_code&>()));
-        EXPECT_TRUE((std::is_constructible<expect<T>, std::error_code const&>()));
+        EXPECT_TRUE((std::is_constructible<expect<T>, monero::error_code>()));
+        EXPECT_TRUE((std::is_constructible<expect<T>, monero::error_code&&>()));
+        EXPECT_TRUE((std::is_constructible<expect<T>, monero::error_code&>()));
+        EXPECT_TRUE((std::is_constructible<expect<T>, monero::error_code const&>()));
     }
 }
 
@@ -236,10 +236,10 @@ TEST(Expect, NoExcept)
     EXPECT_TRUE(noexcept(std::declval<expect<int>>() != 0));
     EXPECT_TRUE(noexcept(0 != std::declval<expect<int>>()));
 
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, std::error_code>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, std::error_code&&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, std::error_code&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, std::error_code const&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, monero::error_code>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, monero::error_code&&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, monero::error_code&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, monero::error_code const&>()));
     EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, throw_construct>()));
     EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, throw_construct&&>()));
     EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_construct>, throw_construct&>()));
@@ -254,10 +254,10 @@ TEST(Expect, NoExcept)
     EXPECT_TRUE(std::is_nothrow_move_assignable<expect<throw_construct>>());
     EXPECT_TRUE(std::is_nothrow_destructible<expect<throw_construct>>());
 
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, std::error_code>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, std::error_code&&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, std::error_code&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, std::error_code const&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, monero::error_code>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, monero::error_code&&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, monero::error_code&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, monero::error_code const&>()));
     EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, throw_copies>()));
     EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_copies>, throw_copies&&>()));
     EXPECT_TRUE(!(std::is_nothrow_constructible<expect<throw_copies>, throw_copies&>()));
@@ -284,10 +284,10 @@ TEST(Expect, NoExcept)
     EXPECT_TRUE(noexcept(std::declval<expect<throw_copies>>() != std::declval<throw_moves>()));
     EXPECT_TRUE(noexcept(std::declval<throw_moves>() != std::declval<expect<throw_copies>>()));
 
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, std::error_code>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, std::error_code&&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, std::error_code&>()));
-    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, std::error_code const&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, monero::error_code>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, monero::error_code&&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, monero::error_code&>()));
+    EXPECT_TRUE((std::is_nothrow_constructible<expect<throw_moves>, monero::error_code const&>()));
     EXPECT_TRUE(!(std::is_nothrow_constructible<expect<throw_moves>, throw_moves>()));
     EXPECT_TRUE(!(std::is_nothrow_constructible<expect<throw_moves>, throw_moves&&>()));
     EXPECT_TRUE(!(std::is_nothrow_constructible<expect<throw_moves>, throw_moves&>()));
@@ -339,20 +339,20 @@ TEST(Expect, Assignment)
     EXPECT_TRUE(val2.value() == "foobar");
     EXPECT_TRUE(*val2 == "foobar");
     EXPECT_TRUE(boost::equals(val2->c_str(), "foobar"));
-    EXPECT_EQ(val1.error(), std::error_code{});
-    EXPECT_EQ(val2.error(), std::error_code{});
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val1.error(), monero::error::none);
+    EXPECT_EQ(val2.error(), monero::error::none);
+    EXPECT_TRUE(!val1.equal(monero::error::none));
+    EXPECT_TRUE(!val2.equal(monero::error::none));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val1 = std::move(val2);
 
@@ -368,20 +368,20 @@ TEST(Expect, Assignment)
     EXPECT_EQ(val2.value(), std::string{});
     EXPECT_TRUE(*val2 == std::string{});
     EXPECT_TRUE(boost::equals(val2->c_str(), ""));
-    EXPECT_EQ(val1.error(), std::error_code{});
-    EXPECT_EQ(val2.error(), std::error_code{});
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val1.error(), monero::error::none);
+    EXPECT_EQ(val2.error(), monero::error::none);
+    EXPECT_TRUE(!val1.equal(monero::error::none));
+    EXPECT_TRUE(!val2.equal(monero::error::none));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val2 = val1;
 
@@ -397,22 +397,22 @@ TEST(Expect, Assignment)
     EXPECT_EQ(val2.value(), "foobar");
     EXPECT_TRUE(*val2 == "foobar");
     EXPECT_TRUE(boost::equals(val2->c_str(), "foobar"));
-    EXPECT_EQ(val1.error(), std::error_code{});
-    EXPECT_EQ(val2.error(), std::error_code{});
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val1.error(), monero::error::none);
+    EXPECT_EQ(val2.error(), monero::error::none);
+    EXPECT_TRUE(!val1.equal(monero::error::none));
+    EXPECT_TRUE(!val2.equal(monero::error::none));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
-    val1 = make_error_code(common_error::kInvalidArgument);
+    val1 = make_error_code(monero::error::invalid_argument);
 
     ASSERT_TRUE(val1.has_error());
     ASSERT_TRUE(val2.has_value());
@@ -420,27 +420,27 @@ TEST(Expect, Assignment)
     EXPECT_TRUE(bool(val2));
     EXPECT_TRUE(!val1.has_value());
     EXPECT_TRUE(!val2.has_error());
-    EXPECT_EQ(val1.error(), common_error::kInvalidArgument);
-    EXPECT_TRUE(val1 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val1);
+    EXPECT_EQ(val1.error(), monero::error::invalid_argument);
+    EXPECT_TRUE(val1 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val1);
     EXPECT_STREQ(val2.value().c_str(), "foobar");
     EXPECT_TRUE(*val2 == "foobar");
     EXPECT_TRUE(boost::equals(val2->c_str(), "foobar"));
-    EXPECT_NE(val1.error(), std::error_code{});
-    EXPECT_EQ(val2.error(), std::error_code{});
-    EXPECT_TRUE(val1.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(val1.matches(std::errc::invalid_argument));
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_NE(val1.error(), monero::error::none);
+    EXPECT_EQ(val2.error(), monero::error::none);
+    EXPECT_TRUE(val1.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!val2.equal(monero::error::none));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(val1.matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val2 = val1;
 
@@ -450,28 +450,28 @@ TEST(Expect, Assignment)
     EXPECT_TRUE(!val2);
     EXPECT_TRUE(!val1.has_value());
     EXPECT_TRUE(!val2.has_value());
-    EXPECT_EQ(val1.error(), common_error::kInvalidArgument);
-    EXPECT_TRUE(val1 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val1);
-    EXPECT_EQ(val2.error(), common_error::kInvalidArgument);
-    EXPECT_TRUE(val2 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val2);
-    EXPECT_NE(val1.error(), std::error_code{});
-    EXPECT_NE(val2.error(), std::error_code{});
-    EXPECT_TRUE(val1.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(val2.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(val1.matches(std::errc::invalid_argument));
-    EXPECT_TRUE(val2.matches(std::errc::invalid_argument));
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val1.error(), monero::error::invalid_argument);
+    EXPECT_TRUE(val1 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val1);
+    EXPECT_EQ(val2.error(), monero::error::invalid_argument);
+    EXPECT_TRUE(val2 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val2);
+    EXPECT_NE(val1.error(), monero::error::none);
+    EXPECT_NE(val2.error(), monero::error::none);
+    EXPECT_TRUE(val1.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(val2.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(val1.matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(val2.matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val1 = std::string{"barfoo"};
 
@@ -484,24 +484,24 @@ TEST(Expect, Assignment)
     EXPECT_STREQ(val1.value().c_str(), "barfoo");
     EXPECT_TRUE(*val1 == "barfoo");
     EXPECT_TRUE(boost::equals(val1->c_str(), "barfoo"));
-    EXPECT_EQ(val2.error(), common_error::kInvalidArgument);
-    EXPECT_TRUE(val2 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val2);
-    EXPECT_EQ(val1.error(), std::error_code{});
-    EXPECT_NE(val2.error(), std::error_code{});
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(val2.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(val2.matches(std::errc::invalid_argument));
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val2.error(), monero::error::invalid_argument);
+    EXPECT_TRUE(val2 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val2);
+    EXPECT_EQ(val1.error(), monero::error::none);
+    EXPECT_NE(val2.error(), monero::error::none);
+    EXPECT_TRUE(!val1.equal(monero::error::none));
+    EXPECT_TRUE(val2.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(val2.matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val2 = val1;
 
@@ -517,20 +517,20 @@ TEST(Expect, Assignment)
     EXPECT_EQ(val2.value(), "barfoo");
     EXPECT_TRUE(*val2 == "barfoo");
     EXPECT_TRUE(boost::equals(val2->c_str(), "barfoo"));
-    EXPECT_EQ(val1.error(), std::error_code{});
-    EXPECT_EQ(val2.error(), std::error_code{});
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_EQ(val1.error(), monero::error::none);
+    EXPECT_EQ(val2.error(), monero::error::none);
+    EXPECT_TRUE(!val1.equal(monero::error::none));
+    EXPECT_TRUE(!val2.equal(monero::error::none));
+    EXPECT_TRUE(!(val1 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val1));
+    EXPECT_TRUE(!(val2 == monero::error::none));
+    EXPECT_TRUE(!(monero::error::none == val2));
+    EXPECT_TRUE(val1 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val1);
+    EXPECT_TRUE(val2 != monero::error::none);
+    EXPECT_TRUE(monero::error::none != val2);
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 }
 
 TEST(Expect, AssignmentThrowsOnMove)
@@ -554,14 +554,14 @@ TEST(Expect, AssignmentThrowsOnMove)
     };
 
     expect<throw_on_move> val1{expect<const char*>{"foobar"}};
-    expect<throw_on_move> val2{common_error::kInvalidArgument};
+    expect<throw_on_move> val2{monero::error::invalid_argument};
 
     ASSERT_TRUE(val1.has_value());
     ASSERT_TRUE(val2.has_error());
     EXPECT_TRUE(!val1.has_error());
     EXPECT_TRUE(!val2.has_value());
     EXPECT_STREQ(val1->msg.c_str(), "foobar");
-    EXPECT_EQ(val2.error(), common_error::kInvalidArgument);
+    EXPECT_EQ(val2.error(), monero::error::invalid_argument);
 
     EXPECT_THROW(val2 = std::move(val1), construct_error);
 
@@ -570,7 +570,7 @@ TEST(Expect, AssignmentThrowsOnMove)
     EXPECT_TRUE(!val1.has_error());
     EXPECT_TRUE(!val2.has_value());
     EXPECT_STREQ(val1->msg.c_str(), "foobar");
-    EXPECT_EQ(val2.error(), common_error::kInvalidArgument);
+    EXPECT_EQ(val2.error(), monero::error::invalid_argument);
 
     EXPECT_THROW(val1 = expect<const char*>{"barfoo"}, assignment_error);
 
@@ -579,7 +579,7 @@ TEST(Expect, AssignmentThrowsOnMove)
     EXPECT_TRUE(!val1.has_error());
     EXPECT_TRUE(!val2.has_value());
     EXPECT_STREQ(val1->msg.c_str(), "foobar");
-    EXPECT_EQ(val2.error(), common_error::kInvalidArgument);
+    EXPECT_EQ(val2.error(), monero::error::invalid_argument);
 
     EXPECT_NO_THROW(val2 = val1);
 
@@ -619,9 +619,9 @@ TEST(Expect, EqualWithStrings)
     EXPECT_TRUE(val1.equal(""));
     EXPECT_TRUE(val2.equal("barfoo"));
     EXPECT_TRUE(val3.equal(""));
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
-    EXPECT_TRUE(!val3.equal(std::error_code{}));
+    EXPECT_TRUE(!val1.equal(monero::error_code{}));
+    EXPECT_TRUE(!val2.equal(monero::error_code{}));
+    EXPECT_TRUE(!val3.equal(monero::error_code{}));
     EXPECT_TRUE(val1 == "");
     EXPECT_TRUE("" == val1);
     EXPECT_TRUE(val2 == "barfoo");
@@ -634,23 +634,23 @@ TEST(Expect, EqualWithStrings)
     EXPECT_TRUE(!("barfoo" != val2));
     EXPECT_TRUE(!(val3 != ""));
     EXPECT_TRUE(!("" != val3));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
-    EXPECT_TRUE(!(val3 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val3));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
-    EXPECT_TRUE(val3 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val3);
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
-    EXPECT_TRUE(!val3.matches(std::error_condition{}));
+    EXPECT_TRUE(!(val1 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val1));
+    EXPECT_TRUE(!(val2 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val2));
+    EXPECT_TRUE(!(val3 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val3));
+    EXPECT_TRUE(val1 != monero::error_code{});
+    EXPECT_TRUE(monero::error_code{} != val1);
+    EXPECT_TRUE(val2 != monero::error_code{});
+    EXPECT_TRUE(monero::error_code{} != val2);
+    EXPECT_TRUE(val3 != monero::error_code{});
+    EXPECT_TRUE(monero::error_code{} != val3);
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val3.matches(monero::error_condition{}));
 
-    val2 = make_error_code(common_error::kInvalidArgument);
+    val2 = make_error_code(monero::error::invalid_argument);
 
     EXPECT_TRUE(!val1.equal(val2));
     EXPECT_TRUE(val1.equal(val3));
@@ -671,15 +671,15 @@ TEST(Expect, EqualWithStrings)
     EXPECT_TRUE(val2 != val3);
     EXPECT_TRUE(val3 != val2);
 
-    EXPECT_TRUE(!val1.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(val2.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!val3.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(val2 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val2);
-    EXPECT_TRUE(!(val2 != common_error::kInvalidArgument));
-    EXPECT_TRUE(!(common_error::kInvalidArgument != val2));
-    EXPECT_TRUE(val2.matches(std::errc::invalid_argument));
-    EXPECT_TRUE(!val2.matches(std::error_condition{}));
+    EXPECT_TRUE(!val1.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(val2.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!val3.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(val2 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val2);
+    EXPECT_TRUE(!(val2 != monero::error::invalid_argument));
+    EXPECT_TRUE(!(monero::error::invalid_argument != val2));
+    EXPECT_TRUE(val2.matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(!val2.matches(monero::error_condition{}));
 
     val1 = expect<std::string>{"barfoo"};
 
@@ -707,13 +707,13 @@ TEST(Expect, EqualWithStrings)
     EXPECT_TRUE("barfoo" == val1);
     EXPECT_TRUE(!(val1 != "barfoo"));
     EXPECT_TRUE(!("barfoo" != val1));
-    EXPECT_TRUE(!val1.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!(val1 == common_error::kInvalidArgument));
-    EXPECT_TRUE(!(common_error::kInvalidArgument == val1));
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!val1.matches(std::error_condition{}));
-    EXPECT_TRUE(!val1.matches(std::errc::invalid_argument));
+    EXPECT_TRUE(!val1.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!(val1 == monero::error::invalid_argument));
+    EXPECT_TRUE(!(monero::error::invalid_argument == val1));
+    EXPECT_TRUE(!(val1 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val1));
+    EXPECT_TRUE(!val1.matches(monero::error_condition{}));
+    EXPECT_TRUE(!val1.matches(monero::errc::invalid_argument));
 }
 
 TEST(Expect, EqualWithVoid)
@@ -723,40 +723,40 @@ TEST(Expect, EqualWithVoid)
 
     EXPECT_TRUE(val1.equal(val2));
     EXPECT_TRUE(val2.equal(val1));
-    EXPECT_TRUE(!val1.equal(std::error_code{}));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
+    EXPECT_TRUE(!val1.equal(monero::error_code{}));
+    EXPECT_TRUE(!val2.equal(monero::error_code{}));
     EXPECT_TRUE(val1 == val2);
     EXPECT_TRUE(val2 == val1);
-    EXPECT_TRUE(!(val1 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val1));
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
+    EXPECT_TRUE(!(val1 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val1));
+    EXPECT_TRUE(!(val2 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val2));
     EXPECT_TRUE(!(val1 != val2));
     EXPECT_TRUE(!(val2 != val1));
-    EXPECT_TRUE(val1 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val1);
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
+    EXPECT_TRUE(val1 != monero::error_code{});
+    EXPECT_TRUE(monero::error_code{} != val1);
+    EXPECT_TRUE(!(val2 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val2));
 
-    val2 = make_error_code(common_error::kInvalidArgument);
+    val2 = make_error_code(monero::error::invalid_argument);
 
     EXPECT_TRUE(!val1.equal(val2));
     EXPECT_TRUE(!val2.equal(val1));
-    EXPECT_TRUE(!val1.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(val2.equal(common_error::kInvalidArgument));
-    EXPECT_TRUE(!val2.equal(std::error_code{}));
+    EXPECT_TRUE(!val1.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(val2.equal(monero::error::invalid_argument));
+    EXPECT_TRUE(!val2.equal(monero::error_code{}));
     EXPECT_TRUE(!(val1 == val2));
     EXPECT_TRUE(!(val2 == val1));
-    EXPECT_TRUE(val2 == common_error::kInvalidArgument);
-    EXPECT_TRUE(common_error::kInvalidArgument == val2);
-    EXPECT_TRUE(!(val2 == std::error_code{}));
-    EXPECT_TRUE(!(std::error_code{} == val2));
+    EXPECT_TRUE(val2 == monero::error::invalid_argument);
+    EXPECT_TRUE(monero::error::invalid_argument == val2);
+    EXPECT_TRUE(!(val2 == monero::error_code{}));
+    EXPECT_TRUE(!(monero::error_code{} == val2));
     EXPECT_TRUE(val1 != val2);
     EXPECT_TRUE(val2 != val1);
-    EXPECT_TRUE(!(val2 != common_error::kInvalidArgument));
-    EXPECT_TRUE(!(common_error::kInvalidArgument != val2));
-    EXPECT_TRUE(val2 != std::error_code{});
-    EXPECT_TRUE(std::error_code{} != val2);
+    EXPECT_TRUE(!(val2 != monero::error::invalid_argument));
+    EXPECT_TRUE(!(monero::error::invalid_argument != val2));
+    EXPECT_TRUE(val2 != monero::error_code{});
+    EXPECT_TRUE(monero::error_code{} != val2);
 }
 
 TEST(Expect, EqualNoCopies)
@@ -801,7 +801,7 @@ TEST(Expect, EqualNoCopies)
     EXPECT_TRUE(!(val1 != val3));
     EXPECT_TRUE(!(val3 != val1));
 
-    expect<throw_on_copy> val4{common_error::kInvalidArgument};
+    expect<throw_on_copy> val4{monero::error::invalid_argument};
 
     EXPECT_TRUE(!val4.equal(throw_on_copy{}));
     EXPECT_TRUE(!(val4 == throw_on_copy{}));
@@ -817,99 +817,99 @@ TEST(Expect, EqualNoCopies)
 
 TEST(Expect, Macros) {
     EXPECT_TRUE(
-        [] () -> ::common_error {
+        [] () -> ::monero::error {
             MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
-        [] () -> ::common_error {
+        [] () -> ::monero::error {
             MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
     EXPECT_TRUE(
-        [] () -> std::error_code {
+        [] () -> monero::error_code {
             MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
-        [] () -> std::error_code {
+        [] () -> monero::error_code {
             MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
     EXPECT_TRUE(
         [] () -> expect<void> {
             MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
         [] () -> expect<void> {
             MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
     EXPECT_TRUE(
         [] () -> expect<int> {
             MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
         [] () -> expect<int> {
             MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
 
     EXPECT_TRUE(
-        [] () -> std::error_code {
+        [] () -> monero::error_code {
             MONERO_CHECK(expect<void>{});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
-        [] () -> std::error_code {
-            MONERO_CHECK(expect<void>{common_error::kInvalidArgument});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+        [] () -> monero::error_code {
+            MONERO_CHECK(expect<void>{monero::error::invalid_argument});
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
     EXPECT_TRUE(
         [] () -> expect<void> {
             MONERO_CHECK(expect<void>{});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
         [] () -> expect<void> {
-            MONERO_CHECK(expect<void>{common_error::kInvalidArgument});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            MONERO_CHECK(expect<void>{monero::error::invalid_argument});
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
     EXPECT_TRUE(
         [] () -> expect<int> {
             MONERO_CHECK(expect<void>{});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_error_code
     );
     EXPECT_TRUE(
         [] () -> expect<int> {
-            MONERO_CHECK(expect<void>{common_error::kInvalidArgument});
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
+            MONERO_CHECK(expect<void>{monero::error::invalid_argument});
+            return {monero::error::invalid_error_code};
+        } () == monero::error::invalid_argument
     );
 
     EXPECT_NO_THROW(MONERO_UNWRAP(success()));
     EXPECT_NO_THROW(MONERO_UNWRAP(expect<void>{}));
     EXPECT_NO_THROW(MONERO_UNWRAP(expect<int>{0}));
     EXPECT_THROW(
-        MONERO_UNWRAP(expect<void>{common_error::kInvalidArgument}), std::system_error
+        MONERO_UNWRAP(expect<void>{monero::error::invalid_argument}), monero::system_error
     );
     EXPECT_THROW(
-        MONERO_UNWRAP(expect<int>{common_error::kInvalidArgument}), std::system_error
+        MONERO_UNWRAP(expect<int>{monero::error::invalid_argument}), monero::system_error
     );
 }
 

--- a/tests/unit_tests/lmdb.cpp
+++ b/tests/unit_tests/lmdb.cpp
@@ -190,7 +190,7 @@ TEST(LMDB, Table)
     static_assert(test.flags == 0, "bad flags");
     static_assert(&lmdb::less<unsigned> == test.key_cmp, "bad key_cmp");
     static_assert(test.value_cmp == nullptr, "bad value_cmp");
-    EXPECT_TRUE(test.get_value<bytes>(MDB_val{}).matches(std::errc::invalid_argument));
+    EXPECT_TRUE(test.get_value<bytes>(MDB_val{}).matches(monero::errc::invalid_argument));
 
     lmdb::basic_table<big_choice, one> test2{
         "foo2", MDB_DUPSORT, &lmdb::compare<one>
@@ -200,7 +200,7 @@ TEST(LMDB, Table)
     EXPECT_EQ((MDB_DUPSORT | MDB_DUPFIXED), test2.flags);
     EXPECT_EQ(&lmdb::less<unsigned long>, test2.key_cmp);
     EXPECT_EQ(&lmdb::compare<one>, test2.value_cmp);
-    EXPECT_TRUE(test2.get_value<one>(MDB_val{}).matches(std::errc::invalid_argument));
+    EXPECT_TRUE(test2.get_value<one>(MDB_val{}).matches(monero::errc::invalid_argument));
 
     one record{};
     boost::iota(record.i.data, 0);
@@ -216,18 +216,18 @@ TEST(LMDB, Table)
     EXPECT_TRUE(boost::equal(record.j.data, j_copy.data));
 
     EXPECT_TRUE(
-        test.get_key_stream(test_cursor{}).matches(std::errc::invalid_argument)
+        test.get_key_stream(test_cursor{}).matches(monero::errc::invalid_argument)
     );
     EXPECT_TRUE(
-        test2.get_key_stream(test_cursor{}).matches(std::errc::invalid_argument)
+        test2.get_key_stream(test_cursor{}).matches(monero::errc::invalid_argument)
     );
 
 
     EXPECT_TRUE(
-        test.get_value_stream(choice(0), test_cursor{}).matches(std::errc::invalid_argument)
+        test.get_value_stream(choice(0), test_cursor{}).matches(monero::errc::invalid_argument)
     );
     EXPECT_TRUE(
-        test2.get_value_stream(big_choice(0), test_cursor{}).matches(std::errc::invalid_argument)
+        test2.get_value_stream(big_choice(0), test_cursor{}).matches(monero::errc::invalid_argument)
     );
 }
 
@@ -235,14 +235,14 @@ TEST(LMDB, InvalidDatabase)
 {
    lmdb::database test{lmdb::environment{}};
 
-    EXPECT_TRUE(test.resize().matches(std::errc::invalid_argument));
-    EXPECT_TRUE(test.create_read_txn().matches(std::errc::invalid_argument));
-    EXPECT_TRUE(test.reset_txn(lmdb::read_txn{}).matches(std::errc::invalid_argument));
-    EXPECT_TRUE(test.create_write_txn().matches(std::errc::invalid_argument));
-    EXPECT_TRUE(test.commit(lmdb::write_txn{}).matches(std::errc::invalid_argument));
+    EXPECT_TRUE(test.resize().matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(test.create_read_txn().matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(test.reset_txn(lmdb::read_txn{}).matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(test.create_write_txn().matches(monero::errc::invalid_argument));
+    EXPECT_TRUE(test.commit(lmdb::write_txn{}).matches(monero::errc::invalid_argument));
 
     EXPECT_TRUE(
-        test.try_write( [](MDB_txn&) { return success(); } ).matches(std::errc::invalid_argument)
+        test.try_write( [](MDB_txn&) { return success(); } ).matches(monero::errc::invalid_argument)
     );
 }
 

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -1653,7 +1653,7 @@ TEST(zmq, error_codes)
         std::addressof(net::zmq::make_error_code(0).category())
     );
     EXPECT_EQ(
-        std::make_error_condition(std::errc::not_a_socket),
+        make_error_condition(monero::errc::not_a_socket),
         net::zmq::make_error_code(ENOTSOCK)
     );
 
@@ -1662,7 +1662,7 @@ TEST(zmq, error_codes)
         {
             MONERO_ZMQ_CHECK(zmq_msg_send(nullptr, nullptr, 0));
             return success();
-        }().matches(std::errc::not_a_socket)
+        }().matches(monero::errc::not_a_socket)
     );
 
     bool thrown = false;
@@ -1670,10 +1670,10 @@ TEST(zmq, error_codes)
     {
         MONERO_ZMQ_THROW("stuff");
     }
-    catch (const std::system_error& e)
+    catch (const boost::system::system_error& e)
     {
         thrown = true;
-        EXPECT_EQ(std::make_error_condition(std::errc::not_a_socket), e.code());
+        EXPECT_EQ(make_error_condition(monero::errc::not_a_socket), e.code());
     }
     EXPECT_TRUE(thrown);
 }


### PR DESCRIPTION
This PR was in response to #7057 . This change is **not** strictly needed, so reject if the "churn" is too high. Its mostly comments and tests. #7057 could remove `expect<void>` usage, but the syntax is more natural.

This switches `expect<T>` to `boost::system::error_code`. This makes it easier to interoperate with `boost::asio` and `boost::filesystem` before Boost 1.65 (which provides conversions to `std::error_code`). Nothing in `std::` uses `std::error_code` until C++17 really, so `boost::system::error_code` makes more sense.

This also aliases things into the `monero::` namespace, so that it could be switched back to `std::error_code` if necessary. Definitely need some feedback/criticism on this approach.

I've taken a look at the disassembly, and with all of these changes (see some comments) the differences in runtime should be negligible.