### PR TITLE
[DO NOT MERGE] Some LOG_ERROR messages disappear when headers are included

### DIFF
--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -31,6 +31,7 @@
 
 #include "common/command_line.h"
 #include "cryptonote_config.h"
+#include "cryptonote_core/cryptonote_core.h"
 #include "daemonizer/daemonizer.h"
 
 namespace daemon_args

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -122,6 +122,7 @@ monero_add_library(daemon_rpc_server
 target_link_libraries(rpc_base
   PUBLIC
     common
+    cryptonote_core
     epee
     ${Boost_REGEX_LIBRARY}
     ${Boost_THREAD_LIBRARY}

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -33,6 +33,7 @@
 #include <functional>
 #include "common/command_line.h"
 #include "common/i18n.h"
+#include "daemon/command_line_args.h"
 #include "hex.h"
 
 namespace cryptonote


### PR DESCRIPTION
Runing the command `monerod --rpc-access-control-origins '*'` on master shows an error message (this is fine):

    E rpc-access-control-origins requires RPC server password --rpc-login cannot be empty

However, running the same command with these changes does not show that error. This behavior is consistent no matter what other arguments are supplied, network type, platform, etc. I will note that the message is logged in bitmonero.log, just not on the terminal. It is not clear to me why this is happening, but it appears to be a bug. Finding out why this is happening might benefit future development.