### PR TITLE
Tests: Fix test node_server.bind_same_p2p_port from randomly crashing

### DIFF
--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -293,6 +293,18 @@ TEST(node_server, bind_same_p2p_port)
     boost::program_options::variables_map vm;
     boost::program_options::store(boost::program_options::parse_command_line(1, argv, desc_options), vm);
 
+    /*
+    Reason for choosing '127.0.0.2' as the IP:
+
+    A TCP local socket address that has been bound is unavailable for some time after closing, unless the SO_REUSEADDR flag has been set.
+    That's why connections with automatically assigned source port 48080/58080 from previous test blocks the next to bind acceptor
+    so solution is to either set reuse_addr option for each socket in all tests
+    or use ip different from localhost for acceptors in order to not interfere with automatically assigned source endpoints
+
+    Relevant part about REUSEADDR from man:
+    https://www.man7.org/linux/man-pages/man7/ip.7.html
+    */
+    vm.find(nodetool::arg_p2p_bind_ip.name)->second   = boost::program_options::variable_value(std::string("127.0.0.2"), false);
     vm.find(nodetool::arg_p2p_bind_port.name)->second = boost::program_options::variable_value(std::string(port), false);
 
     boost::program_options::notify(vm);


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero/issues/7645

The test was crashing on Github with ~10% probability.

The fix and the comment block has been written by `wfaressuissia`. I only reported the problem and provided steps to reproduce, as well as confirmed each other's local experiments.

See the added comment block for an in-depth description.
