### PR TITLE
CMake epee: add minimalistic test setup +CI

### DIFF
--- a/contrib/epee/CMakeLists.txt
+++ b/contrib/epee/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2020, The Monero Project
+# Copyright (c) 2014-2021, The Monero Project
 # 
 # All rights reserved.
 # 
@@ -27,4 +27,8 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 add_subdirectory(src)
+
+if (BUILD_TESTS)
+	add_subdirectory(tests/src)
+endif()
 

--- a/contrib/epee/tests/src/CMakeLists.txt
+++ b/contrib/epee/tests/src/CMakeLists.txt
@@ -2,12 +2,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(Boost_USE_MULTITHREADED ON)
+set(NAME tests_epee)
 
 include_directories(.)
-include_directories(../../include)
-
-find_package(Boost COMPONENTS system filesystem thread date_time chrono regex)
-include_directories( ${Boost_INCLUDE_DIRS} )
 
 IF (MSVC)
 	add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4345  /nologo /D_WIN32_WINNT=0x0600 /DWIN32_LEAN_AND_MEAN /bigobj" )
@@ -19,15 +16,17 @@ ELSE()
 ENDIF()
 
 
-# Add folders to filters
-file(GLOB_RECURSE SRC        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-			     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
-			     ${CMAKE_CURRENT_SOURCE_DIR}/*.inl
-			     ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+set(SRC
+	main.cpp
+)
 
-source_group(general  FILES ${SRC})
+monero_find_all_headers(EPEE_TESTS_HEADERS_PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+monero_add_minimal_executable(${NAME} ${SRC} ${EPEE_TESTS_HEADERS_PUBLIC})
+target_link_libraries(${NAME}
+	epee
+	${Boost_SYSTEM_LIBRARY}
+	${CMAKE_THREAD_LIBS_INIT}
+)
 
-
-add_executable(tests ${SRC} )
-target_link_libraries( tests ${Boost_LIBRARIES} )
+add_test(${NAME} ${NAME})
 

--- a/contrib/epee/tests/src/main.cpp
+++ b/contrib/epee/tests/src/main.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include "misc/test_math.h"
+
+#include "misc_log_ex.h"
+#include "string_tools.h"
+
+int main(int argc, char** argv)
+{
+  TRY_ENTRY();
+
+  epee::string_tools::set_module_name_and_folder(argv[0]);
+  mlog_configure(mlog_get_default_log_path("tests_epee.log"), true);
+  epee::debug::get_set_enable_assert(true, false);
+
+  if(!epee::tests::test_median())
+  {
+    LOG_ERROR("median test failed");
+    return 1;
+  }
+
+  CATCH_ENTRY_L0("main", 1);
+
+  return 0;
+}

--- a/contrib/epee/tests/src/misc/test_math.h
+++ b/contrib/epee/tests/src/misc/test_math.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "misc_language.h"
+#include "misc_log_ex.h"
 
 namespace epee
 {


### PR DESCRIPTION
Integrating patch from https://github.com/monero-project/monero/pull/7833#issuecomment-896796218.

The discussion there was about how to test epee code, and whether it makes sense to test it before it is being distributed to the dependees. My opinion is, that whenever possible, a given package should be responsible to test its own basic functionality in isolation from other components as the first line of defense.

The second point in the mentioned PR was, that such tests, in case of epee as well as others, aren't part of the CI. This PR adds the boilerplate code, necessary to include the test in our CI. The PR also (for now) removes the epee's `tests.cpp` file from the CMakeLists.txt file, since it doesn't compile anymore. In the future, we can re-include the working tests from `tests.cpp` step by step. For now, I only extracted the math tests as a starting example.

### Result:
```
Running tests...
Test project /home/runner/work/monero/monero/build
      Start  1: tests_epee
 1/23 Test  #1: tests_epee .......................   Passed    0.00 sec
      Start  2: hash-target
 2/23 Test  #2: hash-target ......................   Passed    0.35 sec
      Start  3: wallet-crypto-bench
```