### PR TITLE
Avoid unnecessary 'Invalid hashing blob' error message

### DIFF
--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -306,7 +306,12 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_payment_info(bool mining, boo
     m_rpc_payment_seed_height = resp_t.seed_height;
     m_rpc_payment_cookie = resp_t.cookie;
 
-    if (!epee::string_tools::parse_hexstr_to_binbuff(resp_t.hashing_blob, m_rpc_payment_blob) || m_rpc_payment_blob.size() < 43)
+    if (m_rpc_payment_diff == 0)
+    {
+      // If no payment required daemon doesn't give us back a hashing blob
+      m_rpc_payment_blob.clear();
+    }
+    else if (!epee::string_tools::parse_hexstr_to_binbuff(resp_t.hashing_blob, m_rpc_payment_blob) || m_rpc_payment_blob.size() < 43)
     {
       MERROR("Invalid hashing blob: " << resp_t.hashing_blob);
       return std::string("Invalid hashing blob");


### PR DESCRIPTION
If Pay For RPC is not active the daemon RPC call `rpc_access_info` does not return a hashing blob, and trying to parse the hex string in `NodeRPCProxy::get_rpc_payment_info` as it's currently done results in an unnecessary error message that will appear repeatedly in a wallet log file is logging is active.