### PR TITLE
tests: integrated_address: remove missing payment id assertion

### DIFF
--- a/tests/functional_tests/integrated_address.py
+++ b/tests/functional_tests/integrated_address.py
@@ -80,13 +80,11 @@ class IntegratedAddressTest():
         except: fails += 1
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '112233445566778')
         except: fails += 1
-        try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '')
-        except: fails += 1
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '112233445566778g')
         except: fails += 1
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '1122334455667788112233445566778811223344556677881122334455667788')
         except: fails += 1
-        assert fails == 5
+        assert fails == 4
 
         print('Checking bad standard address')
         fails = 0


### PR DESCRIPTION
The integrated address functional test fails in the workflows due
to an assertion for missing payment id that is no longer needed.
Remove the assertion and update the assertion count.

Fixes 7dcfccb: ("wallet_rpc_server: fix make_integrated_address with no payment id")