### PR TITLE
Fixed warnings for Clang (used as CMAKE_CXX compiler)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,7 +764,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAG}")
 
   set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if(ARM)
       set(WARNINGS "${WARNINGS} -Wno-error=inline-asm")
     endif()


### PR DESCRIPTION
I set Clang as `CMAKE_CXX` compiler. Due to non-existent warnings flags of Clang, in the building phase, an annoying number of `unknown warning option` is printed.

This patch, badly, fixes this problem. Since it's one of my first patches on Monero repository and I have no knowledge of CMake, please let me know about any feedback.