### PR TITLE
Remove dead code from parserse_base_utils and fix unit tests

### DIFF
--- a/contrib/epee/include/storages/parserse_base_utils.h
+++ b/contrib/epee/include/storages/parserse_base_utils.h
@@ -107,48 +107,10 @@ namespace misc_utils
 
       */
       void match_string2(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string& val);
-      inline bool match_string(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string& val)
-      {
-        try
-        {
 
-          match_string2(star_end_string, buf_end, val);
-          return true;
-        }
-        catch(...)
-        {
-          return false;
-        }
-      }
       void match_number2(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, boost::string_ref& val, bool& is_float_val, bool& is_signed_val);
-      inline bool match_number(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, boost::string_ref& val)
-      {
-        try
-        {
-          bool is_v_float = false;bool is_signed_val = false;
-          match_number2(star_end_string, buf_end, val, is_v_float, is_signed_val);
-          return !is_v_float;
-        }
-        catch(...)
-        {
-          return false;
-        }
-      }
+
       void match_word2(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, boost::string_ref& val);
-      inline bool match_word(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, boost::string_ref& val)
-      {
-        try
-        {
-          match_word2(star_end_string, buf_end, val);
-          return true;
-        }
-        catch(...)
-        {
-          return false;
-        }
-      }
-      bool match_word_with_extrasymb(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string& val);
-      bool match_word_til_equal_mark(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string::const_iterator& word_end);
   }
 }
 }

--- a/contrib/epee/src/parserse_base_utils.cpp
+++ b/contrib/epee/src/parserse_base_utils.cpp
@@ -239,44 +239,6 @@ namespace misc_utils
         }
         ASSERT_MES_AND_THROW("failed to match word number in json entry: " << std::string(star_end_string, buf_end));
       }
-      bool match_word_with_extrasymb(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string& val)
-      {
-        val.clear();
-
-        for(std::string::const_iterator it = star_end_string;it != buf_end;++it)
-        {
-          if(!isalnum(*it) && *it != '-' && *it != '_')
-          {
-            val.assign(star_end_string, it);
-            if(val.size())
-            {
-              star_end_string = --it;
-              return true;
-            }else 
-              return false;
-          }
-        }
-        return false;
-      }
-      bool match_word_til_equal_mark(std::string::const_iterator& star_end_string, std::string::const_iterator buf_end, std::string::const_iterator& word_end)
-      {
-        word_end = star_end_string;
-
-        for(std::string::const_iterator it = star_end_string;it != buf_end;++it)
-        {
-          if(isspace(*it))
-          {
-
-            continue;
-          }else if( *it == '=' )
-          {            
-            star_end_string = it;
-            word_end = it;
-            return true;
-          }
-        }
-        return false;
-      }
   }
 }
 }


### PR DESCRIPTION
* Remove `match_string()`, `match_number()`, and `match_word()`
* Remove `match_word_with_extrasymb()` and `match_word_til_equal_mark()`
* Adapt unit test for `match_number()` to `match_number2()`
* Adapt unit test for `match_string()` to `match_string2()`

Note: the unit tests were testing for the old version of the functions, and
the interfaces for these functions changed slightly, so I had to also edit
the tests.

As of writing, this PR has no merge conflicts with #8211