### PR TITLE
rpc: source file extensions must be explicit (cmake warning)

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -39,7 +39,7 @@ set(rpc_sources
   core_rpc_server.cpp
   rpc_payment.cpp
   rpc_version_str.cpp
-  instanciations)
+  instanciations.cpp)
 
 set(daemon_messages_sources
   message.cpp


### PR DESCRIPTION
```
CMake Warning (dev) at CMakeLists.txt:566 (add_library):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /Users/selsta/dev/monero/src/rpc/instanciations.cpp
Call Stack (most recent call first):
  CMakeLists.txt:554 (monero_add_library_with_deps)
  src/rpc/CMakeLists.txt:101 (monero_add_library)
This warning is for project developers.  Use -Wno-dev to suppress it.
```