### PR TITLE
CMake: Add missing BUILD_SHARED_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,9 +472,11 @@ endif()
 option(STATIC "Link libraries statically" ${DEFAULT_STATIC})
 
 # This is a CMake built-in switch that concerns internal libraries
-if (NOT DEFINED BUILD_SHARED_LIBS AND NOT STATIC AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
-    set(BUILD_SHARED_LIBS ON)
+set(BUILD_SHARED_LIBS_DEFAULT OFF)
+if (NOT STATIC AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
+	set(BUILD_SHARED_LIBS_DEFAULT ON)
 endif()
+option(BUILD_SHARED_LIBS "Build internal libraries as shared" ${BUILD_SHARED_LIBS_DEFAULT})
 
 if (BUILD_SHARED_LIBS)
   message(STATUS "Building internal libraries with position independent code")


### PR DESCRIPTION
The option `BUILD_SHARED_LIBS` was inaccessible to GUI CMake's wrappers. One such GUI wrapper is used by VSCodium, and is the only way to change the variables from that IDE. VSCodium was the most popular IDE, as [a result of my Reddit poll](https://www.reddit.com/r/Monero/comments/t9iy3b/poll_what_ide_would_you_like_to_have_documented/). The option is required to minimize linking time when practicing test driven development, [as described here](https://github.com/monero-project/monero/blob/master/docs/COMPILING_DEBUGGING_TESTING.md#test-driven-development-tdd---shared-libraries-for-release-builds).

In order not to break the traditional flow, the option is only advertised after the line 476:
```CMake
if (NOT STATIC AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
```
and only given distinct default values for each of the 2 cases.


The practical impact of this change is, that whenever the debug version is selected via CMake, the linking will still produce shared libraries by default, but the variable's value still be changed via CMake's GUIs, that work in-source (VSCode / VSCodium). Without it, building the release version under these in-source IDEs forces the build to be statically linked. Out-of-source IDEs, like Code::Blocks, are able to get around it without this PR.

## Measurements

| Directory |  Static    |      Dynamic      | Change |
|-------------|----------|-------------|-------------|
| total  |   700M  | 434M  |  -38.04% |
| bin   |   121M  | 15M  | -88.24%  |

As you can see, quite a lot was achieved on the total directory, but even more in the `bin` directory, which will serve as a regularizer for future, should more executables be created.