### PR TITLE
[CRITICAL] Fixes x86-64 compatibility problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,12 +335,6 @@ set(RISCV   1)
 set(RISCV32 1)
 endif()
 
-if(WIN32 OR ARM OR PPC64LE OR PPC64 OR PPC)
-  set(OPT_FLAGS_RELEASE "-O2")
-else()
-  set(OPT_FLAGS_RELEASE "-Ofast")
-endif()
-
 # BUILD_TAG is used to select the build type to check for a new version
 if(BUILD_TAG)
   message(STATUS "Building build tag ${BUILD_TAG}")
@@ -372,6 +366,7 @@ if(NOT MANUAL_SUBMODULES)
   endif()
 endif()
 
+set(OPT_FLAGS_RELEASE "-O2")
 set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 


### PR DESCRIPTION
I'm sorry for shouting this as critical, but please **don't use** `-Ofast` flag for sake of compatibility as it causes compiler to produce opcode which older CPU cannot comprehend. As a result, that older generation CPU (as example Intel Atom D510) throws [IOT illegal instruction](https://www.intel.com/content/www/us/en/docs/programmable/683620/current/illegal-instruction.html) error while running monero utilities. This makes entire monero utilities useless on all older x86-64 machines. For the worst, all release binaries of monero at package managers are compiled with`-Ofast` flag. Enthusiasts with potato server are suffering while trying to contribute their server as a full node.

As a reference, this is [an explanation from manual](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html):

> **-Ofast:** Disregard strict standards compliance. -Ofast enables all -O3 optimizations. It also enables optimizations that are not valid for all standard-compliant programs. It turns on -ffast-math, -fallow-store-data-races and the Fortran-specific -fstack-arrays, unless -fmax-stack-var-size is specified, and -fno-protect-parens. It turns off -fsemantic-interposition.

See? This type of optimization breaks well-known standards! If a superuser want to optimize stuffs, let him/her compile it himself/herself. Please please do not bother to let others down. Thank you for your support.