### PR TITLE
Update copyright to 2022 for Hardfork files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2021, The Monero Project
+Copyright (c) 2014-2022, The Monero Project
 
 All rights reserved.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2020, The Monero Project
+# Copyright (c) 2014-2022, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/multisig/multisig_account.cpp
+++ b/src/multisig/multisig_account.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_account.h
+++ b/src/multisig/multisig_account.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_account_kex_impl.cpp
+++ b/src/multisig/multisig_account_kex_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_kex_msg.cpp
+++ b/src/multisig/multisig_kex_msg.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_kex_msg.h
+++ b/src/multisig/multisig_kex_msg.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_kex_msg_serialization.h
+++ b/src/multisig/multisig_kex_msg_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, The Monero Project
+// Copyright (c) 2021-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/bulletproofs_plus.cc
+++ b/src/ringct/bulletproofs_plus.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, The Monero Project
+// Copyright (c) 2017-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/bulletproofs_plus.h
+++ b/src/ringct/bulletproofs_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, The Monero Project
+// Copyright (c) 2017-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproof_plus.cpp
+++ b/tests/core_tests/bulletproof_plus.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproof_plus.h
+++ b/tests/core_tests/bulletproof_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/bulletproof_plus.h
+++ b/tests/performance_tests/bulletproof_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/derive_view_tag.h
+++ b/tests/performance_tests/derive_view_tag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/performance_tests/out_can_be_to_acc.h
+++ b/tests/performance_tests/out_can_be_to_acc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/bulletproofs_plus.cpp
+++ b/tests/unit_tests/bulletproofs_plus.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, The Monero Project
+// Copyright (c) 2017-2022, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/scaling_2021.cpp
+++ b/tests/unit_tests/scaling_2021.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, The Monero Project
+// Copyright (c) 2019-2022, The Monero Project
 // 
 // All rights reserved.
 // 


### PR DESCRIPTION
The newly merged files have overwritten the copyright to previous year apparently.

Also added the `Makefile` and `LICENSE` files, discovered by @AkritW in https://github.com/monero-project/monero/pull/8297 .