### PR TITLE
Mac: fix dynamic linkage in device

### DIFF
--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -77,5 +77,7 @@ target_link_libraries(device
     ${Boost_SERIALIZATION_LIBRARY}
   PRIVATE
     version
+    obj_cryptonote_basic
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Blocks}
     ${EXTRA_LIBRARIES})


### PR DESCRIPTION
Delivered by: @TimSycamore

Fixes dynamic linkage for Mac / `libdevice`. I have ran a test before, confirming, that the dynamic linkage was indeed broken under Mac.

Reproduce with:
`cmake .. -DBUILD_SHARED_LIBS=ON && make`
from the build directory.