### PR TITLE
Epee: add headers to project files (via glob)

### DIFF
--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -26,11 +26,20 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+set(EPEE_INCLUDE_DIR_BASE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+
+# Adding headers to the file list, to be able to search for them in IDEs.
+file(GLOB EPEE_HEADERS_PUBLIC 
+	"${EPEE_INCLUDE_DIR_BASE}/*.h*"    # h* will include hpps as well.
+	"${EPEE_INCLUDE_DIR_BASE}/**/*.h*" # Any number of subdirs will be included.
+)
 
 add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
     int-util.cpp portable_storage.cpp
     misc_language.cpp
+
+    ${EPEE_HEADERS_PUBLIC}
     )
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
@@ -74,5 +83,5 @@ if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
     ${GNU_READLINE_LIBRARY})
 endif()
 
-target_include_directories(epee PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_include_directories(epee PUBLIC "${EPEE_INCLUDE_DIR_BASE}")
 


### PR DESCRIPTION
This change allows the epee headers to be searched for easily via IDEs. Additionally, the IDEs will automatically save the changed headers, when compile command is issued.