### PR TITLE
rpc: skip bootstrap nodes that are lower than last checkpoint

### DIFF
--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -159,6 +159,13 @@ namespace cryptonote
     bool deinit();
 
     /**
+     * @brief get a set of blockchain checkpoint hashes
+     *
+     * @return set of blockchain checkpoint hashes
+     */
+    const checkpoints& get_checkpoints() const { return m_checkpoints; }
+
+    /**
      * @brief assign a set of blockchain checkpoint hashes
      *
      * @param chk_pts the set of checkpoints to assign

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -252,6 +252,10 @@ namespace cryptonote
       m_pprotocol = &m_protocol_stub;
   }
   //-----------------------------------------------------------------------------------
+  const checkpoints& core::get_checkpoints() const
+  {
+    return m_blockchain_storage.get_checkpoints();
+  }
   void core::set_checkpoints(checkpoints&& chk_pts)
   {
     m_blockchain_storage.set_checkpoints(std::move(chk_pts));

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -437,6 +437,13 @@ namespace cryptonote
      void set_cryptonote_protocol(i_cryptonote_protocol* pprotocol);
 
      /**
+      * @copydoc Blockchain::get_checkpoints
+      *
+      * @note see Blockchain::get_checkpoints()
+      */
+     const checkpoints& get_checkpoints() const;
+
+     /**
       * @copydoc Blockchain::set_checkpoints
       *
       * @note see Blockchain::set_checkpoints()

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2290,6 +2290,12 @@ namespace cryptonote
         return m_bootstrap_daemon->handle_result(false, {});
       }
 
+      if (bootstrap_daemon_height < m_core.get_checkpoints().get_max_height())
+      {
+        MINFO("Bootstrap daemon height is lower than the latest checkpoint");
+        return m_bootstrap_daemon->handle_result(false, {});
+      }
+
       if (!m_p2p.get_payload_object().no_sync())
       {
         uint64_t top_height = m_core.get_current_blockchain_height();


### PR DESCRIPTION
~~Also outdated nodes now get 50 fail points instead of 2.~~ Not necessary anymore with #8544.