### PR TITLE
[Feature Request] Give monerod node operators the ability to add a custom string to the get_info rpc call

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -534,6 +534,7 @@ namespace cryptonote
     res.version = restricted ? "" : MONERO_VERSION_FULL;
     res.synchronized = check_core_ready();
     res.busy_syncing = m_p2p.get_payload_object().is_busy_syncing();
+    res.node_info = getenv("MONERO_NODE_INFO") ? getenv("MONERO_NODE_INFO") : "{}";
 
     res.status = CORE_RPC_STATUS_OK;
     return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -687,6 +687,7 @@ namespace cryptonote
       uint64_t database_size;
       bool update_available;
       bool busy_syncing;
+      std::string node_info;
       std::string version;
       bool synchronized;
 
@@ -728,6 +729,7 @@ namespace cryptonote
         KV_SERIALIZE(database_size)
         KV_SERIALIZE(update_available)
         KV_SERIALIZE(busy_syncing)
+        KV_SERIALIZE(node_info)
         KV_SERIALIZE(version)
         KV_SERIALIZE(synchronized)
       END_KV_SERIALIZE_MAP()

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -199,6 +199,7 @@ namespace rpc
     uint64_t adjusted_time;
     uint64_t block_weight_median;
     uint64_t start_time;
+    std::string node_info;
     std::string version;
   };
 

--- a/tests/functional_tests/daemon_info.py
+++ b/tests/functional_tests/daemon_info.py
@@ -86,6 +86,11 @@ class DaemonGetInfoTest():
         assert 'height' in res.keys()
         assert res.height >= 1
 
+        # node_info should be a JSON string
+        assert 'node_info' in res.keys()
+        assert res.node_info == os.environ.get('NODE_INFO', "{}")
+
+
 
 if __name__ == '__main__':
     DaemonGetInfoTest().run_test()


### PR DESCRIPTION
Hi, a project I'm working on would benefit greatly from being able to verify that a pseudonymous entity is running a specific full node.

One way a node operator could verify ownership is by returning a secret in the public rpc call "get_info" using an environment variable (MONERO_NODE_INFO?) or an empty JSON object if that's not set. This would populate a key named "node_info" and could be used for all sorts of other things too.

I wasn't sure where the "framework" import comes from in the file `tests/functional_tests/daemon_info.py` so I couldn't verify that this patch passes that test; however, I did run curl against the rpc endpoint and confirmed that it is functional. Maybe someone can chime in with what to pip install to run that test.

Any and all feedback is much appreciated. Thanks!