### PR TITLE
Honor LARGE_PAGES flag in randomx umask

### DIFF
--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -264,12 +264,14 @@ void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const ch
 
   cache = rx_sp->rs_cache;
   if (cache == NULL) {
-    if (cache == NULL) {
+    if (!(disabled_flags() & RANDOMX_FLAG_LARGE_PAGES)) {
       cache = randomx_alloc_cache(flags | RANDOMX_FLAG_LARGE_PAGES);
       if (cache == NULL) {
         mdebug(RX_LOGCAT, "Couldn't use largePages for RandomX cache");
-        cache = randomx_alloc_cache(flags);
       }
+    }
+    if (cache == NULL) {
+      cache = randomx_alloc_cache(flags);
       if (cache == NULL)
         local_abort("Couldn't allocate RandomX cache");
     }
@@ -291,11 +293,14 @@ void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const ch
       CTHR_MUTEX_LOCK(rx_dataset_mutex);
       if (!rx_dataset_nomem) {
         if (rx_dataset == NULL) {
-          rx_dataset = randomx_alloc_dataset(RANDOMX_FLAG_LARGE_PAGES);
-          if (rx_dataset == NULL) {
-            mdebug(RX_LOGCAT, "Couldn't use largePages for RandomX dataset");
-            rx_dataset = randomx_alloc_dataset(RANDOMX_FLAG_DEFAULT);
+          if (!(disabled_flags() & RANDOMX_FLAG_LARGE_PAGES)) {
+            rx_dataset = randomx_alloc_dataset(RANDOMX_FLAG_LARGE_PAGES);
+            if (rx_dataset == NULL) {
+              mdebug(RX_LOGCAT, "Couldn't use largePages for RandomX dataset");
+            }
           }
+          if (rx_dataset == NULL)
+            rx_dataset = randomx_alloc_dataset(RANDOMX_FLAG_DEFAULT);
           if (rx_dataset != NULL)
             rx_initdata(rx_sp->rs_cache, miners, seedheight);
         }
@@ -311,11 +316,14 @@ void rx_slow_hash(const uint64_t mainheight, const uint64_t seedheight, const ch
       }
       CTHR_MUTEX_UNLOCK(rx_dataset_mutex);
     }
-    rx_vm = randomx_create_vm(flags | RANDOMX_FLAG_LARGE_PAGES, rx_sp->rs_cache, rx_dataset);
-    if(rx_vm == NULL) { //large pages failed
-      mdebug(RX_LOGCAT, "Couldn't use largePages for RandomX VM");
-      rx_vm = randomx_create_vm(flags, rx_sp->rs_cache, rx_dataset);
+    if (!(disabled_flags() & RANDOMX_FLAG_LARGE_PAGES)) {
+      rx_vm = randomx_create_vm(flags | RANDOMX_FLAG_LARGE_PAGES, rx_sp->rs_cache, rx_dataset);
+      if(rx_vm == NULL) { //large pages failed
+        mdebug(RX_LOGCAT, "Couldn't use largePages for RandomX VM");
+      }
     }
+    if (rx_vm == NULL)
+      rx_vm = randomx_create_vm(flags, rx_sp->rs_cache, rx_dataset);
     if(rx_vm == NULL) {//fallback if everything fails
       flags = RANDOMX_FLAG_DEFAULT | (miners ? RANDOMX_FLAG_FULL_MEM : 0);
       rx_vm = randomx_create_vm(flags, rx_sp->rs_cache, rx_dataset);


### PR DESCRIPTION
Flag in MONERO_RANDOMX_UMASK was being ignored, leaving no way to disable use of large pages.
