### PR TITLE
Remove unused variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,7 +629,7 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAG}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAG}")
 
-  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-variable -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
+  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     if(ARM)
       set(WARNINGS "${WARNINGS} -Wno-error=inline-asm")

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -575,7 +575,6 @@ int main(int argc, char* argv[])
             {
               add_ancestry(state.ancestry, txid, ancestor{amount, offset});
               // find the tx which created this output
-              bool found = false;
               crypto::hash output_txid;
               if (!get_output_txid(state, db, amount, offset, output_txid))
               {
@@ -693,7 +692,6 @@ int main(int argc, char* argv[])
             add_ancestor(ancestry, amount, offset);
 
             // find the tx which created this output
-            bool found = false;
             crypto::hash output_txid;
             if (!get_output_txid(state, db, amount, offset, output_txid))
             {

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -47,9 +47,6 @@ namespace po = boost::program_options;
 using namespace epee;
 using namespace cryptonote;
 
-static const char zerokey[8] = {0};
-static const MDB_val zerokval = { sizeof(zerokey), (void *)zerokey };
-
 static uint64_t records_per_sync = 200;
 static uint64_t db_flags = 0;
 static MDB_dbi dbi_relative_rings;
@@ -703,7 +700,6 @@ static void get_per_amount_outputs(MDB_txn *txn, uint64_t amount, uint64_t &tota
   int dbr = mdb_cursor_open(txn, dbi_per_amount, &cur);
   CHECK_AND_ASSERT_THROW_MES(!dbr, "Failed to open cursor for per amount outputs: " + std::string(mdb_strerror(dbr)));
   MDB_val k, v;
-  mdb_size_t count = 0;
   k.mv_size = sizeof(uint64_t);
   k.mv_data = (void*)&amount;
   dbr = mdb_cursor_get(cur, &k, &v, MDB_SET);
@@ -726,7 +722,6 @@ static void inc_per_amount_outputs(MDB_txn *txn, uint64_t amount, uint64_t total
   int dbr = mdb_cursor_open(txn, dbi_per_amount, &cur);
   CHECK_AND_ASSERT_THROW_MES(!dbr, "Failed to open cursor for per amount outputs: " + std::string(mdb_strerror(dbr)));
   MDB_val k, v;
-  mdb_size_t count = 0;
   k.mv_size = sizeof(uint64_t);
   k.mv_data = (void*)&amount;
   dbr = mdb_cursor_get(cur, &k, &v, MDB_SET);
@@ -1077,7 +1072,6 @@ static std::vector<std::pair<uint64_t, uint64_t>> load_outputs(const std::string
       s[len - 1] = 0;
     if (!s[0])
       continue;
-    std::pair<uint64_t, uint64_t> output;
     uint64_t offset, num_offsets;
     if (sscanf(s, "@%" PRIu64, &amount) == 1)
     {
@@ -1268,8 +1262,6 @@ int main(int argc, char* argv[])
   init(cache_dir);
 
   LOG_PRINT_L0("Scanning for spent outputs...");
-
-  size_t done = 0;
 
   const uint64_t start_blackballed_outputs = get_num_spent_outputs();
 

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -227,7 +227,7 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
     return false;
   }
 
-  uint64_t block_first, block_last;
+  uint64_t block_first;
   uint64_t start_height = 1, seek_height;
   if (opt_resume)
     start_height = core.get_blockchain_storage().get_current_blockchain_height();

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -66,7 +66,6 @@ static std::map<uint64_t, uint64_t> load_outputs(const std::string &filename)
       s[len - 1] = 0;
     if (!s[0])
       continue;
-    std::pair<uint64_t, uint64_t> output;
     uint64_t offset, num_offsets;
     if (sscanf(s, "@%" PRIu64, &amount) == 1)
     {

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -180,7 +180,6 @@ int main(int argc, char* argv[])
 
   LOG_PRINT_L0("Building usage patterns...");
 
-  size_t done = 0;
   std::unordered_map<output_data, std::list<reference>> outputs;
   std::unordered_map<uint64_t,uint64_t> indices;
 
@@ -195,7 +194,7 @@ int main(int argc, char* argv[])
     {
       if (opt_rct_only && out.amount)
         continue;
-      uint64_t index = indices[out.amount]++;
+      indices[out.amount]++;
       output_data od(out.amount, indices[out.amount], coinbase, height);
       auto itb = outputs.emplace(od, std::list<reference>());
       itb.first->first.info(coinbase, height);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -104,7 +104,6 @@ namespace cryptonote
 
   uint64_t get_transaction_weight_clawback(const transaction &tx, size_t n_padded_outputs)
   {
-    const rct::rctSig &rv = tx.rct_signatures;
     const uint64_t bp_base = 368;
     const size_t n_outputs = tx.vout.size();
     if (n_padded_outputs <= 2)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3438,7 +3438,6 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       bool failed = false;
       for (size_t i = 0; i < tx.vin.size(); i++)
       {
-        const txin_to_key& in_to_key = boost::get<txin_to_key>(tx.vin[i]);
         if(!failed && !results[i])
           failed = true;
       }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -383,7 +383,6 @@ namespace cryptonote
   bool tx_memory_pool::add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed, uint8_t version)
   {
     crypto::hash h = null_hash;
-    size_t blob_size = 0;
     cryptonote::blobdata bl;
     t_serializable_object_to_blob(tx, bl);
     if (bl.size() == 0 || !get_transaction_hash(tx, h))
@@ -1041,7 +1040,6 @@ namespace cryptonote
       return true;
     }, true, category);
 
-    txpool_tx_meta_t meta;
     for (const key_images_container::value_type& kee : m_spent_key_images) {
       const crypto::key_image& k_image = kee.first;
       const std::unordered_set<crypto::hash>& kei_image_set = kee.second;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1849,10 +1849,8 @@ skip:
   bool t_cryptonote_protocol_handler<t_core>::should_download_next_span(cryptonote_connection_context& context, bool standby)
   {
     std::vector<crypto::hash> hashes;
-    boost::uuids::uuid span_connection_id;
     boost::posix_time::ptime request_time;
     boost::uuids::uuid connection_id;
-    std::pair<uint64_t, uint64_t> span;
     bool filled;
 
     const uint64_t blockchain_height = m_core.get_current_blockchain_height();
@@ -1878,7 +1876,6 @@ skip:
 
         // in standby, be ready to double download early since we're idling anyway
         // let the fastest peer trigger first
-        long threshold;
         const double dl_speed = context.m_max_speed_down;
         if (standby && dt >= REQUEST_NEXT_SCHEDULED_SPAN_THRESHOLD_STANDBY && dl_speed > 0)
         {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1059,7 +1059,6 @@ bool t_rpc_command_executor::print_transaction(crypto::hash transaction_hash,
     // Print json if requested
     if (include_json)
     {
-      crypto::hash tx_hash, tx_prefix_hash;
       cryptonote::transaction tx;
       cryptonote::blobdata blob;
       std::string source = as_hex.empty() ? pruned_as_hex + prunable_as_hex : as_hex;

--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -181,7 +181,6 @@ namespace hw {
       unsigned char padding_buffer[MAX_BLOCK+1];
       unsigned int  result;
                int  hid_ret;
-      unsigned int  sw_offset;
       unsigned int  remaining;
       unsigned int  offset = 0;
 

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -74,8 +74,6 @@ namespace
   const command_line::arg_descriptor<bool, false> arg_testnet = {"testnet", genms::tr("Create testnet multisig wallets"), false};
   const command_line::arg_descriptor<bool, false> arg_stagenet = {"stagenet", genms::tr("Create stagenet multisig wallets"), false};
   const command_line::arg_descriptor<bool, false> arg_create_address_file = {"create-address-file", genms::tr("Create an address file for new wallets"), false};
-
-  const command_line::arg_descriptor< std::vector<std::string> > arg_command = {"command", ""};
 }
 
 static bool generate_multisig(uint32_t threshold, uint32_t total, const std::string &basename, network_type nettype, bool create_address_file)

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -194,7 +194,6 @@ namespace
   {
     epee::wipeable_string trimmed_words = "", word;
 
-    const auto &word_map = language->get_word_map();
     const auto &trimmed_word_map = language->get_trimmed_word_map();
     const uint32_t unique_prefix_length = language->get_unique_prefix_length();
     for (std::vector<epee::wipeable_string>::const_iterator it = word_list.begin(); it != word_list.end(); it++)

--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -48,7 +48,6 @@ namespace socks
 {
     namespace
     {
-        constexpr const unsigned v4_reply_size = 8;
         constexpr const std::uint8_t v4_connect_command = 1;
         constexpr const std::uint8_t v4tor_resolve_command = 0xf0;
         constexpr const std::uint8_t v4_request_granted = 90;

--- a/src/ringct/multiexp.cc
+++ b/src/ringct/multiexp.cc
@@ -372,7 +372,6 @@ std::shared_ptr<straus_cached_data> straus_init_cache(const std::vector<Multiexp
   if (N == 0)
     N = data.size();
   CHECK_AND_ASSERT_THROW_MES(N <= data.size(), "Bad cache base data");
-  ge_cached cached;
   ge_p1p1 p1;
   ge_p3 p3;
   std::shared_ptr<straus_cached_data> cache(new straus_cached_data());
@@ -454,7 +453,6 @@ rct::key straus(const std::vector<MultiexpData> &data, const std::shared_ptr<str
   std::shared_ptr<straus_cached_data> local_cache = cache == NULL ? straus_init_cache(data) : cache;
   ge_cached cached;
   ge_p1p1 p1;
-  ge_p3 p3;
 
 #ifdef TRACK_STRAUS_ZERO_IDENTITY
   MULTIEXP_PERF(PERF_TIMER_START_UNIT(skip, 1000000));
@@ -587,7 +585,6 @@ std::shared_ptr<pippenger_cached_data> pippenger_init_cache(const std::vector<Mu
   if (N == 0)
     N = data.size() - start_offset;
   CHECK_AND_ASSERT_THROW_MES(N <= data.size() - start_offset, "Bad cache base data");
-  ge_cached cached;
   std::shared_ptr<pippenger_cached_data> cache(new pippenger_cached_data());
 
   cache->size = N;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -725,7 +725,6 @@ namespace rct {
         CHECK_AND_ASSERT_THROW_MES((kLRki && mscout) || (!kLRki && !mscout), "Only one of kLRki/mscout is present");
         keyV tmp(rows + 1);
         keyV sk(rows + 1);
-        size_t i;
         keyM M(cols, tmp);
 
         keyV P, C, C_nonzero;
@@ -899,7 +898,6 @@ namespace rct {
             key R;
             geDsmp P_precomp;
             geDsmp C_precomp;
-            geDsmp H_precomp;
             size_t i = 0;
             ge_p3 hash8_p3;
             geDsmp hash_precomp;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -367,7 +367,6 @@ namespace cryptonote
       message = "Client signature does not verify for " + rpc;
       return false;
     }
-    crypto::public_key local_client;
     if (!m_rpc_payment->pay(client, ts, payment, rpc, same_ts, credits))
     {
       message = CORE_RPC_STATUS_PAYMENT_REQUIRED;
@@ -1806,7 +1805,6 @@ namespace cryptonote
         return false;
       }
     }
-    uint64_t seed_height;
     crypto::hash seed_hash, next_seed_hash;
     if (!get_block_template(info.address, req.prev_block.empty() ? NULL : &prev_block, blob_reserve, reserved_offset, wdiff, res.height, res.expected_reward, b, res.seed_height, seed_hash, next_seed_hash, error_resp))
       return false;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1360,7 +1360,7 @@ bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, b
     size_t n_outputs = m_wallet->import_multisig(info);
     // Clear line "Height xxx of xxx"
     std::cout << "\r                                                                \r";
-    success_msg_writer() << tr("Multisig info imported");
+    success_msg_writer() << tr("Multisig info imported. Number of outputs updated: ") << n_outputs;
   }
   catch (const std::exception &e)
   {
@@ -6468,8 +6468,6 @@ void simple_wallet::check_for_inactivity_lock(bool user)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::on_command(bool (simple_wallet::*cmd)(const std::vector<std::string>&), const std::vector<std::string> &args)
 {
-  const time_t now = time(NULL);
-  time_t dt = now - m_last_activity_time;
   m_last_activity_time = time(NULL);
 
   m_in_command = true;
@@ -7435,7 +7433,6 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   if (local_args.size() == 3)
   {
     crypto::hash payment_id;
-    crypto::hash8 payment_id8;
     std::string extra_nonce;
     if (tools::wallet2::parse_long_payment_id(local_args.back(), payment_id))
     {
@@ -8601,7 +8598,6 @@ bool simple_wallet::get_transfers(std::vector<std::string>& local_args, std::vec
       if (!unlocked)
       {
         locked_msg = "locked";
-        const uint64_t unlock_time = pd.m_unlock_time;
         if (pd.m_unlock_time < CRYPTONOTE_MAX_BLOCK_NUMBER)
         {
           uint64_t bh = std::max(pd.m_unlock_time, pd.m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
@@ -11180,7 +11176,6 @@ void simple_wallet::mms_next(const std::vector<std::string> &args)
 
 void simple_wallet::mms_sync(const std::vector<std::string> &args)
 {
-  mms::message_store& ms = m_wallet->get_message_store();
   if (args.size() != 0)
   {
     fail_msg_writer() << tr("Usage: mms sync");
@@ -11278,7 +11273,6 @@ void simple_wallet::mms_export(const std::vector<std::string> &args)
     return;
   }
   LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
   mms::message m;
   bool valid_id = get_message_from_arg(args[0], m);
   if (valid_id)
@@ -11347,7 +11341,6 @@ void simple_wallet::mms_show(const std::vector<std::string> &args)
     return;
   }
   LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
   mms::message m;
   bool valid_id = get_message_from_arg(args[0], m);
   if (valid_id)

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -1340,7 +1340,10 @@ bool message_store::check_for_messages(const multisig_wallet_state &state, std::
     }
   }
   std::vector<transport_message> transport_messages;
-  bool r = m_transporter.receive_messages(destinations, transport_messages);
+  if (!m_transporter.receive_messages(destinations, transport_messages))
+  {
+    return false;
+  }
   if (!m_run.load(std::memory_order_relaxed))
   {
     // Stop was called, don't waste time processing the messages

--- a/src/wallet/ringdb.cpp
+++ b/src/wallet/ringdb.cpp
@@ -42,9 +42,6 @@
 
 #define V1TAG ((uint64_t)798237759845202)
 
-static const char zerokey[8] = {0};
-static const MDB_val zerokeyval = { sizeof(zerokey), (void *)zerokey };
-
 static int compare_hash32(const MDB_val *a, const MDB_val *b)
 {
   uint32_t *va = (uint32_t*) a->mv_data;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -367,7 +367,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
 
   // user specified CA file or fingeprints implies enabled SSL by default
   epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
-  if (command_line::get_arg(vm, opts.daemon_ssl_allow_any_cert))
+  if (daemon_ssl_allow_any_cert)
     ssl_options.verification = epee::net_utils::ssl_verification_t::none;
   else if (!daemon_ssl_ca_file.empty() || !daemon_ssl_allowed_fingerprints.empty())
   {
@@ -1004,9 +1004,6 @@ bool get_pruned_tx(const cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry &entry,
 
 namespace tools
 {
-// for now, limit to 30 attempts.  TODO: discuss a good number to limit to.
-const size_t MAX_SPLIT_ATTEMPTS = 30;
-
 constexpr const std::chrono::seconds wallet2::rpc_timeout;
 const char* wallet2::tr(const char* str) { return i18n_translate(str, "tools::wallet2"); }
 
@@ -7984,7 +7981,6 @@ void wallet2::light_wallet_get_outs(std::vector<std::vector<tools::wallet2::get_
   
   // Check if we got enough outputs for each amount
   for(auto& out: ores.amount_outs) {
-    const uint64_t out_amount = boost::lexical_cast<uint64_t>(out.amount);
     THROW_WALLET_EXCEPTION_IF(out.outputs.size() < light_wallet_requested_outputs_count , error::wallet_internal_error, "Not enough outputs for amount: " + boost::lexical_cast<std::string>(out.amount));
     MDEBUG(out.outputs.size() << " outputs for amount "+ boost::lexical_cast<std::string>(out.amount) + " received from light wallet node");
   }
@@ -10303,8 +10299,6 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, s
 {
   MDEBUG("sanity_check: " << ptx_vector.size() << " txes, " << dsts.size() << " destinations");
 
-  hw::device &hwdev = m_account.get_device();
-
   THROW_WALLET_EXCEPTION_IF(ptx_vector.empty(), error::wallet_internal_error, "No transactions");
 
   // check every party in there does receive at least the required amount
@@ -10341,7 +10335,6 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, s
   for (const auto &r: required)
   {
     const account_public_address &address = r.first;
-    const crypto::public_key &view_pkey = address.m_view_public_key;
 
     uint64_t total_received = 0;
     for (const auto &ptx: ptx_vector)
@@ -13229,7 +13222,6 @@ rct::multisig_kLRki wallet2::get_multisig_composite_kLRki(size_t n, const std::u
 {
   CHECK_AND_ASSERT_THROW_MES(n < m_transfers.size(), "Bad transfer index");
 
-  const transfer_details &td = m_transfers[n];
   rct::multisig_kLRki kLRki = get_multisig_kLRki(n, rct::skGen());
 
   // pick a L/R pair from every other participant but one

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1282,7 +1282,6 @@ namespace tools
             dests.erase(cd.change_dts.addr);
         }
 
-        size_t n_dummy_outputs = 0;
         for (auto i = dests.begin(); i != dests.end(); )
         {
           if (i->second.second > 0)

--- a/tests/core_tests/transaction_tests.cpp
+++ b/tests/core_tests/transaction_tests.cpp
@@ -78,8 +78,6 @@ bool test_transaction_generation_and_ring_signature()
   tx_source_entry& src = sources.back();
   src.amount = 70368744177663;
   {
-    tx_output_entry oe;
-
     src.push_output(0, boost::get<txout_to_key>(tx_mine_1.vout[0].target).key, src.amount);
 
     src.push_output(1, boost::get<txout_to_key>(tx_mine_2.vout[0].target).key, src.amount);

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -165,9 +165,6 @@ bool txpool_double_spend_base::timestamp_change_pause(cryptonote::core& /*c*/, s
 
 bool txpool_double_spend_base::check_changed(cryptonote::core& c, const size_t ev_index, relay_test condition)
 {
-  const std::size_t public_hash_count = m_broadcasted_hashes.size();
-  const std::size_t all_hash_count = m_all_hashes.size();
-
   const std::size_t new_broadcasted_hash_count = m_broadcasted_hashes.size() + unsigned(condition == relay_test::broadcasted);
   const std::size_t new_all_hash_count = m_all_hashes.size() + unsigned(condition == relay_test::hidden) + unsigned(condition == relay_test::no_relay);
 

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -41,7 +41,6 @@ using namespace cryptonote;
 namespace
 {
   uint64_t const TEST_FEE = 5000000000; // 5 * 10^9
-  uint64_t const TEST_DUST_THRESHOLD = 5000000000; // 5 * 10^9
 }
 
 std::string generate_random_wallet_name()

--- a/tests/net_load_tests/srv.cpp
+++ b/tests/net_load_tests/srv.cpp
@@ -169,7 +169,7 @@ namespace
       LOG_PRINT_L0("Closing connections. Number of opened connections: " << m_tcp_server.get_config_object().get_connections_count());
 
       size_t count = 0;
-      bool r = m_tcp_server.get_config_object().foreach_connection([&](test_connection_context& ctx) {
+      m_tcp_server.get_config_object().foreach_connection([&](test_connection_context& ctx) {
         if (ctx.m_connection_id != cmd_conn_id)
         {
           ++count;

--- a/tests/performance_tests/performance_tests.h
+++ b/tests/performance_tests/performance_tests.h
@@ -215,7 +215,6 @@ void run_test(const std::string &filter, Params &params, const char* test_name)
     if (params.stats)
     {
       uint64_t mins = min / scale;
-      uint64_t maxs = max / scale;
       uint64_t meds = med / scale;
       uint64_t p95s = quantiles[9] / scale;
       uint64_t stddevs = stddev / scale;

--- a/tests/unit_tests/bulletproofs.cpp
+++ b/tests/unit_tests/bulletproofs.cpp
@@ -296,7 +296,6 @@ TEST(bulletproof, weight_pruned)
     ASSERT_TRUE(tx.version == 2);
     ASSERT_FALSE(tx.pruned);
     ASSERT_TRUE(rct::is_rct_bulletproof(tx.rct_signatures.type));
-    const uint64_t tx_size = bd.size();
     const uint64_t tx_weight = cryptonote::get_transaction_weight(tx);
     ASSERT_TRUE(parse_and_validate_tx_base_from_blob(bd, pruned_tx));
     ASSERT_TRUE(pruned_tx.version == 2);

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -432,7 +432,6 @@ TEST(voting, info)
 
   //                                             0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5  6  7  8  9
   static const uint8_t block_versions[]      = { 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4 };
-  static const uint8_t expected_versions[]   = { 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
   static const uint8_t expected_thresholds[] = { 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 2, 2, 2, 2 };
 
   for (uint64_t h = 0; h < sizeof(block_versions) / sizeof(block_versions[0]); ++h) {

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -250,7 +250,6 @@ TEST(ban, subnet)
 
 TEST(ban, ignores_port)
 {
-  time_t seconds;
   test_core pr_core;
   cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
   Server server(cprotocol);

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -206,7 +206,7 @@ TEST(select_outputs, same_distribution)
   for (size_t i = 0; i < chain_picks.size(); ++i)
     chain_norm[i * 100 / chain_picks.size()] += chain_picks[i];
 
-  double max_dev = 0.0, avg_dev = 0.0;
+  double avg_dev = 0.0;
   for (size_t i = 0; i < 100; ++i)
   {
     const double diff = (double)output_norm[i] - (double)chain_norm[i];

--- a/tests/unit_tests/zmq_rpc.cpp
+++ b/tests/unit_tests/zmq_rpc.cpp
@@ -202,7 +202,6 @@ namespace
     MASSERT(!expected.empty());
 
     std::size_t actual_height = 0;
-    crypto::hash actual_id{};
     crypto::hash actual_prev_id{};
     std::vector<crypto::hash> actual_ids{};
     GET_FROM_JSON_OBJECT(pub.second, actual_height, first_height);


### PR DESCRIPTION
There are quite a few variables in the code that are no longer (or perhaps never were) in use. These were discovered by enabling compiler warnings for unused variables and cleaning them up.

In most cases where the unused variables were the result of a function call the call was left but the variable assignment removed, unless it was obvious that it was a simple getter with no side effects.