### PR TITLE
Compil. time: cryptonote_core minus portable_storage header

### DIFF
--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -40,7 +40,6 @@
 #include "cryptonote_core/i_core_events.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler_common.h"
 #include "cryptonote_protocol/enums.h"
-#include "storages/portable_storage_template_helper.h"
 #include "common/download.h"
 #include "common/command_line.h"
 #include "tx_pool.h"

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -35,6 +35,8 @@
 #include "tx_pool.h"
 #include "transaction_tests.h"
 
+#include <boost/regex.hpp>
+
 namespace po = boost::program_options;
 
 namespace


### PR DESCRIPTION
## Result
-1.5% overall compilation time after changing just 2 files.

Before:
Please look to the right at the `cryptonote_core.h`. This entire tree is now disposed of.
![portable__storage__template__helper_8h__dep__incl](https://user-images.githubusercontent.com/63722585/156744123-e277f000-bba9-4786-8fba-6a083abd5891.png)

After:
![image](https://user-images.githubusercontent.com/63722585/156742332-fccebed8-ac76-49f0-84da-3bdc8b5a6d6d.png)

## Measurements
To be able to test the change in the most objective way, please execute:
```
mkdir -p build/time && cd build/time
git checkout master
cmake ../.. -DUSE_CCACHE=OFF -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS=ON && make clean && time make > /dev/null
git checkout compil-time-cryptonote_core-portable_storage
cmake ../.. -DUSE_CCACHE=OFF -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS=ON && make clean && time make > /dev/null
```

| Previous   |      Current      | Change |
|----------|-------------|-------------|
| real	104m23,886s |     real	102m50,045s  |  -1.5% | 
