### PR TITLE
Fix shared_ptr cycle in test_epee_connection.test_lifetime

### DIFF
--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -212,11 +212,14 @@ TEST(test_epee_connection, test_lifetime)
   server.get_config_shared()->set_handler(new command_handler_t, &command_handler_t::destroy);
 
   io_context.post([&io_context, &work, &endpoint, &server]{
-    auto scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&work]{
+    shared_state_ptr shared_state;
+    auto scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&work, &shared_state]{
       work.reset();
+      if (shared_state)
+        shared_state->set_handler(nullptr, nullptr);
     });
 
-    shared_state_ptr shared_state(std::make_shared<shared_state_t>());
+    shared_state = std::make_shared<shared_state_t>();
     shared_state->set_handler(new command_handler_t, &command_handler_t::destroy);
 
     auto create_connection = [&io_context, &endpoint, &shared_state] {


### PR DESCRIPTION
While updating PR #7345 address sanitizer caught a memory leak due to a `std::shared_ptr` cycle.