### PR TITLE
CMake: Install and publish stripped binaries for Depends

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -81,5 +81,5 @@ jobs:
       with:
         name: ${{ matrix.toolchain.name }}
         path: |
-          /home/runner/work/monero/monero/build/${{ matrix.toolchain.host }}/release/bin/monero-wallet-cli*
-          /home/runner/work/monero/monero/build/${{ matrix.toolchain.host }}/release/bin/monerod*
+          /home/runner/work/monero/monero/build/${{ matrix.toolchain.host }}/release/install/bin/monero-wallet-cli*
+          /home/runner/work/monero/monero/build/${{ matrix.toolchain.host }}/release/install/bin/monerod*

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: release-all
 
 depends:
 	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
-	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
+	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake -DCMAKE_INSTALL_PREFIX=install ../../.. && $(MAKE) && $(MAKE) install/strip
 
 cmake-debug:
 	mkdir -p $(builddir)/debug


### PR DESCRIPTION
Using CMake's special `install/strip` target, which strips the final binaries while installing them into the installation directory. The directory is pointed by the `CMAKE_INSTALL_PREFIX` variable.

The below changes were measured for the unpacked artifacts, so nearest to the end-user's space consumption.

| Target | Previous   |      Current      | Change |
|--------|----------|-------------|-------------|
|Win64 | 63.7 MB  |  32.9 MB |  -48.35% |
| x86_64 Linux | 55.8 MB | 44.4 MB  |  -20.43%  | 
| Cross-Mac| 	47.3 MB  |  41.6 MB  | -12.05% |