### PR TITLE
extend payment uri scheme to support multiple recipients per tx

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2285,7 +2285,19 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
 
 bool WalletImpl::parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error)
 {
-    return m_wallet->parse_uri(uri, address, payment_id, amount, tx_description, recipient_name, unknown_parameters, error);
+    std::vector<tools::wallet2::uri_data> data;
+    if (!m_wallet->parse_uri(uri, data, payment_id, tx_description, unknown_parameters, error)) {
+      setStatusError(tr("Failed to parse uri"));
+      return false;
+    }
+    if (data.size() > 1) {
+      setStatusError(tr("Multi-recipient URIs currently unsupported"));
+      return false;
+    }
+    address = data[0].address;
+    amount = data[0].amount;
+    recipient_name = data[0].recipient_name;
+    return true;
 }
 
 std::string WalletImpl::getDefaultDataDir() const

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -696,6 +696,13 @@ private:
       bool empty() const { return tx_extra_fields.empty() && primary.empty() && additional.empty(); }
     };
 
+    struct uri_data
+    {
+      std::string address;
+      uint64_t amount;
+      std::string recipient_name;
+    };
+
     /*!
      * \brief  Generates a wallet or restores one.
      * \param  wallet_              Name of wallet file
@@ -1401,8 +1408,8 @@ private:
     template<typename T=std::string> T decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated = true) const;
     std::string decrypt_with_view_secret_key(const std::string &ciphertext, bool authenticated = true) const;
 
-    std::string make_uri(const std::string &address, const std::string &payment_id, uint64_t amount, const std::string &tx_description, const std::string &recipient_name, std::string &error) const;
-    bool parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error);
+    std::string make_uri(std::vector<uri_data> data, const std::string &payment_id, const std::string &tx_description, std::string &error) const;
+    bool parse_uri(const std::string &uri, std::vector<uri_data> &data, std::string &payment_id, std::string &tx_description, std::vector<std::string> &unknown_parameters, std::string &error);
 
     uint64_t get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day);    // 1<=month<=12, 1<=day<=31
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 21
+#define WALLET_RPC_VERSION_MINOR 22
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools
@@ -1797,27 +1797,44 @@ namespace wallet_rpc
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
-  struct uri_spec
+  struct uri_payment
   {
     std::string address;
-    std::string payment_id;
     uint64_t amount;
-    std::string tx_description;
     std::string recipient_name;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(address);
-      KV_SERIALIZE(payment_id);
-      KV_SERIALIZE(amount);
-      KV_SERIALIZE(tx_description);
+      KV_SERIALIZE_OPT(amount, (uint64_t)0);
       KV_SERIALIZE(recipient_name);
+    END_KV_SERIALIZE_MAP()
+  };
+
+  struct uri_spec
+  {
+    std::vector<uri_payment> payments;
+    std::string tx_description;
+    std::string payment_id;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(payments);
+      KV_SERIALIZE(tx_description);
+      KV_SERIALIZE(payment_id);
     END_KV_SERIALIZE_MAP()
   };
 
   struct COMMAND_RPC_MAKE_URI
   {
-    struct request_t: public uri_spec
+    struct request_t
     {
+      std::vector<uri_payment> payments;
+      std::string tx_description;
+      std::string payment_id;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(payments);
+        KV_SERIALIZE(tx_description);
+        KV_SERIALIZE(payment_id);
+      END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 


### PR DESCRIPTION
Addresses #7731 for https://github.com/haveno-dex/haveno/issues/83

Changes to make_uri: now accepts an array of objects holding the address, amount, and recipient name. You can have as many of these as you want. only one payment id and one tx_description are allowed per transaction

Changes to parse_uri: parses the new scheme. Important: a valid uri that uses amounts or recipient names must have one for each address.

example usage:

For reference I started up my rpc wallet as such: `./monero-wallet-rpc --wallet-file new --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18082 --rpc-login test:test --prompt-for-password`

request to make uri

` curl -u test:test --digest -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"make_uri","params":{"payments":[{"address":"41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC","amount":10,"recipient_name":"me"},{"address":"41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC","amount":1560,"recipient_name":"him"},{"address":"41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC","amount":2000,"recipient_name":"you"}],"tx_description":"abc","payment_id":"420fa29b2d9a49f54201119b2d9a49f5420fa29b2d9a49f5420fa29b2d9a49f5"}' -H 'Content-Type: application/json' `

response

`{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "uri": "monero:41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC;41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC;41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC?tx_amount=0.000000000010;0.000000001560;0.000000002000&recipient_name=me;him;you&tx_description=abc&tx_payment_id=420fa29b2d9a49f54201119b2d9a49f5420fa29b2d9a49f5420fa29b2d9a49f5"
  }
}`

request to parse uri

 `curl -u test:test --digest -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"parse_uri","params":{"uri":"monero:41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC;41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC;41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC?tx_amount=0.000000000010;0.000000001560;0.000000002000&recipient_name=me;him;you&tx_description=abc&tx_payment_id=420fa29b2d9a49f54201119b2d9a49f5420fa29b2d9a49f5420fa29b2d9a49f5"}}' -H 'Content-Type: application/json'`

response

`  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "uri": {
      "payment_id": "420fa29b2d9a49f54201119b2d9a49f5420fa29b2d9a49f5420fa29b2d9a49f5",
      "payments": [{
        "address": "41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC",
        "amount": 10,
        "recipient_name": "me"
      },{
        "address": "41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC",
        "amount": 1560,
        "recipient_name": "him"
      },{
        "address": "41tQjL6UoNxEsxKf1DEkMuTBVUXMAxP74TSRR9WTrBX39Z9t4BUt1XmaQdUPZG2EnsjCEYaqUSBhYEweSTLHMgTDHtrgRxC",
        "amount": 2000,
        "recipient_name": "you"
      }],
      "tx_description": "abc"
    }
  }
}`

These changes are backwards compatible in that the scheme for single recipient (minus dust) uris is unchanged, however an older wallet will not be able to parse a multi recipient payment uri.

I wasn't sure about the wallet api since other applications depend on it so I've limited it to parsing simple uris, I hope this is okay, otherwise drop suggestions.