### PR TITLE
translations: use full path in cmake

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -73,7 +73,7 @@ string(REPLACE ".ts" ".qm" qm_files "${ts_files}")
 
 add_custom_command(TARGET generate_translations_header
   POST_BUILD
-  COMMAND ./generate_translations_header ${qm_files}
+  COMMAND $<TARGET_FILE:generate_translations_header> ${qm_files}
   WORKING_DIRECTORY "${CMAKE_CURRENT_BIN_DIR}"
   COMMENT "Generating embedded translations header")
 


### PR DESCRIPTION
Required for some IDEs (e.g. Xcode)