### PR TITLE
EasyLogging++: Add UTests, that protect against regressions

### DIFF
--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -195,3 +195,16 @@ TEST(logging, multiline)
   cleanup();
 }
 
+// These operations might segfault
+TEST(logging, copy_ctor_segfault)
+{
+    const el::Logger log1("id1", nullptr);
+    const el::Logger log2(log1);
+}
+
+TEST(logging, operator_equals_segfault)
+{
+    const el::Logger log1("id1", nullptr);
+    el::Logger log2("id2", nullptr);
+    log2 = log1;
+}


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero/issues/7756

Updates https://github.com/monero-project/monero/pull/7380 with the patch: https://github.com/monero-project/monero/pull/7380#issuecomment-788222115 since the PR got merged.

The patch contained 4 new UTests for EasyLogging++. 2 of them work correctly only after merging https://github.com/monero-project/monero/pull/7380 while the other 2 still await for the implementation to be improved.

[EDIT]
The 2 unresolved issues are now exported as a patch. See below https://github.com/monero-project/monero/pull/7771#issuecomment-874458351.