### PR TITLE
CMake: glob missing headers for easylogging

### DIFF
--- a/external/easylogging++/CMakeLists.txt
+++ b/external/easylogging++/CMakeLists.txt
@@ -36,8 +36,12 @@ monero_enable_coverage()
 find_package(Threads)
 find_package(Backtrace)
 
+monero_find_all_headers(EASYLOGGING_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}")
+
 add_library(easylogging
-  easylogging++.cc)
+  easylogging++.cc
+  ${EASYLOGGING_HEADERS}
+  )
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
`EasyLogging` was missing the header file `ea_config.h` from its IDE project file. Now it's being globed automatically.