### PR TITLE
CI: ubuntu 18.04 backward compat. test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,17 @@ jobs:
         ccache --max-size=150M
         make release-static-win64 -j2
 
+# See the OS labels and monitor deprecations here:
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-18.04]
     steps:
     - uses: actions/checkout@v1
       with:
@@ -72,8 +78,10 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ccache-ubuntu-build-${{ github.sha }}
-        restore-keys: ccache-ubuntu-build-
+        key: ccache-ubuntu-build-${{ matrix.os }}-${{ github.sha }}
+        restore-keys: | 
+          ccache-ubuntu-build-${{ matrix.os }}
+          ccache-ubuntu-build-
     - name: remove bundled boost
       run: ${{env.REMOVE_BUNDLED_BOOST}}
     - name: set apt conf


### PR DESCRIPTION
A follow up of https://github.com/monero-project/monero/pull/7768 , where it was decided, that Ubuntu 18.04 shall be tested, but is a separate use case than Boost matrix use case. The Ubuntu 18.04 use case thus doesn't need the Boost matrix, and can be built with the default options.

Temp. info: This draft PR contains a commit to be reverted, taken from https://github.com/monero-project/monero/pull/7762 , which has to be merged first. Afterwards this PR will be published and rebased. The specific to-be-reverted commit helps to check if the both the fix and the verification method work.