### PR TITLE
GCC: Suppress -Wstringop-overflow= warnings in external/boost

### DIFF
--- a/external/boost/archive/portable_binary_archive.hpp
+++ b/external/boost/archive/portable_binary_archive.hpp
@@ -44,9 +44,12 @@ reverse_bytes(signed char size, char *address){
     char * first = address;
     char * last = first + size - 1;
     for(;first < last;++first, --last){
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
         char x = *last;
         *last = *first;
         *first = x;
+#pragma GCC diagnostic pop
     }
 }
 


### PR DESCRIPTION
Resolves #8320 