### PR TITLE
Trezor: fix memory access problems, crash

### DIFF
--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -368,7 +368,10 @@ namespace trezor {
       std::string tmp_session_id;
       auto initMsg = std::make_shared<messages::management::Initialize>();
       const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
-        memwipe(&tmp_session_id[0], tmp_session_id.size());
+        initMsg->release_session_id();
+        if (!tmp_session_id.empty()) {
+          memwipe(&tmp_session_id[0], tmp_session_id.size());
+        }
       });
 
       if(!m_device_session_id.empty()) {
@@ -382,8 +385,6 @@ namespace trezor {
       } else {
         m_device_session_id.clear();
       }
-
-      initMsg->release_session_id();
     }
 
     void device_trezor_base::device_state_reset()

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -165,7 +165,7 @@ namespace trezor {
 
         // Scoped session closer
         BOOST_SCOPE_EXIT_ALL(&, this) {
-          if (open_session){
+          if (open_session && this->get_transport()){
             this->get_transport()->close();
           }
         };


### PR DESCRIPTION
I inspected a code and looked for issues similar to the #7306. IMO this fixes the culprit of the crash when Trezor connection fails (https://github.com/monero-project/monero-gui/issues/3296).  

I also checked for correct protobuf message allocation and releasing. This is all I found, other places are handled well. 

@vtnerd pls can you review also this? 🙏 

Thanks!