### PR TITLE
Documentation correction for Ubuntu instructions for making the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,14 @@ library archives (`.a`).
 | libudev      | ?             | No       | `libudev-dev`        | `systemd`    | `eudev-libudev-devel` | `systemd-devel`  | YES      | Hardware wallet |
 
 [1] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
-build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv lib/libg* /usr/lib/```
+build the library binary manually. This can be done with the following command `sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make`
+Then:
+
+* on Debian:
+  `sudo mv libg* /usr/lib/`
+* on Ubuntu:
+  `sudo mv lib/libg* /usr/lib/`
+
 [2] libnorm-dev is needed if your zmq library was built with libnorm, and not needed otherwise
 
 Install all dependencies at once on Debian/Ubuntu:

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ library archives (`.a`).
 | libudev      | ?             | No       | `libudev-dev`        | `systemd`    | `eudev-libudev-devel` | `systemd-devel`  | YES      | Hardware wallet |
 
 [1] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
-build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
+build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv lib/libg* /usr/lib/```
 [2] libnorm-dev is needed if your zmq library was built with libnorm, and not needed otherwise
 
 Install all dependencies at once on Debian/Ubuntu:


### PR DESCRIPTION
This is what actually seems to work correctly on ubuntu 20

The libg* directory does not exist at the higher level.

```
ubuntu@ip-X:/usr/src/gtest$ ls
CMakeCache.txt  CMakeLists.txt  Makefile   bin    cmake_install.cmake  include  samples  src
CMakeFiles      CONTRIBUTORS    README.md  cmake  docs                 lib      scripts  test
```

You can see that there is no libg here ^^^