### PR TITLE
wallet2: Erase payments for self-spends or change when importing key images

### DIFF
--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -35,12 +35,17 @@ from __future__ import print_function
 from framework.daemon import Daemon
 from framework.wallet import Wallet
 
+SEED = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
+STANDARD_ADDRESS = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+SUBADDRESS = '84QRUYawRNrU3NN1VpFRndSukeyEb3Xpv8qZjjsoJZnTYpDYceuUTpog13D7qPxpviS7J29bSgSkR11hFFoXWk2yNdsR9WF'
+
 class ColdSigningTest():
     def run_test(self):
         self.reset()
         self.create(0)
         self.mine()
         self.transfer()
+        self.self_transfer_to_subaddress()
 
     def reset(self):
         print('Resetting blockchain')
@@ -62,12 +67,11 @@ class ColdSigningTest():
         try: self.cold_wallet.close_wallet()
         except: pass
 
-        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
-        res = self.cold_wallet.restore_deterministic_wallet(seed = seed)
+        res = self.cold_wallet.restore_deterministic_wallet(seed = SEED)
         self.cold_wallet.set_daemon('127.0.0.1:11111', ssl_support = "disabled")
         spend_key = self.cold_wallet.query_key("spend_key").key
         view_key = self.cold_wallet.query_key("view_key").key
-        res = self.hot_wallet.generate_from_keys(viewkey = view_key, address = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm')
+        res = self.hot_wallet.generate_from_keys(viewkey = view_key, address = STANDARD_ADDRESS)
 
         ok = False
         try: res = self.hot_wallet.query_key("spend_key")
@@ -79,26 +83,26 @@ class ColdSigningTest():
         assert ok
         assert self.cold_wallet.query_key("view_key").key == view_key
         assert self.cold_wallet.get_address().address == self.hot_wallet.get_address().address
+        assert self.cold_wallet.get_address().address == STANDARD_ADDRESS
+        assert self.cold_wallet.create_address().address == SUBADDRESS
 
     def mine(self):
         print("Mining some blocks")
         daemon = Daemon()
         wallet = Wallet()
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 80)
+        daemon.generateblocks(STANDARD_ADDRESS, 80)
         wallet.refresh()
 
-    def transfer(self):
+    def create_tx(self, destination_addr):
         daemon = Daemon()
 
-        print("Creating transaction in hot wallet")
+        dst = {'address': destination_addr, 'amount': 1000000000000}
 
-        dst = {'address': '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'amount': 1000000000000}
-
-        self.hot_wallet.refresh()
-        res = self.hot_wallet.export_outputs()
+        self.hot_wallet.rescan_blockchain(hard = True)
+        res = self.hot_wallet.export_outputs(all_ = True)
         self.cold_wallet.import_outputs(res.outputs_data_hex)
-        res = self.cold_wallet.export_key_images(True)
+        res = self.cold_wallet.export_key_images(all_ = True)
         self.hot_wallet.import_key_images(res.signed_key_images, offset = res.offset)
 
         res = self.hot_wallet.transfer([dst], ring_size = 11, get_tx_key = False)
@@ -125,11 +129,11 @@ class ColdSigningTest():
         assert desc.unlock_time == 0
         assert desc.payment_id in ['', '0000000000000000']
         assert desc.change_amount == desc.amount_in - 1000000000000 - fee
-        assert desc.change_address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert desc.change_address == STANDARD_ADDRESS
         assert desc.fee == fee
         assert len(desc.recipients) == 1
         rec = desc.recipients[0]
-        assert rec.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert rec.address == destination_addr
         assert rec.amount == 1000000000000
 
         res = self.cold_wallet.sign_transfer(unsigned_txset)
@@ -145,13 +149,15 @@ class ColdSigningTest():
         assert res.tx_hash_list[0] == txid
 
         res = self.hot_wallet.get_transfers()
+        assert len([x for x in (res['in'] if 'in' in res else []) if x.txid == txid]) == 0
         assert len([x for x in (res['pending'] if 'pending' in res else []) if x.txid == txid]) == 1
         assert len([x for x in (res['out'] if 'out' in res else []) if x.txid == txid]) == 0
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks(STANDARD_ADDRESS, 1)
         self.hot_wallet.refresh()
 
         res = self.hot_wallet.get_transfers()
+        assert len([x for x in (res['in'] if 'in' in res else []) if x.txid == txid]) == 0
         assert len([x for x in (res['pending'] if 'pending' in res else []) if x.txid == txid]) == 0
         assert len([x for x in (res['out'] if 'out' in res else []) if x.txid == txid]) == 1
 
@@ -160,6 +166,25 @@ class ColdSigningTest():
         res = self.cold_wallet.get_tx_key(txid)
         assert len(res.tx_key) == 64
 
+        self.hot_wallet.rescan_blockchain(hard = True)
+
+        res = self.hot_wallet.export_outputs(all_ = True)
+        self.cold_wallet.import_outputs(res.outputs_data_hex)
+        res = self.cold_wallet.export_key_images(all_ = True)
+        self.hot_wallet.import_key_images(res.signed_key_images, offset = res.offset)
+
+        res = self.hot_wallet.get_transfers()
+        assert len([x for x in (res['in'] if 'in' in res else []) if x.txid == txid]) == 0
+        assert len([x for x in (res['pending'] if 'pending' in res else []) if x.txid == txid]) == 0
+        assert len([x for x in (res['out'] if 'out' in res else []) if x.txid == txid]) == 1
+
+    def transfer(self):
+        print("Creating transaction in hot wallet")
+        self.create_tx(STANDARD_ADDRESS)
+
+    def self_transfer_to_subaddress(self):
+        print("Self-spending to subaddress in hot wallet")
+        self.create_tx(SUBADDRESS)
 
 class Guard:
     def __enter__(self):

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -762,10 +762,11 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(get_languages)
 
-    def export_outputs(self):
+    def export_outputs(self, all_ = False):
         export_outputs = {
             'method': 'export_outputs',
             'params': {
+                'all': all_
             },
             'jsonrpc': '2.0', 
             'id': '0'


### PR DESCRIPTION
When self-spending to a subaddress, a view-only wallet that had not already imported key images prior to scanning the tx will misinterpret the change in the tx as a "payment". This PR ensures that change and self-spends to the spending account are removed from payments upon importing key images.

Related to (and hopefully fixes) #8167 