### PR TITLE
Device: remove unused and incorrect non-default constructor

### DIFF
--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -91,7 +91,6 @@ namespace hw {
     public:
 
         device(): mode(NONE)  {}
-        device(const device &hwdev) {}
         virtual ~device()   {}
 
         explicit virtual operator bool() const = 0;


### PR DESCRIPTION
See https://github.com/monero-project/monero/pull/7875#issuecomment-902196927

Previous description:

The variable `mode` in `device` was being uninitialized when the non-empty constructor was being used. By delegating the constructor to the default constructor (C++11 feature), where the variable is initialized, I get the variable initialized and prevent code duplication.