### PR TITLE
workflows: build gitian on tag

### DIFF
--- a/.github/workflows/gitian.yml
+++ b/.github/workflows/gitian.yml
@@ -1,0 +1,49 @@
+name: ci/gh-actions/gitian
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-gitian:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system:
+          - name: "Linux"
+            option: "l"
+          - name: "Windows"
+            option: "w"
+          - name: "Android"
+            option: "a"
+          - name: "FreeBSD"
+            option: "f"
+          - name: "macOS"
+            option: "m"
+    name: ${{ matrix.operating-system.name }}
+    steps:
+    - name: prepare
+      run: |
+        sudo apt update
+        curl -O https://raw.githubusercontent.com/monero-project/monero/${{ github.ref_name }}/contrib/gitian/gitian-build.py
+        chmod +x gitian-build.py
+    - name: setup
+      run: |
+        ./gitian-build.py --setup --docker github-actions ${{ github.ref_name }}
+    - name: build
+      run: |
+        ./gitian-build.py --docker --detach-sign --no-commit --build -j 3 -o ${{ matrix.operating-system.option }} github-actions ${{ github.ref_name }}
+    - name: post build
+      run: |
+        cd out/${{ github.ref_name }}
+        shasum -a256 *
+        echo \`\`\` >> $GITHUB_STEP_SUMMARY
+        shasum -a256 * >> $GITHUB_STEP_SUMMARY
+        echo \`\`\` >> $GITHUB_STEP_SUMMARY
+    - uses: actions/upload-artifact@v3.1.0
+      with:
+        name: ${{ matrix.operating-system.name }}
+        path: |
+          out/${{ github.ref_name }}/*


### PR DESCRIPTION
- only runs on tag
- each OS uses a separate runner
- hashes get printed on summary page
- the resulting build archives get uploaded as artifacts