### PR TITLE
db_lmdb: catch exceptions testing for mmap support

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1354,7 +1354,8 @@ void BlockchainLMDB::open(const std::string& filename, const int db_flags)
 
   m_folder = filename;
 
-  check_mmap_support();
+  try { check_mmap_support(); }
+  catch(...) { MERROR("Failed to check for mmap support, proceeding"); }
 
 #ifdef __OpenBSD__
   if ((mdb_flags & MDB_WRITEMAP) == 0) {


### PR DESCRIPTION
Turns out at least one arch (armel based) does not have unique_path
implemented and throws