### PR TITLE
Reduced executable size; reduced call sequence to "allowed" log function

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -41,7 +41,7 @@
 #define MAX_LOG_FILES 50
 
 #define MCLOG_TYPE(level, cat, color, type, x) do { \
-    if (ELPP->vRegistry()->allowed(level, cat)) { \
+    if (el::Loggers::allowed(level, cat)) { \
       el::base::Writer(level, color, __FILE__, __LINE__, ELPP_FUNC, type).construct(cat) << x; \
     } \
   } while (0)
@@ -89,7 +89,7 @@
 
 #define IFLOG(level, cat, color, type, init, x) \
   do { \
-    if (ELPP->vRegistry()->allowed(level, cat)) { \
+    if (el::Loggers::allowed(level, cat)) { \
       init; \
       el::base::Writer(level, color, __FILE__, __LINE__, ELPP_FUNC, type).construct(cat) << x; \
     } \

--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -17,6 +17,7 @@
 #define EASYLOGGING_CC
 #include "easylogging++.h"
 
+#include <atomic>
 #include <unistd.h>
 
 #if defined(AUTO_INITIALIZE_EASYLOGGINGPP)
@@ -2035,7 +2036,7 @@ void RegisteredLoggers::unsafeFlushAll(void) {
 
 // VRegistry
 
-VRegistry::VRegistry(base::type::VerboseLevel level, base::type::EnumType* pFlags) : m_level(level), m_pFlags(pFlags), m_lowest_priority(INT_MAX) {
+VRegistry::VRegistry(base::type::VerboseLevel level, base::type::EnumType* pFlags) : m_level(level), m_pFlags(pFlags) {
 }
 
 /// @brief Sets verbose level. Accepted range is 0-9
@@ -2131,18 +2132,30 @@ static int priority(Level level) {
   return 7;
 }
 
+namespace
+{
+  std::atomic<int> s_lowest_priority{INT_MAX};
+}
+
+void VRegistry::clearCategories(void) {
+  const base::threading::ScopedLock scopedLock(lock());
+  m_categories.clear();
+  m_cached_allowed_categories.clear();
+  s_lowest_priority = INT_MAX;
+}
+
 void VRegistry::setCategories(const char* categories, bool clear) {
   base::threading::ScopedLock scopedLock(lock());
   auto insert = [&](std::stringstream& ss, Level level) {
     m_categories.push_back(std::make_pair(ss.str(), level));
     m_cached_allowed_categories.clear();
     int pri = priority(level);
-    if (pri > m_lowest_priority)
-      m_lowest_priority = pri;
+    if (pri > s_lowest_priority)
+      s_lowest_priority = pri;
   };
 
   if (clear) {
-    m_lowest_priority = 0;
+    s_lowest_priority = 0;
     m_categories.clear();
     m_cached_allowed_categories.clear();
     m_categoriesString.clear();
@@ -2200,9 +2213,9 @@ std::string VRegistry::getCategories() {
 }
 
 bool VRegistry::allowed(Level level, const std::string &category) {
-  const int pri = priority(level);
-  if (pri > m_lowest_priority)
-    return false;
+  return priority_allowed(priority(level), category);
+}
+bool VRegistry::priority_allowed(const int pri, const std::string &category) {
   base::threading::ScopedLock scopedLock(lock());
   const std::map<std::string, int>::const_iterator it = m_cached_allowed_categories.find(category);
   if (it != m_cached_allowed_categories.end())
@@ -3334,6 +3347,14 @@ void Helpers::logCrashReason(int sig, bool stackTraceIfAvailable, Level level, c
 #endif // defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_CRASH_LOG)
 
 // Loggers
+
+bool Loggers::allowed(Level level, const char* cat)
+{
+  const int pri = base::priority(level);
+  if (pri > base::s_lowest_priority)
+    return false;
+  return ELPP->vRegistry()->priority_allowed(pri, std::string{cat});
+}
 
 Logger* Loggers::getLogger(const std::string& identity, bool registerIfNotAvailable) {
   return ELPP->registeredLoggers()->get(identity, registerIfNotAvailable);


### PR DESCRIPTION
This small patch reduces `monerod` by ~3.1%, `monero-wallet-rpc` by ~2.8%, and `monero-wallet-cli` by ~2.4%. This numbers are from a static build with gcc 9.3.

This is a bit of micro-optimization, but this will help the CPU instruction cache slightly. Every call to log a message : (1) calls a function to get a global pointer, (2) constructs a `std::string`, (3) dereferences a pointer, (4) sets 3 register values for a function call. This moves steps (1), (2), and (3) to a single instance in another cpp file and reduces the number of register values needed to 2.

This also moves the "quick check" variable to static memory and delays `std::string` construction, which shortens the number of instructions executed to do the quick check. Since an overwhelming majority of calls "fails" this quick check, this improves things a bit further.