### PR TITLE
[CI] Add ccache to Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: C:\Users\runneradmin\.ccache-temp
+      CCACHE_DIR: C:\Users\runneradmin\.ccache
     defaults:
       run:
         shell: msys2 {0}
@@ -33,12 +37,19 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: actions/cache@v2
+      with:
+        path: C:\Users\runneradmin\.ccache
+        key: ccache-windows-build-${{ github.sha }}
+        restore-keys: ccache-windows-build-
     - uses: eine/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
+        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
     - name: build
-      run: make release-static-win64 -j2
+      run: |
+        ccache --max-size=150M
+        make release-static-win64 -j2
 
   build-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tested using a repeated build, as well as an additional build, where one source file was intentionally changed to fail. The reaction was correct - all OSes, including Windows, failed.

Based on @selsta 's [input](https://github.com/monero-project/monero/compare/02eec3513e82aa9dd55b874c598bb27f1d8184c7..12a422c0935d19915c143114d682b3208f6edf8d).

Work time: ~ 1.7h