### PR TITLE
Mac: fix unit test bind_same_p2p_port

### DIFF
--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -303,6 +303,9 @@ TEST(node_server, bind_same_p2p_port)
 
     Relevant part about REUSEADDR from man:
     https://www.man7.org/linux/man-pages/man7/ip.7.html
+
+    For Mac OSX, set the following alias, before running the test, or else it will fail:
+    sudo ifconfig lo0 alias 127.0.0.2
     */
     vm.find(nodetool::arg_p2p_bind_ip.name)->second   = boost::program_options::variable_value(std::string("127.0.0.2"), false);
     vm.find(nodetool::arg_p2p_bind_port.name)->second = boost::program_options::variable_value(std::string(port), false);


### PR DESCRIPTION
After fixing the random failure under Ubuntu of the test `bind_same_p2p_port` belonging to the suite `node_server`, the same test under Mac OSX ceased to work completely. @TimSycamore noted, that under OSX, the IP has to stay 127.0.0.1, and not 127.0.0.2.

There are some temporary commits in this PR to prove the point - that the UTs under OSX were failing without the IP fix. Also the unit tests for Mac are temporarily enabled, but maybe it wouldn't be a bad idea to run them regularly either, since they don't cost that much time (< 2 minutes)? Of course enabling them for good shall be done in a separate PR.