### PR TITLE
Mac: Enable on ARM, by not enforcing x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "(SunOS|Solaris)")
 endif ()
 
 if (APPLE AND NOT IOS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -fvisibility=default -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default -std=c++11")
   if (NOT OPENSSL_ROOT_DIR)
       EXECUTE_PROCESS(COMMAND brew --prefix openssl
         OUTPUT_VARIABLE OPENSSL_ROOT_DIR


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero/issues/7392

The use case for this change is ARM Mac (i.e. the "M1" SoC)
Both x86_64 Mac builds (real and `depends`) compile fine.

@selsta : Would you be so kind and run a short test on your Mac with this change?