### PR TITLE
Balance includes unconfirmed transfers to self

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6126,6 +6126,19 @@ std::map<uint32_t, uint64_t> wallet2::balance_per_subaddress(uint32_t index_majo
         amount_per_subaddr[0] = utx.second.m_change;
       else
         found->second += utx.second.m_change;
+
+      // add transfers to same wallet
+      for (const auto &dest: utx.second.m_dests) {
+        auto index = get_subaddress_index(dest.addr);
+        if (index && (*index).major == index_major)
+        {
+          auto found = amount_per_subaddr.find((*index).minor);
+          if (found == amount_per_subaddr.end())
+            amount_per_subaddr[(*index).minor] = dest.amount;
+          else
+            found->second += dest.amount;
+        }
+      }
     }
    }
 

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -171,7 +171,7 @@ class TransferTest():
         assert e.double_spend_seen == False
         assert not 'confirmations' in e or e.confirmations == 0
 
-        running_balances[0] -= 1000000000000 + fee
+        running_balances[0] -= fee
 
         res = self.wallet[0].get_balance()
         assert res.balance == running_balances[0]
@@ -182,8 +182,6 @@ class TransferTest():
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
         self.wallet[0].refresh()
-
-        running_balances[0] += 1000000000000
 
         res = self.wallet[0].get_transfers()
         assert len(res['in']) == height # coinbases
@@ -337,7 +335,7 @@ class TransferTest():
         assert len(res.unsigned_txset) == 0
         unsigned_txset = res.unsigned_txset
 
-        running_balances[0] -= 1000000000000 + 1100000000000 + 1200000000000 + fee
+        running_balances[0] -= 1100000000000 + 1200000000000 + fee
 
         res = self.wallet[0].get_balance()
         assert res.balance == running_balances[0]
@@ -347,7 +345,6 @@ class TransferTest():
         daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
-        running_balances[0] += 1000000000000
         running_balances[1] += 1100000000000
         running_balances[2] += 1200000000000
         self.wallet[0].refresh()


### PR DESCRIPTION
Closes #8073

The wallet balance should correctly reflect unconfirmed transfers and change when used with #6986 and when strict mode is false.