### PR TITLE
CI: Single threaded 'make' after parallelism fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ env:
   REMOVE_BUNDLED_BOOST : rm -rf /usr/local/share/boost
   BUILD_DEFAULT_LINUX: |
         ccache --max-size=150M
-        cmake -S . -B build -D ARCH="default" -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && cmake --build build -j3
+        cmake -S . -B build -D ARCH="default" -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && (cmake --build build -j3 || cmake --build build)
   APT_INSTALL_LINUX: 'sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler ccache'
   APT_SET_CONF: |
         echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
@@ -34,7 +34,7 @@ jobs:
     - name: build
       run: |
         ccache --max-size=150M
-        make -j3
+        make -j3 || make
 
   build-windows:
     runs-on: windows-latest
@@ -61,7 +61,7 @@ jobs:
     - name: build
       run: |
         ccache --max-size=150M
-        make release-static-win64 -j2
+        make release-static-win64 -j2 || make release-static-win64
 
 # See the OS labels and monitor deprecations here:
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
@@ -120,7 +120,7 @@ jobs:
       run: |
         ccache --max-size=150M
         cmake .
-        make wallet_api -j3
+        make wallet_api -j3 || make wallet_api
 
   test-ubuntu:
     needs: build-ubuntu


### PR DESCRIPTION
If the parallel version of make fails, running make in single threaded mode with the same parameters as before. This brings no side effects if the parallel version succeeds, but if it fails, then it makes it much more clearer what the error was. This is because for the single threaded version of make the first error that occurred, will be visible at the very bottom of the log, instead of being cluttered with potentially many unrelated warnings below the actual error.