### PR TITLE
v0.17: Fix Boost-1.77: Add missing algorithm header to i18n.cpp

### DIFF
--- a/src/common/i18n.cpp
+++ b/src/common/i18n.cpp
@@ -34,6 +34,7 @@
 #include "file_io_utils.h"
 #include "common/i18n.h"
 #include "translation_files.h"
+#include <algorithm>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "i18n"


### PR DESCRIPTION
The error message was:
`/run/build/monero/src/common/i18n.cpp:74:8: error: ‘transform’ is not a member of ‘std’`
resulting from Boost 1.77 minimizing their headers. The above file assumed, that the `<algorithm>` header would be implicitly included by the Boost headers.