### PR TITLE
workflows: skip ci when only changing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: ci/gh-actions/cli
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**/README.md'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -2,6 +2,9 @@ name: ci/gh-actions/depends
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**/README.md'
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
`paths-ignore` has to be added to both push and pull_request, there is no fall through.