### PR TITLE
Rename build-macos CI Job

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -17,7 +17,7 @@ env:
         ccache --set-config=compression=true
 
 jobs:
-  build-macos:
+  build-cross:
     runs-on: ubuntu-18.04
     env:
       CCACHE_TEMPDIR: /tmp/.ccache-temp


### PR DESCRIPTION
Rename the "build-macos" job within "depends", as it is not building on macOS as the similarly named job within build.yml does. Also, both names overlap which is confusing when looking for step-by-step build instruction examples or when looking at the logfile.