### PR TITLE
updates: verify DNS hash against GItian reproducible build hashes

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -43,6 +43,7 @@ set(common_sources
   pruning.cpp
   spawn.cpp
   threadpool.cpp
+  update_hash_checker.cpp
   updates.cpp
   aligned.c
   timings.cc
@@ -83,6 +84,7 @@ set(common_private_headers
   spawn.h
   stack_trace.h
   threadpool.h
+  update_hash_checker.h
   updates.h
   aligned.h
   timings.h

--- a/src/common/update_hash_checker.cpp
+++ b/src/common/update_hash_checker.cpp
@@ -1,0 +1,384 @@
+// Copyright (c) 2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "update_hash_checker.h"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+#include <boost/algorithm/string.hpp>
+
+#include "hex.h"
+#include "misc_log_ex.h"
+#include "serialization/keyvalue_serialization.h"
+#include "storages/portable_storage_template_helper.h"
+#include "string_coding.h"
+#include "string_tools.h"
+#include "string_tools_lexical.h"
+
+#include "crypto/crypto.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "update_hash_checker"
+
+namespace tools
+{
+
+namespace
+{
+
+class gitian_assert
+{
+public:
+  gitian_assert(const std::string &assert)
+  {
+    boost::split(m_contents, assert, boost::is_any_of("\n"));
+  }
+
+  bool find_hash(const crypto::hash &hash, const std::string &version, const std::string &platform) const
+  {
+    for (const auto &line : m_contents)
+    {
+      if (line.find(version) == std::string::npos)
+      {
+        continue;
+      }
+      if (line.find(platform) == std::string::npos)
+      {
+        continue;
+      }
+
+      bool found_whitespace = false;
+      const auto hash_end = std::find_if(line.rbegin(), line.rend(), [&found_whitespace](const char &ch) {
+        if (ch == ' ' || ch == '\t')
+        {
+          found_whitespace = true;
+          return false;
+        }
+        return found_whitespace;
+      });
+      const auto hash_start = std::find_if(hash_end, line.rend(), [](const char &ch) {
+        if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f'))
+        {
+          return false;
+        }
+        return true;
+      });
+
+      crypto::hash current_hash;
+      const size_t hash_len = std::distance(hash_start.base(), hash_end.base());
+      if (!epee::from_hex::to_buffer(epee::as_mut_byte_span(current_hash), {&*hash_start.base(), hash_len}))
+      {
+        continue;
+      }
+
+      if (current_hash == hash)
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+private:
+  std::vector<std::string> m_contents;
+};
+
+class gitian_path
+{
+public:
+  gitian_path(const std::string &project, const std::string &version, const std::string &build_tag)
+  {
+    std::vector<std::string> semver;
+    boost::split(semver, version, boost::is_any_of(".-"));
+
+    if (semver.size() < 2)
+    {
+      throw std::runtime_error("failed to detect major/minor version");
+    }
+
+    const std::pair<std::string, std::string> &platform_os = build_tag_to_platform_tuple(build_tag);
+    m_build_assert_filename = project + "-" + platform_os.first + "-" + semver[0] + "." + semver[1] + "-build.assert";
+    m_platform = platform_os.second;
+    m_signatures_folder = "v" + version + "-" + platform_os.first;
+  }
+
+  std::string build_assert_path(const std::string &signer) const
+  {
+    return m_signatures_folder + "/" + signer + "/" + m_build_assert_filename;
+  }
+
+  std::string build_assert_signature_path(const std::string &signer) const
+  {
+    return build_assert_path(signer) + ".sig";
+  }
+
+  std::string platform() const
+  {
+    return m_platform;
+  }
+
+  std::string signatures_folder() const
+  {
+    return m_signatures_folder;
+  }
+
+private:
+  static const std::pair<std::string, std::string> &build_tag_to_platform_tuple(const std::string &build_tag)
+  {
+    static const std::unordered_map<std::string, std::pair<std::string, std::string>> mapping = {
+      {"android", {"android", "android"}},
+      {"freebsd", {"freebsd", "freebsd"}},
+      {"linux", {"linux", "linux"}},
+      {"mac", {"osx", "apple"}},
+      {"win", {"win", "w64"}}};
+
+    std::vector<std::string> build_tag_tuple;
+    boost::split(build_tag_tuple, build_tag, boost::is_any_of("-"));
+
+    const auto item = mapping.find(build_tag_tuple[0]);
+    if (item == mapping.end())
+    {
+      throw std::runtime_error(std::string("Unsupported build tag: ") + build_tag);
+    }
+
+    return item->second;
+  }
+
+private:
+  std::string m_build_assert_filename;
+  std::string m_platform;
+  std::string m_signatures_folder;
+};
+
+struct file_contents_reply
+{
+  std::string content;
+
+  BEGIN_KV_SERIALIZE_MAP()
+  KV_SERIALIZE(content)
+  END_KV_SERIALIZE_MAP()
+};
+
+struct repository_tree_reply
+{
+  struct entry
+  {
+    std::string name;
+    std::string type;
+
+    BEGIN_KV_SERIALIZE_MAP()
+    KV_SERIALIZE(name)
+    KV_SERIALIZE(type)
+    END_KV_SERIALIZE_MAP()
+  };
+
+  std::vector<entry> entries;
+
+  BEGIN_KV_SERIALIZE_MAP()
+  KV_SERIALIZE(entries)
+  END_KV_SERIALIZE_MAP()
+};
+
+} // namespace
+
+gitlab_repo::gitlab_repo(
+  const std::string &host,
+  uint16_t port,
+  const std::string &owner,
+  const std::string &repo,
+  std::unique_ptr<epee::net_utils::http::abstract_http_client> http_client,
+  std::chrono::seconds timeout,
+  std::string user_agent)
+  : m_base_url(std::string("/api/v4/projects/") + epee::net_utils::convert_to_url_format_force_all(owner + "/" + repo))
+  , m_http(std::move(http_client))
+  , m_timeout(timeout)
+  , m_user_agent(std::move(user_agent))
+{
+  m_http->set_server(host, std::to_string(port), {});
+}
+
+std::string gitlab_repo::get_file_contents(const std::string &path) const
+{
+  const epee::net_utils::http::http_response_info *info;
+  const bool result = m_http->invoke_get(
+    m_base_url + "/repository/files/" + epee::net_utils::convert_to_url_format_force_all(path) + "?ref=master",
+    m_timeout,
+    {},
+    &info);
+  if (!result)
+  {
+    throw std::runtime_error("Gitlab repository files request failed");
+  }
+
+  file_contents_reply reply;
+  if (!epee::serialization::load_t_from_json(reply, info->m_body))
+  {
+    throw std::runtime_error("failed to deserialize Gitlab repository files reply");
+  }
+
+  reply.content.erase(std::remove(reply.content.begin(), reply.content.end(), '\n'), reply.content.end());
+  return epee::string_encoding::base64_decode(reply.content);
+}
+
+std::unordered_set<std::string> gitlab_repo::list_directories(const std::string &path) const
+{
+  std::unordered_set<std::string> directories;
+
+  constexpr size_t per_page = 100;
+  const std::string url = m_base_url +
+    "/repository/tree?path=" + epee::net_utils::convert_to_url_format_force_all(path) +
+    "&per_page=" + std::to_string(per_page);
+
+  size_t page = 0;
+  size_t total_pages = 1;
+  do
+  {
+    const epee::net_utils::http::http_response_info *info;
+    const bool result = m_http->invoke_get(url + "&page=" + std::to_string(page), m_timeout, {}, &info);
+    if (!result)
+    {
+      throw std::runtime_error("Gitlab repository tree request failed");
+    }
+
+    // Gitlab /repository/tree request returns JSON array
+    // Used a hack to utilize BEGIN_KV_SERIALIZE_MAP:
+    // Had to manually "convert" the reply into struct: '{"entries": <JSON array>}'
+    repository_tree_reply reply;
+    if (!epee::serialization::load_t_from_json(reply, std::string("{\"entries\": ") + info->m_body + "}"))
+    {
+      throw std::runtime_error("failed to deserialize Gitlab repository tree reply");
+    }
+
+    for (const auto &entry : reply.entries)
+    {
+      if (entry.type == "tree")
+      {
+        directories.emplace(entry.name);
+      }
+    }
+
+    const bool first_time = page == 0;
+    if (first_time)
+    {
+      for (const auto &field : info->m_header_info.m_etc_fields)
+      {
+        static const std::string x_total_pages("x-total-pages");
+        if (!epee::string_tools::compare_no_case(field.first, x_total_pages))
+        {
+          size_t value;
+          if (epee::string_tools::get_xtype_from_string(value, field.second))
+          {
+            total_pages = std::max(total_pages, value);
+          }
+        }
+      }
+    }
+  } while (++page < total_pages);
+
+  return directories;
+}
+
+gitian_hash_checker::gitian_hash_checker(
+  std::unique_ptr<repo_explorer> repo_explorer,
+  std::unique_ptr<signature_verifier> verifier,
+  std::string project,
+  size_t minimum_participants,
+  bool check_all_available)
+  : m_check_all_available(check_all_available)
+  , m_explorer(std::move(repo_explorer))
+  , m_minimum_participants(minimum_participants)
+  , m_project(std::move(project))
+  , m_verifier(std::move(verifier))
+{
+}
+
+void gitian_hash_checker::check(const crypto::hash &hash, const std::string &version, const std::string &build_tag)
+  const
+{
+  gitian_path path(m_project, version, build_tag);
+
+  std::unordered_set<std::string> signers = m_explorer->list_directories(path.signatures_folder());
+  MDEBUG("Found " << signers.size() << " Gitian build signatures (v" << version << " " << build_tag << ")");
+  if (signers.size() < m_minimum_participants)
+  {
+    throw std::runtime_error("failed to fetch minimum required number of Gitian signatures");
+  }
+
+  if (!m_check_all_available)
+  {
+    while (signers.size() > m_minimum_participants)
+    {
+      auto item_to_remove = signers.begin();
+      std::advance(item_to_remove, crypto::rand_idx(signers.size()));
+      MDEBUG(*item_to_remove << ": skipping");
+      signers.erase(item_to_remove);
+    }
+  }
+
+  for (const std::string &signer : signers)
+  {
+    std::string assert = m_explorer->get_file_contents(path.build_assert_path(signer));
+    const bool found = gitian_assert(assert).find_hash(hash, version, path.platform());
+    if (!found)
+    {
+      std::stringstream ss;
+      ss << "Gitian expected hash not found. Signer: " << signer << ", version: " << version
+         << ", platform: " << path.platform() << ", expected hash: " << hash;
+      throw std::runtime_error(ss.str());
+    }
+
+    const std::string signature = m_explorer->get_file_contents(path.build_assert_signature_path(signer));
+    const bool valid = m_verifier->verify(signer, epee::strspan<uint8_t>(assert), epee::strspan<uint8_t>(signature));
+    if (!valid)
+    {
+      std::stringstream ss;
+      ss << "Gitian signature verification failed. Signer: " << signer << ", version: " << version
+         << ", platform: " << path.platform() << ", expected hash: " << hash;
+      throw std::runtime_error(ss.str());
+    }
+
+    MDEBUG(signer << ": build hash matches expected hash");
+  }
+}
+
+void gitian_hash_checker::check(const std::string &hash, const std::string &version, const std::string &build_tag) const
+{
+  crypto::hash hash_buffer;
+  if (!epee::from_hex::to_buffer(epee::as_mut_byte_span(hash_buffer), hash))
+  {
+    throw std::runtime_error(std::string("failed to deserialize hash string '") + hash + "'");
+  }
+  return check(hash_buffer, version, build_tag);
+}
+
+} // namespace tools

--- a/src/common/update_hash_checker.h
+++ b/src/common/update_hash_checker.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "net/abstract_http_client.h"
+#include "span.h"
+
+#include "crypto/hash.h"
+
+namespace tools
+{
+
+class repo_explorer
+{
+public:
+  virtual ~repo_explorer() = default;
+
+  virtual std::string get_file_contents(const std::string &path) const = 0;
+  virtual std::unordered_set<std::string> list_directories(const std::string &path) const = 0;
+};
+
+class signature_verifier
+{
+public:
+  virtual ~signature_verifier() = default;
+
+  virtual bool verify(
+    const std::string &signed_by,
+    epee::span<const uint8_t> message,
+    epee::span<const uint8_t> signature) const = 0;
+};
+
+class dummy_signature_verifier : public signature_verifier
+{
+public:
+  dummy_signature_verifier(bool result = true)
+    : m_result(result)
+  {
+  }
+
+  virtual bool verify(
+    const std::string &signed_by,
+    epee::span<const uint8_t> message,
+    epee::span<const uint8_t> signature) const override
+  {
+    return m_result;
+  }
+
+private:
+  bool m_result;
+};
+
+class gitian_hash_checker
+{
+public:
+  gitian_hash_checker(
+    std::unique_ptr<repo_explorer> repo_explorer,
+    std::unique_ptr<signature_verifier> verifier,
+    std::string project,
+    size_t minimum_participants,
+    bool check_all_available = true);
+
+  void check(const crypto::hash &hash, const std::string &version, const std::string &build_tag) const;
+  void check(const std::string &hash, const std::string &version, const std::string &build_tag) const;
+
+private:
+  const bool m_check_all_available;
+  const std::unique_ptr<repo_explorer> m_explorer;
+  const size_t m_minimum_participants;
+  const std::string m_project;
+  const std::unique_ptr<signature_verifier> m_verifier;
+};
+
+class gitlab_repo : public repo_explorer
+{
+public:
+  gitlab_repo(
+    const std::string &host,
+    uint16_t port,
+    const std::string &owner,
+    const std::string &repo,
+    std::unique_ptr<epee::net_utils::http::abstract_http_client> client,
+    std::chrono::seconds timeout,
+    std::string user_agent);
+
+  virtual std::string get_file_contents(const std::string &path) const override;
+  virtual std::unordered_set<std::string> list_directories(const std::string &path) const override;
+
+private:
+  const std::string m_base_url;
+  const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http;
+  const std::chrono::seconds m_timeout;
+  const std::string m_user_agent;
+};
+
+} // namespace tools

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -797,6 +797,17 @@ namespace cryptonote
      bool is_update_available() const { return m_update_available; }
 
      /**
+      * @brief verifies new version hash against published Gitian reproducible build hashes
+      *
+      * @return true on success, false otherwise
+      */
+     bool verify_update_hash(
+       const std::string &expected_hash,
+       const std::string &software,
+       const std::string &build_tag,
+       const std::string &version) const;
+
+     /**
       * @brief get whether fluffy blocks are enabled
       *
       * @return whether fluffy blocks are enabled
@@ -1113,6 +1124,7 @@ namespace cryptonote
      tools::download_async_handle m_update_download;
      size_t m_last_update_length;
      boost::mutex m_update_mutex;
+     bool m_update_verify_hash;
 
      bool m_fluffy_blocks_enabled;
      bool m_offline;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2929,6 +2929,13 @@ namespace cryptonote
       res.status = CORE_RPC_STATUS_OK;
       return true;
     }
+
+    if (!m_core.verify_update_hash(hash, software, buildtag, version))
+    {
+      res.status = "Failed to verify update hash";
+      return true;
+    }
+
     res.update = true;
     res.version = version;
     res.user_uri = tools::get_update_url(software, subdir, buildtag, version, true);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -87,6 +87,7 @@ set(unit_tests_sources
   tx_proof.cpp
   hardfork.cpp
   unbound.cpp
+  update_hash_checker.cpp
   uri.cpp
   varint.cpp
   ringct.cpp

--- a/tests/unit_tests/update_hash_checker.cpp
+++ b/tests/unit_tests/update_hash_checker.cpp
@@ -1,0 +1,542 @@
+// Copyright (c) 2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "common/update_hash_checker.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <boost/utility/string_ref.hpp>
+
+#include "gtest/gtest.h"
+
+#include "net/abstract_http_client.h"
+#include "string_coding.h"
+
+namespace
+{
+
+class http_client : public epee::net_utils::http::abstract_http_client
+{
+public:
+  http_client(std::unordered_map<std::string, std::string> files = {})
+    : m_base_url(
+        std::string("/api/v4/projects/") +
+        epee::net_utils::convert_to_url_format_force_all("monero-project/gitian.sigs"))
+    , m_files(std::move(files))
+  {
+  }
+
+  virtual void set_server(
+    std::string host,
+    std::string port,
+    boost::optional<epee::net_utils::http::login> user,
+    epee::net_utils::ssl_options_t ssl_options) override
+  {
+  }
+
+  virtual void set_auto_connect(bool auto_connect) override {}
+
+  virtual bool connect(std::chrono::milliseconds timeout) override
+  {
+    return true;
+  }
+
+  virtual bool disconnect() override
+  {
+    return true;
+  }
+
+  virtual bool is_connected(bool *ssl = NULL) override
+  {
+    return true;
+  }
+
+  virtual bool invoke(
+    const boost::string_ref uri,
+    const boost::string_ref method,
+    const boost::string_ref body,
+    std::chrono::milliseconds timeout,
+    const epee::net_utils::http::http_response_info **ppresponse_info = nullptr,
+    const epee::net_utils::http::fields_list &additional_params = {}) override
+  {
+    return false;
+  }
+
+  virtual bool handle_repository_files(boost::string_ref path, epee::net_utils::http::http_response_info &response)
+  {
+    std::stringstream result;
+    for (const auto &file : m_files)
+    {
+      if (file.first == path)
+      {
+        result << "{\"content\": \""
+               << epee::string_encoding::base64_encode(
+                    reinterpret_cast<const uint8_t *>(&file.second[0]),
+                    file.second.size())
+               << "\"}";
+        break;
+      }
+    }
+    response.m_body = result.str();
+    return true;
+  }
+
+  virtual bool handle_repository_tree(boost::string_ref path, epee::net_utils::http::http_response_info &response)
+  {
+    std::unordered_map<std::string, std::string> entries;
+    for (const auto &file : m_files)
+    {
+      boost::string_ref name(file.first);
+      if (name.starts_with(std::string(path) + "/"))
+      {
+        name.remove_prefix(path.size() + 1);
+        const auto pos = name.find('/');
+        if (pos != boost::string_ref::npos)
+        {
+          entries.emplace(name.substr(0, pos), "tree");
+        }
+        else
+        {
+          entries.emplace(name, "blob");
+        }
+      }
+    }
+
+    std::stringstream result;
+    result << "[";
+    bool first = true;
+    for (const auto &name : entries)
+    {
+      result << (first ? "" : ",") << "{\"type\": \"" << name.second << "\", \"name\": \"" << name.first << "\"}";
+      first = false;
+    }
+    result << "]";
+
+    response.m_header_info.m_etc_fields.push_back({"x-total-pages", "1"});
+    response.m_body = result.str();
+    return true;
+  }
+
+  virtual bool invoke_get(
+    boost::string_ref uri,
+    std::chrono::milliseconds timeout,
+    const std::string &body = std::string(),
+    const epee::net_utils::http::http_response_info **ppresponse_info = nullptr,
+    const epee::net_utils::http::fields_list &additional_params = {}) override
+  {
+    static epee::net_utils::http::http_response_info response;
+    response.clear();
+    *ppresponse_info = &response;
+
+    if (!uri.starts_with(m_base_url))
+    {
+      return false;
+    }
+    uri.remove_prefix(m_base_url.size());
+
+    static const boost::string_ref repository_files("/repository/files/");
+    if (uri.starts_with(repository_files))
+    {
+      uri.remove_prefix(repository_files.size());
+      uri = uri.substr(0, uri.find('?'));
+      return handle_repository_files(epee::net_utils::convert_from_url_format(std::string(uri)), response);
+    }
+    else if (uri.starts_with("/repository/tree?path="))
+    {
+      uri = uri.substr(0, uri.find('&'));
+      uri.remove_prefix(uri.find('=') + 1);
+      return handle_repository_tree(epee::net_utils::convert_from_url_format(std::string(uri)), response);
+    }
+    return false;
+  }
+
+  virtual bool invoke_post(
+    const boost::string_ref uri,
+    const std::string &body,
+    std::chrono::milliseconds timeout,
+    const epee::net_utils::http::http_response_info **ppresponse_info = nullptr,
+    const epee::net_utils::http::fields_list &additional_params = {}) override
+  {
+    return false;
+  }
+
+  virtual uint64_t get_bytes_sent() const override
+  {
+    return 0;
+  }
+
+  virtual uint64_t get_bytes_received() const override
+  {
+    return 0;
+  }
+
+private:
+  const std::unordered_map<std::string, std::string> m_files;
+  const std::string m_base_url;
+};
+
+class http_client_mock : public http_client
+{
+public:
+  http_client_mock(std::string body, bool result)
+    : m_body(std::move(body))
+    , m_result(result)
+  {
+  }
+
+  bool handle_repository_tree(boost::string_ref path, epee::net_utils::http::http_response_info &response) override
+  {
+    response.m_body = m_body;
+    return m_result;
+  }
+
+  bool handle_repository_files(boost::string_ref path, epee::net_utils::http::http_response_info &response) override
+  {
+    response.m_body = m_body;
+    return m_result;
+  }
+
+private:
+  const std::string m_body;
+  const bool m_result;
+};
+
+std::unique_ptr<tools::repo_explorer> repo_explorer_2_signers()
+{
+  std::unordered_map<std::string, std::string> files;
+  files["v0.17.2.0-win/README.md"] = {};
+
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    c772070ebdfe9e0d6abda5073808e648e69f8c35f8010e66b80f45a6bdb01792  monero-i686-w64-mingw32-v0.17.2.0.zip\n\
+    71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf  monero-x86_64-w64-mingw32-v0.17.2.0.zip";
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-linux/signer1/monero-linux-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    a004fad5348549e2f1610380775353f19db7cbca0cbe4acbfab87832c484da62  monero-aarch64-linux-gnu-v0.17.2.0.tar.bz2\n\
+    b5986d6dfbddee14e32b28305dd0dc6352c18b632f569227f2c7265ef7dc5081  monero-arm-linux-gnueabihf-v0.17.2.0.tar.bz2\n\
+    e8a39be486549908c10524d851a006c21c30b1a49142586aff0a17e7c4d46077  monero-i686-linux-gnu-v0.17.2.0.tar.bz2\n\
+    59e16c53b2aff8d9ab7a8ba3279ee826ac1f2480fbb98e79a149e6be23dd9086  monero-x86_64-linux-gnu-v0.17.2.0.tar.bz2";
+  files["v0.17.2.0-linux/signer1/monero-linux-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-osx/signer1/monero-osx-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: '2e95dc107ab0dab36f5544bec040180264256e45407c383cfb45cfe328fe42e0  monero-x86_64-apple-darwin11-v0.17.2.0.tar.bz2\n\
+\n\
+'";
+  files["v0.17.2.0-osx/signer1/monero-osx-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-freebsd/signer1/monero-freebsd-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: '34ef5702a050298f48ccea7db992137bc98c8e6eba45ecd90b47ce0a4b7bf0f8  monero-x86_64-unknown-freebsd-v0.17.2.0.tar.bz2\n\
+\n\
+'";
+  files["v0.17.2.0-freebsd/signer1/monero-freebsd-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-android/signer1/monero-android-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    b8a353f02feaee9aae3d279c043ea33a32413a298d8b6122d00a65508f15169d  monero-aarch64-linux-android-v0.17.2.0.tar.bz2\n\
+    815341f7d46f75a8905f8b51932e1034a7f6b1669757ff48224632d08339d1bf  monero-arm-linux-android-v0.17.2.0.tar.bz2";
+  files["v0.17.2.0-android/signer1/monero-android-0.17-build.assert.sig"] = {};
+
+  files["v0.17.2.0-win/signer2/monero-win-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    c772070ebdfe9e0d6abda5073808e648e69f8c35f8010e66b80f45a6bdb01792  monero-i686-w64-mingw32-v0.17.2.0.zip\n\
+    71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf  monero-x86_64-w64-mingw32-v0.17.2.0.zip";
+  files["v0.17.2.0-win/signer2/monero-win-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-linux/signer2/monero-linux-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    a004fad5348549e2f1610380775353f19db7cbca0cbe4acbfab87832c484da62  monero-aarch64-linux-gnu-v0.17.2.0.tar.bz2\n\
+    b5986d6dfbddee14e32b28305dd0dc6352c18b632f569227f2c7265ef7dc5081  monero-arm-linux-gnueabihf-v0.17.2.0.tar.bz2\n\
+    e8a39be486549908c10524d851a006c21c30b1a49142586aff0a17e7c4d46077  monero-i686-linux-gnu-v0.17.2.0.tar.bz2\n\
+    59e16c53b2aff8d9ab7a8ba3279ee826ac1f2480fbb98e79a149e6be23dd9086  monero-x86_64-linux-gnu-v0.17.2.0.tar.bz2";
+  files["v0.17.2.0-linux/signer2/monero-linux-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-osx/signer2/monero-osx-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: '2e95dc107ab0dab36f5544bec040180264256e45407c383cfb45cfe328fe42e0  monero-x86_64-apple-darwin11-v0.17.2.0.tar.bz2\n\
+\n\
+'";
+  files["v0.17.2.0-osx/signer2/monero-osx-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-freebsd/signer2/monero-freebsd-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: '34ef5702a050298f48ccea7db992137bc98c8e6eba45ecd90b47ce0a4b7bf0f8  monero-x86_64-unknown-freebsd-v0.17.2.0.tar.bz2\n\
+\n\
+'";
+  files["v0.17.2.0-freebsd/signer2/monero-freebsd-0.17-build.assert.sig"] = {};
+  files["v0.17.2.0-android/signer2/monero-android-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    b8a353f02feaee9aae3d279c043ea33a32413a298d8b6122d00a65508f15169d  monero-aarch64-linux-android-v0.17.2.0.tar.bz2\n\
+    815341f7d46f75a8905f8b51932e1034a7f6b1669757ff48224632d08339d1bf  monero-arm-linux-android-v0.17.2.0.tar.bz2";
+  files["v0.17.2.0-android/signer2/monero-android-0.17-build.assert.sig"] = {};
+
+  return std::unique_ptr<tools::repo_explorer>(new tools::gitlab_repo(
+    "repo.getmonero.org",
+    443,
+    "monero-project",
+    "gitian.sigs",
+    std::unique_ptr<epee::net_utils::http::abstract_http_client>(new http_client(std::move(files))),
+    std::chrono::seconds(30),
+    "monero-project"));
+}
+
+std::unique_ptr<tools::repo_explorer> repo_explorer_invalid_platform()
+{
+  std::unordered_map<std::string, std::string> files;
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    c772070ebdfe9e0d6abda5073808e648e69f8c35f8010e66b80f45a6bdb01792  monero-i686-linux-gnu-v0.17.2.0.tar.bz2\n\
+    71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf  monero-x86_64-linux-gnu-v0.17.2.0.tar.bz2";
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert.sig"] = {};
+  return std::unique_ptr<tools::repo_explorer>(new tools::gitlab_repo(
+    "repo.getmonero.org",
+    443,
+    "monero-project",
+    "gitian.sigs",
+    std::unique_ptr<epee::net_utils::http::abstract_http_client>(new http_client(std::move(files))),
+    std::chrono::seconds(30),
+    "monero-project"));
+}
+
+std::unique_ptr<tools::repo_explorer> repo_explorer_invalid_hash()
+{
+  std::unordered_map<std::string, std::string> files;
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert"] = "--- !!omap\n\
+- out_manifest: |\n\
+    c  monero-x86_64-w64-mingw32-v0.17.2.0.zip\n\
+monero-x86_64-w64-mingw32-v0.17.2.0.zip";
+  files["v0.17.2.0-win/signer1/monero-win-0.17-build.assert.sig"] = {};
+  return std::unique_ptr<tools::repo_explorer>(new tools::gitlab_repo(
+    "repo.getmonero.org",
+    443,
+    "monero-project",
+    "gitian.sigs",
+    std::unique_ptr<epee::net_utils::http::abstract_http_client>(new http_client(std::move(files))),
+    std::chrono::seconds(30),
+    "monero-project"));
+}
+
+} // namespace
+
+TEST(UpdateHashChecker, BuildTag)
+{
+  const tools::gitian_hash_checker hash_checker(
+    repo_explorer_2_signers(),
+    std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+    "monero",
+    1);
+  EXPECT_NO_THROW(hash_checker.check(
+    "815341f7d46f75a8905f8b51932e1034a7f6b1669757ff48224632d08339d1bf",
+    "0.17.2.0",
+    "android-armv7"));
+  EXPECT_NO_THROW(hash_checker.check(
+    "b8a353f02feaee9aae3d279c043ea33a32413a298d8b6122d00a65508f15169d",
+    "0.17.2.0",
+    "android-armv8"));
+  EXPECT_NO_THROW(
+    hash_checker.check("34ef5702a050298f48ccea7db992137bc98c8e6eba45ecd90b47ce0a4b7bf0f8", "0.17.2.0", "freebsd-x64"));
+  EXPECT_NO_THROW(
+    hash_checker.check("b5986d6dfbddee14e32b28305dd0dc6352c18b632f569227f2c7265ef7dc5081", "0.17.2.0", "linux-armv7"));
+  EXPECT_NO_THROW(
+    hash_checker.check("a004fad5348549e2f1610380775353f19db7cbca0cbe4acbfab87832c484da62", "0.17.2.0", "linux-armv8"));
+  EXPECT_NO_THROW(
+    hash_checker.check("59e16c53b2aff8d9ab7a8ba3279ee826ac1f2480fbb98e79a149e6be23dd9086", "0.17.2.0", "linux-x64"));
+  EXPECT_NO_THROW(
+    hash_checker.check("e8a39be486549908c10524d851a006c21c30b1a49142586aff0a17e7c4d46077", "0.17.2.0", "linux-x86"));
+  EXPECT_NO_THROW(
+    hash_checker.check("2e95dc107ab0dab36f5544bec040180264256e45407c383cfb45cfe328fe42e0", "0.17.2.0", "mac-x64"));
+  EXPECT_NO_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  EXPECT_NO_THROW(
+    hash_checker.check("c772070ebdfe9e0d6abda5073808e648e69f8c35f8010e66b80f45a6bdb01792", "0.17.2.0", "win-x32"));
+  EXPECT_ANY_THROW(
+    hash_checker.check("c772070ebdfe9e0d6abda5073808e648e69f8c35f8010e66b80f45a6bdb01792", "0.17.2.0", "invalid"));
+}
+
+TEST(UpdateHashChecker, Hash)
+{
+  const tools::gitian_hash_checker hash_checker(
+    repo_explorer_2_signers(),
+    std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+    "monero",
+    1);
+  EXPECT_NO_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  EXPECT_ANY_THROW(
+    hash_checker.check("00e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  EXPECT_ANY_THROW(hash_checker.check("7", "0.17.2.0", "win-x64"));
+}
+
+TEST(UpdateHashChecker, InvalidHash)
+{
+  const tools::gitian_hash_checker hash_checker(
+    repo_explorer_invalid_hash(),
+    std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+    "monero",
+    1);
+  EXPECT_ANY_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+}
+
+TEST(UpdateHashChecker, Participants)
+{
+  {
+    const size_t minimum_participants = 1;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "monero",
+      minimum_participants,
+      true);
+    EXPECT_NO_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+  {
+    const size_t minimum_participants = 1;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "monero",
+      minimum_participants,
+      false);
+    EXPECT_NO_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+  {
+    const size_t minimum_participants = 2;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "monero",
+      minimum_participants);
+    EXPECT_NO_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+  {
+    const size_t minimum_participants = 3;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "monero",
+      minimum_participants);
+    EXPECT_ANY_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+}
+
+TEST(UpdateHashChecker, Platform)
+{
+  const tools::gitian_hash_checker hash_checker(
+    repo_explorer_invalid_platform(),
+    std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+    "monero",
+    1);
+  EXPECT_ANY_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+}
+
+TEST(UpdateHashChecker, Project)
+{
+  {
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "monero",
+      1);
+    EXPECT_NO_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+  {
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+      "nonexistent-project",
+      1);
+    EXPECT_ANY_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+}
+
+TEST(UpdateHashChecker, Signature)
+{
+  {
+    const bool valid_signature = true;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier(valid_signature)),
+      "monero",
+      1);
+    EXPECT_NO_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+  {
+    const bool valid_signature = false;
+    const tools::gitian_hash_checker hash_checker(
+      repo_explorer_2_signers(),
+      std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier(valid_signature)),
+      "monero",
+      1);
+    EXPECT_ANY_THROW(
+      hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  }
+}
+
+TEST(UpdateHashChecker, Version)
+{
+  const tools::gitian_hash_checker hash_checker(
+    repo_explorer_2_signers(),
+    std::unique_ptr<tools::signature_verifier>(new tools::dummy_signature_verifier()),
+    "monero",
+    1);
+  EXPECT_NO_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17.2.0", "win-x64"));
+  EXPECT_ANY_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0.17", "win-x64"));
+  EXPECT_ANY_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "0", "win-x64"));
+  EXPECT_ANY_THROW(
+    hash_checker.check("71e531a0f799c80e3f6319888bd5b85a737091b9bd5d66366cae036163857caf", "1.17.2.0", "win-x64"));
+}
+
+TEST(UpdateHashChecker, GitlabApi)
+{
+  const auto gitlab_repo = [](std::string body, bool result = true) {
+    return std::unique_ptr<tools::repo_explorer>(new tools::gitlab_repo(
+      "repo.getmonero.org",
+      443,
+      "monero-project",
+      "gitian.sigs",
+      std::unique_ptr<epee::net_utils::http::abstract_http_client>(new http_client_mock(std::move(body), result)),
+      std::chrono::seconds(30),
+      "monero-project"));
+  };
+
+  EXPECT_NO_THROW(gitlab_repo("[{\"name\": \"somename\", \"type\": \"tree\"}]")->list_directories("/"));
+  EXPECT_ANY_THROW(gitlab_repo("[{\"name\": \"somename\", \"type\": \"tree\"}]", false)->list_directories("/"));
+  EXPECT_ANY_THROW(gitlab_repo("{invalid json")->list_directories("some_directory"));
+
+  EXPECT_NO_THROW(gitlab_repo("{\"content\": \"\"}")->get_file_contents("/SomeFile"));
+  EXPECT_ANY_THROW(gitlab_repo("{\"content\": \"\"}", false)->get_file_contents("/SomeFile"));
+  EXPECT_ANY_THROW(gitlab_repo("{invalid json")->get_file_contents("/SomeFile"));
+}


### PR DESCRIPTION
Implemented additional new version hash verification against published GItian reproducible build hashes (https://repo.getmonero.org/monero-project/gitian.sigs Gitlab repo).

By default it requires at least 3 build hashes published by Gitian contributors (builders). If there are more available, it will check all of them.  Both parameters are configurable.

Errors out if any Gitian assert doesn't contain expected new version hash for specific platform.

CLI option `--no-verify-update-hash` disables the logic.

Applies to:
1. Periodic update check (`--check-updates [disabled|notify|download|update]` CLI option)
2.  `/update` daemon RPC
3. `update [check|download]` daemon console command 

PS: Doesn't verify Gitian OpenPGP signatures yet. Will implement this in a separate PR.