### PR TITLE
multisig: add key exchange round booster

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1354,6 +1354,21 @@ std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &inf
     return string();
 }
 
+std::string WalletImpl::getMultisigKeyExchangeBooster(const std::vector<std::string> &info,
+    const std::uint32_t threshold,
+    const std::uint32_t num_signers) {
+    try {
+        clearStatus();
+
+        return m_wallet->get_multisig_key_exchange_booster(epee::wipeable_string(m_password), info, threshold, num_signers);
+    } catch (const exception& e) {
+        LOG_ERROR("Error on boosting multisig key exchange: " << e.what());
+        setStatusError(string(tr("Failed to boost multisig key exchange: ")) + e.what());
+    }
+
+    return string();
+}
+
 bool WalletImpl::exportMultisigImages(string& images) {
     try {
         clearStatus();

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -148,6 +148,7 @@ public:
     std::string getMultisigInfo() const override;
     std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) override;
     std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution = false) override;
+    std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) override;
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -803,6 +803,15 @@ struct Wallet
      */
     virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution) = 0;
     /**
+     * @brief getMultisigKeyExchangeBooster - obtain partial information for the key exchange round after the in-progress round,
+     *                                        to speed up another signer's key exchange process
+     * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
+     * @param threshold - number of required signers to make valid transaction. Must be <= number of participants.
+     * @param num_signers - total number of multisig participants.
+     * @return new info string if more rounds required or exception if no more rounds (i.e. no rounds to boost)
+     */
+    virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) = 0;
+    /**
      * @brief exportMultisigImages - exports transfers' key images
      * @param images - output paramter for hex encoded array of images
      * @return true if success

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -86,6 +86,7 @@
 
 class Serialization_portability_wallet_Test;
 class wallet_accessor_test;
+namespace multisig { class multisig_account; }
 
 namespace tools
 {
@@ -892,6 +893,23 @@ private:
      */
     void restore(const std::string& wallet_, const epee::wipeable_string& password, const std::string &device_name, bool create_address_file = false);
 
+  private:
+    /*!
+     * \brief Decrypts the account keys
+     * \return an RAII reencryptor for the account keys
+     */
+    epee::misc_utils::auto_scope_leave_caller decrypt_account_for_multisig(const epee::wipeable_string &password);
+    /*!
+     * \brief Creates an uninitialized multisig account
+     * \outparam: the uninitialized multisig account
+     */
+    void get_uninitialized_multisig_account(multisig::multisig_account &account_out) const;
+    /*!
+     * \brief Reconstructs a multisig account from wallet2 state
+     * \outparam: the reconstructed multisig account
+     */
+    void get_reconstructed_multisig_account(multisig::multisig_account &account_out) const;
+  public:
     /*!
      * \brief Creates a multisig wallet
      * \return empty if done, non empty if we need to send another string
@@ -913,6 +931,13 @@ private:
      * \return string to send to other participants
      */
     std::string get_multisig_first_kex_msg() const;
+    /*!
+     * \brief Use multisig kex messages for an in-progress kex round to 'boost' the following round for another group member
+     */
+    std::string get_multisig_key_exchange_booster(const epee::wipeable_string &password,
+      const std::vector<std::string> &kex_messages,
+      const std::uint32_t threshold,
+      const std::uint32_t num_signers);
     /*!
      * Export multisig info
      * This will generate and remember new k values

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -151,6 +151,7 @@ namespace tools
         MAP_JON_RPC_WE("import_multisig_info", on_import_multisig,  wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG)
         MAP_JON_RPC_WE("finalize_multisig",  on_finalize_multisig,  wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG)
         MAP_JON_RPC_WE("exchange_multisig_keys",  on_exchange_multisig_keys,  wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS)
+        MAP_JON_RPC_WE("get_multisig_key_exchange_booster",  on_get_multisig_key_exchange_booster,  wallet_rpc::COMMAND_RPC_GET_MULTISIG_KEY_EXCHANGE_BOOSTER)
         MAP_JON_RPC_WE("sign_multisig",      on_sign_multisig,      wallet_rpc::COMMAND_RPC_SIGN_MULTISIG)
         MAP_JON_RPC_WE("submit_multisig",    on_submit_multisig,    wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG)
         MAP_JON_RPC_WE("validate_address",   on_validate_address,   wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS)
@@ -242,6 +243,7 @@ namespace tools
       bool on_import_multisig(const wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_finalize_multisig(const wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_exchange_multisig_keys(const wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::request& req, wallet_rpc::COMMAND_RPC_EXCHANGE_MULTISIG_KEYS::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
+      bool on_get_multisig_key_exchange_booster(const wallet_rpc::COMMAND_RPC_GET_MULTISIG_KEY_EXCHANGE_BOOSTER::request& req, wallet_rpc::COMMAND_RPC_GET_MULTISIG_KEY_EXCHANGE_BOOSTER::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_sign_multisig(const wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_submit_multisig(const wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_validate_address(const wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2481,6 +2481,35 @@ namespace wallet_rpc
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct COMMAND_RPC_GET_MULTISIG_KEY_EXCHANGE_BOOSTER
+  {
+    struct request_t
+    {
+      std::string password;
+      std::vector<std::string> multisig_info;
+      uint32_t threshold;
+      uint32_t num_signers;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(password)
+        KV_SERIALIZE(multisig_info)
+        KV_SERIALIZE(threshold)
+        KV_SERIALIZE(num_signers)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+      std::string multisig_info;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(multisig_info)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
   struct COMMAND_RPC_SIGN_MULTISIG
   {
     struct request_t

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -149,6 +149,7 @@ static void check_results(const std::vector<std::string> &intermediate_infos,
   std::unordered_set<crypto::secret_key> unique_privkeys;
   rct::key composite_pubkey = rct::identity();
 
+  ASSERT_TRUE(wallets.size() > 0);
   wallets[0].decrypt_keys("");
   crypto::public_key spend_pubkey = wallets[0].get_account().get_keys().m_account_address.m_spend_public_key;
   crypto::secret_key view_privkey = wallets[0].get_account().get_keys().m_view_secret_key;
@@ -156,32 +157,48 @@ static void check_results(const std::vector<std::string> &intermediate_infos,
   EXPECT_TRUE(crypto::secret_key_to_public_key(view_privkey, view_pubkey));
   wallets[0].encrypt_keys("");
 
-  for (size_t i = 0; i < wallets.size(); ++i)
+  // at the end of multisig kex, all wallets should emit a post-kex message with the same two pubkeys
+  std::vector<crypto::public_key> post_kex_msg_pubkeys;
+  ASSERT_TRUE(intermediate_infos.size() == wallets.size());
+  for (const std::string &intermediate_info : intermediate_infos)
   {
-    EXPECT_TRUE(!intermediate_infos[i].empty());
-    const multisig::multisig_account_status ms_status{wallets[i].get_multisig_status()};
+    multisig::multisig_kex_msg post_kex_msg;
+    EXPECT_TRUE(!intermediate_info.empty());
+    EXPECT_NO_THROW(post_kex_msg = intermediate_info);
+
+    if (post_kex_msg_pubkeys.size() != 0)
+      EXPECT_TRUE(post_kex_msg_pubkeys == post_kex_msg.get_msg_pubkeys());  //assumes sorting is always the same
+    else
+      post_kex_msg_pubkeys = post_kex_msg.get_msg_pubkeys();
+
+    EXPECT_TRUE(post_kex_msg_pubkeys.size() == 2);
+  }
+
+  // the post-kex pubkeys should equal the account's public view and spend keys
+  EXPECT_TRUE(std::find(post_kex_msg_pubkeys.begin(), post_kex_msg_pubkeys.end(), spend_pubkey) != post_kex_msg_pubkeys.end());
+  EXPECT_TRUE(std::find(post_kex_msg_pubkeys.begin(), post_kex_msg_pubkeys.end(), view_pubkey) != post_kex_msg_pubkeys.end());
+
+  // each wallet should have the same state (private view key, public spend key), and the public spend key should be
+  //   reproducible from the private spend keys found in each account
+  for (tools::wallet2 &wallet : wallets)
+  {
+    wallet.decrypt_keys("");
+    const multisig::multisig_account_status ms_status{wallet.get_multisig_status()};
     EXPECT_TRUE(ms_status.multisig_is_active);
     EXPECT_TRUE(ms_status.kex_is_done);
     EXPECT_TRUE(ms_status.is_ready);
     EXPECT_TRUE(ms_status.threshold == M);
     EXPECT_TRUE(ms_status.total == wallets.size());
 
-    wallets[i].decrypt_keys("");
-
-    if (i != 0)
-    {
-      // "equals" is transitive relation so we need only to compare first wallet's address to each others' addresses.
-      // no need to compare 0's address with itself.
-      EXPECT_TRUE(wallets[0].get_account().get_public_address_str(cryptonote::TESTNET) ==
-        wallets[i].get_account().get_public_address_str(cryptonote::TESTNET));
-      
-      EXPECT_EQ(spend_pubkey, wallets[i].get_account().get_keys().m_account_address.m_spend_public_key);
-      EXPECT_EQ(view_privkey, wallets[i].get_account().get_keys().m_view_secret_key);
-      EXPECT_EQ(view_pubkey, wallets[i].get_account().get_keys().m_account_address.m_view_public_key);
-    }
+    EXPECT_TRUE(wallets[0].get_account().get_public_address_str(cryptonote::TESTNET) ==
+      wallet.get_account().get_public_address_str(cryptonote::TESTNET));
+    
+    EXPECT_EQ(spend_pubkey, wallet.get_account().get_keys().m_account_address.m_spend_public_key);
+    EXPECT_EQ(view_privkey, wallet.get_account().get_keys().m_view_secret_key);
+    EXPECT_EQ(view_pubkey, wallet.get_account().get_keys().m_account_address.m_view_public_key);
 
     // sum together unique multisig keys
-    for (const auto &privkey : wallets[i].get_account().get_keys().m_multisig_keys)
+    for (const auto &privkey : wallet.get_account().get_keys().m_multisig_keys)
     {
       EXPECT_NE(privkey, crypto::null_skey);
 
@@ -189,17 +206,17 @@ static void check_results(const std::vector<std::string> &intermediate_infos,
       {
         unique_privkeys.insert(privkey);
         crypto::public_key pubkey;
-        crypto::secret_key_to_public_key(privkey, pubkey);
+        EXPECT_TRUE(crypto::secret_key_to_public_key(privkey, pubkey));
         EXPECT_NE(privkey, crypto::null_skey);
         EXPECT_NE(pubkey, crypto::null_pkey);
         EXPECT_NE(pubkey, rct::rct2pk(rct::identity()));
         rct::addKeys(composite_pubkey, composite_pubkey, rct::pk2rct(pubkey));
       }
     }
-    wallets[i].encrypt_keys("");
+    wallet.encrypt_keys("");
   }
 
-  // final key via sums should equal the wallets' public spend key
+  // final key via sum of privkeys should equal the wallets' public spend key
   wallets[0].decrypt_keys("");
   EXPECT_EQ(wallets[0].get_account().get_keys().m_account_address.m_spend_public_key, rct::rct2pk(composite_pubkey));
   wallets[0].encrypt_keys("");
@@ -257,6 +274,104 @@ static void make_wallets(const unsigned int M, const unsigned int N, const bool 
   check_results(intermediate_infos, wallets, M);
 }
 
+static void make_wallets_boosting(std::vector<tools::wallet2>& wallets, unsigned int M)
+{
+  ASSERT_TRUE(wallets.size() > 1 && wallets.size() <= KEYS_COUNT);
+  ASSERT_TRUE(M <= wallets.size());
+  std::uint32_t kex_rounds_required = multisig::multisig_kex_rounds_required(wallets.size(), M);
+  std::uint32_t rounds_required = multisig::multisig_setup_rounds_required(wallets.size(), M);
+  std::uint32_t rounds_complete{0};
+
+  // initialize wallets, get first round multisig kex msgs
+  std::vector<std::string> initial_infos(wallets.size());
+
+  for (size_t i = 0; i < wallets.size(); ++i)
+  {
+    make_wallet(i, wallets[i]);
+
+    wallets[i].decrypt_keys("");
+    initial_infos[i] = wallets[i].get_multisig_first_kex_msg();
+    wallets[i].encrypt_keys("");
+  }
+
+  // wallets should not be multisig yet
+  for (const auto &wallet: wallets)
+  {
+    const multisig::multisig_account_status ms_status{wallet.get_multisig_status()};
+    ASSERT_FALSE(ms_status.multisig_is_active);
+  }
+
+  // get round 2 booster messages for wallet0 (if appropriate)
+  auto initial_infos_truncated = initial_infos;
+  initial_infos_truncated.erase(initial_infos_truncated.begin());
+
+  std::vector<std::string> wallet0_booster_infos;
+  wallet0_booster_infos.reserve(wallets.size() - 1);
+
+  if (rounds_complete + 1 < kex_rounds_required)
+  {
+    for (size_t i = 1; i < wallets.size(); ++i)
+    {
+      wallet0_booster_infos.push_back(
+          wallets[i].get_multisig_key_exchange_booster("", initial_infos_truncated, M, wallets.size())
+        );
+    }
+  }
+
+  // make wallets multisig
+  std::vector<std::string> intermediate_infos(wallets.size());
+
+  for (size_t i = 0; i < wallets.size(); ++i)
+    intermediate_infos[i] = wallets[i].make_multisig("", initial_infos, M);
+
+  ++rounds_complete;
+
+  // perform all kex rounds
+  // boost wallet0 each round, so wallet0 is always 1 round ahead
+  std::string wallet0_intermediate_info;
+  std::vector<std::string> new_infos(intermediate_infos.size());
+  multisig::multisig_account_status ms_status{wallets[0].get_multisig_status()};
+  while (!ms_status.is_ready)
+  {
+    // use booster infos to update wallet0 'early'
+    if (rounds_complete < kex_rounds_required)
+      new_infos[0] = wallets[0].exchange_multisig_keys("", wallet0_booster_infos);
+    else
+    {
+      // force update the post-kex round with wallet0's post-kex message since wallet0 is 'ahead' of the other wallets
+      wallet0_booster_infos = {wallets[0].exchange_multisig_keys("", {})};
+      new_infos[0] = wallets[0].exchange_multisig_keys("", wallet0_booster_infos, true);
+    }
+
+    // get wallet0 booster infos for next round
+    if (rounds_complete + 1 < kex_rounds_required)
+    {
+      // remove wallet0 info for this round (so boosters have incomplete kex message set)
+      auto intermediate_infos_truncated = intermediate_infos;
+      intermediate_infos_truncated.erase(intermediate_infos_truncated.begin());
+
+      // obtain booster messages from all other wallets
+      for (size_t i = 1; i < wallets.size(); ++i)
+      {
+        wallet0_booster_infos[i-1] =
+          wallets[i].get_multisig_key_exchange_booster("", intermediate_infos_truncated, M, wallets.size());
+      }
+    }
+
+    // update other wallets
+    for (size_t i = 1; i < wallets.size(); ++i)
+        new_infos[i] = wallets[i].exchange_multisig_keys("", intermediate_infos);
+
+    intermediate_infos = new_infos;
+    ++rounds_complete;
+    ms_status = wallets[0].get_multisig_status();
+  }
+
+  EXPECT_EQ(rounds_required, rounds_complete);
+
+  check_results(intermediate_infos, wallets, M);
+}
+
 TEST(multisig, make_1_2)
 {
   make_wallets(1, 2, false);
@@ -291,6 +406,12 @@ TEST(multisig, make_2_4)
 {
   make_wallets(2, 4, false);
   make_wallets(2, 4, true);
+}
+
+TEST(multisig, make_2_4_boosting)
+{
+  std::vector<tools::wallet2> wallets(4);
+  make_wallets_boosting(wallets, 2);
 }
 
 TEST(multisig, multisig_kex_msg)

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -540,6 +540,20 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(exchange_multisig_keys)
 
+    def get_multisig_key_exchange_booster(self, multisig_info, threshold, num_signers, password = ''):
+        exchange_multisig_keys = {
+            'method': 'get_multisig_key_exchange_booster',
+            'params' : {
+                'multisig_info': multisig_info,
+                'threshold': threshold,
+                'num_signers': num_signers,
+                'password': password,
+            },
+            'jsonrpc': '2.0', 
+            'id': '0'
+        }
+        return self.rpc.send_json_rpc_request(get_multisig_key_exchange_booster)
+
     def export_multisig_info(self):
         export_multisig_info = {
             'method': 'export_multisig_info',


### PR DESCRIPTION
This PR adds a small optimization to multisig account creation that is especially useful for 2-of-3 groups (disclaimer: there is a bounty for it [here](https://github.com/haveno-dex/haveno/issues/86)).

Multisig account creation is a series of rounds. Each round consists of sending messages to all the other group members. A member cannot complete a round until they have received a message for that round from each other member.

A standard 2-of-3 setup ceremony looks like this:
**Round 1**: Members A, B, C send initial messages to all other members.
**Round 2**: Members A, B, C use the previous round's messages to make their personal shares of the final key. They send a second message to all other members.
**Finalization**: Once a member has a full set of round 2 messages, they can finish the account.

That setup ceremony requires 2 communication rounds. For 2-of-3 escrowed markets, the buyer party should instead be able to complete the ceremony in one step so they can fund the multisig wallet right away.

With boosting, we can instead have this setup ceremony:
1. Members A, B send initial messages to each other and to member C.
2. Members A, B create 'round 2 booster' messages and send them to member C.
3. Member C completes round 1 immediately. He creates a round 1 and a round 2 message and sends them to members A, B. Member C then uses the booster messages to complete round 2, finalizing his local multisig account in the same step.
4. Members A, B complete round 1 then make round 2 messages and send them to each other.
5. Members A, B complete round 2 and finalize the multisig account.

So, by adding rounds to members A and B, member C can complete a 2-of-3 multisig account in one step.

**DISCLAIMER**: Kex boosting is expected to be used in conjunction with account force-updating. Extreme care must be taken when designing a system that uses these features to avoid attack vectors that lead to funds getting stuck or possibly stolen (I'd hesitate to use it at all until I or someone else does a write-up on how to do it safely).

#### TODO

- Still need to update `simplewallet` (and the `mms` presumably @rbrunner7 ).
- This PR is missing functional tests for the expanded wallet2 api (`tests/functional_tests/multisig.py`). It would be cool if someone who likes Python could help me with this.

#### Future Work

- Try to refactor `wallet2` so creating a multisig wallet doesn't involve converting an existing normal wallet's keys. Once a multisig wallet has been created, there should be no way to 'recreate' it using a different M/N configuration. Without that refactor, a user could boost a multisig account using one M/N configuration with a normal account (before converting their normal account to multisig), then later on when they actually convert to a multisig account use a different M/N configuration. If either of those M/N configs was an (N-1)-of-N, then the user will leak their multisig private key shares for that setup when setting up the _other_ configuration (via the key exchange ceremony).