### PR TITLE
epee: fixed incorrect RNG usage

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -44,6 +44,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
+#include <random>
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
@@ -192,6 +193,8 @@ namespace net_utils
     bool m_local;
     bool m_ready_to_close;
     std::string m_host;
+
+    std::mt19937_64 m_rng;
 
 	public:
 			void setRpcStation();

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -49,7 +49,6 @@
 #include <iomanip>
 #include <algorithm>
 #include <functional>
-#include <random>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net"
@@ -103,6 +102,18 @@ namespace net_utils
 		m_local(false),
 		m_ready_to_close(false)
   {
+    constexpr size_t N = std::mt19937_64::state_size;
+
+    std::random_device dev;
+    std::seed_seq::result_type rand[N]{};  // Use complete bit space
+
+    std::generate_n(rand, N, std::ref(dev));
+    std::seed_seq seed(rand, rand + N);
+    m_rng.seed(seed);
+
+    // Diffuse the initial state in case it has low quality
+    m_rng.discard(1000);
+
     MDEBUG("test, connection constructor set m_connection_type="<<m_connection_type);
   }
 
@@ -639,17 +650,7 @@ namespace net_utils
             return false; // aborted
         }*/
 
-        using engine = std::mt19937;
-
-        engine rng;
-        std::random_device dev;
-        std::seed_seq::result_type rand[engine::state_size]{};  // Use complete bit space
-
-        std::generate_n(rand, engine::state_size, std::ref(dev));
-        std::seed_seq seed(rand, rand + engine::state_size);
-        rng.seed(seed);
-
-        long int ms = 250 + (rng() % 50);
+        long int ms = 250 + (m_rng() % 50);
         MDEBUG("Sleeping because QUEUE is FULL, in " << __FUNCTION__ << " for " << ms << " ms before packet_size="<<chunk.size()); // XXX debug sleep
         m_send_que_lock.unlock();
         boost::this_thread::sleep(boost::posix_time::milliseconds( ms ) );


### PR DESCRIPTION
Using `std::random_device` inside the loop to initialize the RNG is wrong. What it does in essence is using ~2500 bytes of entropy to get a single random value that is used for this_thread::sleep() calls. It doesn't need to be a high quality/cryptographically secure random number in this use case, so initializing RNG once in the constructor is sufficient and it doesn't deplete OS entropy source.

Also switched to `std::mt19937_64` because (1) `sizeof(std::mt19937_64) = 2504` and `sizeof(std::mt19937) = 5000`, and (2) it's more efficient on 64-bit systems.