### PR TITLE
cmake: use CMAKE_CURRENT_LIST_DIR in FindLibUSB

### DIFF
--- a/cmake/FindLibUSB.cmake
+++ b/cmake/FindLibUSB.cmake
@@ -134,7 +134,7 @@ if ( LibUSB_FOUND )
 
         try_compile(LibUSB_COMPILE_TEST_PASSED
                 ${CMAKE_BINARY_DIR}
-                "${CMAKE_SOURCE_DIR}/cmake/test-libusb-version.c"
+                "${CMAKE_CURRENT_LIST_DIR}/test-libusb-version.c"
                 CMAKE_FLAGS
                     "-DINCLUDE_DIRECTORIES=${LibUSB_INCLUDE_DIRS}"
                     "-DLINK_DIRECTORIES=${LibUSB_LIBRARIES}"


### PR DESCRIPTION
If we add monero as a subdirectory in the GUI it will look for `test-libusb-version.c` inside the GUI repo, which we don't want.