### PR TITLE
Fix export_transfers amount for send-to-self outputs

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1979,8 +1979,9 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   PERF_TIMER(process_new_transaction);
   // In this function, tx (probably) only contains the base information
   // (that is, the prunable stuff may or may not be included)
+  confirmed_transfer_details* just_confirmed = nullptr;
   if (!miner_tx && !pool)
-    process_unconfirmed(txid, tx, height);
+    just_confirmed = process_unconfirmed(txid, tx, height);
 
   // per receiving subaddress index
   std::unordered_map<cryptonote::subaddress_index, uint64_t> tx_money_got_in_outs;
@@ -2457,6 +2458,11 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
     else
       ++i;
   }
+  // Update the "change" value in the confirmed details to include everything we sent to ourselves
+  // as changed so that we properly reflect net output amounts when reporting transfer details.
+  if (just_confirmed && sub_change > 0)
+      just_confirmed->m_change = sub_change;
+
 
   // create payment_details for each incoming transfer to a subaddress index
   if (tx_money_got_in_outs.size() > 0)
@@ -2559,16 +2565,23 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   }
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height)
-{
-  if (m_unconfirmed_txs.empty())
-    return;
+// Called when processing incoming txes; if we find the given txid in the unconfirmed txes set then
+// we move it into confirmed txs, and return a pointer to the new confirmed details struct; the
+// amounts in it may need to be updated needs to have any tx outputs that come back to ourself
+// removed (because the unconfirmed_tx does not know whether the values are to itself or not, and so
+// will currently contain an amount set to the sum of all outputs other than the implicit change
+// output).
 
+wallet2::confirmed_transfer_details* wallet2::process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height)
+{
+  confirmed_transfer_details* ctd = nullptr;
   auto unconf_it = m_unconfirmed_txs.find(txid);
   if(unconf_it != m_unconfirmed_txs.end()) {
     if (store_tx_info()) {
       try {
-        m_confirmed_txs.insert(std::make_pair(txid, confirmed_transfer_details(unconf_it->second, height)));
+        auto ins = m_confirmed_txs.insert(std::make_pair(txid, confirmed_transfer_details(unconf_it->second, height)));
+        if (ins.second)
+          ctd = &ins.first->second;
       }
       catch (...) {
         // can fail if the tx has unexpected input types
@@ -2577,6 +2590,7 @@ void wallet2::process_unconfirmed(const crypto::hash &txid, const cryptonote::tr
     }
     m_unconfirmed_txs.erase(unconf_it);
   }
+  return ctd;
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::transaction &tx, uint64_t height, uint64_t ts, uint64_t spent, uint64_t received, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1594,7 +1594,7 @@ private:
     void process_parsed_blocks(uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> *output_tracker_cache = NULL);
     uint64_t select_transfers(uint64_t needed_money, std::vector<size_t> unused_transfers_indices, std::vector<size_t>& selected_transfers) const;
     bool prepare_file_names(const std::string& file_path);
-    void process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height);
+    confirmed_transfer_details* process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height);
     void process_outgoing(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height, uint64_t ts, uint64_t spent, uint64_t received, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
     void add_unconfirmed_tx(const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
     void generate_genesis(cryptonote::block& b) const;


### PR DESCRIPTION
When you send a transaction to yourself then `export_transfers` outputs the wrong amount (and thus balance) in the exported file.

This happens because the unconfirmed transfer only has the actual change amount constructed in the transaction, but proper balance tracking requires identifying *all* outputs returning to the same wallet as change for the purposes of export details.

This fixes the issue by updating the change amount in the transaction to be the sum of all received outputs, instead of just the constructed change value.

(Note that the same issue does *not* occur if we receive the transaction in another copy of the wallet -- in that case all the outputs to self are already counted as change).

I've attached export csv files demonstrating the problem and fix, using a transfer of 6 outputs: 3 to my own wallet of values 0.01, 0.02, 0.03; and 3 to another wallet with the same amounts:
[0-premined.csv](https://github.com/monero-project/monero/files/7131970/0-premined.csv) - the export before the transfer is mined, showing an amount of 0.14 out.  (This is sort of wrong, but happens because unconfirmed transfer details do not look for transfers-to-self.  This is not affected by this PR.).
[1-mined.csv](https://github.com/monero-project/monero/files/7131971/1-mined.csv) - a mined output, showing the wrong amount (shows 0.14 out instead of 0.07 out).
[2-rescan_bc.csv](https://github.com/monero-project/monero/files/7131973/2-rescan_bc.csv) - showing what you get if you `rescan_bc` (or export from another wallet), showing the correct 0.07 out.
[3-fixed.csv](https://github.com/monero-project/monero/files/7131974/3-fixed.csv)- another transfer with this patch applied, using the same recipients and amounts as before, this time showing the correct 0.07 out (post-mining).
