### PR TITLE
epee: dont shrink slice when storing to binary

### DIFF
--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -49,7 +49,7 @@ namespace serialization
     byte_stream ss;
     ss.reserve(initial_buffer_size);
     store_to_binary(ss);
-    target = epee::byte_slice{std::move(ss)};
+    target = epee::byte_slice{std::move(ss), false};
     return true;
     CATCH_ENTRY("portable_storage::store_to_binary", false);
   }


### PR DESCRIPTION
competing with #8535 

Shrinking a moved `byte_stream` in `byte_slice::byte_slice(epee::byte_stream&&, bool)` is very expensive (in glibc) so avoiding shrinking can speed up storing types to binary in RPC calls. This PR is 1 line instead of 100.

Credit: @vtnerd 