### PR TITLE
simplewallet/wallet2: set option - show-detailed-prompt

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2980,6 +2980,19 @@ bool simple_wallet::set_show_wallet_name_when_locked(const std::vector<std::stri
   return true;
 }
 
+bool simple_wallet::set_show_detailed_prompt(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  const auto pwd_container = get_and_verify_password();
+  if (pwd_container)
+  {
+    parse_bool_and_use(args[1], [&](bool r) {
+      m_wallet->show_detailed_prompt(r);
+      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    });
+  }
+  return true;
+}
+
 bool simple_wallet::set_inactivity_lock_timeout(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
 #ifdef _WIN32
@@ -3441,6 +3454,8 @@ simple_wallet::simple_wallet()
                                   "  The RPC payment credits balance to target (0 for default).\n "
                                   "show-wallet-name-when-locked <1|0>\n "
                                   "  Set this if you would like to display the wallet name when locked.\n "
+                                  "show-detailed-prompt <1|0>\n "
+                                  "  Set this if you would like to display the account, wallet name, and block in the prompt.\n "
                                   "enable-multisig-experimental <1|0>\n "
                                   "  Set this to allow multisig commands. Multisig may currently be exploitable if parties do not trust each other.\n "
                                   "inactivity-lock-timeout <unsigned int>\n "
@@ -3849,6 +3864,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "device-name = " << m_wallet->device_name();
     success_msg_writer() << "export-format = " << (m_wallet->export_format() == tools::wallet2::ExportFormat::Ascii ? "ascii" : "binary");
     success_msg_writer() << "show-wallet-name-when-locked = " << m_wallet->show_wallet_name_when_locked();
+    success_msg_writer() << "show-detailed-prompt = " << m_wallet->show_detailed_prompt();
     success_msg_writer() << "inactivity-lock-timeout = " << m_wallet->inactivity_lock_timeout()
 #ifdef _WIN32
         << " (disabled on Windows)"
@@ -3917,6 +3933,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     CHECK_SIMPLE_VARIABLE("ignore-outputs-below", set_ignore_outputs_below, tr("amount"));
     CHECK_SIMPLE_VARIABLE("track-uses", set_track_uses, tr("0 or 1"));
     CHECK_SIMPLE_VARIABLE("show-wallet-name-when-locked", set_show_wallet_name_when_locked, tr("1 or 0"));
+    CHECK_SIMPLE_VARIABLE("show-detailed-prompt", set_show_detailed_prompt, tr("1 or 0"));
     CHECK_SIMPLE_VARIABLE("inactivity-lock-timeout", set_inactivity_lock_timeout, tr("unsigned integer (seconds, 0 to disable)"));
     CHECK_SIMPLE_VARIABLE("setup-background-mining", set_setup_background_mining, tr("1/yes or 0/no"));
     CHECK_SIMPLE_VARIABLE("device-name", set_device_name, tr("<device_name[:device_spec]>"));
@@ -9410,12 +9427,25 @@ std::string simple_wallet::get_prompt() const
   if (m_locked)
     return std::string("[") + tr("locked due to inactivity") + "]";
   std::string addr_start = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0}).substr(0, 6);
-  std::string prompt = std::string("[") + tr("wallet") + " " + addr_start;
+  std::string prompt = std::string("[") + tr("account: ") + addr_start;
+  // Detailed prompt: [account: 4......] [wallet: <file_basename>] [block: xxx]:
+  const bool show_detailed_prompt = m_wallet->show_detailed_prompt();
+  if (show_detailed_prompt)
+  {
+    std::string path = m_wallet->get_wallet_file();
+    std::string wallet = path.substr(path.find_last_of("/\\") + 1);
+    std::string block = std::to_string(m_wallet->get_blockchain_current_height());
+    prompt += std::string("] [") + tr("wallet: ") + wallet;
+    prompt += std::string("] [") + tr("block: ") + block;
+  }
   if (!m_wallet->check_connection(NULL))
-    prompt += tr(" (no daemon)");
-  else if (!m_wallet->is_synced())
-    prompt += tr(" (out of sync)");
-  prompt += "]: ";
+  {
+    prompt += tr("] (no daemon): ");
+  } else if (!m_wallet->is_synced()) {
+    prompt += tr("] (out of sync): ");
+  } else {
+    prompt += "]: ";
+  }
   return prompt;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -148,6 +148,7 @@ namespace cryptonote
     bool set_ignore_outputs_below(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_track_uses(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_show_wallet_name_when_locked(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_show_detailed_prompt(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_inactivity_lock_timeout(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_setup_background_mining(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_device_name(const std::vector<std::string> &args = std::vector<std::string>());

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1188,6 +1188,7 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std
   m_ignore_outputs_below(0),
   m_track_uses(false),
   m_show_wallet_name_when_locked(false),
+  m_show_detailed_prompt(false),
   m_inactivity_lock_timeout(DEFAULT_INACTIVITY_LOCK_TIMEOUT),
   m_setup_background_mining(BackgroundMiningMaybe),
   m_persistent_rpc_client_id(false),
@@ -4035,6 +4036,9 @@ boost::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const epee:
   value2.SetInt(m_show_wallet_name_when_locked ? 1 : 0);
   json.AddMember("show_wallet_name_when_locked", value2, json.GetAllocator());
 
+  value2.SetInt(m_show_detailed_prompt ? 1 : 0);
+  json.AddMember("show_detailed_prompt", value2, json.GetAllocator());
+
   value2.SetInt(m_inactivity_lock_timeout);
   json.AddMember("inactivity_lock_timeout", value2, json.GetAllocator());
 
@@ -4223,6 +4227,7 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     m_ignore_outputs_below = 0;
     m_track_uses = false;
     m_show_wallet_name_when_locked = false;
+    m_show_detailed_prompt = false;
     m_inactivity_lock_timeout = DEFAULT_INACTIVITY_LOCK_TIMEOUT;
     m_setup_background_mining = BackgroundMiningMaybe;
     m_subaddress_lookahead_major = SUBADDRESS_LOOKAHEAD_MAJOR;
@@ -4401,6 +4406,8 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     m_track_uses = field_track_uses;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, show_wallet_name_when_locked, int, Int, false, false);
     m_show_wallet_name_when_locked = field_show_wallet_name_when_locked;
+    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, show_detailed_prompt, int, Int, false, false);
+    m_show_detailed_prompt = field_show_detailed_prompt;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, inactivity_lock_timeout, uint32_t, Uint, false, DEFAULT_INACTIVITY_LOCK_TIMEOUT);
     m_inactivity_lock_timeout = field_inactivity_lock_timeout;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, setup_background_mining, BackgroundMiningSetupType, Int, false, BackgroundMiningMaybe);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1340,6 +1340,8 @@ private:
     void track_uses(bool value) { m_track_uses = value; }
     bool show_wallet_name_when_locked() const { return m_show_wallet_name_when_locked; }
     void show_wallet_name_when_locked(bool value) { m_show_wallet_name_when_locked = value; }
+    bool show_detailed_prompt() const { return m_show_detailed_prompt; }
+    void show_detailed_prompt(bool value) { m_show_detailed_prompt = value; }
     BackgroundMiningSetupType setup_background_mining() const { return m_setup_background_mining; }
     void setup_background_mining(BackgroundMiningSetupType value) { m_setup_background_mining = value; }
     uint32_t inactivity_lock_timeout() const { return m_inactivity_lock_timeout; }
@@ -1863,6 +1865,7 @@ private:
     uint64_t m_ignore_outputs_below;
     bool m_track_uses;
     bool m_show_wallet_name_when_locked;
+    bool m_show_detailed_prompt;
     uint32_t m_inactivity_lock_timeout;
     BackgroundMiningSetupType m_setup_background_mining;
     bool m_persistent_rpc_client_id;


### PR DESCRIPTION
Before:
```
[wallet 44hint]:
[wallet 44hint (no daemon)]:
[wallet 44hint (out of sync)]:
```
After with `show-detailed-prompt = 0|1`
```
[account: 44hint]:
[account: 44hint] (no daemon):
[account: 44hint] (out of sync):
---
[account: 44hint] [wallet: hinto] [block: 2731910]:
[account: 44hint] [wallet: hinto] [block: 2731910] (no daemon):
[account: 44hint] [wallet: hinto] [block: 2731910] (out of sync):
```
Added in the same way as https://github.com/monero-project/monero/pull/7153