### PR TITLE
replace erciccione's seednode with one on haveno's infrastructure

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -717,7 +717,7 @@ namespace nodetool
       full_addrs.insert("176.9.0.187:18080");
       full_addrs.insert("88.198.163.90:18080");
       full_addrs.insert("95.217.25.101:18080");
-      full_addrs.insert("209.250.243.248:18080");
+      full_addrs.insert("136.244.105.131:18080");
       full_addrs.insert("104.238.221.81:18080");
       full_addrs.insert("66.85.74.134:18080");
       full_addrs.insert("88.99.173.38:18080");


### PR DESCRIPTION
I reached the storage limits of my vps, which is currently mostly dedicated to this node. This PR removes my seednode and replaces it with one hosted on [Haveno](https://github.com/haveno-dex)'s infrastructure.