### PR TITLE
multisig: force update option for key exchange [master]

### DIFF
--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -50,7 +50,6 @@
 using namespace std;
 using namespace epee;
 using namespace cryptonote;
-using boost::lexical_cast;
 namespace po = boost::program_options;
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -84,6 +83,9 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
 
   try
   {
+    if (total == 0)
+      throw std::runtime_error("Signer group of size 0 is not allowed.");
+
     // create M wallets first
     std::vector<boost::shared_ptr<tools::wallet2>> wallets(total);
     for (size_t n = 0; n < total; ++n)
@@ -118,13 +120,17 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
       ss << "  " << name << std::endl;
     }
 
-    //exchange keys unless exchange_multisig_keys returns no extra info
-    while (!kex_msgs_intermediate[0].empty())
+    // exchange keys until the wallets are done
+    bool ready{false};
+    wallets[0]->multisig(&ready);
+    while (!ready)
     {
       for (size_t n = 0; n < total; ++n)
       {
           kex_msgs_intermediate[n] = wallets[n]->exchange_multisig_keys(pwd_container->password(), kex_msgs_intermediate);
       }
+
+      wallets[0]->multisig(&ready);
     }
 
     std::string address = wallets[0]->get_account().get_public_address_str(wallets[0]->nettype());

--- a/src/multisig/multisig_account.cpp
+++ b/src/multisig/multisig_account.cpp
@@ -175,19 +175,20 @@ namespace multisig
     // only mutate account if update succeeds
     multisig_account temp_account{*this};
     temp_account.set_multisig_config(threshold, std::move(signers));
-    temp_account.kex_update_impl(expanded_msgs_rnd1);
+    temp_account.kex_update_impl(expanded_msgs_rnd1, false);
     *this = std::move(temp_account);
   }
   //----------------------------------------------------------------------------------------------------------------------
   // multisig_account: EXTERNAL
   //----------------------------------------------------------------------------------------------------------------------
-  void multisig_account::kex_update(const std::vector<multisig_kex_msg> &expanded_msgs)
+  void multisig_account::kex_update(const std::vector<multisig_kex_msg> &expanded_msgs,
+    const bool force_update_use_with_caution /*= false*/)
   {
     CHECK_AND_ASSERT_THROW_MES(account_is_active(), "multisig account: tried to update kex, but kex isn't initialized yet.");
     CHECK_AND_ASSERT_THROW_MES(!multisig_is_ready(), "multisig account: tried to update kex, but kex is already complete.");
 
     multisig_account temp_account{*this};
-    temp_account.kex_update_impl(expanded_msgs);
+    temp_account.kex_update_impl(expanded_msgs, force_update_use_with_caution);
     *this = std::move(temp_account);
   }
   //----------------------------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -235,7 +235,7 @@ namespace cryptonote
     bool make_multisig(const std::vector<std::string>& args);
     bool make_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
     bool exchange_multisig_keys(const std::vector<std::string> &args);
-    bool exchange_multisig_keys_main(const std::vector<std::string> &args, bool called_by_mms);
+    bool exchange_multisig_keys_main(const std::vector<std::string> &args, const bool force_update_use_with_caution, const bool called_by_mms);
     bool export_multisig(const std::vector<std::string>& args);
     bool export_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
     bool import_multisig(const std::vector<std::string>& args);

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1396,12 +1396,12 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
     return string();
 }
 
-std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info) {
+std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution /*= false*/) {
     try {
         clearStatus();
         checkMultisigWalletNotReady(m_wallet);
 
-        return m_wallet->exchange_multisig_keys(epee::wipeable_string(m_password), info);
+        return m_wallet->exchange_multisig_keys(epee::wipeable_string(m_password), info, force_update_use_with_caution);
     } catch (const exception& e) {
         LOG_ERROR("Error on exchanging multisig keys: " << e.what());
         setStatusError(string(tr("Failed to exchange multisig keys: ")) + e.what());

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -146,7 +146,7 @@ public:
     MultisigState multisig() const override;
     std::string getMultisigInfo() const override;
     std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) override;
-    std::string exchangeMultisigKeys(const std::vector<std::string> &info) override;
+    std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution = false) override;
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -796,9 +796,10 @@ struct Wallet
     /**
      * @brief exchange_multisig_keys - provides additional key exchange round for arbitrary multisig schemes (like N-1/N, M/N)
      * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
+     * @param force_update_use_with_caution - force multisig account to update even if not all signers contribute round messages
      * @return new info string if more rounds required or an empty string if wallet creation is done
      */
-    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info) = 0;
+    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution) = 0;
     /**
      * @brief exportMultisigImages - exports transfers' key images
      * @param images - output paramter for hex encoded array of images

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5075,12 +5075,11 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
 }
 //----------------------------------------------------------------------------------------------------
 std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &password,
-  const std::vector<std::string> &kex_messages)
+  const std::vector<std::string> &kex_messages,
+  const bool force_update_use_with_caution /*= false*/)
 {
   bool ready{false};
   CHECK_AND_ASSERT_THROW_MES(multisig(&ready), "The wallet is not multisig");
-  CHECK_AND_ASSERT_THROW_MES(!ready, "Multisig wallet creation process has already been finished");
-  CHECK_AND_ASSERT_THROW_MES(kex_messages.size() > 0, "No key exchange messages passed in.");
 
   // decrypt account keys
   epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
@@ -5098,13 +5097,6 @@ std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &passwor
         }
       );
   }
-
-  // open kex messages
-  std::vector<multisig::multisig_kex_msg> expanded_msgs;
-  expanded_msgs.reserve(kex_messages.size());
-
-  for (const auto &msg : kex_messages)
-    expanded_msgs.emplace_back(msg);
 
   // reconstruct multisig account
   multisig::multisig_keyset_map_memsafe_t kex_origins_map;
@@ -5126,8 +5118,25 @@ std::string wallet2::exchange_multisig_keys(const epee::wipeable_string &passwor
       ""
     };
 
+  // KLUDGE: early return if there are no kex messages and main kex is complete (will return the post-kex verification round
+  //         message) (it's a kludge because this behavior would be more appropriate for a standalone wallet method)
+  if (kex_messages.size() == 0)
+  {
+    CHECK_AND_ASSERT_THROW_MES(multisig_account.main_kex_rounds_done(),
+      "Exchange multisig keys: there are no kex messages but the main kex rounds are not done.");
+
+    return multisig_account.get_next_kex_round_msg();
+  }
+
+  // open kex messages
+  std::vector<multisig::multisig_kex_msg> expanded_msgs;
+  expanded_msgs.reserve(kex_messages.size());
+
+  for (const auto &msg : kex_messages)
+    expanded_msgs.emplace_back(msg);
+
   // update multisig kex
-  multisig_account.kex_update(expanded_msgs);
+  multisig_account.kex_update(expanded_msgs, force_update_use_with_caution);
 
   // update wallet state
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -862,7 +862,8 @@ private:
      * to other participants
      */
     std::string exchange_multisig_keys(const epee::wipeable_string &password,
-      const std::vector<std::string> &kex_messages);
+      const std::vector<std::string> &kex_messages,
+      const bool force_update_use_with_caution = false);
     /*!
      * \brief Get initial message to start multisig key exchange (before 'make_multisig()' is called)
      * \return string to send to other participants

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4146,13 +4146,6 @@ namespace tools
       er.message = "This wallet is not multisig";
       return false;
     }
-
-    if (ready)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_ALREADY_MULTISIG;
-      er.message = "This wallet is multisig, and already finalized";
-      return false;
-    }
     CHECK_MULTISIG_ENABLED();
 
     if (req.multisig_info.size() + 1 < total)
@@ -4164,7 +4157,7 @@ namespace tools
 
     try
     {
-      res.multisig_info = m_wallet->exchange_multisig_keys(req.password, req.multisig_info);
+      res.multisig_info = m_wallet->exchange_multisig_keys(req.password, req.multisig_info, req.force_update_use_with_caution);
       m_wallet->multisig(&ready);
       if (ready)
       {

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 25
+#define WALLET_RPC_VERSION_MINOR 26
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools
@@ -2531,10 +2531,12 @@ namespace wallet_rpc
     {
       std::string password;
       std::vector<std::string> multisig_info;
+      bool force_update_use_with_caution;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(password)
         KV_SERIALIZE(multisig_info)
+        KV_SERIALIZE_OPT(force_update_use_with_caution, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -96,8 +96,46 @@ static std::vector<std::string> exchange_round(std::vector<tools::wallet2>& wall
   new_infos.reserve(infos.size());
 
   for (size_t i = 0; i < wallets.size(); ++i)
+    new_infos.push_back(wallets[i].exchange_multisig_keys("", infos));
+
+  return new_infos;
+}
+
+static std::vector<std::string> exchange_round_force_update(std::vector<tools::wallet2>& wallets,
+  const std::vector<std::string>& infos,
+  const std::size_t round_in_progress)
+{
+  EXPECT_TRUE(wallets.size() == infos.size());
+  std::vector<std::string> new_infos;
+  std::vector<std::string> temp_force_update_infos;
+  new_infos.reserve(infos.size());
+
+  // when force-updating, we only need at most 'num_signers - 1 - (round - 1)' messages from other signers
+  size_t num_other_messages_required{wallets.size() - 1 - (round_in_progress - 1)};
+  if (num_other_messages_required > wallets.size())
+    num_other_messages_required = 0;  //overflow case for post-kex verification round of 1-of-N
+
+  for (size_t i = 0; i < wallets.size(); ++i)
   {
-      new_infos.push_back(wallets[i].exchange_multisig_keys("", infos));
+    temp_force_update_infos.clear();
+    temp_force_update_infos.reserve(num_other_messages_required + 1);
+    temp_force_update_infos.push_back(infos[i]);  //always include the local signer's message for this round
+
+    size_t infos_collected{0};
+    for (size_t wallet_index = 0; wallet_index < wallets.size(); ++wallet_index)
+    {
+      // skip the local signer's message
+      if (wallet_index == i)
+        continue;
+
+      temp_force_update_infos.push_back(infos[wallet_index]);
+      ++infos_collected;
+
+      if (infos_collected == num_other_messages_required)
+        break;
+    }
+
+    new_infos.push_back(wallets[i].exchange_multisig_keys("", temp_force_update_infos, true));
   }
 
   return new_infos;
@@ -105,7 +143,7 @@ static std::vector<std::string> exchange_round(std::vector<tools::wallet2>& wall
 
 static void check_results(const std::vector<std::string> &intermediate_infos,
   std::vector<tools::wallet2>& wallets,
-  std::uint32_t M)
+  const std::uint32_t M)
 {
   // check results
   std::unordered_set<crypto::secret_key> unique_privkeys;
@@ -167,8 +205,9 @@ static void check_results(const std::vector<std::string> &intermediate_infos,
   wallets[0].encrypt_keys("");
 }
 
-static void make_wallets(std::vector<tools::wallet2>& wallets, unsigned int M)
+static void make_wallets(const unsigned int M, const unsigned int N, const bool force_update)
 {
+  std::vector<tools::wallet2> wallets(N);
   ASSERT_TRUE(wallets.size() > 1 && wallets.size() <= KEYS_COUNT);
   ASSERT_TRUE(M <= wallets.size());
   std::uint32_t total_rounds_required = multisig::multisig_kex_rounds_required(wallets.size(), M) + 1;
@@ -207,9 +246,12 @@ static void make_wallets(std::vector<tools::wallet2>& wallets, unsigned int M)
   wallets[0].multisig(&ready);
   while (!ready)
   {
-    intermediate_infos = exchange_round(wallets, intermediate_infos);
-    wallets[0].multisig(&ready);
+    if (force_update)
+      intermediate_infos = exchange_round_force_update(wallets, intermediate_infos, rounds_complete + 1);
+    else
+      intermediate_infos = exchange_round(wallets, intermediate_infos);
 
+    wallets[0].multisig(&ready);
     ++rounds_complete;
   }
 
@@ -220,38 +262,38 @@ static void make_wallets(std::vector<tools::wallet2>& wallets, unsigned int M)
 
 TEST(multisig, make_1_2)
 {
-  std::vector<tools::wallet2> wallets(2);
-  make_wallets(wallets, 1);
+  make_wallets(1, 2, false);
+  make_wallets(1, 2, true);
 }
 
 TEST(multisig, make_1_3)
 {
-  std::vector<tools::wallet2> wallets(3);
-  make_wallets(wallets, 1);
+  make_wallets(1, 3, false);
+  make_wallets(1, 3, true);
 }
 
 TEST(multisig, make_2_2)
 {
-  std::vector<tools::wallet2> wallets(2);
-  make_wallets(wallets, 2);
+  make_wallets(2, 2, false);
+  make_wallets(2, 2, true);
 }
 
 TEST(multisig, make_3_3)
 {
-  std::vector<tools::wallet2> wallets(3);
-  make_wallets(wallets, 3);
+  make_wallets(3, 3, false);
+  make_wallets(3, 3, true);
 }
 
 TEST(multisig, make_2_3)
 {
-  std::vector<tools::wallet2> wallets(3);
-  make_wallets(wallets, 2);
+  make_wallets(2, 3, false);
+  make_wallets(2, 3, true);
 }
 
 TEST(multisig, make_2_4)
 {
-  std::vector<tools::wallet2> wallets(4);
-  make_wallets(wallets, 2);
+  make_wallets(2, 4, false);
+  make_wallets(2, 4, true);
 }
 
 TEST(multisig, multisig_kex_msg)
@@ -272,9 +314,7 @@ TEST(multisig, multisig_kex_msg)
     signing_skey = rct::rct2sk(rct::skGen());
   }
 
-  crypto::secret_key ancillary_skey = rct::rct2sk(rct::skGen());
-  while (ancillary_skey == crypto::null_skey)
-    ancillary_skey = rct::rct2sk(rct::skGen());
+  const crypto::secret_key ancillary_skey{rct::rct2sk(rct::skGen())};
 
   // misc. edge cases
   EXPECT_NO_THROW((multisig_kex_msg{}));
@@ -312,8 +352,8 @@ TEST(multisig, multisig_kex_msg)
   // test that keys can be recovered if stored in a message and the message's reverse
 
   // round 1
-  multisig_kex_msg msg_rnd1{1, signing_skey, std::vector<crypto::public_key>{pubkey1}, ancillary_skey};
-  multisig_kex_msg msg_rnd1_reverse{msg_rnd1.get_msg()};
+  const multisig_kex_msg msg_rnd1{1, signing_skey, std::vector<crypto::public_key>{pubkey1}, ancillary_skey};
+  const multisig_kex_msg msg_rnd1_reverse{msg_rnd1.get_msg()};
   EXPECT_EQ(msg_rnd1.get_round(), 1);
   EXPECT_EQ(msg_rnd1.get_round(), msg_rnd1_reverse.get_round());
   EXPECT_EQ(msg_rnd1.get_signing_pubkey(), signing_pubkey);
@@ -324,8 +364,8 @@ TEST(multisig, multisig_kex_msg)
   EXPECT_EQ(msg_rnd1.get_msg_privkey(), msg_rnd1_reverse.get_msg_privkey());
 
   // round 2
-  multisig_kex_msg msg_rnd2{2, signing_skey, std::vector<crypto::public_key>{pubkey1, pubkey2}, ancillary_skey};
-  multisig_kex_msg msg_rnd2_reverse{msg_rnd2.get_msg()};
+  const multisig_kex_msg msg_rnd2{2, signing_skey, std::vector<crypto::public_key>{pubkey1, pubkey2}, ancillary_skey};
+  const multisig_kex_msg msg_rnd2_reverse{msg_rnd2.get_msg()};
   EXPECT_EQ(msg_rnd2.get_round(), 2);
   EXPECT_EQ(msg_rnd2.get_round(), msg_rnd2_reverse.get_round());
   EXPECT_EQ(msg_rnd2.get_signing_pubkey(), signing_pubkey);

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -524,12 +524,13 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(finalize_multisig)
 
-    def exchange_multisig_keys(self, multisig_info, password = ''):
+    def exchange_multisig_keys(self, multisig_info, password = '', force_update_use_with_caution = False):
         exchange_multisig_keys = {
             'method': 'exchange_multisig_keys',
             'params' : {
                 'multisig_info': multisig_info,
                 'password': password,
+                'force_update_use_with_caution': force_update_use_with_caution,
             },
             'jsonrpc': '2.0', 
             'id': '0'


### PR DESCRIPTION
### Motivation

In the default multisig key exchange (account setup) ceremony, every key exchange round requires a message from every signer. That requirement may not be strictly necessary in some real-world use-cases (where it may be safe to assume some or all signers are trustworthy during account setup), so this PR adds an option to 'force-update' key exchange.

### Changes

- Adds a `force_update_use_with_caution` flag to the `multisig_account::kex_update()` method (it defaults to `false`). That interface change is propagated up the call stack to the `exchange_multisig_keys()` method in `wallet2` and the RPC.
  - When force-updating an intermediate key exchange round, you need at least `num_signers - current_round_num` messages from _other_ signers (this is the bare minimum to actually make progress).
  - When force-updating the post-kex verification round, you only need to pass in the local account's post-kex verification message (which was the local account's output from the previous round).
- Adds a unit test demoing the new method.
- Miscellaneous cleanup related to multisig (`gen_multisig.cpp`, unit tests, etc.).

### Future Work

- Currently, `simplewallet` and the MMS don't have an interface for the force update flag (I just defaulted it to `false`). A future PR can update the interface there if it's desired (@rbrunner7 ).

### Dangers

The new flag is a foot-gun that can enable the following problems.

- A signer's account created through force-updating may be unable to participate in signing (i.e. the final multisig address they obtain is malformed if there is a malicious player during account setup).
- If a signer force-updates the post-kex verification round, they may believe their account is complete and the multisig group is able to create signatures. In reality, there may not be a threshold of honest signers that completed their accounts. Any funds sent to the multisig address obtained by the force-updater might be lost forever.
- If honest multisig signers force-update any intermediate key exchange round, a malicious player could execute an 'address hostage' attack where the final address produced can only make signatures if that malicious player participates (although he wouldn't be able to make signatures on his own).
