### PR TITLE
wallet2: fix key encryption when changing ask-password from 0/1 to 2

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1798,9 +1798,7 @@ private:
     crypto::secret_key m_original_view_secret_key;
 
     crypto::chacha_key m_cache_key;
-    boost::optional<epee::wipeable_string> m_encrypt_keys_after_refresh;
-    boost::mutex m_decrypt_keys_lock;
-    unsigned int m_decrypt_keys_lockers;
+    std::shared_ptr<wallet_keys_unlocker> m_encrypt_keys_after_refresh;
 
     bool m_unattended;
     bool m_devices_registered;


### PR DESCRIPTION
we reuse the wallet_keys_unlocker object, which does the right thing
in conjunction with other users of decrypt/encrypt (ie, refresh).