### PR TITLE
CMake: Trezor link flags stored in the build dir, not source

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -151,8 +151,9 @@ if (BUILD_GUI_DEPS)
 
     install(FILES ${TREZOR_DEP_LIBS}
             DESTINATION ${lib_folder})
-    file(WRITE "trezor_link_flags.txt" ${TREZOR_DEP_LINKER})
-    install(FILES "trezor_link_flags.txt"
+    set(TREZOR_LINK_FLAGS_FILE "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/trezor_link_flags.txt")
+    file(WRITE ${TREZOR_LINK_FLAGS_FILE} ${TREZOR_DEP_LINKER})
+    install(FILES ${TREZOR_LINK_FLAGS_FILE}
             DESTINATION ${lib_folder})
 endif()
 


### PR DESCRIPTION
The temporary file `trezor_link_flags.txt` was being written in the source directory, thus confusing the `git status` command. I moved the generation of the file to CMake's build dir, where all the temporary files belong.