### PR TITLE
CI: fail-fast set to false for build.yml, to better leverage ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build-macos:
     runs-on: macOS-latest
+    strategy:
+      fail-fast: false # Allows to store the cache, even if there's an error. (i.e. during the compilation)
     env:
       CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
@@ -26,6 +28,8 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false # Allows to store the cache, even if there's an error. (i.e. during the compilation)
     env:
       CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: C:\Users\runneradmin\.ccache-temp
@@ -53,6 +57,8 @@ jobs:
 
   build-ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Allows to store the cache, even if there's an error. (i.e. during the compilation)
     env:
       CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
@@ -83,6 +89,8 @@ jobs:
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Allows to store the cache, even if there's an error. (i.e. during the compilation)
     env:
       CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp


### PR DESCRIPTION
Copying part of the description from https://github.com/monero-project/monero/pull/7489 :

Since the compilation might fail prematurely, even on the first run, the default `fail-fast: true` strategy would not allow to store the ccache's output as Workflow's cache, leaving us with no possibility to use ccache until the first entirely successful compilation. The fail-fast strategy is therefore set to false for all jobs (except test-ubuntu, where there's currently no ccache enabled before https://github.com/monero-project/monero/pull/7489 is merged).

P.S. The depends.yml already disables the `fail-fast` strategy