### PR TITLE
Warnings: treat warnings as errors: 'switch' & 'return-type'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,6 +744,13 @@ else()
     add_linker_flag_if_supported(-Wl,--high-entropy-va LD_SECURITY_FLAGS)
   endif()
 
+  # Warnings, that when ignored are so severe, that they can segfault or even UB any application.
+  # Treat them as errors.
+  add_c_flag_if_supported(  -Werror=switch      C_SECURITY_FLAGS)
+  add_cxx_flag_if_supported(-Werror=switch      CXX_SECURITY_FLAGS)
+  add_c_flag_if_supported(  -Werror=return-type C_SECURITY_FLAGS)
+  add_cxx_flag_if_supported(-Werror=return-type CXX_SECURITY_FLAGS)
+
   message(STATUS "Using C security hardening flags: ${C_SECURITY_FLAGS}")
   message(STATUS "Using C++ security hardening flags: ${CXX_SECURITY_FLAGS}")
   message(STATUS "Using linker security hardening flags: ${LD_SECURITY_FLAGS}")


### PR DESCRIPTION
 Treating such warnings as errors, that when ignored are so severe, that they can segfault or even [UB](https://en.cppreference.com/w/cpp/language/ub) any application.

- `return-type`: aborts compilation when you forget to return a value from a function, when the caller expects it (or worse: there's a unnoticed branch of a complex function, which ends without returning the expected value)
- `switch`: aborts compilation when a new case isn't handled for a newly added enum entry. With this error in place, you can safely delete all `default:` cases made for runtime safety checks and enjoy static checks instead (so less need for time consuming  tests execution, as well as writing).