### PR TITLE
crypto: fix ge_p3_is_point_at_infinity()

### DIFF
--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -162,4 +162,4 @@ void fe_add(fe h, const fe f, const fe g);
 void fe_tobytes(unsigned char *, const fe);
 void fe_invert(fe out, const fe z);
 
-int ge_p3_is_point_at_infinity(const ge_p3 *p);
+int ge_p3_is_point_at_infinity_vartime(const ge_p3 *p);

--- a/src/ringct/multiexp.cc
+++ b/src/ringct/multiexp.cc
@@ -235,7 +235,7 @@ rct::key bos_coster_heap_conv_robust(std::vector<MultiexpData> data)
   heap.reserve(points);
   for (size_t n = 0; n < points; ++n)
   {
-    if (!(data[n].scalar == rct::zero()) && !ge_p3_is_point_at_infinity(&data[n].point))
+    if (!(data[n].scalar == rct::zero()) && !ge_p3_is_point_at_infinity_vartime(&data[n].point))
       heap.push_back(n);
   }
   points = heap.size();
@@ -457,7 +457,7 @@ rct::key straus(const std::vector<MultiexpData> &data, const std::shared_ptr<str
   MULTIEXP_PERF(PERF_TIMER_START_UNIT(skip, 1000000));
   std::vector<uint8_t> skip(data.size());
   for (size_t i = 0; i < data.size(); ++i)
-    skip[i] = data[i].scalar == rct::zero() || ge_p3_is_point_at_infinity(&data[i].point);
+    skip[i] = data[i].scalar == rct::zero() || ge_p3_is_point_at_infinity_vartime(&data[i].point);
   MULTIEXP_PERF(PERF_TIMER_STOP(skip));
 #endif
 

--- a/tests/crypto/crypto-tests.h
+++ b/tests/crypto/crypto-tests.h
@@ -46,4 +46,6 @@ void random_scalar(crypto::ec_scalar &res);
 void hash_to_scalar(const void *data, std::size_t length, crypto::ec_scalar &res);
 void hash_to_point(const crypto::hash &h, crypto::ec_point &res);
 void hash_to_ec(const crypto::public_key &key, crypto::ec_point &res);
+bool check_ge_p3_identity_failure(const crypto::public_key &point);
+bool check_ge_p3_identity_success(const crypto::public_key &point);
 #endif

--- a/tests/crypto/main.cpp
+++ b/tests/crypto/main.cpp
@@ -259,6 +259,16 @@ int main(int argc, char *argv[]) {
       if (expected != actual) {
         goto error;
       }
+    } else if (cmd == "check_ge_p3_identity") {
+      cerr << "Testing: " << cmd << endl;
+      public_key point;
+      bool expected_bad, expected_good, result_badfunc, result_goodfunc;
+      get(input, point, expected_bad, expected_good);
+      result_badfunc = check_ge_p3_identity_failure(point);
+      result_goodfunc = check_ge_p3_identity_success(point);
+      if (expected_bad != result_badfunc || expected_good != result_goodfunc) {
+        goto error;
+      }
     } else {
       throw ios_base::failure("Unknown function: " + cmd);
     }


### PR DESCRIPTION
### Summary
The function `ge_p3_is_point_at_infinity()` is naively evaluating field elements that haven't been reduced by the field order.

### Problem severity/impact
Low, this function is not currently used for anything important (only performance testing of some `multiexp` functions). In general, whether a crypto element is reduced mod its group/field order or not, is only important in byte-aware contexts such as byte-wise comparisons (as in this case), or hash inputs (`ge_p3` point representations are never hashed in Monero).

### Fix
Convert all field elements in the input `ge_p3` point to canonical representation (32-byte numbers reduced `mod q`) before evaluating them.

### Visibility
I added test cases with experimentally-found failures of the old function (these occurred in ~1 in 600k random `ge_p3` point representations of the identity element).

### Impact
Unfortunately, doing these conversions somewhat reduces the utility of `ge_p3_is_point_at_infinity()`, which was originally much more efficient than fully converting a `ge_p3` point representation to compressed-point representation with `ge_tobytes()` and doing a byte-wise comparison with the identity element. It is still more efficient, just not _as_ efficient.

### References
- [Paper that introduced extended Twisted Edwards coordinates (i.e. `ge_p3`)](https://eprint.iacr.org/2008/522)