### PR TITLE
Doxygen: Hide anonymous namespaces from documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -452,7 +452,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # are hidden.
 # The default value is: NO.
 
-EXTRACT_ANON_NSPACES   = YES
+EXTRACT_ANON_NSPACES   = NO
 
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, doxygen will hide all
 # undocumented members inside documented classes or files. If set to NO these

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -104,7 +104,7 @@ namespace net_utils
     //! \return False iff ssl is disabled, otherwise true.
     explicit operator bool() const noexcept { return support != ssl_support_t::e_ssl_support_disabled; }
 
-    //! \retrurn True if `host` can be verified using `this` configuration WITHOUT system "root" CAs.
+    //! \return True if `host` can be verified using `this` configuration WITHOUT system "root" CAs.
     bool has_strong_verification(boost::string_ref host) const noexcept;
 
     //! Search against internal fingerprints. Always false if `behavior() != user_certificate_check`.


### PR DESCRIPTION
Thanks to @selsta for pointing out the Doxygen option!

No more of this:

![Screenshot from 2022-04-28 18-46-03](https://user-images.githubusercontent.com/10839482/165868858-c999356f-f9ed-4a06-b0e9-30d9090bd590.png)

Bonus: little doc fix for net_ssl.h

