### PR TITLE
clang: warning fix for #8338

### DIFF
--- a/external/boost/archive/portable_binary_archive.hpp
+++ b/external/boost/archive/portable_binary_archive.hpp
@@ -44,12 +44,16 @@ reverse_bytes(signed char size, char *address){
     char * first = address;
     char * last = first + size - 1;
     for(;first < last;++first, --last){
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow="
+#endif
         char x = *last;
         *last = *first;
         *first = x;
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
     }
 }
 


### PR DESCRIPTION
Unlike with some other warnings, clang does not have a `stringop-overflow` group so it doesn't recognize the `#pragma GCC ...` directive in #8338 