### PR TITLE
Compil. time: http_client.h -> abstract_http_client.h

### DIFF
--- a/.github/workflows/build-time-test.yml
+++ b/.github/workflows/build-time-test.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         ${{env.CCACHE_SETTINGS}}
         ${{env.CLONE_PATCHES}}
-        ${{env.TEST_BUILD_TIME}}
 
 # See the OS labels and monitor deprecations here:
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

--- a/.github/workflows/build-time-test.yml
+++ b/.github/workflows/build-time-test.yml
@@ -19,7 +19,7 @@ env:
         ccache --max-size=150M
         ccache --set-config=compression=true
   CLONE_PATCHES: git clone --recursive https://github.com/mj-xmr/monero-patches.git
-  TEST_BUILD_TIME: time ./monero-patches/src/monero-test-build-time.sh compil-epee-http-client wallet/api/wallet_api
+  TEST_BUILD_TIME: time ./monero-patches/src/monero-test-build-time.sh compil-epee-http-client src/wallet/api
 
 jobs:
   time-macos:

--- a/.github/workflows/build-time-test.yml
+++ b/.github/workflows/build-time-test.yml
@@ -1,0 +1,88 @@
+name: ci/gh-actions/build-time-test
+
+on:
+  push:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/README.md'
+
+# The below variables reduce repetitions across similar targets
+env:
+  REMOVE_BUNDLED_BOOST : rm -rf /usr/local/share/boost
+  APT_INSTALL_LINUX: 'sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler ccache ninja-build'
+  APT_SET_CONF: |
+        echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
+  CCACHE_SETTINGS: |
+        ccache --max-size=150M
+        ccache --set-config=compression=true
+  CLONE_PATCHES: git clone --recursive https://github.com/mj-xmr/monero-patches.git
+  TEST_BUILD_TIME: time ./monero-patches/src/monero-test-build-time.sh compil-epee-http-client tests/trezor
+
+jobs:
+  time-macos:
+    runs-on: macOS-latest
+    env:
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: install dependencies
+      run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc ldns expat libunwind-headers protobuf ccache
+    - name: build
+      run: |
+        ${{env.CCACHE_SETTINGS}}
+        ${{env.CLONE_PATCHES}}
+        ${{env.TEST_BUILD_TIME}}
+
+# See the OS labels and monitor deprecations here:
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+
+  time-ubuntu:
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: remove bundled boost
+      run: ${{env.REMOVE_BUNDLED_BOOST}}
+    - name: set apt conf
+      run: ${{env.APT_SET_CONF}}
+    - name: update apt
+      run: sudo apt update
+    - name: install monero dependencies
+      run: ${{env.APT_INSTALL_LINUX}}
+    - name: build
+      run: |
+        ${{env.CCACHE_SETTINGS}}
+        ${{env.CLONE_PATCHES}}
+        ${{env.TEST_BUILD_TIME}}
+
+  time-ubuntu-ninja:
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: remove bundled boost
+      run: ${{env.REMOVE_BUNDLED_BOOST}}
+    - name: set apt conf
+      run: ${{env.APT_SET_CONF}}
+    - name: update apt
+      run: sudo apt update
+    - name: install monero dependencies
+      run: ${{env.APT_INSTALL_LINUX}}
+    - name: build
+      run: |
+        ${{env.CCACHE_SETTINGS}}
+        ${{env.CLONE_PATCHES}}
+        echo "Does't work yet :(. Needs fixes on Monero's end?"
+        ls || time ./monero-patches/src/monero-test-build-time.sh cmake-unity-build tests/core_tests ninja
+

--- a/.github/workflows/build-time-test.yml
+++ b/.github/workflows/build-time-test.yml
@@ -19,7 +19,7 @@ env:
         ccache --max-size=150M
         ccache --set-config=compression=true
   CLONE_PATCHES: git clone --recursive https://github.com/mj-xmr/monero-patches.git
-  TEST_BUILD_TIME: time ./monero-patches/src/monero-test-build-time.sh compil-epee-http-client tests/trezor
+  TEST_BUILD_TIME: time ./monero-patches/src/monero-test-build-time.sh compil-epee-http-client wallet/api/wallet_api
 
 jobs:
   time-macos:

--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -75,6 +75,9 @@ namespace http
     virtual bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual uint64_t get_bytes_sent() const = 0;
     virtual uint64_t get_bytes_received() const = 0;
+    virtual const std::string &get_host() const = 0;
+    virtual const std::string &get_port() const = 0;
+    virtual void wipe_response() = 0;
   };
 
   class http_client_factory

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -162,8 +162,8 @@ namespace net_utils
 				, m_lock()
 			{}
 
-			const std::string &get_host() const { return m_host_buff; };
-			const std::string &get_port() const { return m_port; };
+			const std::string &get_host() const override { return m_host_buff; };
+			const std::string &get_port() const override { return m_port; };
 
 			using abstract_http_client::set_server;
 
@@ -324,7 +324,7 @@ namespace net_utils
 				return m_net_client.get_bytes_received();
 			}
 			//---------------------------------------------------------------------------
-			void wipe_response()
+			void wipe_response() override
 			{
 				m_response_info.wipe();
 			}

--- a/src/common/http_connection.h
+++ b/src/common/http_connection.h
@@ -30,13 +30,13 @@
 
 #include <chrono>
 #include "string_tools.h"
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
 
 namespace tools {
 
 class t_http_connection {
 private:
-  epee::net_utils::http::http_simple_client * mp_http_client;
+  epee::net_utils::http::abstract_http_client * mp_http_client;
   bool m_ok;
 public:
   static constexpr std::chrono::seconds TIMEOUT()
@@ -44,7 +44,7 @@ public:
     return std::chrono::minutes(3) + std::chrono::seconds(30);
   }
 
-  t_http_connection(epee::net_utils::http::http_simple_client* p_http_client)
+  t_http_connection(epee::net_utils::http::abstract_http_client* p_http_client)
     : mp_http_client(p_http_client)
     , m_ok(false)
   {

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -88,6 +88,7 @@ if(DEVICE_TREZOR_READY)
             ringct_basic
             cryptonote_core
             common
+            net
             ${SODIUM_LIBRARY}
             ${Boost_CHRONO_LIBRARY}
             ${Protobuf_LIBRARY}

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -31,8 +31,13 @@
 #include <libusb.h>
 #endif
 
+#include "net/http.h"
+#include "string_tools.h"
+#include "string_tools_lexical.h"
+
 #include <algorithm>
 #include <functional>
+#include <boost/bind/bind.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
@@ -338,6 +343,7 @@ namespace trezor{
   BridgeTransport::BridgeTransport(
         boost::optional<std::string> device_path,
         boost::optional<std::string> bridge_host):
+    m_http_client(net::http::client_factory().create()),
     m_device_path(device_path),
     m_bridge_host(bridge_host ? bridge_host.get() : DEFAULT_BRIDGE),
     m_response(boost::none),
@@ -355,7 +361,7 @@ namespace trezor{
         MDEBUG("Bridge host: " << m_bridge_host);
       }
 
-      m_http_client.set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+      m_http_client->set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     }
 
   std::string BridgeTransport::get_path() const {
@@ -371,7 +377,7 @@ namespace trezor{
     json bridge_res;
     std::string req;
 
-    bool req_status = invoke_bridge_http("/enumerate", req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http("/enumerate", req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Bridge enumeration failed");
     }
@@ -415,7 +421,7 @@ namespace trezor{
     std::string uri = "/acquire/" + m_device_path.get() + "/null";
     std::string req;
     json bridge_res;
-    bool req_status = invoke_bridge_http(uri, req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Failed to acquire device");
     }
@@ -437,7 +443,7 @@ namespace trezor{
     std::string uri = "/release/" + m_session.get();
     std::string req;
     json bridge_res;
-    bool req_status = invoke_bridge_http(uri, req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Failed to release device");
     }
@@ -461,7 +467,7 @@ namespace trezor{
     epee::wipeable_string res_hex;
     epee::wipeable_string req_hex = epee::to_hex::wipeable_string(epee::span<const std::uint8_t>(req_buff_raw, buff_size));
 
-    bool req_status = invoke_bridge_http(uri, req_hex, res_hex, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req_hex, res_hex, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Call method failed");
     }

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -38,7 +38,9 @@
 
 #include <typeinfo>
 #include <type_traits>
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
+#include "misc_language.h"
+#include "misc_log_ex.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -191,7 +193,7 @@ namespace trezor {
     std::ostream& dump(std::ostream& o) const override;
 
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     std::string m_bridge_host;
     boost::optional<std::string> m_device_path;
     boost::optional<std::string> m_session;

--- a/src/net/http.cpp
+++ b/src/net/http.cpp
@@ -32,10 +32,18 @@
 #include "parse.h"
 #include "socks_connect.h"
 
+#include "net/http_client.h"
+
 namespace net
 {
 namespace http
 {
+
+class client : public epee::net_utils::http::http_simple_client
+{
+public:
+  bool set_proxy(const std::string &address) override;
+};
 
 bool client::set_proxy(const std::string &address)
 {

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -29,18 +29,12 @@
 
 #pragma once
 
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
 
 namespace net
 {
 namespace http
 {
-
-class client : public epee::net_utils::http::http_simple_client
-{
-public:
-  bool set_proxy(const std::string &address) override;
-};
 
 class client_factory : public epee::net_utils::http::http_client_factory
 {

--- a/src/rpc/bootstrap_daemon.h
+++ b/src/rpc/bootstrap_daemon.h
@@ -8,7 +8,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/utility/string_ref.hpp>
 
-#include "net/http.h"
+#include "net/abstract_http_client.h"
 #include "storages/http_abstract_invoke.h"
 
 #include "bootstrap_node_selector.h"
@@ -41,7 +41,7 @@ namespace cryptonote
         return false;
       }
 
-      const bool result = epee::net_utils::invoke_http_json(uri, out_struct, result_struct, m_http_client);
+      const bool result = epee::net_utils::invoke_http_json(uri, out_struct, result_struct, *m_http_client);
       return handle_result(result, result_struct.status);
     }
 
@@ -53,7 +53,7 @@ namespace cryptonote
         return false;
       }
 
-      const bool result = epee::net_utils::invoke_http_bin(uri, out_struct, result_struct, m_http_client);
+      const bool result = epee::net_utils::invoke_http_bin(uri, out_struct, result_struct, *m_http_client);
       return handle_result(result, result_struct.status);
     }
 
@@ -70,7 +70,7 @@ namespace cryptonote
         std::string(command_name.begin(), command_name.end()),
         out_struct,
         result_struct,
-        m_http_client);
+        *m_http_client);
       return handle_result(result, result_struct.status);
     }
 
@@ -81,7 +81,7 @@ namespace cryptonote
     bool switch_server_if_needed();
 
   private:
-    net::http::client m_http_client;
+    const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     const bool m_rpc_payment_enabled;
     const std::unique_ptr<bootstrap_node::selector> m_selector;
     boost::mutex m_selector_mutex;

--- a/src/rpc/bootstrap_node_selector.h
+++ b/src/rpc/bootstrap_node_selector.h
@@ -29,6 +29,8 @@
 
 #pragma  once
 
+#include "net/http_auth.h"
+
 #include <functional>
 #include <limits>
 #include <map>
@@ -39,8 +41,6 @@
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/optional/optional.hpp>
-
-#include "net/http_client.h"
 
 namespace cryptonote
 {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -37,7 +37,6 @@
 
 #include "bootstrap_daemon.h"
 #include "net/http_server_impl_base.h"
-#include "net/http_client.h"
 #include "core_rpc_server_commands_defs.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "p2p/net_node.h"

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -97,7 +97,7 @@ public:
 private:
     WalletManagerImpl();
     friend struct WalletManagerFactory;
-    net::http::client m_http_client;
+    std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     std::string m_errorString;
 };
 

--- a/src/wallet/message_transporter.cpp
+++ b/src/wallet/message_transporter.cpp
@@ -31,7 +31,6 @@
 #include "string_coding.h"
 #include <boost/format.hpp>
 #include "wallet_errors.h"
-#include "net/http_client.h"
 #include "net/net_parse_helpers.h"
 #include <algorithm>
 

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -33,7 +33,6 @@
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "net/http_server_impl_base.h"
-#include "net/http_client.h"
 #include "net/abstract_http_client.h"
 #include "common/util.h"
 #include "wipeable_string.h"

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -33,6 +33,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <unordered_map>
 
+#include "net/http.h"
 #include "include_base_utils.h"
 using namespace epee;
 #include "wallet/wallet2.h"
@@ -156,7 +157,8 @@ bool transactions_flow_test(std::string& working_folder,
     << "Target:  " << w2.get_account().get_public_address_str(MAINNET) << ENDL << "Path: " << working_folder + "/" + path_target_wallet);
 
   //lets do some money
-  epee::net_utils::http::http_simple_client http_client;
+  const std::unique_ptr<epee::net_utils::http::abstract_http_client> ptr_http_client = net::http::client_factory().create();
+  epee::net_utils::http::abstract_http_client & http_client = *ptr_http_client;
   COMMAND_RPC_STOP_MINING::request daemon1_req = AUTO_VAL_INIT(daemon1_req);
   COMMAND_RPC_STOP_MINING::response daemon1_rsp = AUTO_VAL_INIT(daemon1_rsp);
   bool r = http_client.set_server(daemon_addr_a, boost::none) && net_utils::invoke_http_json("/stop_mine", daemon1_req, daemon1_rsp, http_client, std::chrono::seconds(10));


### PR DESCRIPTION
## Result
Compilation time reduced by -10% .

## Description

Below is the complexity of the `http_client` class:

![image](https://user-images.githubusercontent.com/63722585/156336023-aa4cf9c0-5090-47f2-b5aa-efcde0bef784.png)

It's a class derived from `epee::net_utils::http::abstract_http_client` and could be pointed at using this base class' pointer.

This is how the `http_client`'s dependees tree looks like on master:
![image](https://user-images.githubusercontent.com/63722585/156336404-a6c4c643-98a3-4805-9536-b2ded75d0c80.png)

and this is how I was able to reduce it:
![image](https://user-images.githubusercontent.com/63722585/156364054-72e0ac4f-d798-4916-afc7-656b4897cc02.png)

According to my [compilation time report](http://cryptog.hopto.org/monero/health/data/9aab19f34/9aab19f34-cba-result.txt), on master, the header `net/http_client.h` takes over a minute to compile:

```
78479 ms: /tmp/monero/monero-clean/external/easylogging++/easylogging++.h (included 226 times, avg 347 ms), included via:
(...)
68317 ms: /tmp/monero/monero-clean/contrib/epee/include/net/http_client.h (included 38 times, avg 1797 ms), included via:
(...)
64580 ms: /tmp/monero/monero-clean/src/cryptonote_basic/difficulty.h (included 89 times, avg 725 ms), included via:
(...)
```

A side effect was, that I had to add the following 3 pure virtual methods to `epee::net_utils::http::abstract_http_client`:
```c++
    virtual const std::string &get_host() const = 0;
    virtual const std::string &get_port() const = 0;
    virtual void wipe_response() = 0;
```

## Measurements
using `time make` on master and on the branch:
| Previous   |      Current      | Change |
|----------|-------------|-------------|
| real	49m0,890s |     real	44m16,309s  |  -10.06% | 

Of course, individual verification is welcome.