### PR TITLE
keccak: error out if passed mdlen 100

### DIFF
--- a/src/crypto/keccak.c
+++ b/src/crypto/keccak.c
@@ -123,7 +123,7 @@ void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
     size_t i, rsiz, rsizw;
 
     static_assert(HASH_DATA_AREA <= sizeof(temp), "Bad keccak preconditions");
-    if (mdlen <= 0 || (mdlen > 100 && sizeof(st) != (size_t)mdlen))
+    if (mdlen <= 0 || (mdlen >= 100 && sizeof(st) != (size_t)mdlen))
     {
       local_abort("Bad keccak use");
     }


### PR DESCRIPTION
If we were to call it with 100, it would cause rsiz to be 0,
leading to an infinite loop.
This is really a pedantic patch, but since there's already a
range test, might as well make it better.