### PR TITLE
Avoid nullptr dereference when constructing `Blockchain` and `tx_memory_pool`

### DIFF
--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -41,6 +41,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"
 #include "blockchain_db/blockchain_db.h"
+#include "blockchain_and_pool.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -449,9 +450,7 @@ int main(int argc, char* argv[])
   // because unlike blockchain_storage constructor, which takes a pointer to
   // tx_memory_pool, Blockchain's constructor takes tx_memory_pool object.
   LOG_PRINT_L0("Initializing source blockchain (BlockchainDB)");
-  std::unique_ptr<Blockchain> core_storage;
-  tx_memory_pool m_mempool(*core_storage);
-  core_storage.reset(new Blockchain(m_mempool));
+  std::unique_ptr<BlockchainAndPool> core_storage = std::make_unique<BlockchainAndPool>();
   BlockchainDB *db = new_db();
   if (db == NULL)
   {
@@ -472,7 +471,7 @@ int main(int argc, char* argv[])
     LOG_PRINT_L0("Error opening database: " << e.what());
     return 1;
   }
-  r = core_storage->init(db, net_type);
+  r = core_storage->blockchain.init(db, net_type);
 
   CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
   LOG_PRINT_L0("Source blockchain storage initialized OK");
@@ -716,7 +715,7 @@ int main(int argc, char* argv[])
   }
 
 done:
-  core_storage->deinit();
+  core_storage->blockchain.deinit();
 
   if (opt_show_cache_stats)
   MINFO("cache: txes " << std::to_string(cached_txes*100./total_txes)

--- a/src/blockchain_utilities/blockchain_and_pool.h
+++ b/src/blockchain_utilities/blockchain_and_pool.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2014-2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list
+//    of conditions and the following disclaimer in the documentation and/or
+//    other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be
+//    used to endorse or promote products derived from this software without
+//    specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "cryptonote_core/blockchain.h"
+#include "cryptonote_core/tx_pool.h"
+
+struct BlockchainAndPool {
+  cryptonote::Blockchain blockchain;
+  cryptonote::tx_memory_pool tx_pool;
+
+  BlockchainAndPool() : blockchain(tx_pool), tx_pool(blockchain) {}
+};

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -35,6 +35,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"
 #include "blockchain_db/blockchain_db.h"
+#include "blockchain_and_pool.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -129,16 +130,8 @@ int main(int argc, char* argv[])
   // Use Blockchain instead of lower-level BlockchainDB for two reasons:
   // 1. Blockchain has the init() method for easy setup
   // 2. exporter needs to use get_current_blockchain_height(), get_block_id_by_height(), get_block_by_hash()
-  //
-  // cannot match blockchain_storage setup above with just one line,
-  // e.g.
-  //   Blockchain* core_storage = new Blockchain(NULL);
-  // because unlike blockchain_storage constructor, which takes a pointer to
-  // tx_memory_pool, Blockchain's constructor takes tx_memory_pool object.
   LOG_PRINT_L0("Initializing source blockchain (BlockchainDB)");
-  std::unique_ptr<Blockchain> core_storage;
-  tx_memory_pool m_mempool(*core_storage);
-  core_storage.reset(new Blockchain(m_mempool));
+  std::unique_ptr<BlockchainAndPool> core_storage = std::make_unique<BlockchainAndPool>();
   BlockchainDB *db = new_db();
   if (db == NULL)
   {
@@ -159,7 +152,7 @@ int main(int argc, char* argv[])
     LOG_PRINT_L0("Error opening database: " << e.what());
     return 1;
   }
-  r = core_storage->init(db, net_type);
+  r = core_storage->blockchain.init(db, net_type);
 
   CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
   LOG_PRINT_L0("Source blockchain storage initialized OK");
@@ -327,7 +320,7 @@ done:
   LOG_PRINT_L0("Average min depth for " << start_txids.size() << " transaction(s): " << cumulative_depth/(float)depths.size());
   LOG_PRINT_L0("Median min depth for " << start_txids.size() << " transaction(s): " << epee::misc_utils::median(depths));
 
-  core_storage->deinit();
+  core_storage->blockchain.deinit();
   return 0;
 
   CATCH_ENTRY("Depth query error", 1);

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -32,6 +32,7 @@
 #include <boost/system/error_code.hpp>
 #include <boost/filesystem.hpp>
 #include "common/command_line.h"
+#include "blockchain_and_pool.h"
 #include "common/pruning.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"
@@ -516,22 +517,15 @@ int main(int argc, char* argv[])
   // Use Blockchain instead of lower-level BlockchainDB for two reasons:
   // 1. Blockchain has the init() method for easy setup
   // 2. exporter needs to use get_current_blockchain_height(), get_block_id_by_height(), get_block_by_hash()
-  //
-  // cannot match blockchain_storage setup above with just one line,
-  // e.g.
-  //   Blockchain* core_storage = new Blockchain(NULL);
-  // because unlike blockchain_storage constructor, which takes a pointer to
-  // tx_memory_pool, Blockchain's constructor takes tx_memory_pool object.
   MINFO("Initializing source blockchain (BlockchainDB)");
-  std::array<std::unique_ptr<Blockchain>, 2> core_storage;
-  Blockchain *blockchain = NULL;
-  tx_memory_pool m_mempool(*blockchain);
+  std::array<std::unique_ptr<BlockchainAndPool>, 2> core_storage{
+      std::make_unique<BlockchainAndPool>(),
+      std::make_unique<BlockchainAndPool>()};
+
   boost::filesystem::path paths[2];
   bool already_pruned = false;
   for (size_t n = 0; n < core_storage.size(); ++n)
   {
-    core_storage[n].reset(new Blockchain(m_mempool));
-
     BlockchainDB* db = new_db();
     if (db == NULL)
     {
@@ -576,12 +570,12 @@ int main(int argc, char* argv[])
       MERROR("Error opening database: " << e.what());
       return 1;
     }
-    r = core_storage[n]->init(db, net_type);
+    r = core_storage[n]->blockchain.init(db, net_type);
 
     std::string source_dest = n == 0 ? "source" : "pruned";
     CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize " << source_dest << " blockchain storage");
     MINFO(source_dest << " blockchain storage initialized OK");
-    if (n == 0 && core_storage[0]->get_blockchain_pruning_seed())
+    if (n == 0 && core_storage[0]->blockchain.get_blockchain_pruning_seed())
     {
       if (!opt_copy_pruned_database)
       {
@@ -591,9 +585,9 @@ int main(int argc, char* argv[])
       already_pruned = true;
     }
   }
-  core_storage[0]->deinit();
+  core_storage[0]->blockchain.deinit();
   core_storage[0].reset(NULL);
-  core_storage[1]->deinit();
+  core_storage[1]->blockchain.deinit();
   core_storage[1].reset(NULL);
 
   MINFO("Pruning...");

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -34,6 +34,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"
 #include "blockchain_db/blockchain_db.h"
+#include "blockchain_and_pool.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -160,9 +161,8 @@ int main(int argc, char* argv[])
   const std::string input = command_line::get_arg(vm, arg_input);
 
   LOG_PRINT_L0("Initializing source blockchain (BlockchainDB)");
-  std::unique_ptr<Blockchain> core_storage;
-  tx_memory_pool m_mempool(*core_storage);
-  core_storage.reset(new Blockchain(m_mempool));
+  std::unique_ptr<BlockchainAndPool> core_storage = std::make_unique<BlockchainAndPool>();
+
   BlockchainDB *db = new_db();
   if (db == NULL)
   {
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
     LOG_PRINT_L0("Error opening database: " << e.what());
     return 1;
   }
-  r = core_storage->init(db, net_type);
+  r = core_storage->blockchain.init(db, net_type);
 
   CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
   LOG_PRINT_L0("Source blockchain storage initialized OK");
@@ -280,7 +280,7 @@ int main(int argc, char* argv[])
   MINFO("Prunable outputs: " << num_prunable_outputs);
 
   LOG_PRINT_L0("Blockchain known spent data pruned OK");
-  core_storage->deinit();
+  core_storage->blockchain.deinit();
   return 0;
 
   CATCH_ENTRY("Error", 1);

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -31,6 +31,7 @@
 #include "common/command_line.h"
 #include "common/varint.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
+#include "blockchain_and_pool.h"
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_core/blockchain.h"
@@ -132,9 +133,8 @@ int main(int argc, char* argv[])
   bool do_diff = command_line::get_arg(vm, arg_diff);
 
   LOG_PRINT_L0("Initializing source blockchain (BlockchainDB)");
-  std::unique_ptr<Blockchain> core_storage;
-  tx_memory_pool m_mempool(*core_storage);
-  core_storage.reset(new Blockchain(m_mempool));
+  std::unique_ptr<BlockchainAndPool> core_storage = std::make_unique<BlockchainAndPool>();
+
   BlockchainDB *db = new_db();
   if (db == NULL)
   {
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
     LOG_PRINT_L0("Error opening database: " << e.what());
     return 1;
   }
-  r = core_storage->init(db, net_type);
+  r = core_storage->blockchain.init(db, net_type);
 
   CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
   LOG_PRINT_L0("Source blockchain storage initialized OK");
@@ -372,7 +372,7 @@ skip:
       break;
   }
 
-  core_storage->deinit();
+  core_storage->blockchain.deinit();
   return 0;
 
   CATCH_ENTRY("Stats reporting error", 1);


### PR DESCRIPTION
Until now `Blockchain` and `tx_memory_pool` is constructed like the following:
```cpp
std::unique_ptr<Blockchain> core_storage;
tx_memory_pool m_mempool(*core_storage);
core_storage.reset(new Blockchain(m_mempool));
```
This contains a nullptr dereference.

This PR fixes this by introducing a new struct `BlockchainAndPool`
```cpp
struct BlockchainAndPool {
  cryptonote::Blockchain blockchain;
  cryptonote::tx_memory_pool tx_pool;

  BlockchainAndPool() : blockchain(tx_pool), tx_pool(blockchain) {}
};
```
which is used to construct `Blockchain` and `tx_memory_pool` to avoid the nullptr dereferencation.