### PR TITLE
Increase timeout for the mining test 4 times (to 240s)

### DIFF
--- a/tests/functional_tests/mining.py
+++ b/tests/functional_tests/mining.py
@@ -97,7 +97,7 @@ class MiningTest():
         # wait till we mined a few of them
         target_height = prev_height + 5
         height = prev_height
-        timeout = 60 # randomx is slow to init
+        timeout = 240 # randomx is slow to init
         while height < target_height:
             seen_height = height
             for _ in range(timeout):


### PR DESCRIPTION
The mining test fails quite often, due to RandomX taking more time to initialize, than the fixed timeout was set to. I increased it by 4 times for now.
The reason for this problem could be an abnormal stress on the CI machines from our and not only our project, while the RandomX is being initialized.

I have reproduced the problem by setting the timeout artificially to 1, and I got the same error message as we typically get.

In a possible future PR I will check, if I can obtain any feedback from the RX itself.

Active work time: ~0.5h