### PR TITLE
device_trezor: wipe string fields, add check

### DIFF
--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -165,7 +165,7 @@ namespace trezor {
 
         // Scoped session closer
         BOOST_SCOPE_EXIT_ALL(&, this) {
-          if (open_session){
+          if (open_session && this->get_transport()){
             this->get_transport()->close();
           }
         };


### PR DESCRIPTION
ping @ph4r05

This would be a replacement for #7306 and #7330.

From IRC:

```
7330 or unmodified code isn't consistent with library api
1. it's expected be heap allocated memory
2. release_field_name returns string pointer that must be freed by caller in general
3. memwipe should be called before release_field_name in general
but it's better to replace that with set_allocated_field_name(new std::string(...)) and use mutable_field_name in order to wipe it after
```