### PR TITLE
rpc: avoid superfluous buffer copy

### DIFF
--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -126,10 +126,8 @@
         return true; \
       } \
       uint64_t ticks2 = misc_utils::get_tick_count(); \
-      epee::byte_slice buffer; \
-      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), buffer, 64 * 1024); \
+      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), response_info.m_body, 64 * 1024); \
       uint64_t ticks3 = epee::misc_utils::get_tick_count(); \
-      response_info.m_body.assign(reinterpret_cast<const char*>(buffer.data()), buffer.size()); \
       response_info.m_mime_tipe = " application/octet-stream"; \
       response_info.m_header_info.m_content_type = " application/octet-stream"; \
       MDEBUG( s_pattern << "() processed with " << ticks1-ticks << "/"<< ticks2-ticks1 << "/" << ticks3-ticks2 << "ms"); \

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -94,8 +94,6 @@ namespace epee
         return load_from_binary(epee::strspan<uint8_t>(target), limits);
       }
 
-      template<class trace_policy>
-      bool		  dump_as_xml(std::string& targetObj, const std::string& root_name = "");
       bool		  dump_as_json(std::string& targetObj, size_t indent = 0, bool insert_newlines = true);
       bool		  load_from_json(const std::string& source);
 
@@ -107,23 +105,7 @@ namespace epee
       storage_entry* insert_new_entry_get_storage_entry(const std::string& pentry_name, hsection psection, entry_type&& entry);
 
       hsection    insert_new_section(const std::string& pentry_name, hsection psection);
-
-#pragma pack(push)
-#pragma pack(1)
-      struct storage_block_header
-      {
-        uint32_t m_signature_a;
-        uint32_t m_signature_b;
-        uint8_t  m_ver;
-      };
-#pragma pack(pop)
     };
-    
-    template<class trace_policy>
-    bool portable_storage::dump_as_xml(std::string& targetObj, const std::string& root_name)
-    {
-      return false;//TODO: don't think i ever again will use xml - ambiguous and "overtagged" format
-    }    
 
     template<class to_type>
     struct get_value_visitor: boost::static_visitor<void>

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -87,6 +87,7 @@ namespace epee
       //-------------------------------------------------------------------------------
       bool		store_to_binary(byte_slice& target, std::size_t initial_buffer_size = 8192);
       bool		store_to_binary(byte_stream& ss);
+      bool		store_to_binary(std::string& target, std::size_t initial_buffer_size = 8192);
       bool		load_from_binary(const epee::span<const uint8_t> target, const limits_t *limits = nullptr);
       bool		load_from_binary(const std::string& target, const limits_t *limits = nullptr)
       {

--- a/contrib/epee/include/storages/portable_storage_template_helper.h
+++ b/contrib/epee/include/storages/portable_storage_template_helper.h
@@ -137,6 +137,13 @@ namespace epee
       str_in.store(ps);
       return ps.store_to_binary(binary_buff);
     }
-
-  }
-}
+    //-----------------------------------------------------------------------------------------------------------
+    template<class t_struct>
+    bool store_t_to_binary(t_struct& str_in, std::string& bin_str, size_t initial_buffer_size = 8192)
+    {
+      portable_storage ps;
+      str_in.store(ps);
+      return ps.store_to_binary(bin_str, initial_buffer_size);
+    }
+  } // namespace serialization
+} // namespace epee

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -30,8 +30,25 @@
 #include <cstdint>
 #include <gtest/gtest.h>
 
+#include "byte_slice.h"
+#include "serialization/keyvalue_serialization.h"
 #include "storages/portable_storage.h"
+#include "storages/portable_storage_template_helper.h"
 #include "span.h"
+
+namespace
+{
+  struct ExampleData
+  {
+    int i;
+    std::string s;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(i)
+      KV_SERIALIZE(s)
+    END_KV_SERIALIZE_MAP()
+  };
+} // anonymous namespace
 
 TEST(epee_binary, two_keys)
 {
@@ -53,4 +70,14 @@ TEST(epee_binary, duplicate_key)
 
   epee::serialization::portable_storage storage{};
   EXPECT_FALSE(storage.load_from_binary(data));
+}
+
+TEST(epee_binary, to_string_conformity)
+{
+  const ExampleData& data{2023, "cereal"};
+  const epee::byte_slice expected_slice = epee::serialization::store_t_to_binary(data);
+  const std::string expected{reinterpret_cast<const char*>(expected_slice.data()), expected_slice.size()};
+  std::string actual;
+  EXPECT_TRUE(epee::serialization::store_t_to_binary(data, actual));
+  EXPECT_EQ(expected, actual);
 }

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -40,7 +40,7 @@ namespace
 {
   struct ExampleData
   {
-    int i;
+    int16_t i;
     std::string s;
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -70,6 +70,22 @@ TEST(epee_binary, duplicate_key)
 
   epee::serialization::portable_storage storage{};
   EXPECT_FALSE(storage.load_from_binary(data));
+}
+
+TEST(epee_binary, to_string_correctness)
+{
+  static constexpr const std::uint8_t expected_binary[] = {
+    0x01, 0x11, 0x01, 0x01, 0x01, 0x01, 0x02, 0x01,
+    0x01, 0x08, 0x01,  'i', 0x03, 0xe7, 0x07, 0x01,
+     's', 0x0a, 0x18,  'c',  'e',  'r',  'e',  'a',
+      'l'
+  };
+
+  const ExampleData& data{2023, "cereal"};
+  const std::string expected{reinterpret_cast<const char*>(expected_binary), sizeof(expected_binary)};
+  std::string actual;
+  EXPECT_TRUE(epee::serialization::store_t_to_binary(data, actual));
+  EXPECT_EQ(expected, actual);
 }
 
 TEST(epee_binary, to_string_conformity)


### PR DESCRIPTION
In the macro `MAP_URI_AUTO_BIN2`, the response body was written by streaming to a `epee::byte_stream` which is taken by a `epee::byte_slice` (by move) which is then copied into a `std::string` (the variable being `response_info.m_body`). This PR creates a new `store_t_to_binary` template helper which streams the formatted bytes directly into a `std::string`. This should help speed up requests to binary RPC endpoints.

This PR appears to have appropriate correctness (see unit test), but further testing is needed to compare performance. 