### PR TITLE
epee: include public openssl header in cmake

### DIFF
--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -87,5 +87,8 @@ if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
     ${GNU_READLINE_LIBRARY})
 endif()
 
-target_include_directories(epee PUBLIC "${EPEE_INCLUDE_DIR_BASE}")
+target_include_directories(epee
+  PUBLIC
+    "${EPEE_INCLUDE_DIR_BASE}"
+    "${OPENSSL_INCLUDE_DIR}")
 


### PR DESCRIPTION
Allows us to remove the openssl dependency from GUI.