### PR TITLE
Cleanup TCP shutdown sequence in epee server

### DIFF
--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -102,12 +102,14 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		// beware of removing const, net_utils::connection is sketchily doing a cast to prevent storing ptr twice
 		const std::shared_ptr<connection_basic_shared_state> m_state;
 	public:
+		// do not change order (logic changes)
+		enum class status : std::uint8_t { none = 0, flushing, cleanup };
 
 		std::unique_ptr< connection_basic_pimpl > mI; // my Implementation
 
 		// moved here from orginal connecton<> - common member variables that do not depend on template in connection<>
     volatile uint32_t m_want_close_connection;
-    std::atomic<bool> m_was_shutdown;
+    std::atomic<status> m_shutdown_status;
     critical_section m_send_que_lock;
     std::deque<byte_slice> m_send_que;
     volatile bool m_is_multithreaded;

--- a/contrib/epee/include/net/http_protocol_handler.h
+++ b/contrib/epee/include/net/http_protocol_handler.h
@@ -53,6 +53,11 @@ namespace net_utils
 		/************************************************************************/
 		struct http_server_config
 		{
+			static boost::posix_time::milliseconds shutdown_timeout()
+			{
+				return boost::posix_time::milliseconds{10 * 1000};
+			}
+
 			std::string m_folder;
 			std::vector<std::string> m_access_control_origins;
 			boost::optional<login> m_user;

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -597,7 +597,6 @@ namespace net_utils
 			response_data += response.m_body;
 
 		m_psnd_hndlr->do_send(byte_slice{std::move(response_data)});
-		m_psnd_hndlr->send_done();
 		return res;
 	}
 	//-----------------------------------------------------------------------------------

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -103,7 +103,10 @@ public:
   uint64_t m_max_packet_size;
   uint64_t m_invoke_timeout;
 
+  static boost::posix_time::milliseconds shutdown_timeout() { return boost::posix_time::milliseconds{10 * 1000}; }
+
   int invoke(int command, message_writer in_msg, std::string& buff_out, boost::uuids::uuid connection_id);
+
   template<class callback_t>
   int invoke_async(int command, message_writer in_msg, boost::uuids::uuid connection_id, const callback_t &cb, size_t timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED);
 

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -437,7 +437,6 @@ namespace net_utils
 	{
 		virtual bool do_send(byte_slice message)=0;
     virtual bool close()=0;
-    virtual bool send_done()=0;
     virtual bool call_run_once_service_io()=0;
     virtual bool request_callback()=0;
     virtual boost::asio::io_service& get_io_service()=0;

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -135,7 +135,7 @@ connection_basic::connection_basic(boost::asio::ip::tcp::socket&& sock, std::sha
 	strand_(GET_IO_SERVICE(sock)),
 	socket_(GET_IO_SERVICE(sock), get_context(m_state.get())),
 	m_want_close_connection(false),
-	m_was_shutdown(false),
+	m_shutdown_status(status::none),
 	m_is_multithreaded(false),
 	m_ssl_support(ssl_support)
 {
@@ -160,7 +160,7 @@ connection_basic::connection_basic(boost::asio::io_service &io_service, std::sha
 	strand_(io_service),
 	socket_(io_service, get_context(m_state.get())),
 	m_want_close_connection(false),
-	m_was_shutdown(false),
+	m_shutdown_status(status::none),
 	m_is_multithreaded(false),
 	m_ssl_support(ssl_support)
 {
@@ -238,8 +238,8 @@ void connection_basic::sleep_before_packet(size_t packet_size, int phase,  int q
 	double delay=0; // will be calculated
 	do
 	{ // rate limiting
-		if (m_was_shutdown) { 
-			_dbg2("m_was_shutdown - so abort sleep");
+		if (m_shutdown_status != status::none) {
+			_dbg2("m_shutdown_status - so abort sleep");
 			return;
 		}
 

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -50,6 +50,7 @@ namespace
 
   struct test_protocol_handler_config
   {
+    static boost::posix_time::milliseconds shutdown_timeout() { return boost::posix_time::milliseconds{500}; }
   };
 
   struct test_protocol_handler

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -68,11 +68,6 @@ namespace
             return true;
         }
 
-        virtual bool send_done() override final
-        {
-            throw std::logic_error{"send_done not implemented"};
-        }
-
         virtual bool call_run_once_service_io() override final
         {
             return io_service_.run_one();


### PR DESCRIPTION
Some cleanup/refactoring to the shutdown sequence in the TCP server. Affects P2P and RPC. The "flushing" behavior of the send queue should be more obvious. Shutdown calls on the socket and timer are also moved "inside" the strand too, to synchronize with read/write callbacks.