### PR TITLE
cmake: remove including non-existent directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,10 +451,7 @@ endif()
 include_directories(external/rapidjson/include external/easylogging++ src contrib/epee/include external external/supercop/include)
 
 if(APPLE)
-  include_directories(SYSTEM /usr/include/malloc)
-  if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
-  endif()
+  cmake_policy(SET CMP0042 NEW)
 endif()
 
 if(MSVC OR MINGW)


### PR DESCRIPTION
There is no `/usr/include/malloc` on macOS and it builds fine without.

Also CMP0042 always exists with out minimum version, no need to check for it explicitly.