### PR TITLE
wallet/api: remove Bitmonero namespace alias

### DIFF
--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -166,5 +166,3 @@ AddressBookImpl::~AddressBookImpl()
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -66,6 +66,3 @@ private:
 };
 
 }
-
-namespace Bitmonero = Monero;
-

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -264,6 +264,3 @@ std::vector<std::string> PendingTransactionImpl::signersKeys() const {
 }
 
 }
-
-namespace Bitmonero = Monero;
-

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -73,5 +73,3 @@ private:
 
 
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -266,5 +266,3 @@ void TransactionHistoryImpl::refresh()
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -56,6 +56,3 @@ private:
 };
 
 }
-
-namespace Bitmonero = Monero;
-

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -150,5 +150,3 @@ uint64_t TransactionInfoImpl::unlockTime() const
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -87,5 +87,3 @@ private:
 };
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -316,6 +316,3 @@ uint64_t UnsignedTransactionImpl::minMixinCount() const
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;
-

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -71,5 +71,3 @@ private:
 
 
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -60,5 +60,3 @@ void onStartup()
 
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2577,5 +2577,3 @@ void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex,
     m_wallet->device_show_address(accountIndex, addressIndex, payment_id_param);
 }
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -281,7 +281,4 @@ private:
 
 } // namespace
 
-namespace Bitmonero = Monero;
-
 #endif
-

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -1362,6 +1362,3 @@ struct WalletManagerFactory
 
 
 }
-
-namespace Bitmonero = Monero;
-

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -406,5 +406,3 @@ void WalletManagerFactory::setLogCategories(const std::string &categories)
 
 
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -102,5 +102,3 @@ private:
 };
 
 } // namespace
-
-namespace Bitmonero = Monero;


### PR DESCRIPTION
It has been 5 years since we renamed it. I couldn't find any wallet that use the "Bitmonero" namespace.

Also removed trailing empty lines.