### PR TITLE
cmake: only fallback to vendored miniupnpc

### DIFF
--- a/cmake/FindMiniupnpc.cmake
+++ b/cmake/FindMiniupnpc.cmake
@@ -37,7 +37,7 @@ set(MINIUPNP_STATIC_LIBRARIES ${MINIUPNP_STATIC_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  MiniUPnPc DEFAULT_MSG
+  Miniupnpc DEFAULT_MSG
   MINIUPNP_INCLUDE_DIR
   MINIUPNP_LIBRARY
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -35,23 +35,25 @@
 # ...except for FreeBSD, because FreeBSD is a special case that doesn't play well with
 # others.
 
-find_package(Miniupnpc REQUIRED)
+find_package(Miniupnpc)
 
-message(STATUS "Using in-tree miniupnpc")
-set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
-add_subdirectory(miniupnp/miniupnpc)
-set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
-set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-if(MSVC)
-  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
-elseif(NOT MSVC)
-  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
-endif()
-if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-	set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -D_NETBSD_SOURCE")
-endif()
+if(NOT MINIUPNP_FOUND)
+  message(STATUS "Using in-tree miniupnpc")
+  set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
+  add_subdirectory(miniupnp/miniupnpc)
+  set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
+  set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+  if(MSVC)
+    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
+  elseif(NOT MSVC)
+    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
+  endif()
+  if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -D_NETBSD_SOURCE")
+  endif()
 
-set(UPNP_LIBRARIES "libminiupnpc-static" PARENT_SCOPE)
+  set(MINIUPNP_LIBRARY "libminiupnpc-static" PARENT_SCOPE)
+endif()
 
 find_package(Unbound)
 

--- a/src/p2p/CMakeLists.txt
+++ b/src/p2p/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(p2p
     version
     cryptonote_core
     net
-    ${UPNP_LIBRARIES}
+    ${MINIUPNP_LIBRARY}
     ${Boost_CHRONO_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}


### PR DESCRIPTION
The current code seems broken. It runs `find_package(Miniupnpc REQUIRED)` but the script can't even find anything due to incorrect capitalization.

```
  The package name passed to `find_package_handle_standard_args` (MiniUPnPc)
  does not match the name of the calling package (Miniupnpc).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindMiniupnpc.cmake:39 (find_package_handle_standard_args)
  external/CMakeLists.txt:38 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

We added the vendored miniupnpc initially because of an vulnerability but that was 4 years ago: https://github.com/monero-project/monero/pull/3668

Fix it by first searching for system miniupnpc and then only fallback to the vendored version if it isn't found. Needs some testing to make sure it doesn't break static builds.