### PR TITLE
wallet2: move /gettransactions invocations to node_rpc_proxy

### DIFF
--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -531,25 +531,13 @@ boost::optional<std::string> NodeRPCProxy::get_transactions(const tx_cont_t<tx_h
   return boost::none;
 }
 
-boost::optional<std::string> NodeRPCProxy::get_transaction(const crypto::hash& tx_hash, tx_t& tx_out, tx_entry_t& entry_out)
+boost::optional<std::string> NodeRPCProxy::get_transaction(const crypto::hash& tx_hash, tx_t* tx_out, tx_entry_t* entry_out)
 {
-  tx_handler_t tx_passthru_assignment = [&tx_out, &entry_out]
+  tx_handler_t tx_passthru_assignment = [tx_out, entry_out]
     (tx_t&& tx_m, tx_entry_t&& tx_entry_m, const tx_hash_t& ignored) -> bool
   {
-    tx_out = tx_m;
-    entry_out = tx_entry_m;
-    return true;
-  };
-
-  return get_transactions_one_chunk({epee::string_tools::pod_to_hex(tx_hash)}, &tx_hash, tx_passthru_assignment);
-}
-
-boost::optional<std::string> NodeRPCProxy::get_transaction(const crypto::hash& tx_hash, tx_t& tx_out)
-{
-  tx_handler_t tx_passthru_assignment = [&tx_out]
-    (tx_t&& tx_m, tx_entry_t&& ignored_1, const tx_hash_t& ignored_2) -> bool
-  {
-    tx_out = tx_m;
+    if (tx_out != nullptr) *tx_out = tx_m;
+    if (entry_out != nullptr) *entry_out = tx_entry_m;
     return true;
   };
 

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -69,8 +69,9 @@
 /**
  * @brief Acquire RPC mutex and invoke /json_rpc endpoint
  *
- * Only really useful within NodeRPCProxy because it assumes the existence of variables m_daemon_rpc_mutex,
- * m_http_client, and rpc_timeout. The lock_guard is scoped so that it lives as short as possible.
+ * Only really useful within NodeRPCProxy because it assumes the existence of variables
+ * m_daemon_rpc_mutex, m_http_client, and rpc_timeout. The lock_guard is scoped so that it lives as
+ * short as possible.
  *
  * @param method JSON RPC method name as a string
  * @param req cryptonote::COMMAND_RPC_x::request form which will be used with invoke_http_json_rpc

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -549,7 +549,7 @@ boost::optional<std::string> NodeRPCProxy::get_transactions_one_chunk(tx_cont_t<
   // Check if offline
   if (m_offline)
   {
-    return std::string("NodeRPCProxy offline");
+    return std::string("offline");
   }
 
   // Setup request/response forms

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -78,9 +78,6 @@ public:
    * errors, missing txids, and mismatched txids are all checked before invoking the callback, so
    * the caller can assume base transaction validity. This method is thread-safe.
    *
-   * This method is slower than the other get_transactions endpoint since the crypto::hash values
-   * have to be translated into std::strings before being sent over the wire.
-   *
    * @param txids contains request txids
    * @param cb tx_handler_t which processes received transactions
    *
@@ -89,30 +86,20 @@ public:
   boost::optional<std::string> get_transactions(const tx_cont_t<tx_hash_t>& txids, tx_handler_t& cb);
 
   /**
-   * @brief Invoke /get_transactions with one hash, and return parsed transaction.
+   * @brief Invoke /get_transactions with one hash, and get parsed transaction and raw entry.
    *
-   * Same as previous get_transactions() method, but we modify the transaction by reference instead
-   * of using a callback.
+   * We make a /get_transactions request with the given txid encoded as a hex string,
+   * decode_as_json=false, pruned=true, and split=false. RPC errors, transaction parsing
+   * errors, missing txids, and mismatched txids are all checked before setting the result, so
+   * the caller can assume base transaction validity. This method is thread-safe.
    *
-   * @param txids contains request txids
-   * @param[out] tx_res parsed transaction returned by /get_transactions
-   *
-   * @return boost::none on success, otherwise returns error message
-   */
-  boost::optional<std::string> get_transaction(const tx_hash_t& txid, tx_t& tx_res);
-
-  /**
-   * @brief Invoke /get_transactions with one hash, and return parsed transaction.
-   *
-   * Same as previous get_transaction() method, but we also get a tx entry output paramter.
-   *
-   * @param txids contains request txids
-   * @param[out] tx_res parsed transaction returned by /get_transactions
-   * @param[out] tx_entry_res raw transaction entry received from response
+   * @param txid contains request txid
+   * @param[out] tx_res if != nullptr, will be set to parsed cryptonote::transaction received
+   * @param[out] tx_entry_res if != nullptr, will be set to raw transaction entry received
    *
    * @return boost::none on success, otherwise returns error message
    */
-  boost::optional<std::string> get_transaction(const tx_hash_t& txid, tx_t& tx_res, tx_entry_t& tx_entry_res);
+  boost::optional<std::string> get_transaction(const tx_hash_t& txid, tx_t* tx_res, tx_entry_t* tx_entry_res);
 
 private:
   template<typename T> void handle_payment_changes(const T &res, std::true_type) {

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -89,18 +89,6 @@ public:
   boost::optional<std::string> get_transactions(const tx_cont_t<tx_hash_t>& txids, tx_handler_t& cb);
 
   /**
-   * @brief Invoke /get_transactions with list of hashes, and call handler for each entry.
-   *
-   * Same as previous get_transactions() method, but txids container is moved instead of copied.
-   *
-   * @param txids contains request txids
-   * @param cb tx_handler_t which processes received transactions
-   *
-   * @return boost::none on success, otherwise returns error message
-   */
-  boost::optional<std::string> get_transactions(tx_cont_t<std::string>&& txids, tx_handler_t& cb);
-
-  /**
    * @brief Invoke /get_transactions with one hash, and return parsed transaction.
    *
    * Same as previous get_transactions() method, but we modify the transaction by reference instead
@@ -114,7 +102,7 @@ public:
   boost::optional<std::string> get_transaction(const tx_hash_t& txid, tx_t& tx_res);
 
   /**
-   * @brief Invoke /get_transactions  with one hash, and return parsed transaction.
+   * @brief Invoke /get_transactions with one hash, and return parsed transaction.
    *
    * Same as previous get_transaction() method, but we also get a tx entry output paramter.
    *
@@ -146,12 +134,13 @@ private:
    *
    * Used internally by get_transaction[s]()
    *
-   * @param txids contains request txids
+   * @param txids contains request txid strings
+   * @param txid_check Pointer to block of crypto::hashes which has all the same IDs as txids
    * @param cb tx_handler_t which processes received transactions
    *
    * @return boost::none on success, otherwise returns error message
    */
-  boost::optional<std::string> get_transactions_one_chunk(tx_cont_t<std::string>&& txids, tx_handler_t& cb);
+  boost::optional<std::string> get_transactions_one_chunk(tx_cont_t<std::string>&& txids, const tx_hash_t* txid_check, tx_handler_t& cb);
 
   epee::net_utils::http::abstract_http_client &m_http_client;
   rpc_payment_state_t &m_rpc_payment_state;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7742,7 +7742,7 @@ bool wallet2::unset_ring(const crypto::hash &txid)
     return false;
 
   cryptonote::transaction tx;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("Failed to get transaction from daemon: ") + *fail_res);
 
   try { return m_ringdb->remove_rings(get_ringdb_key(), tx); }
@@ -11125,7 +11125,7 @@ bool wallet2::get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, s
   if (tx_key_data.tx_prefix_hash.empty())
   {
     cryptonote::transaction tx;
-    const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+    const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
     THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("RPC proxy: get_transactions failed: ") + *fail_res);
 
     crypto::hash tx_prefix_hash;
@@ -11155,7 +11155,7 @@ bool wallet2::get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, s
 void wallet2::set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const boost::optional<cryptonote::account_public_address> &single_destination_subaddress)
 {
   cryptonote::transaction tx;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("set_tx_key error: ") + *fail_res);
 
   std::vector<tx_extra_field> tx_extra_fields;
@@ -11197,7 +11197,7 @@ std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string
     "get_spend_proof requires spend secret key and is not available for a watch-only wallet");
 
   cryptonote::transaction tx;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("get_spend_proof error: ") + *fail_res);
 
   std::vector<std::vector<crypto::signature>> signatures;
@@ -11299,7 +11299,7 @@ bool wallet2::check_spend_proof(const crypto::hash &txid, const std::string &mes
 
   // fetch tx from daemon
   cryptonote::transaction tx;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("check_spend_proof error: ") + *fail_res);
 
   // check signature size
@@ -11449,7 +11449,7 @@ void wallet2::check_tx_key_helper(const crypto::hash &txid, const crypto::key_de
 
   cryptonote::transaction tx;
   cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry tx_entry;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx, tx_entry);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, &tx_entry);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("check_tx_key_helper error: ") + *fail_res);
 
   THROW_WALLET_EXCEPTION_IF(!additional_derivations.empty() && additional_derivations.size() != tx.vout.size(), error::wallet_internal_error,
@@ -11514,7 +11514,7 @@ bool wallet2::is_out_to_acc(const cryptonote::account_public_address &address, c
 std::string wallet2::get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message)
 {
   cryptonote::transaction tx;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, nullptr);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("get_tx_proof error: ") + *fail_res);
 
     // determine if the address is found in the subaddress hash table (i.e. whether the proof is outbound or inbound)
@@ -11644,7 +11644,7 @@ bool wallet2::check_tx_proof(const crypto::hash &txid, const cryptonote::account
   // fetch tx pubkey from the daemon
   cryptonote::transaction tx;
   cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry tx_entry;
-  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, tx, tx_entry);
+  const auto fail_res = m_node_rpc_proxy.get_transaction(txid, &tx, &tx_entry);
   THROW_WALLET_EXCEPTION_IF(fail_res, error::wallet_internal_error, std::string("check_tx_proof error: ") + *fail_res);
 
   if (!check_tx_proof(tx, address, is_subaddress, message, sig_str, received))


### PR DESCRIPTION
In the future, I plan to wrap all RPC invocations into node_rpc_proxy, those PRs can come later, but this will definitely be one of the bigger ones. This is not just refactoring for the sake of refactoring, however. I plan to implement a "community node" feature for wallet2, which would allow direct connections to different secured daemons without a dependency on starting a local p2p process.

In order to do this, we need one streamlined RPC interface for wallet2. Even if this "community node" feature does not come to fruition, abstracting away the RPC invocation details into a different class will allow us to easily do multi-threaded RPC requests, more responsive public node requests, etc, while the interface remains extremely simple. Also, if (when) the big wallet3 redesign comes around, this will make transitioning easier. 