### PR TITLE
Improve cryptonote (block and tx) binary read performance

### DIFF
--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -31,7 +31,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <type_traits>
 
 namespace epee
@@ -167,10 +166,11 @@ namespace epee
   }
 
   //! make a span from a std::string
-  template<typename T>
-  span<const T> strspan(const std::string &s) noexcept
+  template<typename T, typename U>
+  span<const T> strspan(const U&s) noexcept
   {
-    static_assert(std::is_same<T, char>() || std::is_same<T, unsigned char>() || std::is_same<T, int8_t>() || std::is_same<T, uint8_t>(), "Unexpected type");
+    static_assert(std::is_same<typename U::value_type, char>(), "unexpected source type");
+    static_assert(std::is_same<T, char>() || std::is_same<T, unsigned char>() || std::is_same<T, int8_t>() || std::is_same<T, uint8_t>(), "Unexpected destination type");
     return {reinterpret_cast<const T*>(s.data()), s.size()};
   }
 }

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -388,9 +388,7 @@ static bool for_all_transactions(const std::string &filename, uint64_t &start_id
     cryptonote::transaction_prefix tx;
     blobdata bd;
     bd.assign(reinterpret_cast<char*>(v.mv_data), v.mv_size);
-    std::stringstream ss;
-    ss << bd;
-    binary_archive<false> ba(ss);
+    binary_archive<false> ba{epee::strspan<std::uint8_t>(bd)};
     bool r = do_serialize(ba, tx);
     CHECK_AND_ASSERT_MES(r, false, "Failed to parse transaction from blob");
 

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -152,10 +152,6 @@ namespace cryptonote
 
   };
 
-  template<typename T> static inline unsigned int getpos(T &ar) { return 0; }
-  template<> inline unsigned int getpos(binary_archive<true> &ar) { return ar.stream().tellp(); }
-  template<> inline unsigned int getpos(binary_archive<false> &ar) { return ar.stream().tellg(); }
-
   class transaction_prefix
   {
 
@@ -236,17 +232,17 @@ namespace cryptonote
         set_blob_size_valid(false);
       }
 
-      const unsigned int start_pos = getpos(ar);
+      const auto start_pos = ar.getpos();
 
       FIELDS(*static_cast<transaction_prefix *>(this))
 
       if (std::is_same<Archive<W>, binary_archive<W>>())
-        prefix_size = getpos(ar) - start_pos;
+        prefix_size = ar.getpos() - start_pos;
 
       if (version == 1)
       {
         if (std::is_same<Archive<W>, binary_archive<W>>())
-          unprunable_size = getpos(ar) - start_pos;
+          unprunable_size = ar.getpos() - start_pos;
 
         ar.tag("signatures");
         ar.begin_array();
@@ -284,11 +280,11 @@ namespace cryptonote
         {
           ar.begin_object();
           bool r = rct_signatures.serialize_rctsig_base(ar, vin.size(), vout.size());
-          if (!r || !ar.stream().good()) return false;
+          if (!r || !ar.good()) return false;
           ar.end_object();
 
           if (std::is_same<Archive<W>, binary_archive<W>>())
-            unprunable_size = getpos(ar) - start_pos;
+            unprunable_size = ar.getpos() - start_pos;
 
           if (!pruned && rct_signatures.type != rct::RCTTypeNull)
           {
@@ -296,7 +292,7 @@ namespace cryptonote
             ar.begin_object();
             r = rct_signatures.p.serialize_rctsig_prunable(ar, rct_signatures.type, vin.size(), vout.size(),
                 vin.size() > 0 && vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(vin[0]).key_offsets.size() - 1 : 0);
-            if (!r || !ar.stream().good()) return false;
+            if (!r || !ar.good()) return false;
             ar.end_object();
           }
         }
@@ -320,13 +316,13 @@ namespace cryptonote
         {
           ar.begin_object();
           bool r = rct_signatures.serialize_rctsig_base(ar, vin.size(), vout.size());
-          if (!r || !ar.stream().good()) return false;
+          if (!r || !ar.good()) return false;
           ar.end_object();
         }
       }
       if (!typename Archive<W>::is_saving())
         pruned = true;
-      return ar.stream().good();
+      return ar.good();
     }
 
   private:

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -148,9 +148,7 @@ namespace cryptonote
   template<class t_object>
   bool t_serializable_object_from_blob(t_object& to, const blobdata& b_blob)
   {
-    std::stringstream ss;
-    ss << b_blob;
-    binary_archive<false> ba(ss);
+    binary_archive<false> ba{epee::strspan<std::uint8_t>(b_blob)};
     bool r = ::serialization::serialize(ba, to);
     return r;
   }

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -57,11 +57,7 @@ namespace cryptonote
       // size - 1 - because of variant tag
       for (size = 1; size <= TX_EXTRA_PADDING_MAX_COUNT; ++size)
       {
-        std::ios_base::iostate state = ar.stream().rdstate();
-        bool eof = EOF == ar.stream().peek();
-        ar.stream().clear(state);
-
-        if (eof)
+        if (ar.eof())
           break;
 
         uint8_t zero;
@@ -139,8 +135,7 @@ namespace cryptonote
       if(!::do_serialize(ar, field))
         return false;
 
-      std::istringstream iss(field);
-      binary_archive<false> iar(iss);
+      binary_archive<false> iar{epee::strspan<std::uint8_t>(field)};
       serialize_helper helper(*this);
       return ::serialization::serialize(iar, helper);
     }

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -66,9 +66,7 @@ namespace protocol{
 
   template<typename T>
   bool cn_deserialize(const void * buff, size_t len, T & dst){
-    std::stringstream ss;
-    ss.write(static_cast<const char *>(buff), len);  //ss << tx_blob;
-    binary_archive<false> ba(ss);
+    binary_archive<false> ba{{reinterpret_cast<const std::uint8_t*>(buff), len}};
     bool r = ::serialization::serialize(ba, dst);
     return r;
   }

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -284,7 +284,7 @@ namespace rct {
         {
           FIELD(type)
           if (type == RCTTypeNull)
-            return ar.stream().good();
+            return ar.good();
           if (type != RCTTypeFull && type != RCTTypeSimple && type != RCTTypeBulletproof && type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
             return false;
           VARINT_FIELD(txnFee)
@@ -344,7 +344,7 @@ namespace rct {
               ar.delimit_array();
           }
           ar.end_array();
-          return ar.stream().good();
+          return ar.good();
         }
 
         BEGIN_SERIALIZE_OBJECT()
@@ -375,7 +375,7 @@ namespace rct {
           if (mixin >= 0xffffffff)
             return false;
           if (type == RCTTypeNull)
-            return ar.stream().good();
+            return ar.good();
           if (type != RCTTypeFull && type != RCTTypeSimple && type != RCTTypeBulletproof && type != RCTTypeBulletproof2 && type != RCTTypeCLSAG)
             return false;
           if (type == RCTTypeBulletproof || type == RCTTypeBulletproof2 || type == RCTTypeCLSAG)
@@ -522,7 +522,7 @@ namespace rct {
             }
             ar.end_array();
           }
-          return ar.stream().good();
+          return ar.good();
         }
 
         BEGIN_SERIALIZE_OBJECT()

--- a/src/rpc/rpc_payment.cpp
+++ b/src/rpc/rpc_payment.cpp
@@ -293,12 +293,13 @@ namespace cryptonote
     MINFO("loading rpc payments data from " << state_file_path);
     std::ifstream data;
     data.open(state_file_path, std::ios_base::binary | std::ios_base::in);
+    std::string bytes(std::istream_iterator<char>{data}, std::istream_iterator<char>{});
     if (!data.fail())
     {
       bool loaded = false;
       try
       {
-        binary_archive<false> ar(data);
+        binary_archive<false> ar{epee::strspan<std::uint8_t>(bytes)};
         if (::serialization::serialize(ar, *this))
           if (::serialization::check_stream_state(ar))
             loaded = true;
@@ -306,6 +307,8 @@ namespace cryptonote
       catch (...) {}
       if (!loaded)
       {
+        bytes.clear();
+        bytes.shrink_to_fit();
         try
         {
           boost::archive::portable_binary_iarchive a(data);

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -36,9 +36,11 @@
 #include <cassert>
 #include <iostream>
 #include <iterator>
+#include <boost/endian/conversion.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 
 #include "common/varint.h"
+#include "span.h"
 #include "warnings.h"
 
 /* I have no clue what these lines means */
@@ -55,16 +57,15 @@ DISABLE_VS_WARNINGS(4244)
  * purpse is to define the functions used for the binary_archive. Its
  * a header, basically. I think it was declared simply to save typing...
  */
-template <class Stream, bool IsSaving>
+template <bool IsSaving>
 struct binary_archive_base
 {
-  typedef Stream stream_type;
-  typedef binary_archive_base<Stream, IsSaving> base_type;
+  typedef binary_archive_base<IsSaving> base_type;
   typedef boost::mpl::bool_<IsSaving> is_saving;
 
   typedef uint8_t variant_tag_type;
 
-  explicit binary_archive_base(stream_type &s) : stream_(s) { }
+  explicit binary_archive_base() { }
   
   /* definition of standard API functions */
   void tag(const char *) { }
@@ -72,12 +73,6 @@ struct binary_archive_base
   void end_object() { }
   void begin_variant() { }
   void end_variant() { }
-  /* I just want to leave a comment saying how this line really shows
-     flaws in the ownership model of many OOP languages, that is all. */
-  stream_type &stream() { return stream_; } 
-
-protected:
-  stream_type &stream_;
 };
 
 /* \struct binary_archive
@@ -95,15 +90,18 @@ struct binary_archive;
 
 
 template <>
-struct binary_archive<false> : public binary_archive_base<std::istream, false>
+struct binary_archive<false> : public binary_archive_base<false>
 {
+  explicit binary_archive(epee::span<const std::uint8_t> s)
+    : base_type(), bytes_(s), begin_(s.begin()), good_(true), varint_bug_backward_compatibility_(false)
+  {}
 
-  explicit binary_archive(stream_type &s) : base_type(s), varint_bug_backward_compatibility_(false) {
-    stream_type::pos_type pos = stream_.tellg();
-    stream_.seekg(0, std::ios_base::end);
-    eof_pos_ = stream_.tellg();
-    stream_.seekg(pos);
-  }
+  bool good() const noexcept { return good_; }
+  void set_fail() noexcept { good_ = false; }
+
+  //! If implementing as `std::istream`, reset stream error state after `peek()` call.
+  bool eof() const noexcept { return bytes_.empty(); }
+  std::size_t getpos() const noexcept { return bytes_.begin() - begin_; }
 
   template <class T>
   void serialize_int(T &v)
@@ -116,24 +114,24 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
    * \brief serializes an unsigned integer
    */
   template <class T>
-  void serialize_uint(T &v, size_t width = sizeof(T))
+  void serialize_uint(T &v)
   {
-    T ret = 0;
-    unsigned shift = 0;
-    for (size_t i = 0; i < width; i++) {
-      //std::cerr << "tell: " << stream_.tellg() << " value: " << ret << std::endl;
-      char c;
-      stream_.get(c);
-      T b = (unsigned char)c;
-      ret += (b << shift);	// can this be changed to OR, i think it can.
-      shift += 8;
+    const std::size_t actual = bytes_.remove_prefix(sizeof(T));
+    good_ &= (actual == sizeof(T));
+    if (actual == sizeof(T))
+    {
+      std::memcpy(std::addressof(v), bytes_.data() - sizeof(T), sizeof(T));
+      boost::endian::little_to_native_inplace(v); // epee isn't templated
     }
-    v = ret;
+    else
+      v = 0; // ensures initialization
   }
   
   void serialize_blob(void *buf, size_t len, const char *delimiter="")
   {
-    stream_.read((char *)buf, len);
+    const std::size_t actual = bytes_.remove_prefix(len);
+    good_ &= (len == actual);
+    std::memcpy(buf, bytes_.data() - actual, actual);
   }
   
   template <class T>
@@ -145,9 +143,11 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
   template <class T>
   void serialize_uvarint(T &v)
   {
-    typedef std::istreambuf_iterator<char> it;
-    if (tools::read_varint(it(stream_), it(), v) < 0)
-      stream_.setstate(std::ios_base::failbit);
+    auto current = bytes_.cbegin();
+    auto end = bytes_.cend();
+    good_ &= (0 <= tools::read_varint(current, end, v));
+    current = std::min(current, bytes_.cend());
+    bytes_ = {current, std::size_t(bytes_.cend() - current)};
   }
 
   void begin_array(size_t &s)
@@ -166,26 +166,26 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
     serialize_int(t);
   }
 
-  size_t remaining_bytes() {
-    if (!stream_.good())
-      return 0;
-    //std::cerr << "tell: " << stream_.tellg() << std::endl;
-    assert(stream_.tellg() <= eof_pos_);
-    return eof_pos_ - stream_.tellg();
-  }
-
+  size_t remaining_bytes() const noexcept { return good() ? bytes_.size() : 0; }
   void enable_varint_bug_backward_compatibility() { varint_bug_backward_compatibility_ = true; }
   bool varint_bug_backward_compatibility_enabled() const { return varint_bug_backward_compatibility_; }
-
 protected:
-  std::streamoff eof_pos_;
+  epee::span<const std::uint8_t> bytes_;
+  std::uint8_t const* const begin_;
+  bool good_;
   bool varint_bug_backward_compatibility_;
 };
 
 template <>
-struct binary_archive<true> : public binary_archive_base<std::ostream, true>
+struct binary_archive<true> : public binary_archive_base<true>
 {
-  explicit binary_archive(stream_type &s) : base_type(s) { }
+  typedef std::ostream stream_type;
+  explicit binary_archive(stream_type &s) : base_type(), stream_(s) { }
+
+  bool good() const { return stream_.good(); }
+  void set_fail() { stream_.setstate(std::ios::failbit); }
+
+  std::streampos getpos() const { return stream_.tellp(); }
 
   template <class T>
   void serialize_int(T v)
@@ -234,6 +234,8 @@ struct binary_archive<true> : public binary_archive_base<std::ostream, true>
   }
 
   bool varint_bug_backward_compatibility_enabled() const { return false; }
+protected:
+  stream_type& stream_;
 };
 
 POP_WARNINGS

--- a/src/serialization/binary_utils.h
+++ b/src/serialization/binary_utils.h
@@ -39,8 +39,7 @@ namespace serialization {
   template <class T>
     bool parse_binary(const std::string &blob, T &v)
     {
-      std::istringstream istr(blob);
-      binary_archive<false> iar(istr);
+      binary_archive<false> iar{epee::strspan<std::uint8_t>(blob)};
       return ::serialization::serialize(iar, v);
     }
 

--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -67,13 +67,13 @@ bool do_serialize_container(Archive<false> &ar, C &v)
 {
   size_t cnt;
   ar.begin_array(cnt);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   v.clear();
 
   // very basic sanity check
   if (ar.remaining_bytes() < cnt) {
-    ar.stream().setstate(std::ios::failbit);
+    ar.set_fail();
     return false;
   }
 
@@ -86,7 +86,7 @@ bool do_serialize_container(Archive<false> &ar, C &v)
     if (!::serialization::detail::serialize_container_element(ar, e))
       return false;
     ::serialization::detail::do_add(v, std::move(e));
-    if (!ar.stream().good())
+    if (!ar.good())
       return false;
   }
   ar.end_array();
@@ -100,13 +100,13 @@ bool do_serialize_container(Archive<true> &ar, C &v)
   ar.begin_array(cnt);
   for (auto i = v.begin(); i != v.end(); ++i)
   {
-    if (!ar.stream().good())
+    if (!ar.good())
       return false;
     if (i != v.begin())
       ar.delimit_array();
     if(!::serialization::detail::serialize_container_element(ar, (typename C::value_type&)*i))
       return false;
-    if (!ar.stream().good())
+    if (!ar.good())
       return false;
   }
   ar.end_array();

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -47,7 +47,7 @@ bool do_serialize(Archive<false> &ar, std::vector<crypto::signature> &v)
 
   // very basic sanity check
   if (ar.remaining_bytes() < cnt*sizeof(crypto::signature)) {
-    ar.stream().setstate(std::ios::failbit);
+    ar.set_fail();
     return false;
   }
 
@@ -55,7 +55,7 @@ bool do_serialize(Archive<false> &ar, std::vector<crypto::signature> &v)
   for (size_t i = 0; i < cnt; i++) {
     v.resize(i+1);
     ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.stream().good())
+    if (!ar.good())
       return false;
   }
   return true;
@@ -70,7 +70,7 @@ bool do_serialize(Archive<true> &ar, std::vector<crypto::signature> &v)
   size_t cnt = v.size();
   for (size_t i = 0; i < cnt; i++) {
     ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.stream().good())
+    if (!ar.good())
       return false;
   }
   ar.end_string();

--- a/src/serialization/debug_archive.h
+++ b/src/serialization/debug_archive.h
@@ -38,6 +38,7 @@ struct debug_archive : public json_archive<W> {
   typedef typename json_archive<W>::stream_type stream_type;
 
   debug_archive(stream_type &s) : json_archive<W>(s) { }
+  stream_type& stream() { return this->stream_; }
 };
 
 template <class T>

--- a/src/serialization/difficulty_type.h
+++ b/src/serialization/difficulty_type.h
@@ -38,10 +38,10 @@ inline bool do_serialize(Archive<false>& ar, cryptonote::difficulty_type &diff)
 {
   uint64_t hi, lo;
   ar.serialize_varint(hi);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   ar.serialize_varint(lo);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   diff = hi;
   diff <<= 64;
@@ -52,13 +52,13 @@ inline bool do_serialize(Archive<false>& ar, cryptonote::difficulty_type &diff)
 template <template <bool> class Archive>
 inline bool do_serialize(Archive<true>& ar, cryptonote::difficulty_type &diff)
 {
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   const uint64_t hi = ((diff >> 64) & 0xffffffffffffffff).convert_to<uint64_t>();
   const uint64_t lo = (diff & 0xffffffffffffffff).convert_to<uint64_t>();
   ar.serialize_varint(hi);
   ar.serialize_varint(lo);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   return true;
 }

--- a/src/serialization/json_archive.h
+++ b/src/serialization/json_archive.h
@@ -58,6 +58,10 @@ struct json_archive_base
   json_archive_base(stream_type &s, bool indent = false)
   : stream_(s), indent_(indent), object_begin(false), depth_(0) { }
 
+  bool good() const { return stream_.good(); }
+  void set_fail() { stream_.setstate(std::ios::failbit); }
+  void clear_fail() { stream_.clear(); }
+
   void tag(const char *tag) {
     if (!object_begin)
       stream_ << ", ";
@@ -82,7 +86,6 @@ struct json_archive_base
 
   void begin_variant() { begin_object(); }
   void end_variant() { end_object(); }
-  Stream &stream() { return stream_; }
 
   bool varint_bug_backward_compatibility_enabled() const { return false; }
 
@@ -116,6 +119,8 @@ template <>
 struct json_archive<true> : public json_archive_base<std::ostream, true>
 {
   json_archive(stream_type &s, bool indent = false) : base_type(s, indent), inner_array_size_(0) { }
+
+  std::streampos getpos() const { return stream_.tellp(); }
 
   template<typename T>
   static auto promote_to_printable_integer_type(T v) -> decltype(+v)

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -69,19 +69,19 @@ inline bool do_serialize(Archive<false>& ar, std::pair<F,S>& p)
 {
   size_t cnt;
   ar.begin_array(cnt);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   if (cnt != 2)
     return false;
 
   if (!::serialization::detail::serialize_pair_element(ar, p.first))
     return false;
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   ar.delimit_array();
   if (!::serialization::detail::serialize_pair_element(ar, p.second))
     return false;
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
 
   ar.end_array();
@@ -92,16 +92,16 @@ template <template <bool> class Archive, class F, class S>
 inline bool do_serialize(Archive<true>& ar, std::pair<F,S>& p)
 {
   ar.begin_array(2);
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   if(!::serialization::detail::serialize_pair_element(ar, p.first))
     return false;
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   ar.delimit_array();
   if(!::serialization::detail::serialize_pair_element(ar, p.second))
     return false;
-  if (!ar.stream().good())
+  if (!ar.good())
     return false;
   ar.end_array();
   return true;

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -213,7 +213,7 @@ inline bool do_serialize(Archive &ar, bool &v)
  * \brief self-explanatory
  */
 #define END_SERIALIZE()				\
-  return ar.stream().good();			\
+  return ar.good();				\
   }
 
 /*! \macro VALUE(f)
@@ -223,7 +223,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {							\
     ar.tag(#f);						\
     bool r = ::do_serialize(ar, f);			\
-    if (!r || !ar.stream().good()) return false;	\
+    if (!r || !ar.good()) return false;			\
   } while(0);
 
 /*! \macro FIELD_N(t,f)
@@ -234,7 +234,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {							\
     ar.tag(t);						\
     bool r = ::do_serialize(ar, f);			\
-    if (!r || !ar.stream().good()) return false;	\
+    if (!r || !ar.good()) return false;			\
   } while(0);
 
 /*! \macro FIELD(f)
@@ -245,7 +245,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {							\
     ar.tag(#f);						\
     bool r = ::do_serialize(ar, f);			\
-    if (!r || !ar.stream().good()) return false;	\
+    if (!r || !ar.good()) return false;			\
   } while(0);
 
 /*! \macro FIELDS(f)
@@ -255,7 +255,7 @@ inline bool do_serialize(Archive &ar, bool &v)
 #define FIELDS(f)							\
   do {									\
     bool r = ::do_serialize(ar, f);					\
-    if (!r || !ar.stream().good()) return false;			\
+    if (!r || !ar.good()) return false;					\
   } while(0);
 
 /*! \macro VARINT_FIELD(f)
@@ -265,7 +265,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {						\
     ar.tag(#f);					\
     ar.serialize_varint(f);			\
-    if (!ar.stream().good()) return false;	\
+    if (!ar.good()) return false;		\
   } while(0);
 
 /*! \macro VARINT_FIELD_N(t, f)
@@ -276,7 +276,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {						\
     ar.tag(t);					\
     ar.serialize_varint(f);			\
-    if (!ar.stream().good()) return false;	\
+    if (!ar.good()) return false;		\
   } while(0);
 
 /*! \macro MAGIC_FIELD(m)
@@ -286,7 +286,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {						\
     ar.tag("magic");				\
     ar.serialize_blob((void*)magic.data(), magic.size()); \
-    if (!ar.stream().good()) return false;	\
+    if (!ar.good()) return false;		\
     if (magic != m) return false;		\
   } while(0);
 
@@ -297,7 +297,7 @@ inline bool do_serialize(Archive &ar, bool &v)
   do {						\
     ar.tag("version");				\
     ar.serialize_varint(version);		\
-    if (!ar.stream().good()) return false;	\
+    if (!ar.good()) return false;		\
   } while(0);
 
 
@@ -339,10 +339,10 @@ namespace serialization {
      *
      * \brief self explanatory
      */
-    template<class Stream>
-    bool do_check_stream_state(Stream& s, boost::mpl::bool_<true>, bool noeof)
+    template<class Archive>
+    bool do_check_stream_state(Archive& ar, boost::mpl::bool_<true>, bool noeof)
     {
-      return s.good();
+      return ar.good();
     }
     /*! \fn do_check_stream_state
      *
@@ -350,15 +350,13 @@ namespace serialization {
      *
      * \detailed Also checks to make sure that the stream is not at EOF
      */
-    template<class Stream>
-    bool do_check_stream_state(Stream& s, boost::mpl::bool_<false>, bool noeof)
+    template<class Archive>
+    bool do_check_stream_state(Archive& ar, boost::mpl::bool_<false>, bool noeof)
     {
       bool result = false;
-      if (s.good())
+      if (ar.good())
 	{
-	  std::ios_base::iostate state = s.rdstate();
-	  result = noeof || EOF == s.peek();
-	  s.clear(state);
+	  result = noeof || ar.eof();
 	}
       return result;
     }
@@ -371,7 +369,7 @@ namespace serialization {
   template<class Archive>
   bool check_stream_state(Archive& ar, bool noeof = false)
   {
-    return detail::do_check_stream_state(ar.stream(), typename Archive::is_saving(), noeof);
+    return detail::do_check_stream_state(ar, typename Archive::is_saving(), noeof);
   }
 
   /*! \fn serialize

--- a/src/serialization/string.h
+++ b/src/serialization/string.h
@@ -39,7 +39,7 @@ inline bool do_serialize(Archive<false>& ar, std::string& str)
   ar.serialize_varint(size);
   if (ar.remaining_bytes() < size)
   {
-    ar.stream().setstate(std::ios::failbit);
+    ar.set_fail();
     return false;
   }
 

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -74,7 +74,7 @@ struct variant_reader
       current_type x;
       if(!::do_serialize(ar, x))
       {
-        ar.stream().setstate(std::ios::failbit);
+        ar.set_fail();
         return false;
       }
       v = x;
@@ -95,7 +95,7 @@ struct variant_reader<Archive, Variant, TBegin, TBegin>
 
   static inline bool read(Archive &ar, Variant &v, variant_tag_type t)
   {
-    ar.stream().setstate(std::ios::failbit);
+    ar.set_fail();
     return false;
   }
 };
@@ -116,7 +116,7 @@ struct serializer<Archive<false>, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>>
        typename boost::mpl::begin<types>::type,
        typename boost::mpl::end<types>::type>::read(ar, v, t))
     {
-      ar.stream().setstate(std::ios::failbit);
+      ar.set_fail();
       return false;
     }
     ar.end_variant();
@@ -143,7 +143,7 @@ struct serializer<Archive<true>, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>>
       ar.write_variant_tag(variant_serialization_traits<Archive<true>, T>::get_tag());
       if(!::do_serialize(ar, rv))
       {
-        ar.stream().setstate(std::ios::failbit);
+        ar.set_fail();
         return false;
       }
       ar.end_variant();

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -193,9 +193,7 @@ void message_store::unpack_signer_config(const multisig_wallet_state &state, con
 {
   try
   {
-    std::stringstream iss;
-    iss << signer_config;
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(signer_config)};
     THROW_WALLET_EXCEPTION_IF(!::serialization::serialize(ar, signers), tools::error::wallet_internal_error, "Failed to serialize signer config");
   }
   catch (...)
@@ -383,9 +381,7 @@ void message_store::process_auto_config_data_message(uint32_t id)
   auto_config_data data;
   try
   {
-    std::stringstream iss;
-    iss << m.content;
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(m.content)};
     THROW_WALLET_EXCEPTION_IF(!::serialization::serialize(ar, data), tools::error::wallet_internal_error, "Failed to serialize auto config data");
   }
   catch (...)
@@ -790,9 +786,7 @@ void message_store::read_from_file(const multisig_wallet_state &state, const std
   file_data read_file_data;
   try
   {
-    std::stringstream iss;
-    iss << buf;
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(buf)};
     if (::serialization::serialize(ar, read_file_data))
       if (::serialization::check_stream_state(ar))
         loaded = true;
@@ -829,9 +823,7 @@ void message_store::read_from_file(const multisig_wallet_state &state, const std
   loaded = false;
   try
   {
-    std::stringstream iss;
-    iss << decrypted_data;
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(decrypted_data)};
     if (::serialization::serialize(ar, *this))
       if (::serialization::check_stream_state(ar))
         loaded = true;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5701,17 +5701,13 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
 
         try
         {
-          std::stringstream iss;
-          iss << cache_data;
-          binary_archive<false> ar(iss);
+          binary_archive<false> ar{epee::strspan<std::uint8_t>(cache_data)};
           if (::serialization::serialize(ar, *this))
             if (::serialization::check_stream_state(ar))
               loaded = true;
           if (!loaded)
           {
-            std::stringstream iss;
-            iss << cache_data;
-            binary_archive<false> ar(iss);
+            binary_archive<false> ar{epee::strspan<std::uint8_t>(cache_data)};
             ar.enable_varint_bug_backward_compatibility();
             if (::serialization::serialize(ar, *this))
               if (::serialization::check_stream_state(ar))
@@ -6786,8 +6782,7 @@ bool wallet2::parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsi
     catch(const std::exception &e) { LOG_PRINT_L0("Failed to decrypt unsigned tx: " << e.what()); return false; }
     try
     {
-      std::istringstream iss(s);
-      binary_archive<false> ar(iss);
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(s)};
       if (!::serialization::serialize(ar, exported_txs))
       {
         LOG_PRINT_L0("Failed to parse data from unsigned tx");
@@ -7101,8 +7096,7 @@ bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<too
     catch (const std::exception &e) { LOG_PRINT_L0("Failed to decrypt signed transaction: " << e.what()); return false; }
     try
     {
-      std::istringstream iss(s);
-      binary_archive<false> ar(iss);
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(s)};
       if (!::serialization::serialize(ar, signed_txs))
       {
         LOG_PRINT_L0("Failed to deserialize signed transaction");
@@ -7237,8 +7231,7 @@ bool wallet2::parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx
   bool loaded = false;
   try
   {
-    std::istringstream iss(multisig_tx_st);
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(multisig_tx_st)};
     if (::serialization::serialize(ar, exported_txs))
       if (::serialization::check_stream_state(ar))
         loaded = true;
@@ -12027,8 +12020,7 @@ bool wallet2::check_reserve_proof(const cryptonote::account_public_address &addr
   serializable_unordered_map<crypto::public_key, crypto::signature> subaddr_spendkeys;
   try
   {
-    std::istringstream iss(sig_decoded);
-    binary_archive<false> ar(iss);
+    binary_archive<false> ar{epee::strspan<std::uint8_t>(sig_decoded)};
     if (::serialization::serialize_noeof(ar, proofs))
       if (::serialization::serialize_noeof(ar, subaddr_spendkeys))
         if (::serialization::check_stream_state(ar))
@@ -13212,9 +13204,7 @@ size_t wallet2::import_outputs_from_str(const std::string &outputs_st)
     std::pair<uint64_t, std::vector<tools::wallet2::transfer_details>> outputs;
     try
     {
-      std::stringstream iss;
-      iss << body;
-      binary_archive<false> ar(iss);
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(body)};
       if (::serialization::serialize(ar, outputs))
         if (::serialization::check_stream_state(ar))
           loaded = true;
@@ -13466,8 +13456,7 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
     bool loaded = false;
     try
     {
-      std::istringstream iss(body);
-      binary_archive<false> ar(iss);
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(body)};
       if (::serialization::serialize(ar, i))
         if (::serialization::check_stream_state(ar))
           loaded = true;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1555,8 +1555,7 @@ namespace tools
 
     try
     {
-      std::istringstream iss(blob);
-      binary_archive<false> ar(iss);
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(blob)};
       if (::serialization::serialize(ar, ptx))
         loaded = true;
     }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -648,11 +648,9 @@ public:
       bvc.m_verifivation_failed = true;
 
     cryptonote::block blk;
-    std::stringstream ss;
-    ss << sr_block.data;
-    binary_archive<false> ba(ss);
+    binary_archive<false> ba{epee::strspan<std::uint8_t>(sr_block.data)};
     ::serialization::serialize(ba, blk);
-    if (!ss.good())
+    if (!ba.good())
     {
       blk = cryptonote::block();
     }
@@ -671,11 +669,9 @@ public:
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
 
     cryptonote::transaction tx;
-    std::stringstream ss;
-    ss << sr_tx.data;
-    binary_archive<false> ba(ss);
+    binary_archive<false> ba{epee::strspan<std::uint8_t>(sr_tx.data)};
     ::serialization::serialize(ba, tx);
-    if (!ss.good())
+    if (!ba.good())
     {
       tx = cryptonote::transaction();
     }

--- a/tests/fuzz/bulletproof.cpp
+++ b/tests/fuzz/bulletproof.cpp
@@ -37,9 +37,7 @@ BEGIN_INIT_SIMPLE_FUZZER()
 END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
-  std::stringstream ss;
-  ss << std::string((const char*)buf, len);
-  binary_archive<false> ba(ss);
+  binary_archive<false> ba{{buf, len}};
   rct::Bulletproof proof = AUTO_VAL_INIT(proof);
   ::serialization::serialize(ba, proof);
 END_SIMPLE_FUZZER()

--- a/tests/fuzz/cold-outputs.cpp
+++ b/tests/fuzz/cold-outputs.cpp
@@ -50,11 +50,8 @@ BEGIN_INIT_SIMPLE_FUZZER()
 END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
-  std::string s((const char*)buf, len);
   std::pair<uint64_t, std::vector<tools::wallet2::transfer_details>> outputs;
-  std::stringstream iss;
-  iss << s;
-  binary_archive<false> ar(iss);
+  binary_archive<false> ar{{buf, len}};
   ::serialization::serialize(ar, outputs);
   size_t n_outputs = wallet->import_outputs(outputs);
   std::cout << boost::lexical_cast<std::string>(n_outputs) << " outputs imported" << std::endl;

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -50,11 +50,8 @@ BEGIN_INIT_SIMPLE_FUZZER()
 END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
-  std::string s((const char*)buf, len);
   tools::wallet2::unsigned_tx_set exported_txs;
-  std::stringstream iss;
-  iss << s;
-  binary_archive<false> ar(iss);
+  binary_archive<false> ar{{buf, len}};
   ::serialization::serialize(ar, exported_txs);
   std::vector<tools::wallet2::pending_tx> ptx;
   bool success = wallet->sign_tx(exported_txs, "/tmp/cold-transaction-test-signed", ptx);

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -132,11 +132,10 @@ TEST(Serialization, BinaryArchiveInts) {
   ASSERT_EQ(8, oss.str().size());
   ASSERT_EQ(string("\0\0\0\0\xff\0\0\0", 8), oss.str());
 
-  istringstream iss(oss.str());
-  binary_archive<false> iar(iss);
+  binary_archive<false> iar{epee::strspan<std::uint8_t>(oss.str())};
   iar.serialize_int(x1);
-  ASSERT_EQ(8, iss.tellg());
-  ASSERT_TRUE(iss.good());
+  ASSERT_EQ(8, iar.getpos());
+  ASSERT_TRUE(iar.good());
 
   ASSERT_EQ(x, x1);
 }
@@ -151,10 +150,9 @@ TEST(Serialization, BinaryArchiveVarInts) {
   ASSERT_EQ(6, oss.str().size());
   ASSERT_EQ(string("\x80\x80\x80\x80\xF0\x1F", 6), oss.str());
 
-  istringstream iss(oss.str());
-  binary_archive<false> iar(iss);
+  binary_archive<false> iar{epee::strspan<std::uint8_t>(oss.str())};
   iar.serialize_varint(x1);
-  ASSERT_TRUE(iss.good());
+  ASSERT_TRUE(iar.good());
   ASSERT_EQ(x, x1);
 }
 


### PR DESCRIPTION
This improves block and transaction blob/binary to C/C++ structure performance by ~60% (in some cases, see below). The changes are pretty basic, but touches 27 files in some of the most critical areas of of code. The read performance is already fairly quick, so this might be overzealous. These functions will show up in profiles at times because of the frequency of their use (basically, everytime a block or transaction needs to be "read"). As an example, responding to a p2p download request improves by a tiny ~1.6% on a Ryzen 3 CPU. 

The bulk of the gains come from dropping a copy of the payload before reading. The remainder comes from eliminating virtual methods calls and some `std::istream` stuff. There is also a difficult to measure benefit with CPU cache usage reduction.

Unpacking 100 blocks (2253800-2253799)
      CPU/Build             |  Microseconds  | Difference
------------------------------|----------------------|---------------
Ryzen 3900x / PR       |            86          |    +0%
i7-7Y75 / PR                |            91          |    +5%
Ryzen 3900x / master |            205         |   +135%
i7-7Y75 / master          |            231         |   +168% (+153% relative)

Unpacking 4,224 transactions from above blocks
      CPU/Build             |  Microseconds  | Difference
------------------------------|----------------------|---------------
Ryzen 3900x / PR       |          7,820       |   +0%
i7-7Y75 / PR                |        10,343       |   +32%
Ryzen 3900x / master |        15,623       |   +100%
i7-7Y75 / master          |         25,481      |   +226% (+146% relative)

One thing to note is that the fanless laptop CPU is now +32% from a Ryzen 3900x, instead of the current +63%. My expectation is that the improvements will have more benefits to smaller cache CPUs (amongst other less sophisticated internals).