### PR TITLE
multisig: add post-kex verification round

### DIFF
--- a/src/multisig/multisig_account.cpp
+++ b/src/multisig/multisig_account.cpp
@@ -73,7 +73,7 @@ namespace multisig
     const crypto::public_key &multisig_pubkey,
     const crypto::public_key &common_pubkey,
     const std::uint32_t kex_rounds_complete,
-    kex_origins_map_t kex_origins_map,
+    multisig_keyset_map_memsafe_t kex_origins_map,
     std::string next_round_kex_message) :
       m_base_privkey{base_privkey},
       m_base_common_privkey{base_common_privkey},
@@ -89,6 +89,20 @@ namespace multisig
     CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(m_base_privkey, m_base_pubkey),
       "Failed to derive public key");
     set_multisig_config(threshold, std::move(signers));
+
+    // kex rounds should not exceed post-kex verification round
+    const std::uint32_t kex_rounds_required{multisig_kex_rounds_required(m_signers.size(), m_threshold)};
+    CHECK_AND_ASSERT_THROW_MES(m_kex_rounds_complete <= kex_rounds_required + 1,
+      "multisig account: tried to reconstruct account, but kex rounds complete counter is invalid.");
+
+    // once an account is done with kex, the 'next kex msg' is always the post-kex verification message
+    //   i.e. the multisig account pubkey signed by the signer's privkey AND the common pubkey
+    if (main_kex_rounds_done())
+    {
+      m_next_round_kex_message = multisig_kex_msg{kex_rounds_required + 1,
+        m_base_privkey,
+        std::vector<crypto::public_key>{m_multisig_pubkey, m_common_pubkey}}.get_msg();
+    }
   }
   //----------------------------------------------------------------------------------------------------------------------
   // multisig_account: EXTERNAL
@@ -100,14 +114,24 @@ namespace multisig
   //----------------------------------------------------------------------------------------------------------------------
   // multisig_account: EXTERNAL
   //----------------------------------------------------------------------------------------------------------------------
-  bool multisig_account::multisig_is_ready() const
+  bool multisig_account::main_kex_rounds_done() const
   {
     if (account_is_active())
-      return multisig_kex_rounds_required(m_signers.size(), m_threshold) == m_kex_rounds_complete;
+      return m_kex_rounds_complete >= multisig_kex_rounds_required(m_signers.size(), m_threshold);
     else
       return false;
   }
-    //----------------------------------------------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------------------------------------------------
+  // multisig_account: EXTERNAL
+  //----------------------------------------------------------------------------------------------------------------------
+  bool multisig_account::multisig_is_ready() const
+  {
+    if (main_kex_rounds_done())
+      return m_kex_rounds_complete >= multisig_kex_rounds_required(m_signers.size(), m_threshold) + 1;
+    else
+      return false;
+  }
+  //----------------------------------------------------------------------------------------------------------------------
   // multisig_account: INTERNAL
   //----------------------------------------------------------------------------------------------------------------------
   void multisig_account::set_multisig_config(const std::size_t threshold, std::vector<crypto::public_key> signers)
@@ -119,10 +143,6 @@ namespace multisig
 
     for (auto signer_it = signers.begin(); signer_it != signers.end(); ++signer_it)
     {
-      // signers should all be unique
-      CHECK_AND_ASSERT_THROW_MES(std::find(signers.begin(), signer_it, *signer_it) == signer_it,
-        "multisig account: tried to set signers, but found a duplicate signer unexpectedly.");
-
       // signer pubkeys must be in main subgroup, and not identity
       CHECK_AND_ASSERT_THROW_MES(rct::isInMainSubgroup(rct::pk2rct(*signer_it)) && !(*signer_it == rct::rct2pk(rct::identity())),
         "multisig account: tried to set signers, but a signer pubkey is invalid.");
@@ -133,12 +153,11 @@ namespace multisig
       "multisig account: tried to set signers, but did not find the account's base pubkey in signer list.");
 
     // sort signers
-    std::sort(signers.begin(), signers.end(),
-      [](const crypto::public_key &key1, const crypto::public_key &key2) -> bool
-        {
-          return memcmp(&key1, &key2, sizeof(crypto::public_key)) < 0;
-        }
-      );
+    std::sort(signers.begin(), signers.end());
+
+    // signers should all be unique
+    CHECK_AND_ASSERT_THROW_MES(std::adjacent_find(signers.begin(), signers.end()) == signers.end(),
+      "multisig account: tried to set signers, but there are duplicate signers unexpectedly.");
 
     // set
     m_threshold = threshold;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1091,7 +1091,9 @@ bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, boo
     auto local_args = args;
     local_args.erase(local_args.begin());
     std::string multisig_extra_info = m_wallet->make_multisig(orig_pwd_container->password(), local_args, threshold);
-    if (!multisig_extra_info.empty())
+    bool ready;
+    m_wallet->multisig(&ready);
+    if (!ready)
     {
       success_msg_writer() << tr("Another step is needed");
       success_msg_writer() << multisig_extra_info;
@@ -1152,7 +1154,7 @@ bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &
       return false;
     }
 
-    if (args.size() < 2)
+    if (args.size() < 1)
     {
       PRINT_USAGE(USAGE_EXCHANGE_MULTISIG_KEYS);
       return false;
@@ -1161,7 +1163,9 @@ bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &
     try
     {
       std::string multisig_extra_info = m_wallet->exchange_multisig_keys(orig_pwd_container->password(), args);
-      if (!multisig_extra_info.empty())
+      bool ready;
+      m_wallet->multisig(&ready);
+      if (!ready)
       {
         message_writer() << tr("Another step is needed");
         message_writer() << multisig_extra_info;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4132,7 +4132,8 @@ namespace tools
     try
     {
       res.multisig_info = m_wallet->exchange_multisig_keys(req.password, req.multisig_info);
-      if (res.multisig_info.empty())
+      m_wallet->multisig(&ready);
+      if (ready)
       {
         res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
       }

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -81,9 +81,7 @@ static bool make_multisig_accounts(std::vector<cryptonote::account_base> &accoun
   for (std::size_t account_index{0}; account_index < accounts.size(); ++account_index)
   {
     multisig_accounts[account_index].initialize_kex(threshold, signers, round_msgs);
-
-    if (!multisig_accounts[account_index].multisig_is_ready())
-      temp_round_msgs[account_index] = multisig_accounts[account_index].get_next_kex_round_msg();
+    temp_round_msgs[account_index] = multisig_accounts[account_index].get_next_kex_round_msg();
   }
 
   // perform key exchange rounds
@@ -94,9 +92,7 @@ static bool make_multisig_accounts(std::vector<cryptonote::account_base> &accoun
     for (std::size_t account_index{0}; account_index < multisig_accounts.size(); ++account_index)
     {
       multisig_accounts[account_index].kex_update(round_msgs);
-
-      if (!multisig_accounts[account_index].multisig_is_ready())
-        temp_round_msgs[account_index] = multisig_accounts[account_index].get_next_kex_round_msg();
+      temp_round_msgs[account_index] = multisig_accounts[account_index].get_next_kex_round_msg();
     }
   }
 

--- a/tests/functional_tests/multisig.py
+++ b/tests/functional_tests/multisig.py
@@ -125,17 +125,18 @@ class MultisigTest():
       for i in range(N_total):
         res = self.wallet[i].is_multisig()
         assert res.multisig == True
-        assert res.ready == (M_threshold == N_total)
+        assert not res.ready
         assert res.threshold == M_threshold
         assert res.total == N_total
 
       while True:
-        n_empty = 0
-        for i in range(len(next_stage)):
-          if len(next_stage[i]) == 0:
-            n_empty += 1
-        assert n_empty == 0 or n_empty == len(next_stage)
-        if n_empty == len(next_stage):
+        n_ready = 0
+        for i in range(N_total):
+          res = self.wallet[i].is_multisig()
+          if res.ready == True:
+            n_ready += 1
+        assert n_ready == 0 or n_ready == N_total
+        if n_ready == N_total:
           break
         info = next_stage
         next_stage = []
@@ -162,54 +163,72 @@ class MultisigTest():
             'peeled mixture ionic radar utopia puddle buying illness nuns gadget river spout cavernous bounced paradise drunk looking cottage jump tequila melting went winter adjust spout',
             'dilute gutter certain antics pamphlet macro enjoy left slid guarded bogeys upload nineteen bomb jubilee enhanced irritate turnip eggs swung jukebox loudly reduce sedan slid',
         ]
-        info = []
-        wallet = [None, None, None]
-        for i in range(3):
-            wallet[i] = Wallet(idx = i)
-            try: wallet[i].close_wallet()
+        info2of2 = []
+        wallet2of2 = [None, None]
+        for i in range(2):
+            wallet2of2[i] = Wallet(idx = i)
+            try: wallet2of2[i].close_wallet()
             except: pass
-            res = wallet[i].restore_deterministic_wallet(seed = seeds[i])
-            res = wallet[i].is_multisig()
+            res = wallet2of2[i].restore_deterministic_wallet(seed = seeds[i])
+            res = wallet2of2[i].is_multisig()
             assert not res.multisig
-            res = wallet[i].prepare_multisig()
+            res = wallet2of2[i].prepare_multisig()
             assert len(res.multisig_info) > 0
-            info.append(res.multisig_info)
+            info2of2.append(res.multisig_info)
 
-        for i in range(3):
-            ok = False
-            try: res = wallet[i].exchange_multisig_keys(info)
-            except: ok = True
-            assert ok
-            res = wallet[i].is_multisig()
-            assert not res.multisig
-
-        res = wallet[0].make_multisig(info[0:2], 2)
-        res = wallet[0].is_multisig()
+        kex_info = []
+        res = wallet2of2[0].make_multisig(info2of2, 2)
+        kex_info.append(res.multisig_info)
+        res = wallet2of2[1].make_multisig(info2of2, 2)
+        kex_info.append(res.multisig_info)
+        res = wallet2of2[0].exchange_multisig_keys(kex_info)
+        res = wallet2of2[0].is_multisig()
         assert res.multisig
         assert res.ready
 
         ok = False
-        try: res = wallet[0].prepare_multisig()
+        try: res = wallet2of2[0].prepare_multisig()
         except: ok = True
         assert ok
 
         ok = False
-        try: res = wallet[0].make_multisig(info[0:2], 2)
+        try: res = wallet2of2[0].make_multisig(info2of2, 2)
         except: ok = True
         assert ok
 
-        res = wallet[1].make_multisig(info, 2)
-        res = wallet[1].is_multisig()
+        info2of3 = []
+        wallet2of3 = [None, None, None]
+        for i in range(3):
+            wallet2of3[i] = Wallet(idx = i)
+            try: wallet2of3[i].close_wallet()
+            except: pass
+            res = wallet2of3[i].restore_deterministic_wallet(seed = seeds[i])
+            res = wallet2of3[i].is_multisig()
+            assert not res.multisig
+            res = wallet2of3[i].prepare_multisig()
+            assert len(res.multisig_info) > 0
+            info2of3.append(res.multisig_info)
+
+        for i in range(3):
+            ok = False
+            try: res = wallet2of3[i].exchange_multisig_keys(info)
+            except: ok = True
+            assert ok
+            res = wallet2of3[i].is_multisig()
+            assert not res.multisig
+
+        res = wallet2of3[1].make_multisig(info2of3, 2)
+        res = wallet2of3[1].is_multisig()
         assert res.multisig
         assert not res.ready
 
         ok = False
-        try: res = wallet[1].prepare_multisig()
+        try: res = wallet2of3[1].prepare_multisig()
         except: ok = True
         assert ok
 
         ok = False
-        try: res = wallet[1].make_multisig(info[0:2], 2)
+        try: res = wallet2of3[1].make_multisig(info2of3[0:2], 2)
         except: ok = True
         assert ok
 


### PR DESCRIPTION
**Problem**: When creating a group multisig account, each step of key exchange relies on messages from all other participants. If a malicious player only sends their final message to one honest player, but not others, then the other honest players will be stuck without completed accounts. If that one honest player receives funds to the address he created, then those funds will either be unspendable or only spendable with cooperation from malicious group members.

**Solution**: Add a round to multisig account creation to verify that all other participants have completed their accounts.

This PR also has some semantic and control-flow cleanup of the multisig kex implementation (I am not satisfied with the readability of my earlier work - cleanup will continue in PR #8203 and alongside the Seraphis library which adds support for aggregation-style multisig signing).

**TODO**: In PR #8203 (or maybe a separate PR), I will add an `unsafe_update_use_with_care` flag to the `multisig_account::initialize_kex()` and `multisig_account::kex_update()` methods. This flag will allow users to fast-forward through the extra round added by this PR, and under some conditions even do so safely (without needing to trust other participants).