### PR TITLE
Use CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,6 @@ EXPOSE 18081
 # switch to user monero
 USER monero
 
-ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"]
+ENTRYPOINT ["monerod"]
+CMD ["--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"]
 


### PR DESCRIPTION
According to Dockerfile best practices
(https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint)
the best use for ENTRYPOINT is to set the image’s main command and then
use CMD as the default flags. This makes it easier to change the flags
passed to monerod when running the Docker image.