### PR TITLE
Quicker resource cleanup on p2p socks timeout

### DIFF
--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -201,6 +201,13 @@ namespace socks
             std::shared_ptr<client> self_;
             void operator()(boost::system::error_code error = boost::system::error_code{});
         };
+
+        //! Calls `async_close` on `self` at destruction. NOP if `nullptr`.
+        struct close_on_exit
+        {
+            std::shared_ptr<client> self;
+            ~close_on_exit() { async_close{std::move(self)}(); }
+        };
     };
 
     template<typename Handler>

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -339,6 +339,7 @@ namespace nodetool
             }
         };
 
+        net::socks::client::close_on_exit close_client{};
         boost::unique_future<client_result> socks_result{};
         {
             boost::promise<client_result> socks_promise{};
@@ -347,6 +348,7 @@ namespace nodetool
             auto client = net::socks::make_connect_client(
                 boost::asio::ip::tcp::socket{service}, net::socks::version::v4a, notify{std::move(socks_promise)}
              );
+            close_client.self = client;
             if (!start_socks(std::move(client), proxy, remote))
                 return boost::none;
         }
@@ -368,7 +370,10 @@ namespace nodetool
         {
             auto result = socks_result.get();
             if (!result.first)
+            {
+                close_client.self.reset();
                 return {std::move(result.second)};
+            }
 
             MERROR("Failed to make socks connection to " << remote.str() << " (via " << proxy << "): " << result.first.message());
         }


### PR DESCRIPTION
Found this while reviewing the codebase. If a timeout occurs in p2p socks code, the corresponding socket is left open and cleaned up at the mercy of the socks server. Socks servers are typically daemons run by the same user, so this is unlikely to be a widespread resource DoS issue, but still needs fixing. 

The `net::socks::client` class leaves timeout handling to the caller, with my original thinking that a particularly strategy shouldn't be "forced" upon the caller. Perhaps an `asio::steady_timer` would suffice as it would work "well enough" (although it would be a slight performance hit on the two current use cases).