### PR TITLE
rpc: fix some error return codes/status

### DIFF
--- a/src/rpc/core_rpc_server_error_codes.h
+++ b/src/rpc/core_rpc_server_error_codes.h
@@ -49,6 +49,8 @@
 #define CORE_RPC_ERROR_CODE_DUPLICATE_PAYMENT     -17
 #define CORE_RPC_ERROR_CODE_STALE_PAYMENT         -18
 #define CORE_RPC_ERROR_CODE_RESTRICTED            -19
+#define CORE_RPC_ERROR_CODE_UNSUPPORTED_BOOTSTRAP -20
+#define CORE_RPC_ERROR_CODE_PAYMENTS_NOT_ENABLED  -21
 
 static inline const char *get_rpc_server_error_message(int64_t code)
 {
@@ -72,6 +74,8 @@ static inline const char *get_rpc_server_error_message(int64_t code)
     case CORE_RPC_ERROR_CODE_DUPLICATE_PAYMENT: return "Duplicate payment";
     case CORE_RPC_ERROR_CODE_STALE_PAYMENT: return "Stale payment";
     case CORE_RPC_ERROR_CODE_RESTRICTED: return "Parameters beyond restricted allowance";
+    case CORE_RPC_ERROR_CODE_UNSUPPORTED_BOOTSTRAP: return "Command is unsupported in bootstrap mode";
+    case CORE_RPC_ERROR_CODE_PAYMENTS_NOT_ENABLED: return "Payments not enabled";
     default: MERROR("Unknown error: " << code); return "Unknown error";
   }
 }


### PR DESCRIPTION
Some RPC return an error string in status, and the code must return
true on error (with a status string).