### PR TITLE
clang: fix -Wrange-loop-analysis warnings

### DIFF
--- a/contrib/epee/src/byte_slice.cpp
+++ b/contrib/epee/src/byte_slice.cpp
@@ -151,7 +151,7 @@ namespace epee
     : byte_slice()
   {
     std::size_t space_needed = 0;
-    for (const auto source : sources)
+    for (const auto& source : sources)
       space_needed += source.size();
 
     if (space_needed)
@@ -160,7 +160,7 @@ namespace epee
       span<std::uint8_t> out{reinterpret_cast<std::uint8_t*>(storage.get() + 1), space_needed};
       portion_ = {out.data(), out.size()};
 
-      for (const auto source : sources)
+      for (const auto& source : sources)
       {
         std::memcpy(out.data(), source.data(), source.size());
         if (out.remove_prefix(source.size()) < source.size())

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -365,7 +365,7 @@ inline typename std::enable_if<sfinae::is_vector_like<Vec>::value, void>::type t
   static_assert(!std::is_same<value_type, unsigned char>::value, "encoding an array of unsigned char is faster as hex");
 
   dest.StartArray();
-  for (const auto& t : vec)
+  for (auto t : vec)
     toJsonValue(dest, t);
   dest.EndArray();
 }

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -51,7 +51,7 @@ namespace test
             if (!cryptonote::find_tx_extra_field_by_type(extra_fields, key_field))
                 throw std::runtime_error{"invalid transaction"};
 
-            for (auto const& input : boost::adaptors::index(source.vout))
+            for (auto const input : boost::adaptors::index(source.vout))
             {
                 source_amount += input.value().amount;
                 auto const& key = boost::get<cryptonote::txout_to_key>(input.value().target);


### PR DESCRIPTION
```
/Users/selsta/dev/monero/contrib/epee/src/byte_slice.cpp:154:21: warning: loop variable 'source' of type 'const epee::span<const unsigned char>' creates a copy from type 'const epee::span<const unsigned char>' [-Wrange-loop-analysis]
    for (const auto source : sources)
                    ^
/Users/selsta/dev/monero/contrib/epee/src/byte_slice.cpp:154:10: note: use reference type 'const epee::span<const unsigned char> &' to prevent copying
    for (const auto source : sources)
         ^~~~~~~~~~~~~~~~~~~
                    &
```

```
/Users/selsta/dev/monero/contrib/epee/src/byte_slice.cpp:163:23: warning: loop variable 'source' of type 'const epee::span<const unsigned char>' creates a copy from type 'const epee::span<const unsigned char>' [-Wrange-loop-analysis]
      for (const auto source : sources)
                      ^
/Users/selsta/dev/monero/contrib/epee/src/byte_slice.cpp:163:12: note: use reference type 'const epee::span<const unsigned char> &' to prevent copying
      for (const auto source : sources)
           ^~~~~~~~~~~~~~~~~~~
                      &
```

```
/Users/selsta/dev/monero/src/serialization/json_object.h:368:20: warning: loop variable 't' is always a copy because the range of type 'const boost::range_detail::transformed_range<(lambda at /Users/selsta/dev/monero/src/rpc/zmq_pub.cpp:129:30), const epee::span<const cryptonote::block> >' does not return a reference [-Wrange-loop-analysis]
  for (const auto& t : vec)
                   ^
/Users/selsta/dev/monero/src/rpc/zmq_pub.cpp:142:5: note: in instantiation of function template specialization 'cryptonote::json::toJsonValue<boost::range_detail::transformed_range<(lambda at /Users/selsta/dev/monero/src/rpc/zmq_pub.cpp:129:30), const epee::span<const cryptonote::block> > >' requested here
    INSERT_INTO_JSON_OBJECT(dest, ids, (self.blocks | adapt::transformed(to_block_id)));
    ^
/Users/selsta/dev/monero/src/serialization/json_object.h:56:23: note: expanded from macro 'INSERT_INTO_JSON_OBJECT'
    cryptonote::json::toJsonValue(dest, source);
                      ^
/Users/selsta/dev/monero/src/serialization/json_object.h:368:8: note: use non-reference type 'crypto::hash'
  for (const auto& t : vec)
       ^~~~~~~~~~~~~~~
```

```
/Users/selsta/dev/monero/tests/unit_tests/json_serialization.cpp:54:30: warning: loop variable 'input' is always a copy because the range of type 'indexed_range<const std::__1::vector<cryptonote::tx_out, std::__1::allocator<cryptonote::tx_out> > >' does not return a reference [-Wrange-loop-analysis]
            for (auto const& input : boost::adaptors::index(source.vout))
                             ^
/Users/selsta/dev/monero/tests/unit_tests/json_serialization.cpp:54:18: note: use non-reference type 'boost::range::index_value<const cryptonote::tx_out &, long>'
            for (auto const& input : boost::adaptors::index(source.vout))
                 ^~~~~~~~~~~~~~~~~~~
```