### PR TITLE
gitian: remove ccache

### DIFF
--- a/contrib/gitian/gitian-android.yml
+++ b/contrib/gitian/gitian-android.yml
@@ -24,7 +24,6 @@ packages:
 - "ca-certificates"
 - "python"
 - "cmake"
-- "ccache"
 - "protobuf-compiler"
 - "libdbus-1-dev"
 - "libharfbuzz-dev"

--- a/contrib/gitian/gitian-freebsd.yml
+++ b/contrib/gitian/gitian-freebsd.yml
@@ -25,7 +25,6 @@ packages:
 - "ca-certificates"
 - "python"
 - "cmake"
-- "ccache"
 - "protobuf-compiler"
 - "libdbus-1-dev"
 - "libharfbuzz-dev"

--- a/contrib/gitian/gitian-linux.yml
+++ b/contrib/gitian/gitian-linux.yml
@@ -36,7 +36,6 @@ packages:
 - "ca-certificates"
 - "python"
 - "cmake"
-- "ccache"
 - "protobuf-compiler"
 - "libdbus-1-dev"
 - "libharfbuzz-dev"


### PR DESCRIPTION
It's just wasted overhead since the build VMs are always deleted
and recreated fresh for each run.