### PR TITLE
Basic cleanup

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -287,7 +287,7 @@ uint64_t BlockchainDB::add_block( const std::pair<block, blobdata>& blck
     num_rct_outs += blk.miner_tx.vout.size();
   int tx_i = 0;
   crypto::hash tx_hash = crypto::null_hash;
-  for (const std::pair<transaction, blobdata_ref>& tx : txs)
+  for (const std::pair<transaction, blobdata>& tx : txs)
   {
     tx_hash = blk.tx_hashes[tx_i];
     add_transaction(blk_hash, tx, &tx_hash);

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -149,7 +149,7 @@ struct ancestry_state_t
     {
       std::unordered_map<crypto::hash, cryptonote::transaction> old_tx_cache;
       a & old_tx_cache;
-      for (const auto i: old_tx_cache)
+      for (const auto& i: old_tx_cache)
         tx_cache.insert(std::make_pair(i.first, ::tx_data_t(i.second)));
     }
     else
@@ -161,7 +161,7 @@ struct ancestry_state_t
       std::unordered_map<uint64_t, cryptonote::block> old_block_cache;
       a & old_block_cache;
       block_cache.resize(old_block_cache.size());
-      for (const auto i: old_block_cache)
+      for (const auto& i: old_block_cache)
         block_cache[i.first] = i.second;
     }
     else

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -973,7 +973,7 @@ start:
 std::pair<bool, uint64_t> Blockchain::check_difficulty_checkpoints() const
 {
   uint64_t res = 0;
-  for (const std::pair<uint64_t, difficulty_type>& i : m_checkpoints.get_difficulty_points())
+  for (const std::pair<const uint64_t, difficulty_type>& i : m_checkpoints.get_difficulty_points())
   {
     if (i.first >= m_db->height())
       break;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -630,7 +630,7 @@ namespace cryptonote
 
           void operator()(std::uint64_t, epee::span<const block> blocks) const
           {
-            for (const block bl : blocks)
+            for (const block& bl : blocks)
               cmdline.notify("%s", epee::string_tools::pod_to_hex(get_block_hash(bl)).c_str(), NULL);
           }
         };

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -9466,7 +9466,7 @@ void simple_wallet::print_accounts()
 {
   const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& account_tags = m_wallet->get_account_tags();
   size_t num_untagged_accounts = m_wallet->get_num_subaddress_accounts();
-  for (const std::pair<std::string, std::string>& p : account_tags.first)
+  for (const std::pair<const std::string, std::string>& p : account_tags.first)
   {
     const std::string& tag = p.first;
     print_accounts(tag);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -344,8 +344,6 @@ std::string get_weight_string(const cryptonote::transaction &tx, size_t blob_siz
 
 std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool unattended, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
-  namespace ip = boost::asio::ip;
-
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
   const network_type nettype = testnet ? TESTNET : stagenet ? STAGENET : MAINNET;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -687,7 +687,7 @@ namespace tools
   {
     if (!m_wallet) return not_open(er);
     const std::pair<std::map<std::string, std::string>, std::vector<std::string>> account_tags = m_wallet->get_account_tags();
-    for (const std::pair<std::string, std::string>& p : account_tags.first)
+    for (const std::pair<const std::string, std::string>& p : account_tags.first)
     {
       res.account_tags.resize(res.account_tags.size() + 1);
       auto& info = res.account_tags.back();

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -393,7 +393,7 @@ bool txpool_double_spend_base::check_changed(cryptonote::core& c, const size_t e
     }
   }
 
-  for (const std::pair<crypto::hash, uint64_t>& hash : m_all_hashes)
+  for (const std::pair<const crypto::hash, uint64_t>& hash : m_all_hashes)
   {
     cryptonote::blobdata tx_blob{};
     if (!c.get_pool_transaction(hash.first, tx_blob, cryptonote::relay_category::all))
@@ -411,7 +411,7 @@ bool txpool_double_spend_base::check_changed(cryptonote::core& c, const size_t e
     for (const crypto::hash& hash : m_no_relay_hashes)
       difference.erase(hash);
 
-    for (const std::pair<crypto::hash, uint64_t>& hash : difference)
+    for (const std::pair<const crypto::hash, uint64_t>& hash : difference)
     {
       if (c.pool_has_tx(hash.first))
       {

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -1351,7 +1351,7 @@ TEST(dandelionpp_map, dropped_connection)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(3u, entry.second);
 
         for (const boost::uuids::uuid& connection : in_connections)
@@ -1409,7 +1409,7 @@ TEST(dandelionpp_map, dropped_connection)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(3u, entry.second);
     }
     {
@@ -1472,7 +1472,7 @@ TEST(dandelionpp_map, dropped_connection_remapped)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(3u, entry.second);
 
         for (const boost::uuids::uuid& connection : in_connections)
@@ -1511,7 +1511,7 @@ TEST(dandelionpp_map, dropped_connection_remapped)
         }
 
         EXPECT_EQ(2u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(5u, entry.second);
     }
     // select 3 of 3 connections but do not remap existing links
@@ -1532,7 +1532,7 @@ TEST(dandelionpp_map, dropped_connection_remapped)
         }
 
         EXPECT_EQ(2u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(5u, entry.second);
     }
     // map 8 new incoming connections across 3 outgoing links
@@ -1555,7 +1555,7 @@ TEST(dandelionpp_map, dropped_connection_remapped)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(6u, entry.second);
     }
 }
@@ -1609,7 +1609,7 @@ TEST(dandelionpp_map, dropped_all_connections)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(3u, entry.second);
 
         for (const boost::uuids::uuid& connection : in_connections)
@@ -1641,7 +1641,7 @@ TEST(dandelionpp_map, dropped_all_connections)
         }
 
         EXPECT_EQ(3u, used.size());
-        for (const std::pair<boost::uuids::uuid, std::size_t>& entry : used)
+        for (const std::pair<const boost::uuids::uuid, std::size_t>& entry : used)
             EXPECT_EQ(3u, entry.second);
     }
 }


### PR DESCRIPTION
Clang warns about a number of unexpected copies in for loops. This removes those copies, along with one other simple namespace cleanup.