### PR TITLE
CI: Mac OS-11 transitioning before 13 Dec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,15 @@ env:
 
 jobs:
   build-macos:
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os }}
     env:
       CCACHE_TEMPDIR: /tmp/.ccache-temp
+    strategy:
+      matrix:
+        os: [macOS-latest, macOS-11]
+# TODO: After 13 Dec. 2021 (*) the above line should become either:  (* https://github.com/actions/virtual-environments/issues/4060 )
+#        os: [macOS-latest, macOS-10.15]  - to retain mac10 compatibility and check also against mac11, or
+#        os: [macOS-latest]               - to   drop mac10 compatibility and check only against mac11, but ease the future transitions
     steps:
     - uses: actions/checkout@v1
       with:
@@ -28,8 +34,8 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: /Users/runner/Library/Caches/ccache
-        key: ccache-${{ runner.os }}-build-${{ github.sha }}
-        restore-keys: ccache-${{ runner.os }}-build-
+        key:          ccache-${{ runner.os }}-build-${{ matrix.os }}-${{ github.sha }}
+        restore-keys: ccache-${{ runner.os }}-build-${{ matrix.os }}
     - name: install dependencies
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc ldns expat libunwind-headers protobuf ccache
     - name: build


### PR DESCRIPTION
GH Actions will replace the `macOS-10.15` (aliased as `macOS-latest`)  with `Mac OS-11` on 13 Dec.

The change uses an OS Matrix, to make the change smoother, as well as future changes and backward compatibility efforts.

[Reference](https://github.com/actions/virtual-environments/issues/4060)

> Breaking changes
> macOS-11 is ready to be the default version for the "macos-latest" label in GitHub Actions and Azure DevOps.

> Target date
> This change will be rolled out over a period of several weeks beginning on September, 15. We plan to complete the migration > by November, 3 December, 13.