### PR TITLE
trezor: deprecated ByteSize -> ByteSizeLong

### DIFF
--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -157,7 +157,7 @@ namespace trezor{
 #define PROTO_HEADER_SIZE 6
 
   static size_t message_size(const google::protobuf::Message &req){
-    return static_cast<size_t>(req.ByteSize());
+    return req.ByteSizeLong();
   }
 
   static size_t serialize_message_buffer_size(size_t msg_size) {


### PR DESCRIPTION
```
/Users/selsta/dev/monero/src/device_trezor/trezor/transport.cpp:160:36: warning: 'ByteSize' is deprecated: Please use ByteSizeLong() instead [-Wdeprecated-declarations]
    return static_cast<size_t>(req.ByteSize());
                                   ^
/usr/local/include/google/protobuf/message_lite.h:425:3: note: 'ByteSize' has been explicitly marked deprecated here
  PROTOBUF_DEPRECATED_MSG("Please use ByteSizeLong() instead")
  ^
/usr/local/include/google/protobuf/port_def.inc:177:53: note: expanded from macro 'PROTOBUF_DEPRECATED_MSG'
#define PROTOBUF_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
```