### PR TITLE
add test for string emptiness before wiping in http_base - release-v0.17

### DIFF
--- a/contrib/epee/include/net/http_base.h
+++ b/contrib/epee/include/net/http_base.h
@@ -204,7 +204,8 @@ namespace net_utils
 
 			void wipe()
 			{
-				memwipe(&m_body[0], m_body.size());
+				if (!m_body.empty())
+					memwipe(&m_body[0], m_body.size());
 			}
 		};
 	}


### PR DESCRIPTION
Same as https://github.com/monero-project/monero/pull/7306, for release-v0.17 branch