### PR TITLE
Wallet2: Update 'approximate_testnet_rolled_back_blocks'

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12228,7 +12228,7 @@ uint64_t wallet2::get_approximate_blockchain_height() const
   // Calculated blockchain height
   uint64_t approx_blockchain_height = fork_block + (time(NULL) - fork_time)/seconds_per_block;
   // testnet got some huge rollbacks, so the estimation is way off
-  static const uint64_t approximate_testnet_rolled_back_blocks = 303967;
+  static const uint64_t approximate_testnet_rolled_back_blocks = 342100;
   if (m_nettype == TESTNET && approx_blockchain_height > approximate_testnet_rolled_back_blocks)
     approx_blockchain_height -= approximate_testnet_rolled_back_blocks;
   LOG_PRINT_L2("Calculated blockchain height: " << approx_blockchain_height);


### PR DESCRIPTION
The current value is, for whatever reason, off by roughly 40,000 blocks now. This plays a role when creating testnet wallets with the GUI wallet as that app asks for an estimate of current testnet blockchain height before connecting to any daemon and this way currently produces testnet wallets with restore height in the future, basically creating them broken.