### PR TITLE
cmake: Don't default to -march=native on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,17 @@ endif()
 # Trezor support check
 include(CheckTrezor)
 
+# As of OpenBSD 6.8, -march=<anything> breaks the build
+function(set_default_arch)
+  if (OPENBSD)
+    set(ARCH default)
+  else()
+    set(ARCH native)
+  endif()
+
+  set(ARCH ${ARCH} CACHE STRING "CPU to build for: -march value or 'default' to not pass -march at all")
+endfunction()
+
 if(MSVC)
   add_definitions("/bigobj /MP /W3 /GS- /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4345 /D_WIN32_WINNT=0x0600 /DWIN32_LEAN_AND_MEAN /DGTEST_HAS_TR1_TUPLE=0 /FIinline_c.h /D__SSE4_1__")
   # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Dinline=__inline")
@@ -514,7 +525,7 @@ if(MSVC)
 else()
   include(TestCXXAcceptsFlag)
   if (NOT ARCH)
-    set(ARCH native CACHE STRING "CPU to build for: -march value or 'default' to not pass -march at all")
+    set_default_arch()
   endif()
   message(STATUS "Building on ${CMAKE_SYSTEM_PROCESSOR} for ${ARCH}")
   if(ARCH STREQUAL "default")


### PR DESCRIPTION
Under OpenBSD/amd64 6.8, with its boost package, the `-march=native` option causes a compile failure in any file that includes `boost/thread.hpp`. The same is true for `-march=<any other x86-64 platform>`.

Under OpenBSD/arm64 6.8, the `-march=native` flag isn't even supported. This fact is detected, and the flag is already not used by default, so this change has no effect there.

The compilation error can be reproduced as follows:

```
$ echo '#include <boost/thread.hpp>' | c++ -I/usr/local/include -x c++ - -march=westmere
In file included from <stdin>:1:
In file included from /usr/local/include/boost/thread.hpp:17:
In file included from /usr/local/include/boost/thread/once.hpp:26:
In file included from /usr/local/include/boost/thread/pthread/once_atomic.hpp:20:
In file included from /usr/local/include/boost/atomic.hpp:12:
In file included from /usr/local/include/boost/atomic/atomic.hpp:20:
In file included from /usr/local/include/boost/atomic/fences.hpp:21:
In file included from /usr/local/include/boost/atomic/detail/operations.hpp:17:
In file included from /usr/local/include/boost/atomic/detail/operations_lockfree.hpp:21:
In file included from /usr/local/include/boost/atomic/detail/ops_gcc_atomic.hpp:24:
/usr/local/include/boost/atomic/detail/ops_gcc_x86_dcas.hpp:460:20: error: address argument to atomic builtin must be a
      pointer to integer or pointer ('volatile boost::atomics::detail::gcc_dcas_x86_64::storage_type *' (aka 'volatile
      boost::atomics::detail::storage128_t *') invalid)
        expected = __sync_val_compare_and_swap(&storage, old_expected, desired);
                   ^                           ~~~~~~~~
1 error generated.
```

