### PR TITLE
Fix compiler warning for in keyvalue_serialization.h

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -73,7 +73,8 @@ public: \
   template<bool is_store, class t_storage> \
   bool serialize_map(t_storage& stg, typename t_storage::hsection hparent_section) \
   { \
-    decltype(*this) &this_ref = *this;
+    decltype(*this) &this_ref = *this; \
+    (void) this_ref; // Suppress unused var warnings. Sometimes this var is used, sometimes not.
 
 #define KV_SERIALIZE_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize(this_ref.varialble, stg, hparent_section, val_name);


### PR DESCRIPTION
This compiler warning occurs way too often and pollutes the view.

```
/tmp/monero/monero/src/rpc/instanciations.cpp:36:37:   required from here
/tmp/monero/monero/contrib/epee/include/serialization/keyvalue_serialization.h:76:22: warning: unused variable ‘this_ref’ [-Wunused-variable]
   76 |     decltype(*this) &this_ref = *this;
      |                      ^~~~~~~~
```