### PR TITLE
Depends: mingw32-update-gcc-posix.sh script

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -88,9 +88,7 @@ jobs:
         if [ -f contrib/depends/sdk-sources/MacOSX${{ matrix.toolchain.osx_sdk }}.sdk.tar.gz ]; then tar -C contrib/depends/SDKs -xf contrib/depends/sdk-sources/MacOSX${{ matrix.toolchain.osx_sdk }}.sdk.tar.gz; fi
     - name: prepare w64-mingw32
       if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'i686-w64-mingw32' }}
-      run: |
-        sudo update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
-        sudo update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
+      run: sudo contrib/depends/util/mingw32-update-gcc-posix.sh ${{ matrix.toolchain.host }}
     - name: build
       run: |
         ${{env.CCACHE_SETTINGS}}

--- a/contrib/depends/README.md
+++ b/contrib/depends/README.md
@@ -76,6 +76,12 @@ update-alternatives --set x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++-posix
 update-alternatives --set x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc-posix
 ```
 
+or simply:
+
+```bash
+sudo contrib/depends/util/mingw32-update-gcc-posix.sh x86_64-w64-mingw32
+```
+
 ### Other documentation
 
 - [description.md](description.md): General description of the depends system

--- a/contrib/depends/util/mingw32-update-gcc-posix.sh
+++ b/contrib/depends/util/mingw32-update-gcc-posix.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+# Sets mingw cross compiler to POSIX version.
+
+TOOLCHAIN="$1"
+
+if [ -z "$TOOLCHAIN" ]; then
+	echo "Please supply the toolchain as the first argument, for example:"
+	echo "x86_64-w64-mingw32"
+	echo "i686-w64-mingw32"
+	exit 1
+fi
+
+if (! which "${TOOLCHAIN}"-g++-posix); then
+	echo "Toolchain '${TOOLCHAIN}' is not installed!"
+	exit 1
+fi
+
+update-alternatives --set "${TOOLCHAIN}"-g++ $(which "${TOOLCHAIN}"-g++-posix)
+update-alternatives --set "${TOOLCHAIN}"-gcc $(which "${TOOLCHAIN}"-gcc-posix)
+
+echo "Toolchain '$TOOLCHAIN' is set to POSIX successfuly."


### PR DESCRIPTION
Extracted the MinGW POSIX setting (1) into a script, which may be reused without much effort, ideal for local tests. Also used the script in the `depends.yaml` GitHub Action.

From Monero's main directory:

```bash
sudo contrib/depends/util/mingw32-update-gcc-posix.sh x86_64-w64-mingw32
sudo contrib/depends/util/mingw32-update-gcc-posix.sh i686-w64-mingw32
```

instead of formerly:

```bash
sudo update-alternatives --set x86_64-w64-mingw32-g++ $(which x86_64-w64-mingw32-g++-posix)
sudo update-alternatives --set x86_64-w64-mingw32-gcc $(which x86_64-w64-mingw32-gcc-posix)

sudo update-alternatives --set i686-w64-mingw32-g++ $(which i686-w64-mingw32-g++-posix)
sudo update-alternatives --set i686-w64-mingw32-gcc $(which i686-w64-mingw32-gcc-posix)
```

(1) The setting is required for the MinGW cross-compiler to build Monero.