### PR TITLE
depends: update unbound to 1.15.0

### DIFF
--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -1,8 +1,8 @@
 package=unbound
-$(package)_version=1.13.2
+$(package)_version=1.15.0
 $(package)_download_path=https://www.nlnetlabs.nl/downloads/$(package)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=0a13b547f3b92a026b5ebd0423f54c991e5718037fd9f72445817f6a040e1a83
+$(package)_sha256_hash=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
 $(package)_dependencies=openssl expat ldns
 
 define $(package)_set_vars


### PR DESCRIPTION
Someone reported a crash / memory corruption bug on IRC that had unbound related error messages so I thought about updating `unbound` again.

Change logs:

- https://github.com/NLnetLabs/unbound/releases/tag/release-1.14.0
- https://github.com/NLnetLabs/unbound/releases/tag/release-1.15.0

I don't think there is anything relevant for monero but updating doesn't hurt.