### PR TITLE
Epee logging: Compression of rotated logs; Add zlib to Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1074,7 +1074,7 @@ if(STATIC)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
-find_package(Boost 1.58 QUIET REQUIRED COMPONENTS system filesystem thread date_time chrono regex serialization program_options locale)
+find_package(Boost 1.58 QUIET REQUIRED COMPONENTS system filesystem iostreams thread date_time chrono regex serialization program_options locale OPTIONAL_COMPONENTS zlib)
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${OLD_LIB_SUFFIXES})
 if(NOT Boost_FOUND)

--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -4,25 +4,29 @@ $(package)_download_path=https://downloads.sourceforge.net/project/boost/boost/1
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 $(package)_dependencies=libiconv
+$(package)_dependencies+=zlib
 $(package)_patches=fix_aroptions.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
 $(package)_config_opts_debug=variant=debug
 $(package)_config_opts=--layout=tagged --build-type=complete --user-config=user-config.jam
-$(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=1
-$(package)_config_opts_linux=threadapi=pthread runtime-link=shared
+$(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=0
+$(package)_config_opts+=-sZLIB_SOURCE=$(BASEDIR)/sources/zlib
+$(package)_config_opts_linux=threadapi=pthread runtime-link=static
 $(package)_config_opts_android=threadapi=pthread runtime-link=static target-os=android
 $(package)_config_opts_darwin=--toolset=darwin-4.2.1 runtime-link=shared
 $(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win32 runtime-link=static
 $(package)_config_opts_x86_64_mingw32=address-model=64
 $(package)_config_opts_i686_mingw32=address-model=32
 $(package)_config_opts_i686_linux=address-model=32 architecture=x86
+$(package)_config_opts_linux+=cflags=-fPIC
+$(package)_config_opts_freebsd=cflags=-fPIC
 $(package)_toolset_$(host_os)=gcc
 $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)
-$(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,date_time,regex,serialization,locale
+$(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,date_time,regex,serialization,locale,iostreams
 $(package)_cxxflags=-std=c++11
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_freebsd=-fPIC

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl zeromq libiconv expat ldns unbound
+packages:=boost openssl zeromq libiconv expat ldns unbound zlib
 
 native_packages := native_ccache
 

--- a/contrib/depends/packages/zlib.mk
+++ b/contrib/depends/packages/zlib.mk
@@ -1,0 +1,12 @@
+package=zlib
+$(package)_version=1.2.11
+$(package)_download_path=https://zlib.net
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+# Here all that we do, is copying the content of the package to a fixed directory,
+# so that Boost can find it.
+define $(package)_build_cmds
+  mkdir -p $(BASEDIR)/sources/$(package) && cp * -rf $(BASEDIR)/sources/$(package)
+endef
+

--- a/contrib/epee/include/file_compression.h
+++ b/contrib/epee/include/file_compression.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2014-2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef _FILE_COMPRESSION_H_
+#define _FILE_COMPRESSION_H_
+
+#include <iosfwd>
+#include <string>
+
+namespace epee
+{
+namespace file_compression
+{
+    void decompress_file(const std::string & filename_base, std::ostream & out_stream);
+    void compress_file(const std::string & filename);
+    std::string get_archive_extension();
+}
+}
+
+#endif // _FILE_COMPRESSION_H_

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -33,7 +33,7 @@ monero_find_all_headers(EPEE_HEADERS_PUBLIC "${EPEE_INCLUDE_DIR_BASE}")
 
 monero_add_library(epee byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp parserse_base_utils.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
-    int-util.cpp portable_storage.cpp
+    int-util.cpp portable_storage.cpp file_compression.cpp
     misc_language.cpp
     misc_os_dependent.cpp
     file_io_utils.cpp
@@ -66,6 +66,13 @@ if (BUILD_GUI_DEPS)
     endif()
 endif()
 
+if (Boost_ZLIB_FOUND)
+    set(MONERO_ZLIB ${Boost_ZLIB_LIBRARY})
+else()
+    set(MONERO_ZLIB z)
+endif()
+message(STATUS "Using zlib: ${MONERO_ZLIB}")
+
 target_link_libraries(epee
   PUBLIC
     easylogging
@@ -74,6 +81,8 @@ target_link_libraries(epee
     ${Boost_THREAD_LIBRARY}
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
+    ${Boost_IOSTREAMS_LIBRARY}
+    ${MONERO_ZLIB}
     ${OPENSSL_LIBRARIES}
   PRIVATE
     ${EXTRA_LIBRARIES})

--- a/contrib/epee/src/file_compression.cpp
+++ b/contrib/epee/src/file_compression.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2014-2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "file_compression.h"
+
+#ifdef WIN32
+    #include <boost/iostreams/filter/zlib.hpp>
+    #define COMPRESSOR zlib_compressor()
+    #define DECOMPRESSOR zlib_decompressor()
+    #define EXTENSION ".zip"
+#else
+    #include <boost/iostreams/filter/gzip.hpp>
+    #define COMPRESSOR gzip_compressor()
+    #define DECOMPRESSOR gzip_decompressor()
+    #define EXTENSION ".gz"
+#endif // WIN32
+// Other possibilities to consider with newer Boost:
+//#include <boost/iostreams/filter/lzma.hpp>
+//#include <boost/iostreams/filter/zstd.hpp>
+
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/copy.hpp>
+
+#include <fstream>
+#include <string>
+
+namespace epee
+{
+namespace file_compression
+{
+void decompress_file(const std::string & fileNameBase, std::ostream & outStream)
+{
+    namespace bio = boost::iostreams;
+    std::ifstream file(fileNameBase + get_archive_extension(), std::ios_base::binary);
+    bio::filtering_streambuf<bio::input> in;
+    in.push(bio::DECOMPRESSOR);
+    in.push(file);
+    bio::copy(in, outStream);
+}
+
+void compress_file(const std::string & fileNameBase)
+{
+    namespace bio = boost::iostreams;
+    std::ifstream inStream(fileNameBase, std::ios_base::in);
+    std::ofstream outStream(fileNameBase + get_archive_extension(), std::ios_base::out);
+    boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
+    in.push(bio::COMPRESSOR);
+    in.push(inStream);
+    boost::iostreams::copy(in, outStream);
+}
+
+std::string get_archive_extension()
+{
+    return EXTENSION;
+}
+}
+}

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -42,6 +42,7 @@
 #include "string_tools.h"
 #include "misc_os_dependent.h"
 #include "misc_log_ex.h"
+#include "file_compression.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "logging"
@@ -171,6 +172,10 @@ void mlog_configure(const std::string &filename_base, bool console, const std::s
       // can't log a failure, but don't do the file removal below
       return;
     }
+    // Log rotation works best with compression
+    epee::file_compression::compress_file(rname);
+    remove(rname.c_str());
+
     if (max_log_files != 0)
     {
       std::vector<boost::filesystem::path> found_files;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(unit_tests_sources
   epee_levin_protocol_handler_async.cpp
   epee_serialization.cpp
   epee_utils.cpp
+  epee_file_compression.cpp
   expect.cpp
   fee.cpp
   json_serialization.cpp

--- a/tests/unit_tests/epee_file_compression.cpp
+++ b/tests/unit_tests/epee_file_compression.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2014-2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include "file_compression.h"
+
+#include "gtest/gtest.h"
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <sstream>
+
+TEST(epee_file_compression, compressed_is_same_as_decompressed)
+{
+  namespace bfs = boost::filesystem;
+  namespace epfc = epee::file_compression;
+  const bfs::path p = bfs::temp_directory_path() / bfs::unique_path();
+  const std::string log_filename = p.string();
+  const std::string content = "Some content to compare";
+  {
+      std::ofstream fout(log_filename);
+      fout << content;
+  }
+  epfc::compress_file(log_filename);
+  std::ostringstream oss;
+  epfc::decompress_file(log_filename, oss);
+  ASSERT_EQ(content, oss.str());
+  
+  bfs::remove(log_filename);
+  bfs::remove(log_filename + epfc::get_archive_extension());
+}
+


### PR DESCRIPTION
It's now possible to use file compression using `epee::file_compression` namespace, which is a wrapper around `boost::iostreams`. The current use case is compression of rotated logs in `epee::mlog.cpp`, but it could be also used to compress for instance the generated test data from https://github.com/monero-project/monero/pull/7469.

The `epee::file_compression` also offers a decompression routine, which is able to decompress the data right into an abstract `std::ostream`, which could be either a file (`std::ofstream`), memory (`std::ostringstream`) or some network stream, derived from `std::ostream` (see [example here](https://stackoverflow.com/a/19933011)).


The bulk of the time for this PR was taken by managing the `depends` package and multiple recompilations of the toolchain.