### PR TITLE
epee: overflow bugfix in get_median()

### DIFF
--- a/contrib/epee/include/stats.inl
+++ b/contrib/epee/include/stats.inl
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <limits>
 #include <algorithm>
+#include "misc_language.h"
 #include "stats.h"
 
 enum
@@ -86,7 +87,7 @@ Tpod Stats<T, Tpod>::get_median() const
     }
     else
     {
-      median = (sorted[(sorted.size() - 1) / 2] + sorted[sorted.size() / 2]) / 2;
+      median = epee::misc_utils::get_mid(sorted[(sorted.size() - 1) / 2], sorted[sorted.size() / 2]);
     }
     set_cached(bit_median);
   }


### PR DESCRIPTION
- Fixes potential overflow in `get_median()` function.

Note that `get_mid()` was introduced to prevent overflow edge cases in `rolling_median_t`, and added to `median()` for similar reasons (#6718). This `get_median()` was overlooked at that time.