### PR TITLE
clang: fix -Wpessimizing-move warning

### DIFF
--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -320,7 +320,8 @@ TEST(test_epee_connection, test_lifetime)
             connection_ptr conn;
             {
               lock_guard_t guard(shared_conn->lock);
-              conn = std::move(shared_conn->conn.lock());
+              conn = shared_conn->conn.lock();
+              shared_conn->conn.reset();
             }
             if (conn)
               conn->cancel();


### PR DESCRIPTION
```
/Users/selsta/dev/monero/tests/unit_tests/epee_boosted_tcp_server.cpp:323:22: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
              conn = std::move(shared_conn->conn.lock());
                     ^
/Users/selsta/dev/monero/tests/unit_tests/epee_boosted_tcp_server.cpp:323:22: note: remove std::move call here
              conn = std::move(shared_conn->conn.lock());
                     ^~~~~~~~~~                        ~
1 warning generated.
```