### PR TITLE
CI: ccache for ubuntu-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,19 @@ jobs:
   test-ubuntu:
     needs: build-ubuntu
     runs-on: ubuntu-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: ccache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: test-ubuntu-ccache-${{ github.sha }}
+        restore-keys: test-ubuntu-ccache-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
     - name: set apt conf
@@ -129,10 +138,19 @@ jobs:
     - name: update apt
       run: sudo apt update
     - name: install monero dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler
+      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler ccache
     - name: install Python dependencies
       run: pip install requests psutil monotonic
     - name: tests
       env:
         CTEST_OUTPUT_ON_FAILURE: ON
-      run: make release-test -j3
+      run: |
+        ccache --max-size=150M
+        DIR_BUILD="build/ci/release"
+        DIR_SRC="`pwd`"
+        mkdir -p "${DIR_BUILD}" && cd "${DIR_BUILD}"
+        cmake -S "${DIR_SRC}" -D ARCH="default" -D BUILD_SHARED_LIBS=ON -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && make -j3 && make test
+
+# ARCH="default" (not "native") ensures, that a different execution host can execute binaries compiled elsewhere.
+# BUILD_SHARED_LIBS=ON speeds up the linkage part a bit, reduces size, and is the only place where the dynamic linkage is tested.
+


### PR DESCRIPTION
Result:
Typical run of the ubuntu-test lasts 2 hours. With ccache, the time is reduced down to 1:25 h, so by about 25%.

The reason why ccache was not enabled for test-ubuntu job, was that the compiled binaries for the (by default) native architecture, could be making use of registers (like AXV2) not available at a different host, where the test execution happens on the next run of the Action (as per recent IRC discussion with @selsta ).

The solution for this problem is using the generic build, achievable in Monero by setting the CMake variable ARCH to "default". In order not to interfere with the already existing Makefile target, designed for testing, the `release-test`, I have created an additional, new target, made specifically for CI, called `release-test-ci`, as suggested by @vtnerd some time ago. While creating the new target, I thought, that it would be also a good opportunity to test the dynamic linkage, as this dimension is not tested in neither of the other Workflow jobs. It gives a small linkage speed boost as well, but this is not the most important thing for this job.