### PR TITLE
serialization: forbid reading 0 varints from empty data

### DIFF
--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -145,7 +145,7 @@ struct binary_archive<false> : public binary_archive_base<false>
   {
     auto current = bytes_.cbegin();
     auto end = bytes_.cend();
-    good_ &= (0 <= tools::read_varint(current, end, v));
+    good_ &= (0 < tools::read_varint(current, end, v));
     current = std::min(current, bytes_.cend());
     bytes_ = {current, std::size_t(bytes_.cend() - current)};
   }


### PR DESCRIPTION
this could plausibly be useful as a tail compression scheme,
but every other varint loading code treats 0 bytes read as an
error, and it goes with the principle of least surprise.