### PR TITLE
 EasyLogging++: new anti-UB test and propagating exception at misconfiguration v0.17

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -2027,6 +2027,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
         ELPP_INTERNAL_ERROR("Unable to get configuration [" << confName << "] for level ["
                             << LevelHelper::convertToString(level) << "]"
                             << std::endl << "Please ensure you have properly configured logger.", false);
+        throw; // The exception has to be rethrown, to abort a branch leading to UB.
       }
     }
     return it->second;

--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -195,3 +195,9 @@ TEST(logging, multiline)
   cleanup();
 }
 
+TEST(logging, empty_configurations_throws)
+{
+    el::Logger log1("id1", nullptr);
+    const el::Configurations cfg;
+    EXPECT_ANY_THROW(log1.configure(cfg));
+}


### PR DESCRIPTION
For release v0.17.
See description of https://github.com/monero-project/monero/pull/7828