### PR TITLE
Store RPC SSL key/cert for consistent authentication between runs

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -265,6 +265,12 @@ namespace net_utils
     template<class t_callback>
     bool connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeot, const t_callback &cb, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
 
+    boost::asio::ssl::context& get_ssl_context() noexcept
+    {
+      assert(m_state != nullptr);
+      return m_state->ssl_context;
+    }
+
     typename t_protocol_handler::config_type& get_config_object()
     {
       assert(m_state != nullptr); // always set in constructor

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -36,6 +36,7 @@
 #include <boost/utility/string_ref.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/system/error_code.hpp>
 
 #define SSL_FINGERPRINT_SIZE 32
@@ -144,6 +145,9 @@ namespace net_utils
 
 	bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
 	bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
+
+  //! Store private key for `ssl` at `base + ".key"` unencrypted and certificate for `ssl` at `base + ".crt"`.
+  boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& base);
 }
 }
 

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <thread>
 #include <boost/asio/ssl.hpp>
+#include <boost/cerrno.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <openssl/ssl.h>
 #include <openssl/pem.h>
@@ -565,6 +567,51 @@ bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s)
   else
     return false;
   return true;
+}
+
+boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& base)
+{
+  EVP_PKEY* ssl_key = nullptr;
+  X509* ssl_cert = nullptr;
+  const auto ctx = ssl.native_handle();
+  CHECK_AND_ASSERT_MES(ctx, boost::system::error_code(EINVAL, boost::system::system_category()), "Context is null");
+  CHECK_AND_ASSERT_MES(base.has_filename(), boost::system::error_code(EINVAL, boost::system::system_category()), "Need filename");
+  if (!(ssl_key = SSL_CTX_get0_privatekey(ctx)) || !(ssl_cert = SSL_CTX_get0_certificate(ctx)))
+    return {EINVAL, boost::system::system_category()};
+
+  using file_closer = int(std::FILE*);
+  boost::system::error_code error{};
+  std::unique_ptr<std::FILE, file_closer*> file{nullptr, std::fclose};
+
+  // write key file unencrypted
+  {
+    const boost::filesystem::path key_file{base.string() + ".key"};
+    file.reset(std::fopen(key_file.string().c_str(), "wb"));
+    if (!file)
+      return {errno, boost::system::system_category()};
+    boost::filesystem::permissions(key_file, boost::filesystem::owner_read, error);
+    if (error)
+      return error;
+    if (!PEM_write_PrivateKey(file.get(), ssl_key, nullptr, nullptr, 0, nullptr, nullptr))
+      return boost::asio::error::ssl_errors(ERR_get_error());
+    if (std::fclose(file.release()) != 0)
+      return {errno, boost::system::system_category()};
+  }
+
+  // write certificate file in standard SSL X.509 unencrypted
+  const boost::filesystem::path cert_file{base.string() + ".crt"};
+  file.reset(std::fopen(cert_file.string().c_str(), "wb"));
+  if (!file)
+    return {errno, boost::system::system_category()};
+  const auto cert_perms = (boost::filesystem::owner_read | boost::filesystem::group_read | boost::filesystem::others_read);
+  boost::filesystem::permissions(cert_file, cert_perms, error);
+  if (error)
+    return error;
+  if (!PEM_write_X509(file.get(), ssl_cert))
+    return boost::asio::error::ssl_errors(ERR_get_error());
+  if (std::fclose(file.release()) != 0)
+    return {errno, boost::system::system_category()};
+  return error;
 }
 
 } // namespace


### PR DESCRIPTION
`monerod` creates a new SSL certificate for RPC each run if the user does not provide a custom certificate. This stores the SSL key/cert in the data directory so that it can be re-used across runs. A user provided key always take precedence.

This will allow clients to perform some authentication - I am updating `wallet2` to store SSL fingerprints per host, and notify the user if the certificate changed since first use. A [working prototype for DANE/TLSA](https://github.com/vtnerd/monero/tree/improve/dane_tlsa) in the wallet also exists, which restricts the attack fingerprint of trust-on-first-use to the DNSSEC chain. This is imperfect, but an improvement over users using default settings with arbitrary RPC servers which has no authentication currently. Only DNSSEC is required, no paid certificates or constant certificate re-issues/signatures.