### PR TITLE
Fix docker instructions to account for non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,10 +612,10 @@ More info and versions in the [Debian package tracker](https://tracker.debian.or
     docker build --build-arg NPROC=1 -t monero .
 
     # either run in foreground
-    docker run -it -v /monero/chain:/root/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
+    docker run -it -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
 
     # or in background
-    docker run -it -d -v /monero/chain:/root/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
+    docker run -it -d -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
     ```
 
 * The build needs 3 GB space.


### PR DESCRIPTION
Since the non-root user 'monero' is specified in the Dockerfile, the
bind mount when running the container should be set to this user's home
directory be default, not the root user's home directory.