### PR TITLE
depends: add getmonero package mirror

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -3,7 +3,7 @@
 SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://downloads.getmonero.org/depends-sources
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -32,7 +32,7 @@ endef
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
     ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(4),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash

--- a/contrib/depends/packages/eudev.mk
+++ b/contrib/depends/packages/eudev.mk
@@ -1,7 +1,8 @@
 package=eudev
 $(package)_version=v3.2.6
 $(package)_download_path=https://github.com/gentoo/eudev/archive/
-$(package)_file_name=$($(package)_version).tar.gz
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=a96ecb8637667897b8bd4dee4c22c7c5f08b327be45186e912ce6bc768385852
 
 define $(package)_set_vars

--- a/contrib/depends/packages/gtest.mk
+++ b/contrib/depends/packages/gtest.mk
@@ -1,7 +1,8 @@
 package=gtest
 $(package)_version=1.8.1
 $(package)_download_path=https://github.com/google/googletest/archive/
-$(package)_file_name=release-$($(package)_version).tar.gz
+$(package)_download_file=release-$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
 $(package)_cxxflags=-std=c++11
 $(package)_cxxflags_linux=-fPIC

--- a/contrib/depends/packages/native_cctools.mk
+++ b/contrib/depends/packages/native_cctools.mk
@@ -1,7 +1,8 @@
 package=native_cctools
 $(package)_version=807d6fd1be5d2224872e381870c0a75387fe05e6
 $(package)_download_path=https://github.com/theuni/cctools-port/archive
-$(package)_file_name=$($(package)_version).tar.gz
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
 $(package)_build_subdir=cctools
 $(package)_clang_version=3.7.1


### PR DESCRIPTION
~~Package archives are not uploaded yet to https://downloads.getmonero.org/depends-sources~~ done

I attempted to edit `fetch_file` so that `$(package)_file_name` is always used for the fallback download.