### PR TITLE
Move DB lock guard to later stage

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1534,6 +1534,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   seed_hash = crypto::null_hash;
 
   m_tx_pool.lock();
+  db_rtxn_guard rtxn_guard(m_db);
   const auto unlock_guard = epee::misc_utils::create_scope_leave_handler([&]() { m_tx_pool.unlock(); });
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   if (m_btc_valid && !from_block) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1770,6 +1770,7 @@ namespace cryptonote
       return false;
     }
 
+    // TODO: move next_height, next_seed_hash under the protection of locks in Blockchain::create_block_template to guarantee consistent data
     uint64_t next_height;
     crypto::rx_seedheights(height, &seed_height, &next_height);
     if (next_height != seed_height)
@@ -1877,7 +1878,6 @@ namespace cryptonote
         return false;
       }
     }
-    db_rtxn_guard rtxn_guard(&m_core.get_blockchain_storage().get_db());
     crypto::hash seed_hash, next_seed_hash;
     if (!get_block_template(info.address, req.prev_block.empty() ? NULL : &prev_block, blob_reserve, reserved_offset, wdiff, res.height, res.expected_reward, b, res.seed_height, seed_hash, next_seed_hash, error_resp))
       return false;


### PR DESCRIPTION
It's important to take the DB lock after m_tx_pool lock when get_block_template RPC is run in parallel with a new block being added, otherwise it will return the old data.