### PR TITLE
Preserve commitment format inside transactions

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -241,15 +241,8 @@ void BlockchainDB::add_transaction(const crypto::hash& blk_hash, const std::pair
     }
     else
     {
-      rct::key commitment;
-      if (tx.version > 1)
-      {
-        commitment = tx.rct_signatures.outPk[i].mask;
-        if (rct::is_rct_bulletproof_plus(tx.rct_signatures.type))
-          commitment = rct::scalarmult8(commitment);
-      }
       amount_output_indices[i] = add_output(tx_hash, tx.vout[i], i, tx.unlock_time,
-        tx.version > 1 ? &commitment : NULL);
+        tx.version > 1 ? &tx.rct_signatures.outPk[i].mask : NULL);
     }
   }
   add_tx_amount_output_indices(tx_id, amount_output_indices);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -190,7 +190,7 @@ namespace cryptonote
           CHECK_AND_ASSERT_MES(n_amounts == rv.outPk.size(), false, "Internal error filling out V");
           rv.p.bulletproofs_plus[0].V.resize(n_amounts);
           for (size_t i = 0; i < n_amounts; ++i)
-            rv.p.bulletproofs_plus[0].V[i] = rv.outPk[i].mask;
+            rv.p.bulletproofs_plus[0].V[i] = rct::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
         }
         else if (bulletproof)
         {

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1235,10 +1235,7 @@ namespace rct {
                 }
                 for (i = 0; i < outamounts.size(); ++i)
                 {
-                    if (plus)
-                      rv.outPk[i].mask = C[i];
-                    else
-                      rv.outPk[i].mask = rct::scalarmult8(C[i]);
+                    rv.outPk[i].mask = rct::scalarmult8(C[i]);
                     outSk[i].mask = masks[i];
                 }
             }
@@ -1276,10 +1273,7 @@ namespace rct {
                 }
                 for (i = 0; i < batch_size; ++i)
                 {
-                  if (plus)
-                    rv.outPk[i + amounts_proved].mask = C[i];
-                  else
-                    rv.outPk[i + amounts_proved].mask = rct::scalarmult8(C[i]);
+                  rv.outPk[i + amounts_proved].mask = rct::scalarmult8(C[i]);
                   outSk[i + amounts_proved].mask = masks[i];
                 }
                 amounts_proved += batch_size;
@@ -1486,10 +1480,7 @@ namespace rct {
 
           rct::keyV masks(rv.outPk.size());
           for (size_t i = 0; i < rv.outPk.size(); i++) {
-            if (bulletproof_plus)
-              masks[i] = rct::scalarmult8(rv.outPk[i].mask);
-            else
-              masks[i] = rv.outPk[i].mask;
+            masks[i] = rv.outPk[i].mask;
           }
           key sumOutpks = addKeys(masks);
           DP(sumOutpks);
@@ -1649,8 +1640,6 @@ namespace rct {
         mask = ecdh_info.mask;
         key amount = ecdh_info.amount;
         key C = rv.outPk[i].mask;
-        if (is_rct_bulletproof_plus(rv.type))
-          C = scalarmult8(C);
         DP("C");
         DP(C);
         key Ctmp;
@@ -1682,8 +1671,6 @@ namespace rct {
         mask = ecdh_info.mask;
         key amount = ecdh_info.amount;
         key C = rv.outPk[i].mask;
-        if (is_rct_bulletproof_plus(rv.type))
-          C = scalarmult8(C);
         DP("C");
         DP(C);
         key Ctmp;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11352,9 +11352,7 @@ void wallet2::check_tx_key_helper(const cryptonote::transaction &tx, const crypt
         crypto::derivation_to_scalar(found_derivation, n, scalar1);
         rct::ecdhTuple ecdh_info = tx.rct_signatures.ecdhInfo[n];
         rct::ecdhDecode(ecdh_info, rct::sk2rct(scalar1), tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
-        rct::key C = tx.rct_signatures.outPk[n].mask;
-        if (rct::is_rct_bulletproof_plus(tx.rct_signatures.type))
-          C = rct::scalarmult8(C);
+        const rct::key C = tx.rct_signatures.outPk[n].mask;
         rct::key Ctmp;
         THROW_WALLET_EXCEPTION_IF(sc_check(ecdh_info.mask.bytes) != 0, error::wallet_internal_error, "Bad ECDH input mask");
         THROW_WALLET_EXCEPTION_IF(sc_check(ecdh_info.amount.bytes) != 0, error::wallet_internal_error, "Bad ECDH input amount");

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -450,8 +450,6 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
       rct::ecdhTuple ecdh_info = tx.rct_signatures.ecdhInfo[n];
       rct::ecdhDecode(ecdh_info, rct::sk2rct(scalar1), tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
       rct::key C = tx.rct_signatures.outPk[n].mask;
-      if (rct::is_rct_bulletproof_plus(tx.rct_signatures.type))
-        C = rct::scalarmult8(C);
       rct::addKeys2(Ctmp, ecdh_info.mask, ecdh_info.amount, rct::H);
       CHECK_AND_ASSERT_MES(rct::equalKeys(C, Ctmp), false, "Failed to decode amount");
       amount += rct::h2d(ecdh_info.amount);


### PR DESCRIPTION
A change to the format commitment / 8 was included with BP+, which is a minor optimization which increased complexity, spread out where crypto code is handled, and created a disparate state between transactions and disk (as they were saved in their full form thanks to a processing step inside the DB code).

This PR reverts this planned change. The blockchain_db.cpp edits may look to be further edited than just this reversion, yet that was its code pre-BP+.