### PR TITLE
CMake: Add missing headers via monero_find_all_headers macro

### DIFF
--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -33,10 +33,7 @@ set(blockchain_db_sources
 
 set(blockchain_db_headers)
 
-set(blockchain_db_private_headers
-  blockchain_db.h
-  lmdb/db_lmdb.h
-  )
+monero_find_all_headers(blockchain_db_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(blockchain_db
   ${crypto_private_headers})

--- a/src/checkpoints/CMakeLists.txt
+++ b/src/checkpoints/CMakeLists.txt
@@ -41,8 +41,7 @@ set(checkpoints_sources
 
 set(checkpoints_headers)
 
-set(checkpoints_private_headers
-  checkpoints.h)
+monero_find_all_headers(checkpoints_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(checkpoints
   ${checkpoints_private_headers})

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -58,36 +58,7 @@ endif()
 
 set(common_headers)
 
-set(common_private_headers
-  apply_permutation.h
-  base58.h
-  boost_serialization_helper.h
-  command_line.h
-  common_fwd.h
-  dns_utils.h
-  download.h
-  error.h
-  expect.h
-  http_connection.h
-  notify.h
-  pod-class.h
-  pruning.h
-  rpc_client.h
-  scoped_message_writer.h
-  unordered_containers_boost_serialization.h
-  util.h
-  varint.h
-  i18n.h
-  password.h
-  perf_timer.h
-  spawn.h
-  stack_trace.h
-  threadpool.h
-  updates.h
-  aligned.h
-  timings.h
-  combinator.h
-  utf8.h)
+monero_find_all_headers(common_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(common
   ${common_private_headers})

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -58,27 +58,7 @@ include_directories(${RANDOMX_INCLUDE})
 
 set(crypto_headers)
 
-set(crypto_private_headers
-  blake256.h
-  chacha.h
-  crypto-ops.h
-  crypto.h
-  generic-ops.h
-  groestl.h
-  groestl_tables.h
-  hash-ops.h
-  hash.h
-  hmac-keccak.h
-  initializer.h
-  jh.h
-  keccak.h
-  oaes_config.h
-  oaes_lib.h
-  random.h
-  skein.h
-  skein_port.h
-  CryptonightR_JIT.h
-  CryptonightR_template.h)
+monero_find_all_headers(crypto_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(cncrypto
   ${crypto_private_headers})

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -56,20 +56,7 @@ set(cryptonote_basic_sources
 
 set(cryptonote_basic_headers)
 
-set(cryptonote_basic_private_headers
-  account.h
-  account_boost_serialization.h
-  connection_context.h
-  cryptonote_basic.h
-  cryptonote_basic_impl.h
-  cryptonote_boost_serialization.h
-  cryptonote_format_utils.h
-  difficulty.h
-  hardfork.h
-  merge_mining.h
-  miner.h
-  tx_extra.h
-  verification_context.h)
+monero_find_all_headers(cryptonote_basic_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(cryptonote_basic
   ${cryptonote_basic_private_headers})

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -35,13 +35,7 @@ set(cryptonote_core_sources
 
 set(cryptonote_core_headers)
 
-set(cryptonote_core_private_headers
-  blockchain_storage_boost_serialization.h
-  blockchain.h
-  cryptonote_core.h
-  tx_pool.h
-  tx_sanity_check.h
-  cryptonote_tx_utils.h)
+monero_find_all_headers(cryptonote_core_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(cryptonote_core
   ${cryptonote_core_private_headers})

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -37,30 +37,7 @@ set(daemon_sources
 
 set(daemon_headers)
 
-set(daemon_private_headers
-  command_parser_executor.h
-  command_server.h
-  core.h
-  daemon.h
-  executor.h
-  p2p.h
-  protocol.h
-  rpc.h
-  rpc_command_executor.h
-
-  # cryptonote_protocol
-  ../cryptonote_protocol/cryptonote_protocol_defs.h
-  ../cryptonote_protocol/cryptonote_protocol_handler.h
-  ../cryptonote_protocol/cryptonote_protocol_handler.inl
-  ../cryptonote_protocol/cryptonote_protocol_handler_common.h
-
-  # p2p
-  ../p2p/net_node.h
-  ../p2p/net_node_common.h
-  ../p2p/net_peerlist.h
-  ../p2p/net_peerlist_boost_serialization.h
-  ../p2p/p2p_protocol_defs.h
-  ../p2p/stdafx.h)
+monero_find_all_headers(daemon_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(daemon
   ${daemon_private_headers})

--- a/src/hardforks/CMakeLists.txt
+++ b/src/hardforks/CMakeLists.txt
@@ -29,8 +29,7 @@
 set(hardforks_sources
   hardforks.cpp)
 
-set(hardforks_headers
-  hardforks.h)
+monero_find_all_headers(hardforks_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(hardforks_private_headers)
 

--- a/src/lmdb/CMakeLists.txt
+++ b/src/lmdb/CMakeLists.txt
@@ -27,7 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(lmdb_sources database.cpp error.cpp table.cpp value_stream.cpp)
-set(lmdb_headers database.h error.h key_stream.h table.h transaction.h util.h value_stream.h)
+monero_find_all_headers(lmdb_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_add_library(lmdb_lib ${lmdb_sources} ${lmdb_headers})
 target_link_libraries(lmdb_lib common ${LMDB_LIBRARY})

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -31,23 +31,7 @@ set(mnemonics_sources
 
 set(mnemonics_headers)
 
-set(mnemonics_private_headers
-  electrum-words.h
-  chinese_simplified.h
-  english.h
-  dutch.h
-  french.h
-  german.h
-  italian.h
-  japanese.h
-  language_base.h
-  english_old.h
-  portuguese.h
-  russian.h
-  singleton.h
-  spanish.h
-  esperanto.h
-  lojban.h)
+monero_find_all_headers(mnemonics_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(mnemonics
   ${mnemonics_private_headers})

--- a/src/multisig/CMakeLists.txt
+++ b/src/multisig/CMakeLists.txt
@@ -34,10 +34,7 @@ set(multisig_sources
 
 set(multisig_headers)
 
-set(multisig_private_headers
-  multisig.h
-  multisig_account.h
-  multisig_kex_msg.h)
+monero_find_all_headers(multisig_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(multisig
   ${multisig_private_headers})

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -29,8 +29,7 @@
 
 set(net_sources dandelionpp.cpp error.cpp http.cpp i2p_address.cpp parse.cpp resolve.cpp
     socks.cpp socks_connect.cpp tor_address.cpp zmq.cpp)
-set(net_headers dandelionpp.h error.h http.cpp i2p_address.h parse.h socks.h resolve.h
-    socks_connect.h tor_address.h zmq.h)
+monero_find_all_headers(net_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_add_library(net ${net_sources} ${net_headers})
 target_link_libraries(net common epee ${ZMQ_LIB} ${Boost_ASIO_LIBRARY})

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -34,12 +34,7 @@ set(ringct_basic_sources
   bulletproofs.cc
   bulletproofs_plus.cc)
 
-set(ringct_basic_private_headers
-  rctOps.h
-  rctTypes.h
-  multiexp.h
-  bulletproofs.h
-  bulletproofs_plus.h)
+monero_find_all_headers(ringct_basic_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(ringct_basic
   ${crypto_private_headers})

--- a/src/serialization/CMakeLists.txt
+++ b/src/serialization/CMakeLists.txt
@@ -31,8 +31,7 @@ set(serialization_sources
 
 set(serialization_headers)
 
-set(serialization_private_headers
-  json_object.h)
+monero_find_all_headers(serialization_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(serialization
   ${serialization_private_headers})

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -31,8 +31,7 @@ set(simplewallet_sources
 
 set(simplewallet_headers)
 
-set(simplewallet_private_headers
-  simplewallet.h)
+monero_find_all_headers(simplewallet_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
 
 monero_private_headers(simplewallet
   ${simplewallet_private_headers})


### PR DESCRIPTION
Using the `monero_find_all_headers()` macro to add missing headers, where appropriate.

Whenever it wasn't a good idea, like in `wallet_api`, where the Author actually distinguishes between API and private headers, the macro wasn't used.

## Special cases
- `serialization` was actually missing all of its headers, except for one.
- `daemon` was referencing external headers (`cryptonote_protocol` and `p2p`), which are imported anyway through `target_link_libraries()`, so I took the liberty of removing these references