### PR TITLE
Warnings: unused variable in core/blockchain.cpp

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5150,7 +5150,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     if (m_cancel)
       return false;
 
-    for (const auto &tx_blob : entry.txs)
+    for (size_t i = 0; i < entry.txs.size(); ++i)
     {
       if (tx_index >= txes.size())
         SCAN_TABLE_QUIT("tx_index is out of sync");


### PR DESCRIPTION
Similarly as with https://github.com/monero-project/monero/pull/7705 , the loop was chosen so, that it ends up in an unused variable warning.