### PR TITLE
CI: ccache common settings variable and apt tidying

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,19 +6,20 @@ on: [push, pull_request]
 env:
   REMOVE_BUNDLED_BOOST : rm -rf /usr/local/share/boost
   BUILD_DEFAULT_LINUX: |
-        ccache --max-size=150M
         cmake -S . -B build -D ARCH="default" -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release && cmake --build build -j3
   APT_INSTALL_LINUX: 'sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler ccache'
   APT_SET_CONF: |
-        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
         echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
+  CCACHE_SETTINGS: |
+        ccache --max-size=150M
+        ccache --set-config=compression=true
 
 jobs:
   build-macos:
     runs-on: macOS-latest
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
@@ -33,13 +34,12 @@ jobs:
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf ccache
     - name: build
       run: |
-        ccache --max-size=150M
+        ${{env.CCACHE_SETTINGS}}
         make -j3
 
   build-windows:
     runs-on: windows-latest
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: C:\Users\runneradmin\.ccache-temp
       CCACHE_DIR: C:\Users\runneradmin\.ccache
     defaults:
@@ -60,7 +60,7 @@ jobs:
         install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb mingw-w64-x86_64-unbound git
     - name: build
       run: |
-        ccache --max-size=150M
+        ${{env.CCACHE_SETTINGS}}
         make release-static-win64 -j2
 
 # See the OS labels and monitor deprecations here:
@@ -69,7 +69,6 @@ jobs:
   build-ubuntu:
     runs-on: ${{ matrix.os }}
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     strategy:
       matrix:
@@ -92,12 +91,13 @@ jobs:
     - name: install monero dependencies
       run: ${{env.APT_INSTALL_LINUX}}
     - name: build
-      run: ${{env.BUILD_DEFAULT_LINUX}}
+      run: |
+        ${{env.CCACHE_SETTINGS}}
+        ${{env.BUILD_DEFAULT_LINUX}}
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
@@ -118,7 +118,7 @@ jobs:
       run: ${{env.APT_INSTALL_LINUX}}
     - name: build
       run: |
-        ccache --max-size=150M
+        ${{env.CCACHE_SETTINGS}}
         cmake .
         make wallet_api -j3
 
@@ -126,7 +126,6 @@ jobs:
     needs: build-ubuntu
     runs-on: ubuntu-latest
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
@@ -152,6 +151,7 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: ON
       run: |
+        ${{env.CCACHE_SETTINGS}}
         ${{env.BUILD_DEFAULT_LINUX}}
         cmake --build build --target test
 

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -2,11 +2,19 @@ name: ci/gh-actions/depends
 
 on: [push, pull_request]
 
+env:
+  APT_SET_CONF: |
+        echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
+  CCACHE_SETTINGS: |
+        ccache --max-size=150M
+        ccache --set-config=compression=true
+
 jobs:
   build-macos:
     runs-on: ubuntu-18.04
     env:
-      CCACHE_COMPRESS: 1
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     strategy:
       fail-fast: false
@@ -69,10 +77,7 @@ jobs:
         key: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
         restore-keys: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
     - name: set apt conf
-      run: |
-        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+      run: ${{env.APT_SET_CONF}}
     - name: install dependencies
       run: sudo apt update; sudo apt -y install build-essential libtool cmake autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache ${{ matrix.toolchain.packages }}
     - name: prepare apple-darwin11
@@ -88,7 +93,7 @@ jobs:
         sudo update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
     - name: build
       run: |
-        ccache --max-size=150M
+        ${{env.CCACHE_SETTINGS}}
         make depends target=${{ matrix.toolchain.host }} -j2
     - uses: actions/upload-artifact@v2
       if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'x86_64-apple-darwin11' || matrix.toolchain.host == 'x86_64-unknown-linux-gnu' }}


### PR DESCRIPTION
There was a mixture of `ccache` settings set via env vars and command line. This PR unifies these settings and reuses them as a variable. Also made a tiny cleanup of the apt settings.


# OUTDATED (see comments to learn why): 


`hash_dir=false` helps in reusing the cache, when your project is named differently than the original one.

# References:
https://ccache.dev/manual/latest.html

## hash_dir (CCACHE_HASHDIR or CCACHE_NOHASHDIR, see Boolean values above)

If true (which is the default), ccache will include the current working directory (CWD) in the hash that is used to distinguish two compilations when generating debug info (compiler option -g with variations). Exception: The CWD will not be included in the hash if base_dir is set (and matches the CWD) and the compiler option -fdebug-prefix-map is used. See also the discussion under Compiling in different directories.

https://ccache.dev/manual/latest.html#_compiling_in_different_directories

## Compiling in different directories

Some information included in the hash that identifies a unique compilation can contain absolute paths:

-    The preprocessed source code may contain absolute paths to include files if the compiler option -g is used or if absolute paths are given to -I and similar compiler options.

-    Paths specified by compiler options (such as -I, -MF, etc) on the command line may be absolute.

-    The source code file path may be absolute, and that path may substituted for __FILE__ macros in the source code or included in warnings emitted to standard error by the preprocessor.

This means that if you compile the same code in different locations, you can’t share compilation results between the different build directories since you get cache misses because of the absolute build directory paths that are part of the hash.

Here’s what can be done to enable cache hits between different build directories:

-    If you build with -g (or similar) to add debug information to the object file, you must either:

-   use the compiler option -fdebug-prefix-map=<old>=<new> for relocating debug info to a common prefix (e.g. -fdebug-prefix-map=$PWD=.); or

-    set hash_dir = false.

-    If you use absolute paths anywhere on the command line (e.g. the source code file path or an argument to compiler options like -I and -MF), you must set base_dir to an absolute path to a “base directory”. Ccache will then rewrite absolute paths under that directory to relative before computing the hash.

