### PR TITLE
CMake: strip targets (optional) with -D STRIP_TARGETS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,15 @@ function (monero_set_target_no_relink target)
   endif()
 endfunction()
 
+option(STRIP_TARGETS "Strip symbols from targets?" OFF)
+function (monero_set_target_strip target)
+  if (STRIP_TARGETS)
+    set_target_properties("${target}" PROPERTIES LINK_FLAGS_RELEASE -s)
+    set_target_properties("${target}" PROPERTIES LINK_FLAGS_DEBUG -s)
+    # Stripping from Debug might make sense if you're low on disk space, but want to test if debug version builds properly.
+  endif()
+endfunction()
+
 function (monero_add_minimal_executable name)
   source_group("${name}"
     FILES
@@ -161,7 +170,8 @@ function (monero_add_minimal_executable name)
 
   add_executable("${name}"
     ${ARGN})
-    monero_set_target_no_relink( ${name} )
+    monero_set_target_no_relink("${name}")
+    monero_set_target_strip    ("${name}")
 endfunction()
 
 # Finds all headers in a directory and its subdirs, to be able to search for them and autosave in IDEs.
@@ -556,6 +566,7 @@ function (monero_add_library_with_deps)
   add_library(${objlib} OBJECT ${MONERO_ADD_LIBRARY_SOURCES})
   add_library("${MONERO_ADD_LIBRARY_NAME}" $<TARGET_OBJECTS:${objlib}>)
   monero_set_target_no_relink("${MONERO_ADD_LIBRARY_NAME}")
+  monero_set_target_strip    ("${MONERO_ADD_LIBRARY_NAME}")
   if (MONERO_ADD_LIBRARY_DEPENDS)
     add_dependencies(${objlib} ${MONERO_ADD_LIBRARY_DEPENDS})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ function (monero_add_executable name)
   enable_stack_trace("${name}")
   
   monero_set_target_no_relink("${name}")
+  monero_set_target_strip    ("${name}")
 endfunction ()
 
 include(Version)


### PR DESCRIPTION
`-D STRIP_TARGETS=ON` is also possible for testing the debug build when you're low on ram-disk space.

Results:

| Case | Previous   |      New      | Change |
|----------|----------|-------------|-------------|
| Release-static | 381 MB |  353 MB | -7.35% |
| Release-shared | 225 MB | 213 MB | -5.33% | 
| Debug-shared | 6213 MB | 4582 MB | -26.25% | 

![strip](https://user-images.githubusercontent.com/63722585/115994603-03311780-a5d8-11eb-96de-9e5b9fa0378b.png)

![strip-debug](https://user-images.githubusercontent.com/63722585/115994608-062c0800-a5d8-11eb-88bc-51fb420e5297.png)

Whether to make stripping the default option for the `release` target, is a separate decision.
