### PR TITLE
Added support for Ledger Nano S Plus

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, The Monero Project
+// Copyright (c) 2017-2022, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -524,6 +524,7 @@ namespace hw {
     static const std::vector<hw::io::hid_conn_params> known_devices {
         {0x2c97, 0x0001, 0, 0xffa0}, 
         {0x2c97, 0x0004, 0, 0xffa0},       
+        {0x2c97, 0x0005, 0, 0xffa0},
     };
 
     bool device_ledger::connect(void) {


### PR DESCRIPTION
The [Ledger nano S plus](https://shop.ledger.com/pages/ledger-nano-s-plus?r=00d147b67b6d) has a new Product ID, this PR adds it to the list of known IDs so the Nano S Plus can be used.