### PR TITLE
Doc: mention python requests functional tests' dependencies

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,11 @@ To run the same tests on a release build, replace `debug` with `release`.
 [TODO]
 Functional tests are located under the `tests/functional` directory.
 
+Building all the tests requires installing the following dependencies:
+```bash
+pip install requests
+```
+
 First, run a regtest daemon in the offline mode and with a fixed difficulty:
 ```bash
 monerod --regtest --offline --fixed-difficulty 1


### PR DESCRIPTION
Addresses https://github.com/monero-project/monero/issues/7392

The python's module `requests` wasn't mentioned in the docs, but they are an optional requirement for `functional_tests_rpc`. I placed the info under `tests/README.md`