### PR TITLE
Makefile: release-rpi target for NO_AES rpi binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ release-all:
 	mkdir -p $(builddir)/release
 	cd $(builddir)/release && cmake -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release $(topdir) && $(MAKE)
 
+release-rpi:
+	mkdir -p $(builddir)/release-rpi
+	cd $(builddir)/release-rpi && cmake -D NO_AES=ON -D CMAKE_BUILD_TYPE=release $(topdir) && $(MAKE)
+
 release-static:
 	mkdir -p $(builddir)/release
 	cd $(builddir)/release && cmake -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release $(topdir) && $(MAKE)

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Tested on a Raspberry Pi Zero with a clean install of minimal Raspbian Stretch (
 * Build:
 
     ```bash
-    USE_SINGLE_BUILDDIR=1 make release
+    USE_SINGLE_BUILDDIR=1 make release-rpi
     ```
 
 * Wait 4-6 hours


### PR DESCRIPTION
Originally coming from https://github.com/monero-project/monero/pull/7946 and PRd by @ArqTras, but now with just 1 commit. The appropriate `author` field has been set accordingly.