### PR TITLE
simplewallet: rename duplicate amount headers for clarity

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8818,7 +8818,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
   // header
   file <<
       boost::format("%8.8s,%9.9s,%8.8s,%25.25s,%20.20s,%20.20s,%64.64s,%16.16s,%14.14s,%106.106s,%20.20s,%s,%s") %
-      tr("block") % tr("direction") % tr("unlocked") % tr("timestamp") % tr("amount") % tr("running balance") % tr("hash") % tr("payment ID") % tr("fee") % tr("destination") % tr("amount") % tr("index") % tr("note")
+      tr("block") % tr("direction") % tr("unlocked") % tr("timestamp") % tr("transaction amount") % tr("running balance") % tr("hash") % tr("payment ID") % tr("fee") % tr("destination") % tr("destination amount") % tr("index") % tr("note")
       << std::endl;
 
   uint64_t running_balance = 0;


### PR DESCRIPTION
Closes #8171 

There are duplicate headers for 'amount' when performing export_transfers
all. Column five represents the total amount of the transaction while
column eleven represents the amount transferred per destination (e.g.
multi-destination transactions). The columns have been renamed to
'transaction amount' and 'destination amount` respectively.
