### PR TITLE
CMake: Add missing SANITIZE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,7 @@ if(STATIC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZMQ_STATIC")
 endif()
 
+option(SANITIZE "Use ASAN memory sanitizer" OFF)
 if(SANITIZE)
   if (MSVC)
     message(FATAL_ERROR "Cannot sanitize with MSVC")


### PR DESCRIPTION
The option `SANITIZE` was not being advertised to the external user interfaces of CMake, like ccmake or cmake-qt.

Context: The option is needed for enabling the ASAN memory sanitizer.