### PR TITLE
CMake: ccache fix for FreeBSD

### DIFF
--- a/contrib/depends/packages/freebsd_base.mk
+++ b/contrib/depends/packages/freebsd_base.mk
@@ -12,8 +12,8 @@ endef
 
 define $(package)_build_cmds
   mkdir bin &&\
-  echo "exec /usr/bin/clang-8 -target x86_64-unknown-freebsd$($(package)_version) --sysroot=$(host_prefix)/native $$$$""@" > bin/clang-8 &&\
-  echo "exec /usr/bin/clang++-8 -target x86_64-unknown-freebsd$($(package)_version) --sysroot=$(host_prefix)/native $$$$""@" > bin/clang++-8 &&\
+  echo "#!/bin/sh\n\nexec /usr/bin/clang-8 -target x86_64-unknown-freebsd$($(package)_version) --sysroot=$(host_prefix)/native $$$$""@" > bin/clang-8 &&\
+  echo "#!/bin/sh\n\nexec /usr/bin/clang++-8 -target x86_64-unknown-freebsd$($(package)_version) --sysroot=$(host_prefix)/native $$$$""@" > bin/clang++-8 &&\
   chmod 755 bin/*
 endef
 


### PR DESCRIPTION
A replacement of https://github.com/monero-project/monero/pull/7797, which (/whose ugliness) inspired @wfaressuissia to find a better solution.
The key was treat the original "_Exec format error_" for FreeBSD with prepending its compiler scripts with an explicit interpreter (in this case `/bin/sh`)