### PR TITLE
cmake: fix check_linker_flag

### DIFF
--- a/cmake/CheckLinkerFlag.cmake
+++ b/cmake/CheckLinkerFlag.cmake
@@ -15,6 +15,7 @@ macro(CHECK_LINKER_FLAG flag VARIABLE)
       ${_cle_source}
       COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} ${flag}
       CMAKE_FLAGS
+      "-DCMAKE_EXE_LINKER_FLAGS=${flag}"
       OUTPUT_VARIABLE OUTPUT)
     unset(_cle_source)
     set(CMAKE_C_FLAGS ${saved_CMAKE_C_FLAGS})


### PR DESCRIPTION
Example on Mac with `-G Xcode` and #7692 

```
-- Looking for -Wl,--no-undefined linker flag - found
```

with patch applied:

```
-- Looking for -Wl,--no-undefined linker flag - not found
```