### PR TITLE
txpool: continue pool pruning even if a tx can't be found

### DIFF
--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -406,6 +406,13 @@ namespace cryptonote
      */
     void set_txpool_max_weight(size_t bytes);
 
+    /**
+     * @brief reduce the cumulative txpool weight by the weight provided
+     *
+     * @param weight the weight to reduce the total txpool weight by
+     */
+    void reduce_txpool_weight(size_t weight);
+
 #define CURRENT_MEMPOOL_ARCHIVE_VER    11
 #define CURRENT_MEMPOOL_TX_DETAILS_ARCHIVE_VER    13
 


### PR DESCRIPTION
- Defensive change from `return` to `continue` to ensure pool pruning executes to completion.
- Ensure tx pool weight doesn't underflow.
- Will propose a fix in PR #8076 that prevents the root cause of the `"Failed to find tx_meta in txpool"` error. Noticed the cause of the error while reviewing that PR and that PR seems well positioned to solve it.