### PR TITLE
bootstrap_daemon: proxy configuration support

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -986,17 +986,67 @@ bool t_command_parser_executor::check_blockchain_pruning(const std::vector<std::
 
 bool t_command_parser_executor::set_bootstrap_daemon(const std::vector<std::string>& args)
 {
-  const size_t args_count = args.size();
-  if (args_count < 1 || args_count > 3)
+  struct parsed_t
+  {
+    std::string address;
+    std::string user;
+    std::string password;
+    std::string proxy;
+  };
+
+  boost::optional<parsed_t> parsed = [&args]() -> boost::optional<parsed_t> {
+    const size_t args_count = args.size();
+    if (args_count == 0)
+    {
+      return {};
+    }
+    if (args[0] == "auto")
+    {
+      if (args_count == 1)
+      {
+        return {{args[0], "", "", ""}};
+      }
+      if (args_count == 2)
+      {
+        return {{args[0], "", "", args[1]}};
+      }
+    }
+    else if (args[0] == "none")
+    {
+      if (args_count == 1)
+      {
+        return {{"", "", "", ""}};
+      }
+    }
+    else
+    {
+      if (args_count == 1)
+      {
+        return {{args[0], "", "", ""}};
+      }
+      if (args_count == 2)
+      {
+        return {{args[0], "", "", args[1]}};
+      }
+      if (args_count == 3)
+      {
+        return {{args[0], args[1], args[2], ""}};
+      }
+      if (args_count == 4)
+      {
+        return {{args[0], args[1], args[2], args[3]}};
+      }
+    }
+    return {};
+  }();
+
+  if (!parsed)
   {
     std::cout << "Invalid syntax: Wrong number of parameters. For more details, use the help command." << std::endl;
     return true;
   }
 
-  return m_executor.set_bootstrap_daemon(
-    args[0] != "none" ? args[0] : std::string(),
-    args_count > 1 ? args[1] : std::string(),
-    args_count > 2 ? args[2] : std::string());
+  return m_executor.set_bootstrap_daemon(parsed->address, parsed->user, parsed->password, parsed->proxy);
 }
 
 bool t_command_parser_executor::flush_cache(const std::vector<std::string>& args)

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -326,7 +326,7 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "set_bootstrap_daemon"
     , std::bind(&t_command_parser_executor::set_bootstrap_daemon, &m_parser, p::_1)
-    , "set_bootstrap_daemon (auto | none | host[:port] [username] [password])"
+    , "set_bootstrap_daemon (auto | none | host[:port] [username] [password]) [proxy_ip:proxy_port]"
     , "URL of a 'bootstrap' remote daemon that the connected wallets can use while this daemon is still not fully synced.\n"
       "Use 'auto' to enable automatic public nodes discovering and bootstrap daemon switching"
     );

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2405,7 +2405,8 @@ bool t_rpc_command_executor::check_blockchain_pruning()
 bool t_rpc_command_executor::set_bootstrap_daemon(
   const std::string &address,
   const std::string &username,
-  const std::string &password)
+  const std::string &password,
+  const std::string &proxy)
 {
     cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::request req;
     cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::response res;
@@ -2414,6 +2415,7 @@ bool t_rpc_command_executor::set_bootstrap_daemon(
     req.address = address;
     req.username = username;
     req.password = password;
+    req.proxy = proxy;
 
     if (m_is_rpc)
     {

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -168,7 +168,8 @@ public:
   bool set_bootstrap_daemon(
     const std::string &address,
     const std::string &username,
-    const std::string &password);
+    const std::string &password,
+    const std::string &proxy);
 
   bool rpc_payments();
 

--- a/src/rpc/bootstrap_daemon.h
+++ b/src/rpc/bootstrap_daemon.h
@@ -8,7 +8,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/utility/string_ref.hpp>
 
-#include "net/http_client.h"
+#include "net/http.h"
 #include "storages/http_abstract_invoke.h"
 
 #include "bootstrap_node_selector.h"
@@ -21,11 +21,13 @@ namespace cryptonote
   public:
     bootstrap_daemon(
       std::function<std::map<std::string, bool>()> get_public_nodes,
-      bool rpc_payment_enabled);
+      bool rpc_payment_enabled,
+      const std::string &proxy);
     bootstrap_daemon(
       const std::string &address,
       boost::optional<epee::net_utils::http::login> credentials,
-      bool rpc_payment_enabled);
+      bool rpc_payment_enabled,
+      const std::string &proxy);
 
     std::string address() const noexcept;
     boost::optional<std::pair<uint64_t, uint64_t>> get_height();
@@ -72,12 +74,14 @@ namespace cryptonote
       return handle_result(result, result_struct.status);
     }
 
+    void set_proxy(const std::string &address);
+
   private:
     bool set_server(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials = boost::none);
     bool switch_server_if_needed();
 
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    net::http::client m_http_client;
     const bool m_rpc_payment_enabled;
     const std::unique_ptr<bootstrap_node::selector> m_selector;
     boost::mutex m_selector_mutex;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -72,6 +72,7 @@ namespace cryptonote
     static const command_line::arg_descriptor<bool> arg_rpc_ssl_allow_any_cert;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_login;
+    static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_proxy;
     static const command_line::arg_descriptor<std::string> arg_rpc_payment_address;
     static const command_line::arg_descriptor<uint64_t> arg_rpc_payment_difficulty;
     static const command_line::arg_descriptor<uint64_t> arg_rpc_payment_credits;
@@ -268,8 +269,14 @@ private:
     uint64_t get_block_reward(const block& blk);
     bool fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response, bool fill_pow_hash);
     std::map<std::string, bool> get_public_nodes(uint32_t credits_per_hash_threshold = 0);
-    bool set_bootstrap_daemon(const std::string &address, const std::string &username_password);
-    bool set_bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials);
+    bool set_bootstrap_daemon(
+      const std::string &address,
+      const std::string &username_password,
+      const std::string &proxy);
+    bool set_bootstrap_daemon(
+      const std::string &address,
+      const boost::optional<epee::net_utils::http::login> &credentials,
+      const std::string &proxy);
     enum invoke_http_mode { JON, BIN, JON_RPC };
     template <typename COMMAND_TYPE>
     bool use_bootstrap_daemon_if_necessary(const invoke_http_mode &mode, const std::string &command_name, const typename COMMAND_TYPE::request& req, typename COMMAND_TYPE::response& res, bool &r);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -88,7 +88,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 3
-#define CORE_RPC_VERSION_MINOR 5
+#define CORE_RPC_VERSION_MINOR 6
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -1613,11 +1613,13 @@ namespace cryptonote
       std::string address;
       std::string username;
       std::string password;
+      std::string proxy;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
         KV_SERIALIZE(username)
         KV_SERIALIZE(password)
+        KV_SERIALIZE(proxy)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
Daemon command
`set_bootstrap_daemon (auto | none | host[:port] [username] [password]) [proxy_ip:proxy_port]"`

CLI switch
`--bootstrap-daemon-proxy` - `<ip>:<port> socks proxy to use for bootstrap daemon connections`

RPC
`/set_bootstrap_daemon` - added `proxy` field