### PR TITLE
CMake: new macro - finding all headers (extract from epee)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,18 @@ function (monero_add_minimal_executable name)
     monero_set_target_no_relink( ${name} )
 endfunction()
 
+# Finds all headers in a directory and its subdirs, to be able to search for them and autosave in IDEs.
+#
+# Parameters:
+# - headers_found:    Output variable, which will hold the found headers
+# - module_root_dir:  The search path for the headers. Typically it will be the module's root dir.
+macro (monero_find_all_headers headers_found module_root_dir)
+  file(GLOB ${headers_found}
+           "${module_root_dir}/*.h*"    # h* will include hpps as well.
+           "${module_root_dir}/**/*.h*" # Any number of subdirs will be included.
+)
+endmacro()
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
   message(STATUS "Setting default build type: ${CMAKE_BUILD_TYPE}")

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -28,11 +28,8 @@
 
 set(EPEE_INCLUDE_DIR_BASE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
-# Adding headers to the file list, to be able to search for them in IDEs.
-file(GLOB EPEE_HEADERS_PUBLIC 
-	"${EPEE_INCLUDE_DIR_BASE}/*.h*"    # h* will include hpps as well.
-	"${EPEE_INCLUDE_DIR_BASE}/**/*.h*" # Any number of subdirs will be included.
-)
+# Add headers to the file list, to be able to search for them and autosave in IDEs.
+monero_find_all_headers(EPEE_HEADERS_PUBLIC "${EPEE_INCLUDE_DIR_BASE}")
 
 add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp


### PR DESCRIPTION
I have extracted the already working solution of globbing the headers from `Epee` and put it into the macro `monero_find_all_headers`  in the main `CMakeLists.txt`. This will allow this feature to be reused even in unmaintained external repositories. I have also noticed, that there are numerous headers under the src, that are not being manually included by the according `CMakeLists.txt`. Integrating this macro will ease the maintenance burden of finding the missing headers and adding the new ones in the future. This automation also doesn't really do any harm, since headers (also those with an incorrect syntax) are only taken into account by the compiler, if they are being included by a C/CPP file.