### PR TITLE
simplewallet: fix integrated_address output string

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -9820,7 +9820,7 @@ bool simple_wallet::print_integrated_address(const std::vector<std::string> &arg
     {
       if (info.has_payment_id)
       {
-        success_msg_writer() << boost::format(tr("Integrated address: %s, payment ID: %s")) %
+        success_msg_writer() << boost::format(tr("Standard address: %s, payment ID: %s")) %
           get_account_address_as_str(m_wallet->nettype(), false, info.address) % epee::string_tools::pod_to_hex(info.payment_id);
         device_show_integrated(info.payment_id);
       }


### PR DESCRIPTION
Before:

```
[wallet 49C5ha]: integrated_address 4JtkiNvoi3iSPHHvcfXPPyj66zHQ9h1X9hmLCjDZ6kbNUhtYwDhAMm79p9GZ1iPCUhDMEvKMkMJdgb7JURAkCZUuhuFpASeBvCxRJ5v9Je
Integrated address: 49C5ha7K6nCSPHHvcfXPPyj66zHQ9h1X9hmLCjDZ6kbNUhtYwDhAMm79p9GZ1iPCUhDMEvKMkMJdgb7JURAkCZUuUaa9DCp, payment ID: 87e4b8861f9c69d7
```

After:

```
[wallet 49C5ha]: integrated_address 4JtkiNvoi3iSPHHvcfXPPyj66zHQ9h1X9hmLCjDZ6kbNUhtYwDhAMm79p9GZ1iPCUhDMEvKMkMJdgb7JURAkCZUuhuFpASeBvCxRJ5v9Je
Standard address: 49C5ha7K6nCSPHHvcfXPPyj66zHQ9h1X9hmLCjDZ6kbNUhtYwDhAMm79p9GZ1iPCUhDMEvKMkMJdgb7JURAkCZUuUaa9DCp, payment ID: 87e4b8861f9c69d7
```