### PR TITLE
Focus Doxygen documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -754,7 +754,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = .
+INPUT                  = contrib/epee external/easylogging++ src 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -805,7 +805,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */build/* */contrib/depends/*
+EXCLUDE_PATTERNS       = */src/crypto/crypto_ops_builder/ref10*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
Right now Doxygen is documenting everything in the repo including submodules, everything in contrib, util, tests, etc. This bogs down the documentation to the point where it is very hard to navigate. I think it would be a good move to focus on documenting only the main C++ code which is specific to this repo.

Right now this means documenting `src/` (without SUPERCOP) and `contrib/epee/`. After this commit, Doxygen went from running >6000 graphs to about 2200 graphs.