### PR TITLE
POC minimalist embedding of Java I2P router using JNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1130,6 +1130,18 @@ if(SODIUM_LIBRARY)
   set(ZMQ_LIB "${ZMQ_LIB};${SODIUM_LIBRARY}")
 endif()
 
+# TODO OFF by default
+option(WITH_JNI2P "Include embedded Java I2P router" ON)
+if (WITH_JNI2P)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/i2p-zero/lib/runtime/lib/server")
+  add_subdirectory(external/jni2p)
+  include_directories(${JNI2P_INCLUDE_DIRS})
+  list(APPEND EXTRA_LIBRARIES ${JNI2P_LIBRARIES})
+  add_definitions("-DJNI2P=1")
+endif()
+
 include(external/supercop/functions.cmake) # place after setting flags and before src directory inclusion
 add_subdirectory(contrib)
 add_subdirectory(src)

--- a/external/jni2p/CMakeLists.txt
+++ b/external/jni2p/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright (c) 2014-2021, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.5)
+
+project(jni2p)
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+file(GLOB_RECURSE SOURCES *.cpp)
+file(GLOB_RECURSE HEADERS *.h)
+
+find_package(JNI REQUIRED)
+
+include_directories(${JNI_INCLUDE_DIRS})
+
+add_library(jni2p STATIC
+  ${SOURCES}
+  ${HEADERS})
+
+target_include_directories(jni2p
+  PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/src" ${JNI_INCLUDE_DIRS})
+
+target_link_libraries(jni2p
+  PUBLIC
+    ${JNI_LIBRARIES})
+
+set(JNI2P_LIBRARY "jni2p")
+set(JNI2P_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/src" CACHE STRING "JNI2P Include path")
+
+set(JNI2P_INCLUDE_DIRS "${JNI2P_INCLUDE};${JNI_INCLUDE_DIRS}" CACHE STRING "JNI2P Include paths")
+set(JNI2P_LIBRARIES "${JNI2P_LIBRARY};${JNI_LIBRARIES}" CACHE STRING "JNI2P Libraries")
+
+message(STATUS "JNI2P includes: ${JNI_INCLUDE_DIRS}")
+message(STATUS "JNI2P library: ${JNI2P_LIBRARY};${JNI_LIBRARIES}")
+
+set_property(TARGET jni2p PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET jni2p PROPERTY CXX_STANDARD 11)
+set_property(TARGET jni2p PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET jni2p PROPERTY PUBLIC_HEADER src/jni2p.h)
+
+include(GNUInstallDirs)
+install(TARGETS jni2p
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/external/jni2p/src/jni2p.cpp
+++ b/external/jni2p/src/jni2p.cpp
@@ -1,0 +1,322 @@
+// Copyright (c) 2014-2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "jni2p.h"
+
+#include <chrono>
+#include <iostream>
+#include <string.h>
+#include <thread>
+
+namespace jni2p
+{
+
+Router::Router(const std::vector<std::string> &args, const RouterProperties &defaults)
+   : Router(NULL, defaults)
+{
+    for (const auto &it : args_to_properties(args))
+        m_local_properties[it.first] = it.second;
+}
+
+Router::Router(JavaVM *jvm, const RouterProperties &properties)
+    : m_jvm(jvm)
+    , m_created_jvm(false)
+    , m_local_properties(properties)
+{
+}
+
+Router::~Router()
+{
+    cleanup();
+}
+
+void Router::cleanup()
+{
+    if(not (m_created_jvm && m_jvm)) // Nothing to do
+        return;
+
+    //std::cout << "Destroying jvm ... \n";
+    //TODO m_jvm->DestroyJavaVM();
+    m_jvm = NULL;
+    m_created_jvm = false;
+    //std::cout << "Destroy OK\n";
+}
+
+JNIEnv* Router::get_env(void)
+{
+    // Get a thread specific pointer
+    JNIEnv *env;
+    if( m_jvm->AttachCurrentThread((void**)&env, NULL) < 0)
+       throw std::runtime_error("Failed to attach to current thread");
+    return env;
+}
+
+std::string Router::getProperty(const std::string &key, const std::string &default_val)
+{
+    auto it = m_local_properties.find(key);
+    if(it != m_local_properties.end())
+        return it->second;
+    return getJavaProperty(key, default_val);
+}
+
+std::string Router::getJavaProperty(const std::string &key, const std::string &default_val)
+{
+    if(!started())
+        return default_val;
+    auto env = get_env();
+    auto method = get_method(env, JC_ROUTERCONTEXT, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;");
+    auto property = env->CallObjectMethod(getRouterContext(env), method, env->NewStringUTF(key.c_str()));
+    if(!property)
+        return default_val;
+    if(env->IsInstanceOf(property, get_class(env, JC_STRING)))
+        return std::string(env->GetStringUTFChars(static_cast<jstring>(property), 0));
+
+    throw std::runtime_error("Type not implemented");
+}
+
+void Router::start(void)
+{
+    // Instantiate new Java VM if necessary
+    if(not m_jvm)
+    {
+        if( create_jvm(&m_jvm, getProperty("i2p.dir.base") + "/jbigi.jar") < 0)
+            throw std::runtime_error("Failed to create a new JVM");
+        m_created_jvm = true;
+    }
+    auto env = get_env();
+    // Find Methods
+    auto constructor = get_router_method(env, "<init>", "(Ljava/util/Properties;)V");
+    auto setKillVMOnEnd = get_router_method(env, "setKillVMOnEnd", "(Z)V");
+    auto runRouter = get_router_method(env, "runRouter", "()V");
+    auto jrouter_class = get_java_router_class(env);
+    // Instantiate and start Java router
+    m_router = env->NewObject(jrouter_class, constructor, router_properties_to_java(env, m_local_properties));
+    env->CallVoidMethod(m_router, setKillVMOnEnd, false);
+    env->CallVoidMethod(m_router, runRouter);
+}
+
+bool Router::started(void) const
+{
+    return  m_jvm && m_router;
+}
+
+void Router::waitForRunning(void)
+{
+    if(!started())
+        start();
+    while(!isRunning())
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+std::string Router::connectTo(const std::string &destination)
+{
+    waitForRunning();
+    std::string bind_port = getProperty("jni2p.default_client_port", "54018");
+    executeI2PTunnelCommand("client " + bind_port + " " + destination);
+    return std::string("127.0.0.1:") + bind_port;
+}
+
+std::string Router::listen(const std::string &path, const std::string &port)
+{
+    waitForRunning();
+    auto destination = getDestination(path);
+    if(destination.empty())
+        destination = createDestination(path);
+    executeI2PTunnelCommand("server localhost " + port + " " + path);
+    return destination;
+}
+
+jobject Router::executeI2PTunnelCommand(const std::string &command)
+{
+    auto env = get_env();
+    auto constructor = get_method(env, JC_I2PTUNNEL, "<init>", "([Ljava/lang/String;)V");
+    jobjectArray args;
+    args = (jobjectArray)env->NewObjectArray(6, env->FindClass("java/lang/String"), NULL);
+    env->SetObjectArrayElement(args, 0, env->NewStringUTF("-die"));
+    env->SetObjectArrayElement(args, 1, env->NewStringUTF("-nocli"));
+    env->SetObjectArrayElement(args, 2, env->NewStringUTF("-e"));
+    env->SetObjectArrayElement(args, 3, env->NewStringUTF("config localhost 7654"));
+    env->SetObjectArrayElement(args, 4, env->NewStringUTF("-e"));
+    env->SetObjectArrayElement(args, 5, env->NewStringUTF(command.c_str()));
+    return env->NewObject(get_class(env, JC_I2PTUNNEL), constructor, args);
+}
+
+/**
+ * FileOutputStream writeTo = new FileOutputStream(path)
+ * I2PClient client = I2PClientFactory.createClient();
+ * Destination d = client.createDestination(writeTo);
+ * writeTo.flush();
+ * writeTo.close();
+ * return d.toBase32();
+ */
+// NB: Even if ephemeral, Java I2P API requires the keys to be in the filesystem
+std::string Router::createDestination(const std::string &path)
+{
+    auto env = get_env();
+    auto fos_ctor = get_method(env, "java/io/FileOutputStream", "<init>", "(Ljava/lang/String;)V");
+    auto createClient = env->GetStaticMethodID(get_class(env, "net/i2p/client/I2PClientFactory"), "createClient", "()Lnet/i2p/client/I2PClient;");
+    auto createDestination = get_method(env, "net/i2p/client/I2PClient", "createDestination", "(Ljava/io/OutputStream;)Lnet/i2p/data/Destination;");
+    auto toBase32 = get_method(env, "net/i2p/data/Destination", "toBase32", "()Ljava/lang/String;");
+    auto flush = get_method(env, "java/io/FileOutputStream", "flush", "()V");
+    auto close = get_method(env, "java/io/FileOutputStream", "close", "()V");
+
+    auto fos = env->NewObject(get_class(env, "java/io/FileOutputStream"), fos_ctor, env->NewStringUTF(path.c_str()));
+    auto client = env->CallStaticObjectMethod(get_class(env, "net/i2p/client/I2PClientFactory"), createClient);
+
+    auto destination = env->CallObjectMethod(client, createDestination, fos);
+    env->CallObjectMethod(fos, flush);
+    env->CallObjectMethod(fos, close);
+    auto base32 = (jstring)env->CallObjectMethod(destination, toBase32);
+    if (!base32)
+        throw std::runtime_error("Null base 32 address");
+    return std::string(env->GetStringUTFChars(base32, 0));
+}
+
+/**
+ *   FileInputStream readFrom = new FileInputStream(path);
+ *   Destination d = new Destination();
+ *   d.readBytes(readFrom);
+ *   return d.toBase32();
+ */
+std::string Router::getDestination(const std::string &path)
+{
+    auto env = get_env();
+    auto fis_ctor = get_method(env, "java/io/FileInputStream", "<init>", "(Ljava/lang/String;)V");
+    auto dest_ctor = get_method(env, JC_DESTINATION, "<init>", "()V");
+    auto readBytes = get_method(env, JC_DESTINATION, "readBytes", "(Ljava/io/InputStream;)V");
+    auto toBase32 = get_method(env, JC_DESTINATION, "toBase32", "()Ljava/lang/String;");
+
+    auto fis = env->NewObject(get_class(env, "java/io/FileInputStream"), fis_ctor, env->NewStringUTF(path.c_str()));
+    auto destination = env->NewObject(get_class(env, JC_DESTINATION), dest_ctor);
+    env->CallObjectMethod(destination, readBytes, fis);
+    auto base32 = (jstring)env->CallObjectMethod(destination, toBase32);
+    if (!base32)
+        return std::string();
+    return std::string(env->GetStringUTFChars(base32, 0));
+}
+
+/**
+ *  router.shutdownGracefully();
+ */
+void Router::stop()
+{
+    auto env = get_env();
+    auto shutdownGracefully = get_router_method(env, "shutdownGracefully", "()V");
+    env->CallVoidMethod(m_router, shutdownGracefully);
+    cleanup();
+}
+
+bool Router::callVoidReturnBool(const std::string &name)
+{
+    auto env = get_env();
+    auto method = get_router_method(env, name, "()Z");
+    auto rv = env->CallBooleanMethod(m_router, method);
+    return rv == JNI_TRUE;
+}
+
+bool Router::isAlive(void)
+{
+    return callVoidReturnBool("isAlive");
+}
+
+bool Router::isRunning(void)
+{
+    return callVoidReturnBool("isRunning");
+}
+
+std::string Router::version(void)
+{
+    return getProperty("router.version");
+}
+
+std::string Router::status(void)
+{
+    if(!started())
+        return "down";
+    //TODO getReachability
+    return (isRunning() ? "running (" : "warming up (") + version() + ")";
+}
+
+jobject Router::getRouterContext(JNIEnv *env)
+{
+    auto getContext = get_router_method(env, "getContext", "()Lnet/i2p/router/RouterContext;");
+    return env->CallObjectMethod(m_router, getContext);
+}
+
+RouterStats Router::getAllStats(void)
+{
+    auto env = get_env();
+    auto context = getRouterContext(env);
+    auto statManager = get_method(env, JC_ROUTERCONTEXT, "statManager", std::string("()L").append(JC_STATMANAGER).append(";"));
+    auto manager = env->CallObjectMethod(context, statManager);
+    auto getRateNames = get_method(env, JC_STATMANAGER, "getRateNames", "()Ljava/util/Set;");
+    auto names = (jobjectArray)env->CallObjectMethod(manager, getRateNames);
+
+    jclass setClass = env->FindClass("java/util/Set");
+    jclass iteratorClass = env->FindClass("java/util/Iterator");
+    jmethodID iteratorMethod = env->GetMethodID(setClass, "iterator", "()Ljava/util/Iterator;");
+    auto iterator = env->CallObjectMethod(names, iteratorMethod);
+
+    auto hasNext = get_method(env, "java/util/Iterator", "hasNext", "()Z");
+    auto next = env->GetMethodID(iteratorClass, "next", "()Ljava/lang/Object;");
+
+    auto getRate = get_method(env, JC_STATMANAGER, "getRate", "(Ljava/lang/String;)Lnet/i2p/stat/RateStat;");
+    auto getPeriodRate = get_method(env, "net/i2p/stat/RateStat", "getRate", "(J)Lnet/i2p/stat/Rate;");
+    auto getLifetimeAverageValue = get_method(env, "net/i2p/stat/RateStat", "getLifetimeAverageValue", "()D");
+    auto getAverageValue = get_method(env, "net/i2p/stat/Rate", "getAverageValue", "()D");
+
+    RouterStats stats;
+    // TODO choose periods
+    auto periods = {"0", "60000", "300000", "600000"};
+    std::cout.setf(std::ios::left, std::ios::adjustfield);
+    while (env->CallBooleanMethod(iterator, hasNext))
+    {
+        auto entry = (jstring)env->CallObjectMethod(iterator, next);
+        const char* c_string = env->GetStringUTFChars(entry, 0);
+        // TODO env->ReleaseStringUTFChars(env, obj, c_string);
+        auto rate = env->CallObjectMethod(manager, getRate, entry);
+        std::vector<double> values;
+        for (const auto &period: periods)
+        {
+            if(strncmp(period, "0", 1) == 0)
+            {
+                values.push_back(env->CallDoubleMethod(rate, getLifetimeAverageValue));
+            }
+            else
+            {
+                auto period_rate = env->CallObjectMethod(rate, getPeriodRate, env->NewStringUTF(period));
+                values.push_back(env->CallDoubleMethod(period_rate, getAverageValue));
+            }
+        }
+        stats[c_string] = values;
+    }
+    // TODO add frequency stats
+    return stats;
+}
+
+} // jni2p

--- a/external/jni2p/src/jni2p.h
+++ b/external/jni2p/src/jni2p.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2014-2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "utils.h"
+#include <iomanip>
+#include <ostream>
+
+namespace jni2p
+{
+
+class Router
+{
+public:
+    // Main constructor
+    // In Android, no need to create a new JVM
+    Router(JavaVM *jvm, const RouterProperties &);
+    // Constructor for command line args
+    Router(const std::vector<std::string> &args, const RouterProperties &defaults);
+    virtual ~Router();
+
+    // Lifecycle management
+    void start(void);
+    void stop(void);
+    bool started(void) const;
+    void waitForRunning(void);
+
+    // Create I2P client tunnel to destination
+    std::string connectTo(const std::string &);
+    // Create I2P server tunnel with specific identity and forwards traffic to address
+    std::string listen(const std::string &, const std::string &);
+
+    std::string createDestination(const std::string &);
+    std::string getDestination(const std::string &);
+
+    std::string version(void);
+    std::string status(void);
+    RouterStats getAllStats(void);
+
+    std::string getProperty(const std::string &, const std::string & = std::string());
+
+    template<typename T> void printStats(T& writer)
+    {
+        auto stats = getAllStats();
+        writer << std::left;
+        for(auto stat: stats)
+        {
+            writer << std::setw(44) << stat.first;
+            for(auto value: stat.second)
+            {
+                writer << " | " << std::setw(12) << value;
+            }
+            writer << "\n";
+        }
+    }
+
+private:
+    std::string getJavaProperty(const std::string &, const std::string & = std::string());
+    jobject getRouterContext(JNIEnv *env);
+    jobject executeI2PTunnelCommand(const std::string &);
+
+    bool callVoidReturnBool(const std::string &name);
+    bool isAlive(void);
+    bool isRunning(void);
+
+    void cleanup(void);
+    JNIEnv* get_env(void);
+
+    JavaVM *m_jvm;
+    bool m_created_jvm;
+    RouterProperties m_local_properties;
+    jobject m_router;
+};
+
+} // jni2p

--- a/external/jni2p/src/utils.cpp
+++ b/external/jni2p/src/utils.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2014-2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "utils.h"
+#include <iomanip>
+#include <iostream>
+
+namespace jni2p
+{
+
+int create_jvm(JavaVM **jvm, const std::string &jbigi_path)
+{
+    JNIEnv* env;
+    JavaVMInitArgs args;
+    JavaVMOption options;
+    args.version = JNI_VERSION_1_6;
+    args.nOptions = 1;
+    std::string arg = std::string("-Djava.class.path=") + jbigi_path;
+    options.optionString = const_cast<char*>(arg.c_str());
+    args.options = &options;
+    args.ignoreUnrecognized = false;
+    return JNI_CreateJavaVM(jvm, (void**)&env, &args);
+}
+
+jclass get_class(JNIEnv *env, const std::string &name)
+{
+    //std::cout << "Looking for class " << name << " ...";
+    auto jrouter_class = env->FindClass(name.c_str());
+    if( not jrouter_class)
+       throw std::runtime_error("Failed to find class " + name);
+    //std::cout << "OK\n";
+    return jrouter_class;
+}
+
+jclass get_java_router_class(JNIEnv *env)
+{
+    return get_class(env, JC_ROUTER);
+}
+
+jmethodID get_method(JNIEnv *env, const std::string &class_name, const std::string &name, const std::string &signature)
+{
+    auto jrouter_class = get_class(env, class_name);
+    //std::cout << "Looking for method '" << name << "' ...";
+    auto method = env->GetMethodID(jrouter_class, name.c_str(), signature.c_str());
+    if(not method)
+        throw std::runtime_error("Failed to get method " + name);
+    //std::cout << "OK\n";
+    return method;
+}
+
+jmethodID get_router_method(JNIEnv *env, const std::string &name, const std::string &signature)
+{
+    return get_method(env, JC_ROUTER, name, signature);
+}
+
+RouterProperties args_to_properties(const std::vector<std::string> &args)
+{
+    RouterProperties props;
+    for(auto& it: args)
+    {
+        auto pos = it.find("=");
+        if(pos == std::string::npos)
+            throw std::runtime_error("Invalid argument : no equal sign");
+        props.insert(std::make_pair(it.substr(0, pos), it.substr(pos+1)));
+    }
+    return props;
+}
+
+jobject router_properties_to_java(JNIEnv *env, const RouterProperties &properties)
+{
+    auto constructor = get_method(env, "java/util/Properties", "<init>", "()V");
+    auto put = get_method(env, "java/util/Properties", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+    auto props = env->NewObject(get_class(env, "java/util/Properties"), constructor);
+    for (auto& it: properties)
+    {
+        auto first = env->NewStringUTF(it.first.c_str());
+        auto second = env->NewStringUTF(it.second.c_str());
+        env->CallVoidMethod(props, put, first, second);
+        //TODO env->ReleaseStringUTFChars(first, it.first.c_str());
+        //TODO env->ReleaseStringUTFChars(second, it.second.c_str());
+    }
+    return props;
+}
+
+std::string properties_to_string(JNIEnv *env, jobject properties)
+{
+    auto toString = get_method(env, "java/util/Properties", "toString", "()Ljava/lang/String;");
+    auto rv = (jstring)env->CallObjectMethod(properties, toString);
+    auto string = env->GetStringUTFChars(rv, 0);
+    std::string res(string);
+    //env->ReleaseStringUTFChars(rv, string);
+    return res;
+}
+
+} // jni2p

--- a/external/jni2p/src/utils.h
+++ b/external/jni2p/src/utils.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2014-2021, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <jni.h>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace jni2p
+{
+
+typedef std::unordered_map<std::string, std::string> RouterProperties;
+typedef std::map<std::string, std::vector<double> > RouterStats;
+
+// Java classes
+#define JC_OBJECT "java/lang/Object"
+#define JC_STRING "java/lang/String"
+#define JC_PROPERTIES "java/util/Properties"
+#define JC_ROUTER "net/i2p/router/Router"
+#define JC_ROUTERCONTEXT "net/i2p/router/RouterContext"
+#define JC_I2PTUNNEL "net/i2p/i2ptunnel/I2PTunnel"
+#define JC_STATMANAGER "net/i2p/stat/StatManager"
+#define JC_STATISTICSMANAGER "net/i2p/router/StatisticsManager"
+#define JC_OUTPUTSTREAM "java/io/OutputStream"
+#define JC_BYTEARRAYOUTPUTSTREAM "java/io/ByteArrayOutputStream"
+#define JC_DESTINATION "net/i2p/data/Destination"
+
+// TODO provide contextual defaults ?
+static const RouterProperties default_properties {
+    {"i2p.dir.base.template", "i2p.base"}
+   ,{"router.sharePercentage", "80"}
+   ,{"i2np.bandwidth.inboundKBytesPerSecond", "xy"}
+   ,{"i2np.bandwidth.inboundBurstKBytesPerSecond", "xy"}
+   ,{"i2np.bandwidth.inboundBurstKBytes", "xy"}
+   ,{"i2np.bandwidth.outboundKBytesPerSecond", "xy"}
+   ,{"i2np.bandwidth.outboundBurstKBytesPerSecond", "xy"}
+   ,{"i2np.bandwidth.outboundBurstKBytes", "xy"}
+};
+static const RouterProperties client_default_properties {
+    {"router.floodfillParticipant", "0"}
+   ,{"i2np.laptopMode", "1"}
+};
+static const RouterProperties server_default_properties {
+    {"router.floodfillParticipant", "1"}
+};
+
+int create_jvm(JavaVM **jvm, const std::string &);
+
+// Class & method getters
+jclass get_class(JNIEnv *env, const std::string &name);
+jclass get_java_router_class(JNIEnv *env);
+jmethodID get_method(JNIEnv *env, const std::string&, const std::string &, const std::string &);
+jmethodID get_router_method(JNIEnv *env, const std::string &, const std::string &);
+
+// type helpers
+RouterProperties args_to_properties(const std::vector<std::string> &);
+jobject router_properties_to_java(JNIEnv *env, const RouterProperties&);
+std::string properties_to_string(JNIEnv*, jobject);
+
+} // jni2p

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -540,6 +540,12 @@ bool t_rpc_command_executor::show_status() {
     ;
   }
 
+#ifdef JNI2P
+  auto i2p_router = m_rpc_server->get_i2p_router();
+  if (i2p_router)
+    str << ", Embedded I2P: " << i2p_router->status();
+#endif
+
   tools::success_msg_writer() << str.str();
 
   return true;
@@ -719,6 +725,14 @@ bool t_rpc_command_executor::print_net_stats()
       tools::fail_msg_writer() << make_error(fail_message, limit_res.status);
       return true;
     }
+#ifdef JNI2P
+    auto i2p_router = m_rpc_server->get_i2p_router();
+    if (i2p_router)
+    {
+      auto writer = tools::success_msg_writer();
+      i2p_router->printStats(writer);
+    }
+#endif
   }
 
   uint64_t seconds = (uint64_t)time(NULL) - net_stats_res.start_time;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -43,6 +43,9 @@
 #include "p2p/net_node.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
 #include "rpc_payment.h"
+#ifdef JNI2P
+#include <jni2p.h>
+#endif
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "daemon.rpc"
@@ -262,6 +265,10 @@ namespace cryptonote
     bool on_rpc_access_account(const COMMAND_RPC_ACCESS_ACCOUNT::request& req, COMMAND_RPC_ACCESS_ACCOUNT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
+#ifdef JNI2P
+    jni2p::Router* get_i2p_router(void) { return m_i2p_router.get();}
+#endif
+
 private:
     bool check_core_busy();
     bool check_core_ready();
@@ -298,6 +305,9 @@ private:
     std::unique_ptr<rpc_payment> m_rpc_payment;
     bool disable_rpc_ban;
     bool m_rpc_payment_allow_free_loopback;
+#ifdef JNI2P
+    std::unique_ptr<jni2p::Router> m_i2p_router;
+#endif
   };
 }
 

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -106,6 +106,10 @@ namespace cryptonote
      , rpc_ssl_allow_chained({"rpc-ssl-allow-chained", rpc_args::tr("Allow user (via --rpc-ssl-certificates) chain certificates"), false})
      , rpc_ssl_allow_any_cert({"rpc-ssl-allow-any-cert", rpc_args::tr("Allow any peer certificate"), false})
      , disable_rpc_ban({"disable-rpc-ban", rpc_args::tr("Do not ban hosts on RPC errors"), false, false})
+#ifdef JNI2P
+     , rpc_i2p_key_path({"rpc-i2p-key-path", rpc_args::tr("Specify path to I2P identity key file"), ""})
+     , embedded_i2p_args({"embedded-i2p-args", rpc_args::tr("Arguments for embedded I2P") })
+#endif
   {}
 
   const char* rpc_args::tr(const char* str) { return i18n_translate(str, "cryptonote::rpc_args"); }
@@ -131,6 +135,10 @@ namespace cryptonote
     command_line::add_arg(desc, arg.disable_rpc_ban);
     if (any_cert_option)
       command_line::add_arg(desc, arg.rpc_ssl_allow_any_cert);
+#ifdef JNI2P
+    command_line::add_arg(desc, arg.rpc_i2p_key_path);
+    command_line::add_arg(desc, arg.embedded_i2p_args);
+#endif
   }
 
   boost::optional<rpc_args> rpc_args::process(const boost::program_options::variables_map& vm, const bool any_cert_option)
@@ -145,6 +153,10 @@ namespace cryptonote
     config.use_ipv6 = command_line::get_arg(vm, arg.rpc_use_ipv6);
     config.require_ipv4 = !command_line::get_arg(vm, arg.rpc_ignore_ipv4);
     config.disable_rpc_ban = command_line::get_arg(vm, arg.disable_rpc_ban);
+#ifdef JNI2P
+    config.rpc_i2p_key_path = command_line::get_arg(vm, arg.rpc_i2p_key_path);
+    config.embedded_i2p_args = command_line::get_arg(vm, arg.embedded_i2p_args);
+#endif
     if (!config.bind_ip.empty())
     {
       // always parse IP here for error consistency

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -68,6 +68,10 @@ namespace cryptonote
       const command_line::arg_descriptor<bool> rpc_ssl_allow_chained;
       const command_line::arg_descriptor<bool> rpc_ssl_allow_any_cert;
       const command_line::arg_descriptor<bool> disable_rpc_ban;
+#ifdef JNI2P
+      const command_line::arg_descriptor<std::string> rpc_i2p_key_path;
+      const command_line::arg_descriptor<std::vector<std::string>> embedded_i2p_args;
+#endif
     };
 
     // `allow_any_cert` bool toggles `--rpc-ssl-allow-any-cert` configuration
@@ -91,5 +95,9 @@ namespace cryptonote
     boost::optional<tools::login> login; // currently `boost::none` if unspecified by user
     epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
     bool disable_rpc_ban = false;
+#ifdef JNI2P
+    std::string rpc_i2p_key_path;
+    std::vector<std::string> embedded_i2p_args;
+#endif
   };
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -43,6 +43,9 @@
 #include <boost/thread/lock_guard.hpp>
 #include <atomic>
 #include <random>
+#ifdef JNI2P
+#include <jni2p.h>
+#endif
 
 #include "include_base_utils.h"
 #include "cryptonote_basic/account.h"
@@ -1558,6 +1561,11 @@ private:
 
     static std::string get_default_daemon_address() { CRITICAL_REGION_LOCAL(default_daemon_address_lock); return default_daemon_address; }
 
+#ifdef JNI2P
+    void set_i2p_router(jni2p::Router* router) { m_i2p_router.reset(router); }
+    jni2p::Router* get_i2p_router(void) { return m_i2p_router.get(); }
+#endif
+
   private:
     /*!
      * \brief  Stores wallet information to wallet file.
@@ -1813,6 +1821,10 @@ private:
 
     static boost::mutex default_daemon_address_lock;
     static std::string default_daemon_address;
+
+#ifdef JNI2P
+    std::unique_ptr<jni2p::Router> m_i2p_router;
+#endif
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 29)


### PR DESCRIPTION
This is just a mini proof of concept to see what the community thinks about embedding  the **java** I2P implementation using [JNI](https://en.wikipedia.org/wiki/Java_Native_Interface).

For now, it only handles wallet <-> daemon communications.

- **libjni2p**: it's basically a few lines from [i2p-zero](https://github.com/i2p-zero/i2p-zero) written in C/C++. By linking to the libjvm in i2p-zero, JNI finds (:man_shrugging: ) the java I2P classes.

- **monerod**: new option `--rpc-i2p-key-path`

```sh
monerod --rpc-i2p-key-path /path/to/private_key_file ...
```
Starts a router and creates `server tunnel` with the identity extracted from the given file and the rpc ip/port parameters. if the file doesn't exists, it will create a new private key. The resulting .b32.i2p address is shown in the logs.

- **monero-wallet-cli**: new option `--embedded-i2p`

```sh
monero-wallet-cli --embedded-i2p --daemon-address XXXXXXXXXXXX.b32.i2p
```
Starts a router and creates `client tunnel` to the specified address.

- **Common to wallet and daemon**:
  - Default options expects a directory `i2p-zero` in the same directory as the binary.
  -  point of integrations:
      - start/stop
      - status
      - net_stats / print_net_stats
  - Common option : `--embedded-i2p-args key=value` for standard I2P arguments to be forwarded to [net.i2p.router.Router constructor](https://github.com/i2p/i2p.i2p/blob/master/router/java/src/net/i2p/router/Router.java#L215).  Example: 
```sh
monerod --rpc-i2p-key-path /path/to/private_key_file \
    --embedded-i2p-args i2p.dir.base=/path/to/i2p.base \
    --embedded-i2p-args i2p.dir.config=/path/to/i2p.config \
    --embedded-i2p-args router.sharePercentage=80 \
    --embedded-i2p-args router.floodfillParticipant=1 \
    ...
```
 
Please ignore the current code quality :sweat_smile:, i'll write more serious code if this is not already rejected at this stage.