### PR TITLE
multisig: mitigate fund-burning attack

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -246,6 +246,8 @@ namespace config
   const unsigned char HASH_KEY_CLSAG_AGG_1[] = "CLSAG_agg_1";
   const char HASH_KEY_MESSAGE_SIGNING[] = "MoneroMessageSignature";
   const unsigned char HASH_KEY_MM_SLOT = 'm';
+  const constexpr char HASH_KEY_MULTISIG_TX_PRIVKEYS_SEED[] = "multisig_tx_privkeys_seed";
+  const constexpr char HASH_KEY_MULTISIG_TX_PRIVKEYS[] = "multisig_tx_privkeys";
 
   // Multisig
   const uint32_t MULTISIG_MAX_SIGNERS{16};

--- a/src/multisig/multisig_tx_builder_ringct.h
+++ b/src/multisig/multisig_tx_builder_ringct.h
@@ -82,6 +82,7 @@ public:
     const bool reconstruction,
     crypto::secret_key& tx_secret_key,
     std::vector<crypto::secret_key>& tx_aux_secret_keys,
+    crypto::secret_key& tx_secret_key_entropy,
     cryptonote::transaction& unsigned_tx
   );
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7157,6 +7157,7 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
         true,  //true = we are reconstructing the tx (it was first constructed by the tx proposer)
         ptx.tx_key,
         ptx.additional_tx_keys,
+        ptx.multisig_tx_key_entropy,
         ptx.tx
       ),
       error::wallet_internal_error,
@@ -9006,6 +9007,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
 
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_keys;
+  crypto::secret_key multisig_tx_key_entropy;
   LOG_PRINT_L2("constructing tx");
   auto sources_copy = sources;
   multisig::signing::tx_builder_ringct_t multisig_tx_builder;
@@ -9029,6 +9031,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
         false,
         tx_key,
         additional_tx_keys,
+        multisig_tx_key_entropy,
         tx
       ),
       error::wallet_internal_error,
@@ -9155,6 +9158,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   ptx.additional_tx_keys = additional_tx_keys;
   ptx.dests = dsts;
   ptx.multisig_sigs = multisig_sigs;
+  ptx.multisig_tx_key_entropy = multisig_tx_key_entropy;
   ptx.construction_data.sources = sources_copy;
   ptx.construction_data.change_dts = change_dts;
   ptx.construction_data.splitted_dsts = splitted_dsts;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -632,10 +632,12 @@ private:
       std::vector<crypto::secret_key> additional_tx_keys;
       std::vector<cryptonote::tx_destination_entry> dests;
       std::vector<multisig_sig> multisig_sigs;
+      crypto::secret_key multisig_tx_key_entropy;
 
       tx_construction_data construction_data;
 
       BEGIN_SERIALIZE_OBJECT()
+        VERSION_FIELD(1)
         FIELD(tx)
         FIELD(dust)
         FIELD(fee)
@@ -648,6 +650,12 @@ private:
         FIELD(dests)
         FIELD(construction_data)
         FIELD(multisig_sigs)
+        if (version < 1)
+        {
+          multisig_tx_key_entropy = crypto::null_skey;
+          return true;
+        }
+        FIELD(multisig_tx_key_entropy)
       END_SERIALIZE()
     };
 

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -307,9 +307,10 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
   transaction tx;
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_secret_keys;
+  crypto::secret_key multisig_tx_key_entropy;
   auto sources_copy = sources;
   multisig::signing::tx_builder_ringct_t tx_builder;
-  CHECK_AND_ASSERT_MES(tx_builder.init(miner_account[creator].get_keys(), {}, 0, 0, {0}, sources, destinations, {}, {rct::RangeProofPaddedBulletproof, 4}, true, false, tx_key, additional_tx_secret_keys, tx), false, "error: multisig::signing::tx_builder_t::init");
+  CHECK_AND_ASSERT_MES(tx_builder.init(miner_account[creator].get_keys(), {}, 0, 0, {0}, sources, destinations, {}, {rct::RangeProofPaddedBulletproof, 4}, true, false, tx_key, additional_tx_secret_keys, multisig_tx_key_entropy, tx), false, "error: multisig::signing::tx_builder_ringct_t::init");
 
   // work out the permutation done on sources
   std::vector<size_t> ins_order;
@@ -398,7 +399,7 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
     }
     tools::apply_permutation(ins_order, k);
     multisig::signing::tx_builder_ringct_t signer_tx_builder;
-    CHECK_AND_ASSERT_MES(signer_tx_builder.init(miner_account[signer].get_keys(), {}, 0, 0, {0}, sources, destinations, {}, {rct::RangeProofPaddedBulletproof, 4}, true, true, tx_key, additional_tx_secret_keys, tx), false, "error: multisig::signing::tx_builder_t::init");
+    CHECK_AND_ASSERT_MES(signer_tx_builder.init(miner_account[signer].get_keys(), {}, 0, 0, {0}, sources, destinations, {}, {rct::RangeProofPaddedBulletproof, 4}, true, true, tx_key, additional_tx_secret_keys, multisig_tx_key_entropy, tx), false, "error: multisig::signing::tx_builder_ringct_t::init");
 
     MDEBUG("signing with k size " << k.size());
     for (size_t n = 0; n < multisig::signing::kAlphaComponents; ++n)


### PR DESCRIPTION
To solve [this issue](https://github.com/monero-project/research-lab/issues/103) (@kayabanerve), obtain the ephemeral secrets for a multisig tx's outputs from a hash chain starting with a 32-byte entropy provided by the tx initiator plus the key images of the tx's inputs.