### PR TITLE
[CI] Adaptive mining timeout, depending on available CPU power

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,8 +130,8 @@ jobs:
       run: sudo apt update
     - name: install monero dependencies
       run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler
-    - name: install requests
-      run: pip install requests
+    - name: install Python dependencies
+      run: pip install requests psutil monotonic
     - name: tests
       env:
         CTEST_OUTPUT_ON_FAILURE: ON

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,11 @@ To run the same tests on a release build, replace `debug` with `release`.
 [TODO]
 Functional tests are located under the `tests/functional` directory.
 
+Building all the tests requires installing the following dependencies:
+```bash
+pip install requests psutil monotonic
+```
+
 First, run a regtest daemon in the offline mode and with a fixed difficulty:
 ```bash
 monerod --regtest --offline --fixed-difficulty 1

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(make_test_signature
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 
+monero_add_minimal_executable(cpu_power_test cpu_power_test.cpp)
 find_program(PYTHON3_FOUND python3 REQUIRED)
 
 execute_process(COMMAND ${PYTHON3_FOUND} "-c" "import requests; import psutil; import monotonic; print('OK')" OUTPUT_VARIABLE REQUESTS_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/tests/functional_tests/cpu_power_test.cpp
+++ b/tests/functional_tests/cpu_power_test.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2014-2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+const char * descr = 
+"This program prints the time (ms) needed to calculate a mathematical challenge. It's purpose \n\
+is to be able to use the result to compare the CPU power available on the machine it's being executed \n\
+and under the given circumstances, which can differ for the same machine. For example: \n\
+The printed value will be different when using 2 of 2 cores, when there an another process \n\
+running on one of the cores core, and when no other intense process running. \n\
+ \n\
+The program expects a one argument: a numerical value of the threads to start the calculations on. \n\
+ \n\
+Prints: \n\
+Time to calculate a mathematical challenge in MILLISECONDS. \n\
+ \n\
+Returns: \n\
+0 on success, \n\
+1 on a missing argument, \n\
+2 on an incorrect format of the argument.\n";
+
+#include <iostream>
+#include <future>
+#include <vector>
+#include <sstream>
+#include <chrono>
+
+using namespace std;
+
+/**
+Uses Leibniz Formula for Pi.
+https://en.wikipedia.org/wiki/Leibniz_formula_for_%CF%80
+*/
+static double calcPi(const size_t max_iter)
+{
+    const double n = 4;
+    double pi = 0;
+    double d = 1;
+    for (size_t i = 1; i < max_iter; ++i)
+    {
+        const double a = 2.0 * (i % 2) - 1.0;
+        pi += a * n / d;
+        d += 2;
+    }
+    return pi;
+}
+
+int main(int argc, const char ** argv)
+{
+    const size_t max_iter = 1e9;
+    if (argc < 2)
+    {
+        cout << "Please pass the number of threads to run.\n";
+        
+        cout << '\n' << descr << '\n';
+        return 1;
+    }
+    
+    // Convert argument to an integer.
+    int numThreads = 1;
+    const char * numThreadsStr = argv[1];
+    std::istringstream iss(numThreadsStr);
+    if (! (iss >> numThreads) )
+    {
+        cout << "Incorrect format of number of threads = '" << numThreadsStr << "'\n";
+        return 2;
+    }
+    // Run the calculation in parallel.
+    std::vector<std::future<double>> futures;
+    for(int i = 0; i < numThreads; ++i) 
+    {
+        futures.push_back(std::async(calcPi, max_iter));
+    }    
+    
+    // Start measuring the time.
+    const std::chrono::steady_clock::time_point tbegin = std::chrono::steady_clock::now();
+    for(auto & e : futures) 
+    {
+       e.get();
+    }
+    // Stop measuring the time.
+    const std::chrono::steady_clock::time_point tend = std::chrono::steady_clock::now();
+    
+    // Print the measured duration.
+    cout << std::chrono::duration_cast<std::chrono::milliseconds>(tend - tbegin).count() << std::endl;
+    return 0;
+}
+

--- a/tests/functional_tests/util_resources.py
+++ b/tests/functional_tests/util_resources.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+    Help determine how much CPU power is available at the given time
+    by running numerical calculations
+"""
+
+from __future__ import print_function
+import subprocess
+import psutil
+
+def available_ram_gb():
+    ram_bytes = psutil.virtual_memory().available
+    kilo = 1024.0
+    ram_gb = ram_bytes / kilo**3
+    return ram_gb
+
+def get_time_pi_seconds(cores):
+    app_path = './cpu_power_test'
+    time_calc = subprocess.check_output([app_path, str(cores)])
+    decoded = time_calc.decode('utf-8')
+    miliseconds = int(decoded)
+
+    return miliseconds / 1000.0


### PR DESCRIPTION
### Intro
A more serious approach to determining the appropriate timeout for the mining test in `functional_tests_rpc`. The timeouts are calculated separately for RX init and for the mining of subsequent blocks themselves. Printing also available RAM, in case the RX init went wrong, which needs above 3 GB of RAM. Added comprehensive description.

### More details:
As per the discussion with @iamamyth in https://github.com/monero-project/monero/pull/7371 , the adjustment is done by testing the time of generation of N next digits of Pi - once for a single core (mining use case) and once for as many cores as there are available (RX init). This test helps orientating in the currently available CPU processing power, even in the event of:
- other jobs taking up the virtual resources at the same time
- `ctest` being ran in parallel (with `-j$(nproc)`)

The obtained measurements serve as multipliers for the assumed timeout constants. For the case of RX init, the number of cores serves additionally as a divisor of the timeout constant, since availability of more cores decreases the init time (ideally) linearly.

### Example runs 
(see the bottom of the `tests` log):
[-1-](https://github.com/mj-xmr/monero/runs/1934048564?check_suite_focus=true) [-2-](https://github.com/mj-xmr/monero/runs/1934758910?check_suite_focus=true) [-3-](https://github.com/mj-xmr/monero/runs/1935221231?check_suite_focus=true) [-4-](https://github.com/mj-xmr/monero/runs/1934786457?check_suite_focus=true)

### Example log:
6: [TEST STARTED] mining
6: Resetting blockchain
6: Creating wallet

6: Test mining via daemon
6: Available RAM = 17.0 GB
6: Measuring the currently available CPU power...
6: Time taken to calculate 10000 Pi digits on **4 core(s) was 2.03 s**.
6: Measuring the currently available CPU power...
6: Time taken to calculate 10000 Pi digits on _1 core(s) was 1.31 s_.
6: Timeout for init,   adjusted for the currently available **CPU power, is 31 s**
6: Timeout for mining, adjusted for the currently available _CPU power, is 27 s_
6: Time taken for RX init + mining 1st block = 12 s.
6: Time taken for total mining = 12 s.

6: Test mining via wallet
6: Available RAM = 16.8 GB
6: Measuring the currently available CPU power...
6: Time taken to calculate 10000 Pi digits on **4 core(s) was 2.13 s.**
6: Measuring the currently available CPU power...
6: Time taken to calculate 10000 Pi digits on _1 core(s) was 1.3 s._
6: Timeout for init,   adjusted for the currently available **CPU power, is 33 s**
6: Timeout for mining, adjusted for the currently available _CPU power, is 27 s_
6: Time taken for RX init + mining 1st block = 11 s.
6: Time taken for total mining = 23 s.

6: Test submitblock
6: Resetting blockchain
6: Test RandomX
6: Recreating the chain
6: Mining from genesis block again
6: Adding one to reorg
6: [TEST PASSED] mining

Work time: ~15 h
