### PR TITLE
epee: tidying post-incrementation -> pre-incrementation

### DIFF
--- a/contrib/epee/src/http_base.cpp
+++ b/contrib/epee/src/http_base.cpp
@@ -44,7 +44,7 @@ namespace http
     std::string get_value_from_fields_list(const std::string& param_name, const net_utils::http::fields_list& fields)
     {
         fields_list::const_iterator it = fields.begin();
-        for(; it != fields.end(); it++)
+        for(; it != fields.end(); ++it)
             if(!string_tools::compare_no_case(param_name, it->first))
                 break;
 

--- a/contrib/epee/src/net_parse_helpers.cpp
+++ b/contrib/epee/src/net_parse_helpers.cpp
@@ -48,7 +48,7 @@ namespace net_utils
     state st = st_param_name;
     std::string::const_iterator start_it = query.begin();
     std::pair<std::string, std::string> e;
-    for(std::string::const_iterator it = query.begin(); it != query.end(); it++)
+    for(std::string::const_iterator it = query.begin(); it != query.end(); ++it)
     {
       switch(st)
       {

--- a/contrib/epee/src/parserse_base_utils.cpp
+++ b/contrib/epee/src/parserse_base_utils.cpp
@@ -102,7 +102,7 @@ namespace misc_utils
           ++fi;
         val.assign(it, fi);
         it = fi;
-        for(;it != buf_end;it++)
+        for(;it != buf_end;++it)
         {
           if(escape_mode/*prev_ch == '\\'*/)
           {
@@ -197,7 +197,7 @@ namespace misc_utils
           ++chars;
           ++it;
         }
-        for(;it != buf_end;it++)
+        for(;it != buf_end;++it)
         {
           const uint8_t flags = lut[(uint8_t)*it];
           if (flags & 16)
@@ -224,7 +224,7 @@ namespace misc_utils
       {
         val.clear();
 
-        for(std::string::const_iterator it = star_end_string;it != buf_end;it++)
+        for(std::string::const_iterator it = star_end_string;it != buf_end;++it)
         {
           if (!(lut[(uint8_t)*it] & 4))
           {
@@ -243,7 +243,7 @@ namespace misc_utils
       {
         val.clear();
 
-        for(std::string::const_iterator it = star_end_string;it != buf_end;it++)
+        for(std::string::const_iterator it = star_end_string;it != buf_end;++it)
         {
           if(!isalnum(*it) && *it != '-' && *it != '_')
           {
@@ -262,7 +262,7 @@ namespace misc_utils
       {
         word_end = star_end_string;
 
-        for(std::string::const_iterator it = star_end_string;it != buf_end;it++)
+        for(std::string::const_iterator it = star_end_string;it != buf_end;++it)
         {
           if(isspace(*it))
           {


### PR DESCRIPTION
Found by CppCheck.

_"Prefix ++/-- operators should be preferred for non-primitive types. Pre-increment/decrement can be more efficient than post-increment/decrement. Post-increment/decrement usually involves keeping a copy of the previous value around and adds a little extra code."_