### PR TITLE
Fix boost 1.76.0 compatibility

### DIFF
--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -31,6 +31,8 @@
 #include "misc_log_ex.h"
 #include "span.h"
 
+#include <boost/mpl/contains.hpp>
+
 namespace epee
 {
   class byte_slice;


### PR DESCRIPTION
Untested.

Add missing header boost/mpl/contains.hpp
monero-project/monero/issues/7728

patch by @loqs