### PR TITLE
Eliminate dependence on boost::interprocess

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -49,7 +49,6 @@
 #include <boost/asio/ssl.hpp>
 #include <boost/array.hpp>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/interprocess/detail/atomic.hpp>
 #include <boost/thread/thread.hpp>
 #include "byte_slice.h"
 #include "net_utils_base.h"
@@ -393,7 +392,7 @@ namespace net_utils
     std::vector<boost::shared_ptr<boost::thread> > m_threads;
     boost::thread::id m_main_thread_id;
     critical_section m_threads_lock;
-    volatile uint32_t m_thread_index; // TODO change to std::atomic
+    std::atomic<uint32_t> m_thread_index;
 
     t_connection_type m_connection_type;
 

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -106,7 +106,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		std::unique_ptr< connection_basic_pimpl > mI; // my Implementation
 
 		// moved here from orginal connecton<> - common member variables that do not depend on template in connection<>
-    volatile uint32_t m_want_close_connection;
+    std::atomic<bool> m_want_close_connection;
     std::atomic<bool> m_was_shutdown;
     critical_section m_send_que_lock;
     std::deque<byte_slice> m_send_que;

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -42,11 +42,9 @@
 #include <vector>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
-#include <atomic>
 
 #include <boost/array.hpp>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/interprocess/detail/atomic.hpp>
 #include <boost/thread/thread.hpp>
 
 #include "syncobj.h"

--- a/contrib/epee/include/reg_exp_definer.h
+++ b/contrib/epee/include/reg_exp_definer.h
@@ -28,7 +28,7 @@
 #ifndef _REG_EXP_DEFINER_H_
 #define _REG_EXP_DEFINER_H_
 
-#include <boost/interprocess/detail/atomic.hpp>
+#include <atomic>
 #include <boost/regex.hpp>
 #include "syncobj.h"
 
@@ -46,38 +46,38 @@ namespace epee
   const static global_regexp_critical_section gregexplock;
 
 #define STATIC_REGEXP_EXPR_1(var_name, xpr_text, reg_exp_flags) \
-	static volatile uint32_t regexp_initialized_1 = 0;\
+	static std::atomic<bool> regexp_initialized_1(false);\
 	volatile uint32_t local_is_initialized_1 = regexp_initialized_1;\
 	if(!local_is_initialized_1)\
 	gregexplock.get_lock().lock();\
 	static const boost::regex	var_name(xpr_text , reg_exp_flags);\
 	if(!local_is_initialized_1)\
 {\
-	boost::interprocess::ipcdetail::atomic_write32(&regexp_initialized_1, 1);\
+	regexp_initialized_1 = true;\
 	gregexplock.get_lock().unlock();\
 }
 
 #define STATIC_REGEXP_EXPR_2(var_name, xpr_text, reg_exp_flags) \
-	static volatile uint32_t regexp_initialized_2 = 0;\
+	static std::atomic<bool> regexp_initialized_2(false);\
 	volatile uint32_t local_is_initialized_2 = regexp_initialized_2;\
 	if(!local_is_initialized_2)\
 	gregexplock.get_lock().lock().lock();\
 	static const boost::regex	var_name(xpr_text , reg_exp_flags);\
 	if(!local_is_initialized_2)\
 {\
-	boost::interprocess::ipcdetail::atomic_write32(&regexp_initialized_2, 1);\
+	regexp_initialized_2 = true;\
 	gregexplock.get_lock().lock().unlock();\
 }
 
 #define STATIC_REGEXP_EXPR_3(var_name, xpr_text, reg_exp_flags) \
-	static volatile uint32_t regexp_initialized_3 = 0;\
+	static std::atomic<bool> regexp_initialized_3(false);\
 	volatile uint32_t local_is_initialized_3 = regexp_initialized_3;\
 	if(!local_is_initialized_3)\
 	gregexplock.get_lock().lock().lock();\
 	static const boost::regex	var_name(xpr_text , reg_exp_flags);\
 	if(!local_is_initialized_3)\
 {\
-	boost::interprocess::ipcdetail::atomic_write32(&regexp_initialized_3, 1);\
+	regexp_initialized_3 = true;\
 	gregexplock.get_lock().lock().unlock();\
 }
 }

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -30,7 +30,6 @@
 
 #include <sstream>
 #include <numeric>
-#include <boost/interprocess/detail/atomic.hpp>
 #include <boost/algorithm/string.hpp>
 #include "misc_language.h"
 #include "syncobj.h"
@@ -271,13 +270,13 @@ namespace cryptonote
     // restart all threads
     {
       CRITICAL_REGION_LOCAL(m_threads_lock);
-      boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
+      m_stop = true;
       while (m_threads_active > 0)
         misc_utils::sleep_no_w(100);
       m_threads.clear();
     }
-    boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
-    boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+    m_stop = false;
+    m_thread_index = 0;
     for(size_t i = 0; i != m_threads_total; i++)
       m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
   }
@@ -394,8 +393,8 @@ namespace cryptonote
 
     request_block_template();//lets update block template
 
-    boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
-    boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
+    m_stop = false;
+    m_thread_index = 0;
     set_is_background_mining_enabled(do_background);
     set_ignore_battery(ignore_battery);
     
@@ -435,7 +434,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------------
   void miner::send_stop_signal()
   {
-    boost::interprocess::ipcdetail::atomic_write32(&m_stop, 1);
+    m_stop = true;
   }
   extern "C" void rx_stop_mining(void);
   //-----------------------------------------------------------------------------------------------------
@@ -524,7 +523,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------------
   bool miner::worker_thread()
   {
-    uint32_t th_local_index = boost::interprocess::ipcdetail::atomic_inc32(&m_thread_index);
+    const uint32_t th_local_index = m_thread_index++; // atomically increment, getting value before increment
     MLOG_SET_THREAD_NAME(std::string("[miner ") + std::to_string(th_local_index) + "]");
     MGINFO("Miner thread was started ["<< th_local_index << "]");
     uint32_t nonce = m_starter_nonce + th_local_index;

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -118,14 +118,14 @@ namespace cryptonote
     };
 
 
-    volatile uint32_t m_stop;
+    std::atomic<bool> m_stop;
     epee::critical_section m_template_lock;
     block m_template;
     std::atomic<uint32_t> m_template_no;
     std::atomic<uint32_t> m_starter_nonce;
     difficulty_type m_diffic;
     uint64_t m_height;
-    volatile uint32_t m_thread_index; 
+    std::atomic<uint32_t> m_thread_index;
     volatile uint32_t m_threads_total;
     std::atomic<uint32_t> m_threads_active;
     std::atomic<int32_t> m_pausers_count;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -35,7 +35,6 @@
 // (may contain code and/or modifications by other developers)
 // developer rfree: this code is caller of our new network code, and is modded; e.g. for rate limiting
 
-#include <boost/interprocess/detail/atomic.hpp>
 #include <list>
 #include <ctime>
 


### PR DESCRIPTION
In this repo, `boost::interprocess` was being used soley to make `uint32_t` operations atomic. So I replaced each instance of
`boost::interprocess::ipcdetail::atomic(...)32` with `std::atomic` methods. I replaced member declarations as applicable. For example, when I needed to change a `volatile uint32_t` into a `std::atomic<uint32_t>`. Sometimes, a member was being used a boolean flag, so I replaced it with `std::atomic<bool>`.

You may notice that I didn't touch `levin_client_async.h`. That is because this file is entirely unused and will be deleted in PR #8211.

When I get more time, I will benchmark this to see if this changed the compile time in any manner.