### PR TITLE
wallet2: Don't auto lock device on process parsed blocks

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2773,9 +2773,8 @@ void wallet2::process_parsed_blocks(uint64_t start_height, const std::vector<cry
   {
     if (tx_cache_data[i].empty())
       continue;
-    tpool.submit(&waiter, [&hwdev, &gender, &tx_cache_data, i]() {
+    tpool.submit(&waiter, [&gender, &tx_cache_data, i]() {
       auto &slot = tx_cache_data[i];
-      boost::unique_lock<hw::device> hwdev_lock(hwdev);
       for (auto &iod: slot.primary)
         gender(iod);
       for (auto &iod: slot.additional)


### PR DESCRIPTION
Let device implementation handle locking, if necessary. With ledger, if the viewkey was exported no locking is required because the software implementation is used. With Trezor, the software implementation is always used. This patch speeds up wallet refreshes by 6-7x.

Requires #7745.