### PR TITLE
CMake: glob missing headers for wallet2

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -40,18 +40,7 @@ set(wallet_sources
   wallet_rpc_payments.cpp
 )
 
-set(wallet_private_headers
-  wallet2.h
-  wallet_args.h
-  wallet_errors.h
-  wallet_rpc_server.h
-  wallet_rpc_server_commands_defs.h
-  wallet_rpc_server_error_codes.h
-  ringdb.h
-  node_rpc_proxy.h
-  message_store.h
-  message_transporter.h
-  wallet_rpc_helpers.h)
+monero_find_all_headers(wallet_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(wallet
   ${wallet_private_headers})


### PR DESCRIPTION
Reusing the recently merged `monero_find_all_headers` CMake function to include the missing (read: not added manually) header file `wallet_light_rpc.h`, as well as all the others, which were already there.