### PR TITLE
CI: Ubuntu-Test reuses Ubuntu-Build cache and building static libs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 # The below variables reduce repetitions across similar targets
 env:
   REMOVE_BUNDLED_BOOST : rm -rf /usr/local/share/boost
+  BUILD_DEFAULT_LINUX: |
+        ccache --max-size=150M
+        cmake -S . -B build -D ARCH="default" -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && cmake --build build -j3
   APT_INSTALL_LINUX: 'sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler ccache'
   APT_SET_CONF: |
         echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
@@ -79,9 +82,7 @@ jobs:
       with:
         path: ~/.ccache
         key: ccache-ubuntu-build-${{ matrix.os }}-${{ github.sha }}
-        restore-keys: | 
-          ccache-ubuntu-build-${{ matrix.os }}
-          ccache-ubuntu-build-
+        restore-keys: ccache-ubuntu-build-${{ matrix.os }}
     - name: remove bundled boost
       run: ${{env.REMOVE_BUNDLED_BOOST}}
     - name: set apt conf
@@ -91,9 +92,7 @@ jobs:
     - name: install monero dependencies
       run: ${{env.APT_INSTALL_LINUX}}
     - name: build
-      run: |
-        ccache --max-size=150M
-        make -j3
+      run: ${{env.BUILD_DEFAULT_LINUX}}
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest
@@ -137,8 +136,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: test-ubuntu-ccache-${{ github.sha }}
-        restore-keys: test-ubuntu-ccache-
+        key: ccache-ubuntu-build-ubuntu-latest-${{ github.sha }}
+        restore-keys: ccache-ubuntu-build-ubuntu-latest
     - name: remove bundled boost
       run: ${{env.REMOVE_BUNDLED_BOOST}}
     - name: set apt conf
@@ -153,11 +152,8 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: ON
       run: |
-        ccache --max-size=150M
-        DIR_BUILD="build/ci/release"
-        DIR_SRC="`pwd`"
-        mkdir -p "${DIR_BUILD}" && cd "${DIR_BUILD}"
-        cmake -S "${DIR_SRC}" -D ARCH="default" -D BUILD_SHARED_LIBS=ON -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && make -j3 && make test
+        ${{env.BUILD_DEFAULT_LINUX}}
+        cmake --build build --target test
 
 # ARCH="default" (not "native") ensures, that a different execution host can execute binaries compiled elsewhere.
 # BUILD_SHARED_LIBS=ON speeds up the linkage part a bit, reduces size, and is the only place where the dynamic linkage is tested.


### PR DESCRIPTION
Lately I learned 2 important things:
- multiple runs of multiple jobs very quickly use up our quota for caches, so they get pruned too quick
- the general approach in Monero is rather to test for a typical/default case, while testing all the possible extremes would be too resource hungry, and I started to agree with this

This made me reduce the complexity of the GiutHub Actions, also by reusing the caches as often as possible. I will be testing the left out, resource hungry extremes locally and post them on a periodic report.

Here I'm reusing the cache for the Ubuntu-test from the Ubuntu-build. This will spare time and the disk space for the cache. In this case it might be valid to ask why we need the intermediate Ubuntu-build step then? For 2 reasons:
- if the tests fail, then at least you have your code compiled and cached
- the Ubuntu-build is going to be extended to test previous stable version of Ubuntu as well, while we want to test only the latest one.

There's also an important reason why I chose to build static version after all: the static version is what goes to the end user. Therefore the final test **has** to simulate this situation as close as possible. Formerly I chose shared library version, because it wasn't tested anywhere, but I admit it was a mistake w.r.t. the previous sentence. Also, this view is reinforced by the drive to test the extremes rather locally. A shared build belongs to this group.

The PR is put to draft mode until we merge https://github.com/monero-project/monero/pull/7769, which is more important and will introduce some small merge conflicts for sure.