### PR TITLE
Fix parallel make of OpenSSL

### DIFF
--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -59,11 +59,11 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) -j1 build_libs libcrypto.pc libssl.pc openssl.pc
+  $(MAKE) build_libs
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_sw
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install_sw
 endef
 
 define $(package)_postprocess_cmds


### PR DESCRIPTION
It's been explicitly forcing `-j1` instead of allowing it to build in parallel. Looks like this has been broken since the initial commit. Explicitly specifying the *.pc targets is what breaks the parallel build. If they're omitted they'll get built anyway, in proper order.