### PR TITLE
wallet2: fail to establish daemon cxn == "Disconnected" cxn status [release]

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4787,7 +4787,7 @@ bool simple_wallet::try_connect_to_daemon(bool silent, uint32_t* version)
   uint32_t version_ = 0;
   if (!version)
     version = &version_;
-  bool wallet_is_outdated, daemon_is_outdated = false;
+  bool wallet_is_outdated = false, daemon_is_outdated = false;
   if (!m_wallet->check_connection(version, NULL, 200000, &wallet_is_outdated, &daemon_is_outdated))
   {
     if (!silent)

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -63,8 +63,8 @@ namespace {
     static const int    MAX_REFRESH_INTERVAL_MILLIS = 1000 * 60 * 1;
     // Default refresh interval when connected to remote node
     static const int    DEFAULT_REMOTE_NODE_REFRESH_INTERVAL_MILLIS = 1000 * 10;
-    // Connection timeout 30 sec
-    static const int    DEFAULT_CONNECTION_TIMEOUT_MILLIS = 1000 * 30;
+    // Connection timeout 20 sec
+    static const int    DEFAULT_CONNECTION_TIMEOUT_MILLIS = 1000 * 20;
 
     std::string get_default_ringdb_path(cryptonote::network_type nettype)
     {
@@ -2173,7 +2173,7 @@ bool WalletImpl::connectToDaemon()
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
     uint32_t version = 0;
-    bool wallet_is_outdated, daemon_is_outdated = false;
+    bool wallet_is_outdated = false, daemon_is_outdated = false;
     m_is_connected = m_wallet->check_connection(&version, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS, &wallet_is_outdated, &daemon_is_outdated);
     if (!m_is_connected)
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1346,6 +1346,7 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
     }
     m_rpc_payment_state.expected_spent = 0;
     m_rpc_payment_state.discrepancy = 0;
+    m_rpc_version = 0;
     m_node_rpc_proxy.invalidate();
   }
 


### PR DESCRIPTION
When the wallet fails to establish a connection to a daemon either because the daemon is non-existent or offline, sometimes the wallet will incorrectly think the failure is caused by incompatible versions. Reported by @hinto-janaiyo [here](https://github.com/monero-project/monero/pull/8544#discussion_r974825557) (also the cause of the "Wrong version" status in #8583).

The primary cause of the bug is undefined behavior introduced in #8544 when initializing `wallet_is_outdated`.

Separate from the above bug: in this PR, I also reduced `wallet.cpp`'s default connection timeout from 30s to 20s, which matches wallet2 and helps avoid an infinite "Connecting" loop in the GUI.