### PR TITLE
EasyLogging++: new anti-UB test and propagating exception at misconfiguration

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -2026,6 +2026,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
         ELPP_INTERNAL_ERROR("Unable to get configuration [" << confName << "] for level ["
                             << LevelHelper::convertToString(level) << "]"
                             << std::endl << "Please ensure you have properly configured logger.", false);
+        throw; // The exception has to be rethrown, to abort a branch leading to UB.
       }
     }
     return it->second;

--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -208,3 +208,10 @@ TEST(logging, operator_equals_segfault)
     el::Logger log2("id2", nullptr);
     log2 = log1;
 }
+
+TEST(logging, empty_configurations_throws)
+{
+    el::Logger log1("id1", nullptr);
+    const el::Configurations cfg;
+    EXPECT_ANY_THROW(log1.configure(cfg));
+}


### PR DESCRIPTION
There was a branch of `EasyLogging++` code, that lead to UB during incomplete configuration (see the added UTest). Now the branch will throw an exception, expecting to be handled at a higher level.