### PR TITLE
rpc: --rpc-ssl-persistent CLI option

### DIFF
--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -63,6 +63,7 @@ namespace net_utils
   {
     std::string private_key_path; //!< Private key used for authentication
     std::string certificate_path; //!< Certificate used for authentication to peer.
+    bool persistent;              //!< Whether key & cert should be saved to respective paths
 
     //! Load `private_key_path` and `certificate_path` into `ssl_context`.
     void use_ssl_certificate(boost::asio::ssl::context &ssl_context) const;
@@ -146,8 +147,8 @@ namespace net_utils
 	bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
 	bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert);
 
-  //! Store private key for `ssl` at `base + ".key"` unencrypted and certificate for `ssl` at `base + ".crt"`.
-  boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& base);
+  //! Extract private key and certificate from ssl context `ssl` and store into respective file locations, unencrypted
+  boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const boost::filesystem::path& key_file, const boost::filesystem::path& cert_file);
 }
 }
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -60,16 +60,9 @@ namespace cryptonote
   {
   public:
 
-    static const command_line::arg_descriptor<bool> arg_public_node;
     static const command_line::arg_descriptor<std::string, false, true, 2> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
-    static const command_line::arg_descriptor<std::string> arg_rpc_ssl;
-    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key;
-    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate;
-    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_ca_certificates;
-    static const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_fingerprints;
-    static const command_line::arg_descriptor<bool> arg_rpc_ssl_allow_any_cert;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_login;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_proxy;

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -81,7 +81,7 @@ namespace cryptonote
       }
 
       ssl_options.auth = epee::net_utils::ssl_authentication_t{
-        command_line::get_arg(vm, arg.rpc_ssl_private_key), command_line::get_arg(vm, arg.rpc_ssl_certificate)
+        command_line::get_arg(vm, arg.rpc_ssl_private_key), command_line::get_arg(vm, arg.rpc_ssl_certificate), command_line::get_arg(vm, arg.rpc_ssl_persistent)
       };
 
       return {std::move(ssl_options)};
@@ -102,6 +102,7 @@ namespace cryptonote
      , rpc_ssl_private_key({"rpc-ssl-private-key", rpc_args::tr("Path to a PEM format private key"), ""})
      , rpc_ssl_certificate({"rpc-ssl-certificate", rpc_args::tr("Path to a PEM format certificate"), ""})
      , rpc_ssl_ca_certificates({"rpc-ssl-ca-certificates", rpc_args::tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s)."), ""})
+     , rpc_ssl_persistent({"rpc-ssl-persistent", rpc_args::tr("Save/Load SSL certificate in data directory to maintain persistent identity across restarts"), false})
      , rpc_ssl_allowed_fingerprints({"rpc-ssl-allowed-fingerprints", rpc_args::tr("List of certificate fingerprints to allow")})
      , rpc_ssl_allow_chained({"rpc-ssl-allow-chained", rpc_args::tr("Allow user (via --rpc-ssl-certificates) chain certificates"), false})
      , rpc_ssl_allow_any_cert({"rpc-ssl-allow-any-cert", rpc_args::tr("Allow any peer certificate"), false})
@@ -126,6 +127,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg.rpc_ssl_private_key);
     command_line::add_arg(desc, arg.rpc_ssl_certificate);
     command_line::add_arg(desc, arg.rpc_ssl_ca_certificates);
+    command_line::add_arg(desc, arg.rpc_ssl_persistent);
     command_line::add_arg(desc, arg.rpc_ssl_allowed_fingerprints);
     command_line::add_arg(desc, arg.rpc_ssl_allow_chained);
     command_line::add_arg(desc, arg.disable_rpc_ban);

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -64,6 +64,7 @@ namespace cryptonote
       const command_line::arg_descriptor<std::string> rpc_ssl_private_key;
       const command_line::arg_descriptor<std::string> rpc_ssl_certificate;
       const command_line::arg_descriptor<std::string> rpc_ssl_ca_certificates;
+      const command_line::arg_descriptor<bool> rpc_ssl_persistent;
       const command_line::arg_descriptor<std::vector<std::string>> rpc_ssl_allowed_fingerprints;
       const command_line::arg_descriptor<bool> rpc_ssl_allow_chained;
       const command_line::arg_descriptor<bool> rpc_ssl_allow_any_cert;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -363,7 +363,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   }
 
   ssl_options.auth = epee::net_utils::ssl_authentication_t{
-    std::move(daemon_ssl_private_key), std::move(daemon_ssl_certificate)
+    std::move(daemon_ssl_private_key), std::move(daemon_ssl_certificate), false
   };
 
   THROW_WALLET_EXCEPTION_IF(!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port,

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4402,7 +4402,7 @@ namespace tools
     }
 
     ssl_options.auth = epee::net_utils::ssl_authentication_t{
-      std::move(req.ssl_private_key_path), std::move(req.ssl_certificate_path)
+      std::move(req.ssl_private_key_path), std::move(req.ssl_certificate_path), false
     };
 
     const bool verification_required =


### PR DESCRIPTION
This PR expands on #7366, which introduced the `rpc_ssl.*` files in the data directory. @moneromooo-monero brought up a good point in this comment: https://github.com/monero-project/monero/pull/7366#pullrequestreview-587469276. When a daemon presents the same certificate across restarts and connections, this opens an opportunity for tracking. @vtnerd responded to this critique by limiting the feature to daemons not in restricted mode. In my opinion, this closes off the feature to those nodes who need it most: public nodes. It also didn't address the fact that bad actors can still identify unrestricted daemons. All in all, this feature should have better control, which is why this PR introduces the `--rpc-ssl-persistent` flag, which is OFF by default (for anonymity).

This PR also moves the key/cert storing logic to `net_ssl.cpp`, as opposed to `core_rpc_server.cpp` so it can be used elsewhere later (particularly in `wallet_rpc_server`) if it is deemed beneficial. Currently it is disabled, but can be enabled by passing `true` into the `ssl_authentication_t` constructor before calling `ssl_options_t::create_context`. 

Adopting these new changes may cause unexpected behavior for node operators who 1) run their daemon in unrestricted mode, 2) do not know about the new `--rpc-ssl-persistent` flag, and 3) expect that the RPC server will use the existing `rpc_ssl.crt` certificate. For this reason, I added a log statement which logs a warning in the event that the persistence flag is not given, but old `rpc_ssl.*` files are present.