### PR TITLE
Workflows: depends cache (static) separated from ccache (volatile)

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -45,15 +45,29 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+# Most volatile cache
     - name: ccache
       uses: actions/cache@v2
       with:
-        path: |
-            ~/.ccache
-            contrib/depends/built
-            contrib/depends/sdk-sources
+        path: ~/.ccache
         key: ccache-${{ matrix.toolchain.host }}-${{ github.sha }}
         restore-keys: ccache-${{ matrix.toolchain.host }}-
+# Less volatile cache
+    - name: depends cache
+      uses: actions/cache@v2
+      with:
+        path: contrib/depends/built
+        key: depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
+        restore-keys: |
+          depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
+          depends-${{ matrix.toolchain.host }}-
+# Static cache
+    - name: OSX SDK cache
+      uses: actions/cache@v2
+      with:
+        path: contrib/depends/sdk-sources
+        key: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
+        restore-keys: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
     - name: set apt conf
       run: |
         echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom


### PR DESCRIPTION
I separated `depends`' caches, which were treated as one, into 3 categories:
- most volatile: ccache
- much less volatile: depends packages, that are the base of the toolchains
- static: OSX SDK

In order to achieve this, each cache type uses a different key generation mechanism:
- ccache: the traditional git's commit hash
- depends: a hash of the package list, that build the binaries in the `built` directory
- OSX SDK: simply the version number

This strategy should help reducing the size cache by not mixing the volatile caches with the much more static ones, since there will be fewer writes of the static ones. The newly created volatile caches will not include the static data. This will also help us stay within our limits, ultimately preventing GitHub from deleting our caches due to their cumulative size restrictions. See below:

> **Usage limits and eviction policy**
GitHub will remove any cache entries that have not been accessed in over 7 days. There is no limit on the number of caches you can store, but the total size of all caches in a repository is limited to 5 GB. If you exceed this limit, GitHub will save your cache but will begin evicting caches until the total size is less than 5 GB.

[Source: GitHub docs](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)