### PR TITLE
cryptonote_core: fix unused lambda warning

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1581,7 +1581,7 @@ namespace cryptonote
 
     // get all txids
     std::vector<tx_entry_t> txes;
-    m_blockchain.for_all_txpool_txes([this, &txes](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
+    m_blockchain.for_all_txpool_txes([&txes](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       if (!meta.pruned) // skip pruned txes
         txes.push_back({txid, meta});
       return true;


### PR DESCRIPTION
```
/Users/administrator/monero/src/cryptonote_core/tx_pool.cpp:1584:39: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
    m_blockchain.for_all_txpool_txes([this, &txes](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
                                      ^~~~~
```