### PR TITLE
Removed the redundant 'using namespace std' lines to for readability.

### DIFF
--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -45,7 +45,6 @@ extern "C"
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "account"
 
-using namespace std;
 
 DISABLE_VS_WARNINGS(4244 4345)
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -87,7 +87,6 @@
 #include "readline_buffer.h"
 #endif
 
-using namespace std;
 using namespace epee;
 using namespace cryptonote;
 using boost::lexical_cast;


### PR DESCRIPTION
In these files, all the necessary namespace prefixes are already used. This is meant to prevent a future contributor from not including "std::" before standard library features and maintain consistency in the code base.