### PR TITLE
wallet2: Fix missing semi-colon in error message [release]

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -13395,7 +13395,7 @@ size_t wallet2::import_outputs_from_str(const std::string &outputs_st)
   }
   catch (const std::exception &e)
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to import outputs") + e.what());
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to import outputs: ") + e.what());
   }
 
   return imported_outputs;


### PR DESCRIPTION
@woodser 's suggestion [here](https://github.com/monero-project/monero/pull/8510#issuecomment-1217315218)