### PR TITLE
systemd: remove outdated torsocks example

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -9,27 +9,10 @@ WorkingDirectory=~
 StateDirectory=monero
 LogsDirectory=monero
 
-# Clearnet config
-#
 Type=simple
 ExecStart=/usr/bin/monerod --config-file /etc/monerod.conf --non-interactive
 StandardOutput=null
 StandardError=null
-
-# Tor config
-#
-## We have to use simple, not forking, because we cannot pass --detach
-## because stderr/stdout is not available when detached, but torsocks
-## attempts to write to it, and fails with 'invalid argument', causing
-## monerod to fail.
-#Type=simple
-#Environment=DNS_PUBLIC=tcp
-## The following is needed only when accessing wallet from a different
-## host in the LAN, VPN, etc, the RPC must bind to 0.0.0.0, but
-## by default torsocks only allows binding to localhost.
-#Environment=TORSOCKS_ALLOW_INBOUND=1
-#ExecStart=/usr/bin/torsocks /usr/bin/monerod --config-file /etc/monerod.conf \
-#    --non-interactive
 
 Restart=always
 


### PR DESCRIPTION
monerod now supports `--proxy`, so torsocks shouldn't be recommended anymore.