### PR TITLE
core_tests: remove unused typedef, fix warning

### DIFF
--- a/tests/core_tests/transaction_tests.cpp
+++ b/tests/core_tests/transaction_tests.cpp
@@ -72,7 +72,6 @@ bool test_transaction_generation_and_ring_signature()
   construct_miner_tx(0, 0, 0, 0, 0, miner_acc6.get_keys().m_account_address, tx_mine_6);
 
   //fill inputs entry
-  typedef tx_source_entry::output_entry tx_output_entry;
   std::vector<tx_source_entry> sources;
   sources.resize(sources.size()+1);
   tx_source_entry& src = sources.back();


### PR DESCRIPTION
```
/Users/selsta/dev/monero/tests/core_tests/transaction_tests.cpp:75:41: warning: unused typedef 'tx_output_entry' [-Wunused-local-typedef]
  typedef tx_source_entry::output_entry tx_output_entry;
                                        ^
1 warning generated.
```