### PR TITLE
Gitian: refresh the stale Monero dir via --setup switch

### DIFF
--- a/contrib/gitian/README.md
+++ b/contrib/gitian/README.md
@@ -133,10 +133,11 @@ Common setup part:
 su - gitianuser
 
 GH_USER=YOUR_GITHUB_USER_NAME
-VERSION=v0.17.2.0
+VERSION=v0.17.3.2
 ```
 
 Where `GH_USER` is your GitHub user name and `VERSION` is the version tag you want to build. 
+The `gitian-build.py`'s `--setup` switch will also refresh the environment of any stale files and submodules.
 
 Setup for LXC:
 

--- a/contrib/gitian/gitian-build.py
+++ b/contrib/gitian/gitian-build.py
@@ -31,8 +31,10 @@ def setup():
     subprocess.check_call(['git', 'checkout', 'c0f77ca018cb5332bfd595e0aff0468f77542c23'])
     os.makedirs('inputs', exist_ok=True)
     os.chdir('inputs')
-    if not os.path.isdir('monero'):
-        subprocess.check_call(['git', 'clone', args.url, 'monero'])
+    if os.path.isdir('monero'):
+        # Remove the potentially stale monero dir. Otherwise you might face submodule mismatches.
+        subprocess.check_call(['rm', 'monero', '-fR'])
+    subprocess.check_call(['git', 'clone', args.url, 'monero'])
     os.chdir('..')
     make_image_prog = ['bin/make-base-vm', '--suite', 'bionic', '--arch', 'amd64']
     if args.docker:


### PR DESCRIPTION
Prevents symptoms such as:

`Submodule 'external/miniupnp' is not up-to-date.`

during performing "Reproducible Builds".

A much less obtrusive alternative to https://github.com/monero-project/monero/pull/8292

Here I'm simply deleting the `monero` directory via the `--setup` switch and allow it to be cloned from scratch.
Thanks to @hyc for pointing out the easy way.