### PR TITLE
net_ssl: Switch to elliptic curve SSL certificates

### DIFF
--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -148,7 +148,17 @@ namespace net_utils
 	bool is_ssl(const unsigned char *data, size_t len);
 	bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
 
-	bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
+  /**
+   * @brief Generate a new OpenSSL certificate and key pair using ED25519
+   *
+   * @param[out] pkey Newly generated key pair (must be freed later)
+   * @param[out] cert Newly generated X509 certificate(must be freed later)
+   *
+   * EVP_PKEY and X509 pointers can be freed by EVP_PKEY_free() and X509_free(), respectively
+   *
+   * @return true on succcess, false otherwise
+   */
+  bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert) noexcept;
 
   //! Store private key for `ssl` at `base + ".key"` unencrypted and certificate for `ssl` at `base + ".crt"`.
   boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& base);

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -149,7 +149,6 @@ namespace net_utils
 	bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
 
 	bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
-	bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
 
   //! Store private key for `ssl` at `base + ".key"` unencrypted and certificate for `ssl` at `base + ".crt"`.
   boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& base);

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -149,7 +149,7 @@ namespace net_utils
 	bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
 
   /**
-   * @brief Generate a new OpenSSL certificate and key pair using ED25519
+   * @brief Generate a new OpenSSL certificate and key pair using secp256k1
    *
    * @param[out] pkey Newly generated key pair (must be freed later)
    * @param[out] cert Newly generated X509 certificate(must be freed later)

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -111,7 +111,7 @@ namespace epee
 namespace net_utils
 {
 
-bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
+bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert) noexcept
 {
   MINFO("Generating SSL certificate");
 

--- a/src/gen_ssl_cert/gen_ssl_cert.cpp
+++ b/src/gen_ssl_cert/gen_ssl_cert.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
 
   EVP_PKEY *pkey;
   X509 *cert;
-  r = epee::net_utils::create_rsa_ssl_certificate(pkey, cert);
+  r = epee::net_utils::create_ec_ssl_certificate(pkey, cert);
   if (!r)
   {
     tools::fail_msg_writer() << gencert::tr("Failed to create certificate");


### PR DESCRIPTION
I opened an eariler to PR to make our `net_ssl` RSA certificate generation code to comply with OpenSSL 3.0, but @hyc suggested that we switch to elliptic curve SSL certificates since they are smaller and faster. These PR also complies with OpenSSL 3.0.