### PR TITLE
zmq: publish submitted txs via zmq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
     - name: install monero dependencies
       run: ${{env.APT_INSTALL_LINUX}}
     - name: install Python dependencies
-      run: pip install requests psutil monotonic
+      run: pip install requests psutil monotonic zmq
     - name: tests
       env:
         CTEST_OUTPUT_ON_FAILURE: ON

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1036,6 +1036,13 @@ namespace cryptonote
      bool relay_txpool_transactions();
 
      /**
+      * @brief sends notification of txpool events to subscribers
+      *
+      * @return true on success, false otherwise
+      */
+     bool notify_txpool_event(const epee::span<const cryptonote::blobdata> tx_blobs, epee::span<const crypto::hash> tx_hashes, epee::span<const cryptonote::transaction> txs, const std::vector<bool> &just_broadcasted) const;
+
+     /**
       * @brief checks DNS versions
       *
       * @return true on success, false otherwise

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -353,8 +353,10 @@ namespace cryptonote
      *
      * @param hashes list of tx hashes that are about to be relayed
      * @param tx_relay update how the tx left this node
+     * @param just_broadcasted true if a tx was just broadcasted
+     *
      */
-    void set_relayed(epee::span<const crypto::hash> hashes, relay_method tx_relay);
+    void set_relayed(epee::span<const crypto::hash> hashes, relay_method tx_relay, std::vector<bool> &just_broadcasted);
 
     /**
      * @brief get the total number of transactions in the pool

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,7 +54,7 @@ Functional tests are located under the `tests/functional_tests` directory.
 
 Building all the tests requires installing the following dependencies:
 ```bash
-pip install requests psutil monotonic
+pip install requests psutil monotonic zmq
 ```
 
 First, run a regtest daemon in the offline mode and with a fixed difficulty:

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -67,7 +67,7 @@ target_link_libraries(make_test_signature
 monero_add_minimal_executable(cpu_power_test cpu_power_test.cpp)
 find_program(PYTHON3_FOUND python3 REQUIRED)
 
-execute_process(COMMAND ${PYTHON3_FOUND} "-c" "import requests; import psutil; import monotonic; print('OK')" OUTPUT_VARIABLE REQUESTS_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON3_FOUND} "-c" "import requests; import psutil; import monotonic; import zmq; print('OK')" OUTPUT_VARIABLE REQUESTS_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (REQUESTS_OUTPUT STREQUAL "OK")
   add_test(
     NAME    functional_tests_rpc
@@ -76,6 +76,6 @@ if (REQUESTS_OUTPUT STREQUAL "OK")
     NAME    check_missing_rpc_methods
     COMMAND ${PYTHON3_FOUND} "${CMAKE_CURRENT_SOURCE_DIR}/check_missing_rpc_methods.py" "${CMAKE_SOURCE_DIR}")
 else()
-  message(WARNING "functional_tests_rpc and check_missing_rpc_methods skipped, needs the 'requests', 'psutil' and 'monotonic' python modules")
+  message(WARNING "functional_tests_rpc and check_missing_rpc_methods skipped, needs the 'requests', 'psutil', 'monotonic', and 'zmq' python modules")
   set(CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} functional_tests_rpc check_missing_rpc_methods)
 endif()

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -47,7 +47,7 @@ WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 FUNCTIONAL_TESTS_DIRECTORY = builddir + "/tests/functional_tests"
 DIFFICULTY = 10
 
-monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--no-igd", "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1"]
+monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--no-igd", "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1"]
 monerod_extra = [
   ["--offline"],
   ["--rpc-payment-address", "44SKxxLQw929wRF6BA9paQ1EWFshNnKhXM3qz6Mo3JGDE2YG3xyzVutMStEicxbQGRfrYvAAYxH6Fe8rnD56EaNwUiqhcwR", "--rpc-payment-difficulty", str(DIFFICULTY), "--rpc-payment-credits", "5000", "--offline"],
@@ -69,7 +69,7 @@ outputs = []
 ports = []
 
 for i in range(N_MONERODS):
-  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else builddir + "/functional-tests-directory/monerod" + str(i) if x == "monerod_data_dir" else x for x in monerod_base])
+  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else "tcp://127.0.0.1:" + str(18480+i) if x == "monerod_zmq_pub" else builddir + "/functional-tests-directory/monerod" + str(i) if x == "monerod_data_dir" else x for x in monerod_base])
   if i < len(monerod_extra):
     command_lines[-1] += monerod_extra[i]
   outputs.append(open(FUNCTIONAL_TESTS_DIRECTORY + '/monerod' + str(i) + '.log', 'a+'))

--- a/utils/python-rpc/framework/zmq.py
+++ b/utils/python-rpc/framework/zmq.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2018-2022, The Monero Project
+
+# 
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Class to subscribe to and receive ZMQ events."""
+
+import zmq
+import json
+
+class Zmq(object):
+
+    def __init__(self, protocol='tcp', host='127.0.0.1', port=0, idx=0):
+        self.host = host
+        self.port = port
+        self.socket = zmq.Context().socket(zmq.SUB)
+        self.socket.connect('{protocol}://{host}:{port}'.format(protocol=protocol, host=host, port=port if port else 18480+idx))
+
+    def sub(self, topic):
+        self.socket.setsockopt_string(zmq.SUBSCRIBE, topic)
+
+    def recv(self, topic):
+        msg = self.socket.recv()
+        data = msg.decode().split(topic + ":")[1]
+        return json.loads(data)


### PR DESCRIPTION
### Problem

When a daemon is in the "fluff" epoch and a user submits a tx to the daemon, the tx doesn't get published via zmq's `txpool_add`. Reported by @TrasherDK; see logs [1](https://libera.monerologs.net/monero-dev/20220707#c117558-c117568), [2](https://libera.monerologs.net/monero-dev/20220707#c117619-c117634), and [3](https://libera.monerologs.net/monero-dev/20220708#c117725-c117728).

### Solution

Publish "just broadcasted" txs via zmq.

Of note, the test I added hangs waiting to receive txs that never come over zmq with the code from before this PR.

### Deeper context

- upon tx submission, [`handle_incoming_tx` is called with `relay_method:local`](https://github.com/monero-project/monero/blob/8f48f464957c875af3183cd9d35769592e1aef48/src/rpc/core_rpc_server.cpp#L1258) with no knowledge of the daemon's fluff/stem epoch status or tx propagation method.
- zmq doesn't publish the tx [since the tx has not broadcasted yet](https://github.com/monero-project/monero/blob/9f814edbd78c70c70b814ca934c1ddef58768262/src/cryptonote_core/cryptonote_core.cpp#L1107-L1108) (and therefore is not visible in the pool).
- the daemon then ["fluffs" the tx](https://github.com/monero-project/monero/blob/8f48f464957c875af3183cd9d35769592e1aef48/src/rpc/core_rpc_server.cpp#L1302) and updates its relay status in the db via [`on_transactions_relayed`](https://github.com/monero-project/monero/blob/9a124f681119855949f6406ecd69c2ad91da9770/src/cryptonote_protocol/levin_notify.cpp#L573) making the tx visible to anyone who queries the daemon.
- it's possible no other daemons reflect the tx back to the daemon, which means `handle_incoming_txs` doesn't get called a second time after the initial submission (which is particularly unique to the "fluff" flow).
- even if daemons *do* reflect the tx back to the daemon, since the tx has already updated its relay status to a broadcasted state, it won't publish to zmq since [this `already_have` will be true](https://github.com/monero-project/monero/blob/8f48f464957c875af3183cd9d35769592e1aef48/src/cryptonote_core/cryptonote_core.cpp#L1086).

With the above context in mind, I think `on_transactions_relayed` is the best place to pub txs in this circumstance because:

1. It's the point we know txs are just set to be broadcasted, and become visible/query-able in the pool.
2. It's not guaranteed `handle_incoming_txs` will get called again after the node broadcasts the tx.
3. Even if `handle_incoming_txs` does get called once the node broadcasts the tx, we don't know if the tx was "just broadcasted" or if we're handling a tx we already knew about that we already pub'd via zmq.
4. It seems quite challenging to pass something into `handle_incoming_tx` on the initial submission to make it aware of the relay mechanism that will subsequently be used when the tx is ultimately relayed. Although it seems like it would be safe for "fluff" txs to be immediately visible in the db on initial submission during the "fluff" epoch (and to push them over zmq immediately), the way the relay code is structured, it would take a larger overhaul to safely implement that approach to avoid doing so for "stem" txs.
