### PR TITLE
unit_tests: suppress memwipe uninit warnings

### DIFF
--- a/tests/unit_tests/memwipe.cpp
+++ b/tests/unit_tests/memwipe.cpp
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include "misc_log_ex.h"
 #include "memwipe.h"
+#include "warnings.h"
 
 // Probably won't catch the optimized out case, but at least we test
 // it works in the normal case
@@ -44,12 +45,15 @@ static void test(bool wipe)
   ASSERT_EQ(foo, bar);
   free(foo);
   char *quux = (char*)malloc(4); // same size, just after free, so we're likely to get the same, depending on the allocator
+PUSH_WARNINGS
+DISABLE_GCC_WARNING(maybe-uninitialized)
   if ((intptr_t)quux == foop)
   {
     MDEBUG(std::hex << std::setw(8) << std::setfill('0') << *(uint32_t*)quux);
     if (wipe) { ASSERT_TRUE(memcmp(quux, "bar", 3)); }
   }
   else MWARNING("We did not get the same location, cannot check");
+POP_WARNINGS
   free(quux);
 }
 


### PR DESCRIPTION
Fixes warnings:
```
warning: ‘*(uint32_t*)quux’ may be used uninitialized [-Wmaybe-uninitialized]
   49 |     MDEBUG(std::hex << std::setw(8) << std::setfill('0') << *(uint32_t*)quux);
warning: ‘quux’ may be used uninitialized [-Wmaybe-uninitialized]
   50 |     if (wipe) { ASSERT_TRUE(memcmp(quux, "bar", 3)); }
```