### PR TITLE
Simplewallet: aborting get_mnemonic_language() in case a negative index is used

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4895,7 +4895,7 @@ std::string simple_wallet::get_mnemonic_language()
       fail_msg_writer() << tr("invalid language choice entered. Please try again.\n");
     }
   }
-  return language_list_self[language_number];
+  return language_list_self.at(language_number);
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<tools::password_container> simple_wallet::get_and_verify_password() const


### PR DESCRIPTION
Inside `get_mnemonic_language()` of `Simplewallet`:
In case the error case is indeed reached, the appropriate error logs are stored, but the function carries on with accessing a vector, using a negative index. Using the `vector`'s `at()` method protects against this, by aborting the branch and throwing an exception. Leaving this as it was causes UB.