### PR TITLE
unit_tests: fix broken tests

### DIFF
--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -111,8 +111,7 @@ TEST(boosted_tcp_server, worker_threads_are_exception_resistant)
 
   {
     boost::unique_lock<boost::mutex> lock(mtx);
-    ASSERT_NE(boost::cv_status::timeout, cond.wait_for(lock, boost::chrono::seconds(5)));
-    ASSERT_EQ(4, counter);
+    ASSERT_TRUE(cond.wait_for(lock, boost::chrono::seconds(5), [&counter]{ return counter == 4; }));
   }
 
   // Check if threads are alive
@@ -125,8 +124,7 @@ TEST(boosted_tcp_server, worker_threads_are_exception_resistant)
 
   {
     boost::unique_lock<boost::mutex> lock(mtx);
-    ASSERT_NE(boost::cv_status::timeout, cond.wait_for(lock, boost::chrono::seconds(5)));
-    ASSERT_EQ(4, counter);
+    ASSERT_TRUE(cond.wait_for(lock, boost::chrono::seconds(5), [&counter]{ return counter == 4; }));
   }
 
   srv.send_stop_signal();

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -795,9 +795,11 @@ TEST(cryptonote_protocol_handler, race_condition)
       workers_t workers;
     } check;
     check.work = std::make_shared<work_t>(check.io_context);
-    check.workers.emplace_back([&check]{
-      check.io_context.run();
-    });
+    while (check.workers.size() < 2) {
+      check.workers.emplace_back([&check]{
+        check.io_context.run();
+      });
+    }
     while (daemon.main.conn.size() < 1) {
       daemon.main.conn.emplace_back(new connection_t(check.io_context, daemon.main.shared_state, {}, {}));
       daemon.alt.conn.emplace_back(new connection_t(io_context, daemon.alt.shared_state, {}, {}));
@@ -856,7 +858,7 @@ TEST(cryptonote_protocol_handler, race_condition)
       }
     }
     while (daemon.main.conn.size() < 2) {
-      daemon.main.conn.emplace_back(new connection_t(io_context, daemon.main.shared_state, {}, {}));
+      daemon.main.conn.emplace_back(new connection_t(check.io_context, daemon.main.shared_state, {}, {}));
       daemon.alt.conn.emplace_back(new connection_t(io_context, daemon.alt.shared_state, {}, {}));
       create_conn_pair(daemon.main.conn.back(), daemon.alt.conn.back());
       conduct_handshake(daemon.alt.net_node, daemon.alt.conn.back());


### PR DESCRIPTION
boosted_tcp_server: check condition before sleep too
cryptonote_protocol_handler: each instance of BlockchainLMDB requires separate thread due to private thread local fields