### PR TITLE
src, epee: fix a couple compiler warnings

### DIFF
--- a/contrib/epee/include/storages/portable_storage_from_json.h
+++ b/contrib/epee/include/storages/portable_storage_from_json.h
@@ -51,7 +51,6 @@ namespace epee
       {
         CHECK_AND_ASSERT_THROW_MES(recursion < EPEE_JSON_RECURSION_LIMIT_INTERNAL, "Wrong JSON data: recursion limitation (" << EPEE_JSON_RECURSION_LIMIT_INTERNAL << ") exceeded");
 
-        std::string::const_iterator sub_element_start;
         std::string name;        
         typename t_storage::harray h_array = nullptr;
         enum match_state

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -55,8 +55,6 @@ namespace cryptonote
       KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(m_encryption_iv, default_iv)
     END_KV_SERIALIZE_MAP()
 
-    account_keys& operator=(account_keys const&) = default;
-
     void encrypt(const crypto::chacha_key &key);
     void decrypt(const crypto::chacha_key &key);
     void encrypt_viewkey(const crypto::chacha_key &key);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6560,7 +6560,6 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
 
   vector<cryptonote::address_parse_info> dsts_info;
   vector<cryptonote::tx_destination_entry> dsts;
-  size_t num_subaddresses = 0;
   for (size_t i = 0; i < local_args.size(); )
   {
     dsts_info.emplace_back();
@@ -6619,7 +6618,6 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     de.addr = info.address;
     de.is_subaddress = info.is_subaddress;
     de.is_integrated = info.has_payment_id;
-    num_subaddresses += info.is_subaddress;
 
     if (info.has_payment_id || !payment_id_uri.empty())
     {


### PR DESCRIPTION
It feels like with every clang update new warnings show up. I checked with `git blame` and none of the recent patches introduced the unused variable warnings. The one about implicit copy constructor is especially noisy.

```
In file included from /Users/selsta/dev/monero/contrib/epee/src/portable_storage.cpp:33:
/Users/selsta/dev/monero/contrib/epee/include/storages/portable_storage_from_json.h:54:37: warning: unused variable 'sub_element_start' [-Wunused-variable]
        std::string::const_iterator sub_element_start;
                                    ^
```

```
/Users/selsta/dev/monero/src/simplewallet/simplewallet.cpp:6563:10: warning: variable 'num_subaddresses' set but not used [-Wunused-but-set-variable]
  size_t num_subaddresses = 0;
         ^
```

```
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:58:19: warning: definition of implicit copy constructor for 'account_keys' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
    account_keys& operator=(account_keys const&) = default;
                  ^
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:75:9: note: in implicit copy constructor for 'cryptonote::account_keys' first required here
  class account_base
        ^
/Users/selsta/dev/monero/tests/core_tests/double_spend.cpp:87:42: note: in implicit copy constructor for 'cryptonote::account_base' first required here
  cryptonote::account_base bob_account = boost::get<cryptonote::account_base>(events[1]);
                                         ^
1 warning generated.

```