### PR TITLE
multisig: fix seed restore (suggestions by @UkoeHB) [release]

### DIFF
--- a/src/multisig/multisig_account.cpp
+++ b/src/multisig/multisig_account.cpp
@@ -127,7 +127,7 @@ namespace multisig
   bool multisig_account::multisig_is_ready() const
   {
     if (main_kex_rounds_done())
-      return m_kex_rounds_complete >= multisig_kex_rounds_required(m_signers.size(), m_threshold) + 1;
+      return m_kex_rounds_complete >= multisig_setup_rounds_required(m_signers.size(), m_threshold);
     else
       return false;
   }
@@ -198,6 +198,13 @@ namespace multisig
     CHECK_AND_ASSERT_THROW_MES(num_signers >= threshold, "num_signers must be >= threshold");
     CHECK_AND_ASSERT_THROW_MES(threshold >= 1, "threshold must be >= 1");
     return num_signers - threshold + 1;
+  }
+  //----------------------------------------------------------------------------------------------------------------------
+  // EXTERNAL
+  //----------------------------------------------------------------------------------------------------------------------
+  std::uint32_t multisig_setup_rounds_required(const std::uint32_t num_signers, const std::uint32_t threshold)
+  {
+    return multisig_kex_rounds_required(num_signers, threshold) + 1;
   }
   //----------------------------------------------------------------------------------------------------------------------
 } //namespace multisig

--- a/src/multisig/multisig_account.h
+++ b/src/multisig/multisig_account.h
@@ -245,4 +245,13 @@ namespace multisig
   * return: number of kex rounds required
   */
   std::uint32_t multisig_kex_rounds_required(const std::uint32_t num_signers, const std::uint32_t threshold);
+
+  /**
+  * brief: multisig_setup_rounds_required - The number of setup rounds required to produce an M-of-N shared key.
+  *    - A participant must complete all kex rounds and 1 initialization round.
+  * param: num_signers - number of participants in multisig (N)
+  * param: threshold - threshold of multisig (M)
+  * return: number of setup rounds required
+  */
+  std::uint32_t multisig_setup_rounds_required(const std::uint32_t num_signers, const std::uint32_t threshold);
 } //namespace multisig

--- a/src/multisig/multisig_account_kex_impl.cpp
+++ b/src/multisig/multisig_account_kex_impl.cpp
@@ -74,7 +74,7 @@ namespace multisig
       "Multisig threshold may not be larger than number of signers.");
     CHECK_AND_ASSERT_THROW_MES(threshold > 0, "Multisig threshold must be > 0.");
     CHECK_AND_ASSERT_THROW_MES(round > 0, "Multisig kex round must be > 0.");
-    CHECK_AND_ASSERT_THROW_MES(round <= multisig_kex_rounds_required(num_signers, threshold) + 1,
+    CHECK_AND_ASSERT_THROW_MES(round <= multisig_setup_rounds_required(num_signers, threshold),
       "Trying to process multisig kex for an invalid round.");
   }
   //----------------------------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4134,6 +4134,17 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     if(!ask_wallet_create_if_needed()) return false;
   }
 
+  bool enable_multisig = false;
+  if (m_restore_multisig_wallet) {
+    fail_msg_writer() << tr("Multisig is disabled.");
+    fail_msg_writer() << tr("Multisig is an experimental feature and may have bugs. Things that could go wrong include: funds sent to a multisig wallet can't be spent at all, can only be spent with the participation of a malicious group member, or can be stolen by a malicious group member.");
+    if (!command_line::is_yes(input_line("Do you want to continue restoring a multisig wallet?", true))) {
+      message_writer() << tr("You have canceled restoring a multisig wallet.");
+      return false;
+    }
+    enable_multisig = true;
+  }
+
   if (!m_generate_new.empty() || m_restoring)
   {
     if (!m_subaddress_lookahead.empty() && !parse_subaddress_lookahead(m_subaddress_lookahead))
@@ -4667,6 +4678,8 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
       m_wallet->set_refresh_from_block_height(m_restore_height);
     }
+    if (enable_multisig)
+      m_wallet->enable_multisig(true);
     m_wallet->rewrite(m_wallet_file, password);
   }
   else

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -101,7 +101,7 @@ namespace cryptonote
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
-        const epee::wipeable_string &multisig_keys, const std::string &old_language);
+        const epee::wipeable_string &multisig_keys, const epee::wipeable_string &seed_pass, const std::string &old_language);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm);
     boost::optional<epee::wipeable_string> open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4684,7 +4684,8 @@ void wallet2::init_type(hw::device::device_type device_type)
 }
 
 /*!
- * \brief  Generates a wallet or restores one.
+ * \brief  Generates a wallet or restores one. Assumes the multisig setup
+ *         has already completed for the provided multisig info.
  * \param  wallet_              Name of wallet file
  * \param  password             Password of wallet file
  * \param  multisig_data        The multisig restore info and keys
@@ -4743,11 +4744,6 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   crypto::public_key local_signer;
   THROW_WALLET_EXCEPTION_IF(!crypto::secret_key_to_public_key(spend_secret_key, local_signer), error::invalid_multisig_seed);
   THROW_WALLET_EXCEPTION_IF(std::find(multisig_signers.begin(), multisig_signers.end(), local_signer) == multisig_signers.end(), error::invalid_multisig_seed);
-  rct::key skey = rct::zero();
-  for (const auto &msk: multisig_keys)
-    sc_add(skey.bytes, skey.bytes, rct::sk2rct(msk).bytes);
-  THROW_WALLET_EXCEPTION_IF(!(rct::rct2sk(skey) == spend_secret_key), error::invalid_multisig_seed);
-  memwipe(&skey, sizeof(rct::key));
 
   m_account.make_multisig(view_secret_key, spend_secret_key, spend_public_key, multisig_keys);
 
@@ -4758,6 +4754,8 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   m_multisig = true;
   m_multisig_threshold = threshold;
   m_multisig_signers = multisig_signers;
+  // wallet is assumed already finalized
+  m_multisig_rounds_passed = multisig::multisig_setup_rounds_required(m_multisig_signers.size(), m_multisig_threshold);
   setup_keys(password);
 
   create_keys_file(wallet_, false, password, m_nettype != MAINNET || create_address_file);
@@ -5208,7 +5206,7 @@ bool wallet2::multisig(bool *ready, uint32_t *threshold, uint32_t *total) const
   if (ready)
   {
     *ready = !(get_account().get_keys().m_account_address.m_spend_public_key == rct::rct2pk(rct::identity())) &&
-      (m_multisig_rounds_passed == multisig::multisig_kex_rounds_required(m_multisig_signers.size(), m_multisig_threshold) + 1);
+      (m_multisig_rounds_passed == multisig::multisig_setup_rounds_required(m_multisig_signers.size(), m_multisig_threshold));
   }
   return true;
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -794,7 +794,8 @@ private:
     };
 
     /*!
-     * \brief  Generates a wallet or restores one.
+     * \brief  Generates a wallet or restores one. Assumes the multisig setup
+      *        has already completed for the provided multisig info.
      * \param  wallet_              Name of wallet file
      * \param  password             Password of wallet file
      * \param  multisig_data        The multisig restore info and keys

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -171,7 +171,7 @@ static void make_wallets(std::vector<tools::wallet2>& wallets, unsigned int M)
 {
   ASSERT_TRUE(wallets.size() > 1 && wallets.size() <= KEYS_COUNT);
   ASSERT_TRUE(M <= wallets.size());
-  std::uint32_t total_rounds_required = multisig::multisig_kex_rounds_required(wallets.size(), M) + 1;
+  std::uint32_t total_rounds_required = multisig::multisig_setup_rounds_required(wallets.size(), M);
   std::uint32_t rounds_complete{0};
 
   // initialize wallets, get first round multisig kex msgs


### PR DESCRIPTION
Solves the `invalid multisig seed` error when restoring a multisig wallet, reported by @tmoravec in #8537. Fixes suggested by @UkoeHB.

### [Fix 1](https://github.com/monero-project/monero/issues/8537#issuecomment-1233717683)

> multisig accounts no longer store a sum of multisig keyshares in the spend_secret_key slot. Instead it is the 'base multisig privkey', which is the private key used to sign key exchange messages post-update (and for the first step of key exchange both pre and post update). This explains why new multisig wallets are throwing an error (can be fixed by just deleting lines 4750-4754; there is no verification step like this for post-update spend secret keys).

### [Fix 2](https://github.com/monero-project/monero/issues/8537#issuecomment-1234611444)

> If restoring from 'multisig keys', presumably the wallet is fully set-up, so it's fine to set the rounds passed [in wallet2::generate()].

### Misc

Tested restoring both a v0.17.2.0 and v0.18.1.0 multisig wallet from plaintext seed using this PR applied to v0.18.1.0. Working smoothly on my end.

I have not yet gone deeper into the segfault reported with an encrypted seed in #8537. [UPDATE: solved in this PR]