### PR TITLE
Gitian: refresh submodules before compiling

### DIFF
--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 gsigs = 'https://github.com/monero-project/gitian.sigs.git'
-gbrepo = 'https://github.com/devrandom/gitian-builder.git'
+gbrepo = 'https://github.com/mj-xmr/gitian-builder-mj.git'
 
 platforms = {'l': ['Linux', 'linux', 'tar.bz2'],
         'a': ['Android', 'android', 'tar.bz2'],
@@ -28,7 +28,7 @@ def setup():
     if not os.path.isdir('builder'):
         subprocess.check_call(['git', 'clone', gbrepo, 'builder'])
     os.chdir('builder')
-    subprocess.check_call(['git', 'checkout', 'c0f77ca018cb5332bfd595e0aff0468f77542c23'])
+    subprocess.check_call(['git', 'checkout', '495577125b76c0fe600d3e5b76a2bb951e09f788'])
     os.makedirs('inputs', exist_ok=True)
     os.chdir('inputs')
     if not os.path.isdir('monero'):


### PR DESCRIPTION
Prevents symptoms such as:

`Submodule 'external/miniupnp' is not up-to-date.`

during performing "Reproducible Builds".

The problem lies in `gitian-builder`, where the [submodule synchronisation is not done thoroughly](https://github.com/devrandom/gitian-builder/blob/master/bin/gbuild#L340):

```Ruby
system!("cd inputs/#{dir} && git submodule update --init --recursive --force")
```

Please compare with [my version](https://github.com/mj-xmr/gitian-builder-mj/blob/submodule-update/bin/gbuild#L304-L307):
```Ruby
    system!("cd inputs/#{dir} && git submodule update --init --recursive --force")
    system!("cd inputs/#{dir} && git submodule update --remote")
    system!("cd inputs/#{dir} && git submodule sync")
    system!("cd inputs/#{dir} && git submodule update")
```

[EDIT]: A much less obtrusive alternative can be found here: https://github.com/monero-project/monero/pull/8296