### PR TITLE
Fix monerod --rpc-ssl disabled and --non-interactive combo

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -335,7 +335,7 @@ namespace cryptonote
     if (m_rpc_payment)
       m_net_server.add_idle_handler([this](){ return m_rpc_payment->on_idle(); }, 60 * 1000);
 
-    bool store_ssl_key = !restricted && rpc_config->ssl_options.auth.certificate_path.empty();
+    bool store_ssl_key = !restricted && rpc_config->ssl_options && rpc_config->ssl_options.auth.certificate_path.empty();
     const auto ssl_base_path = (boost::filesystem::path{data_dir} / "rpc_ssl").string();
     if (store_ssl_key && boost::filesystem::exists(ssl_base_path + ".crt"))
     {


### PR DESCRIPTION
When both of those options are set, OpenSSL call fails stopping the daemon from launching.