### PR TITLE
Tiny: add .vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ cmake-build-debug/
 # KDE directory preferences
 .directory
 
+### VSCode ###
+.vscode/
 
 ### Eclipse ###
 *.pydevproject


### PR DESCRIPTION
Added `.vscode/` entry to `.gitignore` ahead of documenting VSCode/VSCodium IDE's specifics.