### PR TITLE
Template hash function to fix compiler error on version < gcc-6

### DIFF
--- a/contrib/epee/include/net/enums.h
+++ b/contrib/epee/include/net/enums.h
@@ -64,3 +64,13 @@ namespace net_utils
 } // net_utils
 } // epee
 
+namespace std
+{
+	template<> struct hash<epee::net_utils::zone>
+	{
+		std::size_t operator()(const epee::net_utils::zone _z) const
+		{
+			return static_cast<std::size_t>(_z);
+		}
+	};
+} // std


### PR DESCRIPTION
My mistake introduced in #8330.

Fixes:
```
In file included from /usr/include/c++/5/bits/hashtable.h:35:0,
                 from /usr/include/c++/5/unordered_map:47,
                 from /monero/monero/external/easylogging++/easylogging++.h:406,
                 from /monero/monero/contrib/epee/include/misc_log_ex.h:35,
                 from /monero/monero/contrib/epee/include/include_base_utils.h:32,
                 from /monero/monero/src/rpc/core_rpc_server.cpp:34:
/usr/include/c++/5/bits/hashtable_policy.h: In instantiation of 'struct std::__detail::__is_noexcept_hash<epee::net_utils::zone, std::hash<epee::net_utils::zone> >':
/usr/include/c++/5/type_traits:137:12:   required from 'struct std::__and_<std::__is_fast_hash<std::hash<epee::net_utils::zone> >, std::__detail::__is_noexcept_hash<epee::net_utils::zone, std::hash<epee::net_utils::zone> > >'
/usr/include/c++/5/type_traits:148:38:   required from 'struct std::__not_<std::__and_<std::__is_fast_hash<std::hash<epee::net_utils::zone> >, std::__detail::__is_noexcept_hash<epee::net_utils::zone, std::hash<epee::net_utils::zone> > > >'
/usr/include/c++/5/bits/unordered_map.h:100:65:   required from 'class std::unordered_map<epee::net_utils::zone, unsigned int>'
```

https://paste.debian.net/1247156/