### PR TITLE
p2p: don't exclusively drop tor/i2p outgoing cxns in idle loop

### DIFF
--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -1026,12 +1026,12 @@ TEST(node_server, race_condition)
     }
     void stop() {}
     void on_connection_close(context_t &context) {}
-    void set_max_out_peers(unsigned int max) {}
+    void set_max_out_peers(epee::net_utils::zone zone, unsigned int max) {}
     bool no_sync() const { return {}; }
     void set_no_sync(bool value) {}
     string_t get_peers_overview() const { return {}; }
     stripes_t get_next_needed_pruning_stripe() const { return {}; }
-    bool needs_new_sync_connections() const { return {}; }
+    bool needs_new_sync_connections(epee::net_utils::zone zone) const { return {}; }
     bool is_busy_syncing() { return {}; }
   };
   using node_server_t = nodetool::node_server<protocol_t>;


### PR DESCRIPTION
### Context

`update_sync_search` runs in the idle loop, checking to see if we have outgoing connections >= the max allowed. If so, a sync'd connection gets dropped so that the daemon can try to connect to nodes that need to sync.

### Before this PR

Currently it's [comparing the tally of **clearnet + tor + i2p** outgoing connections to the max of outgoing **clearnet** peers](https://github.com/monero-project/monero/blob/8349cfe4a63cfc63d50ce3818886b67a05e240a4/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L1798); but, the tally of clearnet + tor + i2p outgoing peers is usually always going to be greater than the max allowed outgoing clearnet peers. Because of this, it's usually just going to drop a tor or i2p connection [right here](https://github.com/monero-project/monero/blob/8349cfe4a63cfc63d50ce3818886b67a05e240a4/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L1802) (because they are last when iterating over all connections), even if the daemon has just 1 outgoing tor or i2p connection.

This seems to be another source of tor/i2p connection reliability issues mentioned in #6938, #6631, #8251.

### This PR

This PR makes sure to tally outgoing connections by zone, then compare to the max by zone. If the max peer count set for tor is 10 for example, and there are <10 outgoing tor connections, an outgoing tor connection won't get dropped.

### Future PR

I left a couple TODO's to investigate updating the pruning logic correctly. Didn't seem as trivial to figure out, so I left the logic how it currently is (just comparing the tally to the clearnet max).