### PR TITLE
cmake: wallet_api doesn't need wallet_merged

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -115,45 +115,4 @@ if(NOT IOS)
   install(TARGETS wallet_rpc_server DESTINATION bin)
 endif()
 
-# build and install libwallet_merged only if we building for GUI
-if (BUILD_GUI_DEPS)
-    set(libs_to_merge
-            wallet_api
-            wallet
-            rpc_base
-            multisig
-            blockchain_db
-            cryptonote_core
-            cryptonote_basic
-            mnemonics
-            common
-            cncrypto
-            device
-            hardforks
-            ringct
-            ringct_basic
-            checkpoints
-            version
-            net
-            device_trezor)
-
-    foreach(lib ${libs_to_merge})
-        list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt
-    endforeach()
-    add_library(wallet_merged STATIC ${objlibs})
-    if(IOS)
-        set(lib_folder lib-${ARCH})
-    else()
-        set(lib_folder lib)
-    endif()
-    install(TARGETS wallet_merged
-        ARCHIVE DESTINATION ${lib_folder})
-
-    install(FILES ${TREZOR_DEP_LIBS}
-            DESTINATION ${lib_folder})
-    file(WRITE "trezor_link_flags.txt" ${TREZOR_DEP_LINKER})
-    install(FILES "trezor_link_flags.txt"
-            DESTINATION ${lib_folder})
-endif()
-
 add_subdirectory(api)


### PR DESCRIPTION
Co-authored-by: @perfect-daemon 

This is relevant for wallets that use wallet_merged, they have to switch to wallet_api, e.g. like https://github.com/monero-project/monero-gui/pull/3448