### PR TITLE
unit tests: Harden flaky decoy output selection tests

### DIFF
--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -109,28 +109,48 @@ TEST(select_outputs, order)
     offset = n_outs += (n); \
   }
 
+void pick_outputs(size_t npicks, std::vector<uint64_t> offsets, size_t n_outs, tools::gamma_picker picker, double &median)
+{
+  std::vector<double> ages(npicks);
+  double age_scale = 120. * (offsets.size() / (double)n_outs);
+  for (size_t i = 0; i < ages.size(); )
+  {
+    uint64_t o = picker.pick();
+    bool acceptable_bad_pick = o == std::numeric_limits<uint64_t>::max();
+    if (acceptable_bad_pick)
+      continue;
+    ages[i] = (n_outs - 1 - o) * age_scale;
+    ASSERT_GE(ages[i], CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE * 120);
+    ASSERT_LE(ages[i], offsets.size() * 120);
+    ++i;
+  }
+  median = epee::misc_utils::median(ages);
+}
+
+// TODO: deterministic tests would be nice
 TEST(select_outputs, gamma)
 {
   std::vector<uint64_t> offsets;
 
   MKOFFSETS(300000, 1);
   tools::gamma_picker picker(offsets);
-  std::vector<double> ages(100000);
-  double age_scale = 120. * (offsets.size() / (double)n_outs);
-  for (size_t i = 0; i < ages.size(); )
-  {
-    uint64_t o = picker.pick();
-    if (o >= n_outs)
-      continue;
-    ages[i] = (n_outs - 1 - o) * age_scale;
-    ASSERT_GE(ages[i], 0);
-    ASSERT_LE(ages[i], offsets.size() * 120);
-    ++i;
-  }
-  double median = epee::misc_utils::median(ages);
-  MDEBUG("median age: " << median / 86400. << " days");
-  ASSERT_GE(median, 1.3 * 86400);
-  ASSERT_LE(median, 1.4 * 86400);
+
+  size_t NPICKS = 100000;
+  double median = 0;
+  pick_outputs(NPICKS, offsets, n_outs, picker, median);
+
+  // expected median is ~115,100s, or 1.33 * 86400. Calculated by running the algorithm
+  // under the same conditions as the paper (outputs <10 blocks old can be selected, and
+  // are selected from chain tip)
+  double MEDIAN_LOWER_BOUND = 1.28 * 86400;
+  double MEDIAN_UPPER_BOUND = 1.38 * 86400;
+
+  // should be rare, but if needed, 10x NPICKS and try again to get a more accurate median
+  if (median < MEDIAN_LOWER_BOUND || median > MEDIAN_UPPER_BOUND)
+    pick_outputs(NPICKS * 10, offsets, n_outs, picker, median);
+
+  ASSERT_GE(median, MEDIAN_LOWER_BOUND);
+  ASSERT_LE(median, MEDIAN_UPPER_BOUND);
 }
 
 TEST(select_outputs, density)
@@ -145,15 +165,16 @@ TEST(select_outputs, density)
   for (int i = 0; i < NPICKS; )
   {
     uint64_t o = picker.pick();
-    if (o >= n_outs)
+    if (o == std::numeric_limits<uint64_t>::max())
       continue;
     auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
-    ASSERT_LT(idx, picks.size());
+    ASSERT_LT(idx, offsets.size() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
     ++picks[idx];
     ++i;
   }
 
+  std::vector<float> selected_ratios;
   for (int d = 1; d < 0x20; ++d)
   {
     // count the number of times an output in a block of d outputs was selected
@@ -172,8 +193,16 @@ TEST(select_outputs, density)
     float chain_ratio = count_chain / (float)n_outs;
     MDEBUG(count_selected << "/" << NPICKS << " outputs selected in blocks of density " << d << ", " << 100.0f * selected_ratio << "%");
     MDEBUG(count_chain << "/" << offsets.size() << " outputs in blocks of density " << d << ", " << 100.0f * chain_ratio << "%");
-    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.025f);
+    ASSERT_GT(selected_ratio, 0.0f);
+    ASSERT_GT(chain_ratio, 0.0f);
+
+    float MAX_DEVIATION = 2.25f;
+    ASSERT_GT(MAX_DEVIATION * selected_ratio, chain_ratio);
+    ASSERT_GT(MAX_DEVIATION * chain_ratio, selected_ratio);
+
+    selected_ratios.push_back(selected_ratio);
   }
+  ASSERT_LT(selected_ratios[0], selected_ratios[selected_ratios.size() - 1]);
 }
 
 TEST(select_outputs, same_distribution)
@@ -189,11 +218,11 @@ TEST(select_outputs, same_distribution)
   for (int i = 0; i < NPICKS; )
   {
     uint64_t o = picker.pick();
-    if (o >= n_outs)
+    if (o == std::numeric_limits<uint64_t>::max())
       continue;
     auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
-    ASSERT_LT(idx, chain_picks.size());
+    ASSERT_LT(idx, offsets.size() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
     ++chain_picks[idx];
     ++output_picks[o];
     ++i;
@@ -216,5 +245,5 @@ TEST(select_outputs, same_distribution)
   }
   avg_dev /= 100;
   MDEBUG("avg_dev: " << avg_dev);
-  ASSERT_LT(avg_dev, 0.02);
+  ASSERT_LT(avg_dev, 0.025);
 }


### PR DESCRIPTION
### Overview

Since gamma tests are not deterministic, there is a non-0 chance they can fail. The recent set of changes to the decoy selection algo (#7821) seem to cause a marginally higher failure rate in the tests. This PR makes small changes to the tests to get them to pass at a much higher frequency, so that they don't disrupt CI, while still maintaining a solid bar to pass.

It would be nice to eventually have deterministic tests using a random seed(s) so that results are reproducible.

### Summary of changes

**select_outputs.gamma**

This tests the median age of selected outputs is the expected median. I decreased the expected median to account for recent changes to the algorithm & added logic to re-attempt the test with a 10x larger sample size if the test fails on first try.

**select_outputs.density**

This tests that outputs from blocks of various sizes are picked in sufficient proportion by the algorithm. I allowed a wider deviation from chain data to selected data for larger blocks, and a smaller deviation for smaller blocks (the allowed deviation is proportional to size now) + tested some other sensible heuristics.

**select_outputs.same_distribution**

This tests that the distribution of outputs picked matches the distribution of blocks which they are part of are picked. I allowed a slightly wider deviation from chain data to selected data.

### Results

I ran all gamma tests 130k times *before* making the final changes included in this PR (special thank you to @Gingeropolous  for letting me use his monster machines), here were my results:

**9 failures total**
`select_outputs.gamma:` 0 failures
`select_outputs.density`: 2 failures
`select_outputs.same_distribution`: 7 failures

#### select_outputs.density

Using a `MAX_DEVIATION` of 2.0, I got the following 2 errors:

```
Expected: (MAX_DEVIATION * chain_ratio) > (selected_ratio), actual: 0.00381708 vs 0.003865
Expected: (MAX_DEVIATION * chain_ratio) > (selected_ratio), actual: 0.00743647 vs 0.007587
```

Going with a `MAX_DEVIATION` > 2.113 would have avoided both. So I increased the `MAX_DEVIATION` to 2.25 in this final PR just to add a decent buffer within reason.

#### select_outputs.same_distribution

Sticking with the original allowed `avg_dev` of 0.02, I got the following 7 errors:

```
Expected: (avg_dev) < (0.02), actual: 0.020848 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.0204963 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.0201313 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.0200123 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.0214195 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.0218481 vs 0.02
Expected: (avg_dev) < (0.02), actual: 0.020335 vs 0.02
```

Bumping to 0.0219 would have avoided all the above errors, so I went with 0.025 following the same logic.