### PR TITLE
hardforks: set mainnet and stagenet v15/16 fork height

### DIFF
--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -71,8 +71,8 @@ const hardfork_t mainnet_hard_forks[] = {
   { 13, 2210000, 0, 1598180817 },
   { 14, 2210720, 0, 1598180818 },
 
-  { 15, 8000000, 0, 1608223241 }, // temp so tests test with these consensus rules
-  { 16, 8000001, 0, 1608223242 }, // temp so tests test with these consensus rules
+  { 15, 2688888, 0, 1656629117 },
+  { 16, 2689608, 0, 1656629118 },
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
@@ -122,5 +122,7 @@ const hardfork_t stagenet_hard_forks[] = {
   { 12, 454721, 0, 1571419280 },
   { 13, 675405, 0, 1598180817 },
   { 14, 676125, 0, 1598180818 },
+  { 15, 1151000, 0, 1656629117 },
+  { 16, 1151720, 0, 1656629118 },
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);


### PR DESCRIPTION
I set the stagenet fork to be around 1 week before mainnet, I'm not sure if this is enough.