### PR TITLE
wallet2: prevent crash when reading tx w/fewer outputs than expected

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -349,6 +349,8 @@ private:
       uint64_t amount() const { return m_amount; }
       const crypto::public_key get_public_key() const {
         crypto::public_key output_public_key;
+        THROW_WALLET_EXCEPTION_IF(m_tx.vout.size() <= m_internal_output_index,
+          error::wallet_internal_error, "Too few outputs, outputs may be corrupted");
         THROW_WALLET_EXCEPTION_IF(!get_output_public_key(m_tx.vout[m_internal_output_index], output_public_key),
           error::wallet_internal_error, "Unable to get output public key from output");
         return output_public_key;


### PR DESCRIPTION
Related #8395 