### PR TITLE
Fix txs_prunable_hash sort functions [DO NOT MERGE]

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1461,8 +1461,7 @@ void BlockchainLMDB::open(const std::string& filename, const int db_flags)
   mdb_set_dupsort(txn, m_block_info, compare_uint64);
   if (!(mdb_flags & MDB_RDONLY))
     mdb_set_dupsort(txn, m_txs_prunable_tip, compare_uint64);
-  mdb_set_compare(txn, m_txs_prunable, compare_uint64);
-  mdb_set_dupsort(txn, m_txs_prunable_hash, compare_uint64);
+  mdb_set_dupsort(txn, m_txs_prunable_hash, compare_hash32);
 
   mdb_set_compare(txn, m_txpool_meta, compare_hash32);
   mdb_set_compare(txn, m_txpool_blob, compare_hash32);


### PR DESCRIPTION
The key is a uint64, the value is a hash

Since the current code is only comparing the first 8 bytes of the 32 byte hash, it is possible
that there have been collisions in txs_prunable_hash table, and possibly dropped records as
a result. As such it seems that the only safe way to fix this is re-import the entire blockchain
so that all the table entries can be recreated.
