### PR TITLE
Add function flush_txes_from_pool() to enable thread safe method of flushing the entire pool

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3995,6 +3995,17 @@ bool Blockchain::flush_txes_from_pool(const std::vector<crypto::hash> &txids)
   return res;
 }
 //------------------------------------------------------------------
+bool Blockchain::flush_txes_from_pool()
+{
+  CRITICAL_REGION_LOCAL(m_tx_pool);
+
+  std::vector<crypto::hash> txids;
+  bool include_sensitive = true;
+  m_tx_pool.get_transaction_hashes(txids, include_sensitive);
+
+  return flush_txes_from_pool(txids);
+}
+//------------------------------------------------------------------
 //      Needs to validate the block and acquire each transaction from the
 //      transaction mem_pool, then pass the block and transactions to
 //      m_db->add_block()

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -877,6 +877,13 @@ namespace cryptonote
     bool flush_txes_from_pool(const std::vector<crypto::hash> &txids);
 
     /**
+     * @brief remove all transactions from the transaction pool (if present)
+     *
+     * @return false if any removals fail, otherwise true
+     */
+    bool flush_txes_from_pool();
+
+    /**
      * @brief return a histogram of outputs on the blockchain
      *
      * @param amounts optional set of amounts to lookup

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2493,30 +2493,16 @@ namespace cryptonote
   {
     RPC_TRACKER(flush_txpool);
 
-    bool failed = false;
+    bool failed_to_parse = false;
     std::vector<crypto::hash> txids;
-    if (req.txids.empty())
-    {
-      std::vector<transaction> pool_txs;
-      bool r = m_core.get_pool_transactions(pool_txs, true);
-      if (!r)
-      {
-        res.status = "Failed to get txpool contents";
-        return true;
-      }
-      for (const auto &tx: pool_txs)
-      {
-        txids.push_back(cryptonote::get_transaction_hash(tx));
-      }
-    }
-    else
+    if (!req.txids.empty())
     {
       for (const auto &str: req.txids)
       {
         crypto::hash txid;
         if(!epee::string_tools::hex_to_pod(str, txid))
         {
-          failed = true;
+          failed_to_parse = true;
         }
         else
         {
@@ -2524,13 +2510,13 @@ namespace cryptonote
         }
       }
     }
-    if (!m_core.get_blockchain_storage().flush_txes_from_pool(txids))
+    if (req.txids.empty() ? !m_core.get_blockchain_storage().flush_txes_from_pool() : !m_core.get_blockchain_storage().flush_txes_from_pool(txids))
     {
       res.status = "Failed to remove one or more tx(es)";
       return false;
     }
 
-    if (failed)
+    if (failed_to_parse)
     {
       if (txids.empty())
         res.status = "Failed to parse txid";

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -771,13 +771,11 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
   c.get_blockchain_storage().get_db().set_batch_transactions(true);
 
   // start with a clean pool
-  std::vector<crypto::hash> pool_txs;
-  if (!c.get_pool_transaction_hashes(pool_txs))
+  if (!c.get_blockchain_storage().flush_txes_from_pool())
   {
     MERROR("Failed to flush txpool");
     return false;
   }
-  c.get_blockchain_storage().flush_txes_from_pool(pool_txs);
 
   t_test_class validator;
   bool ret = replay_events_through_core<t_test_class>(c, events, validator);
@@ -789,13 +787,11 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
 template<class t_test_class>
 inline bool replay_events_through_core_validate(std::vector<test_event_entry>& events, cryptonote::core & c)
 {
-  std::vector<crypto::hash> pool_txs;
-  if (!c.get_pool_transaction_hashes(pool_txs))
+  if (!c.get_blockchain_storage().flush_txes_from_pool())
   {
     MERROR("Failed to flush txpool");
     return false;
   }
-  c.get_blockchain_storage().flush_txes_from_pool(pool_txs);
 
   t_test_class validator;
   return replay_events_through_core_plain<t_test_class>(c, events, validator, false);

--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -319,9 +319,7 @@ static bool init_core_replay_events(std::vector<test_event_entry>& events, crypt
   core->get_blockchain_storage().get_db().set_batch_transactions(true);
 
   // start with a clean pool
-  std::vector<crypto::hash> pool_txs;
-  CHECK_AND_ASSERT_THROW_MES(core->get_pool_transaction_hashes(pool_txs), "Failed to flush txpool");
-  core->get_blockchain_storage().flush_txes_from_pool(pool_txs);
+  CHECK_AND_ASSERT_THROW_MES(core->get_blockchain_storage().flush_txes_from_pool(), "Failed to flush txpool");
 
   t_test_class validator;
   return replay_events_through_core<t_test_class>(*core, events, validator);


### PR DESCRIPTION
### Overview

Add a thread safe way to flush all transactions from the pool.

### Details

Prior to this PR, the only function available to flush the pool was `blockchain.cpp:flush_txes_from_poolI(txids)`. The caller would need to provide `txids` of all hashes to remove. If the caller wanted to flush the entire pool, they would first need to read the db for all pool txes, and then pass the `txids` of those txes into the `flush_txes_from_pool`. With that approach, txes could enter/exit the pool *after* the caller retrieves the list of all `txids`, but *before* flushing.

**Solution**

- Added a new function `flush_txes_from_pool()` with no params that flushes the entire pool
- The function grabs the tx pool lock and reads all txes from the pool, then calls the updated `flush_txes_from_pool(txids)` with the pool's `txids`. Since it's inside the critical region, no tx's should enter/exit the pool when the caller flushes the entire pool