### PR TITLE
wallet_rpc_server: support regex for tags in get_accounts

### DIFF
--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 24
+#define WALLET_RPC_VERSION_MINOR 25
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools
@@ -243,10 +243,12 @@ namespace wallet_rpc
     {
       std::string tag;      // all accounts if empty, otherwise those accounts with this tag
       bool strict_balances;
+      bool regexp; // allow regular expression filters if set to true
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tag)
         KV_SERIALIZE_OPT(strict_balances, false)
+        KV_SERIALIZE_OPT(regexp, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
Closes #8214 
This commit adds a 'regexp' boolean field to the get_accounts
request. The flag is set to false by default and maintains backwards
compatibility. When set to true the user can search tags by regular
expression filters. An additional error message was added for failed
regular expression searches. Bump minor version to 25.