### PR TITLE
wallet: fix create view-only wallet from existing wallet [master]

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -535,7 +535,7 @@ bool WalletImpl::createWatchOnly(const std::string &path, const std::string &pas
         view_wallet->generate(path, password, address, viewkey);
 
         // Export/Import outputs
-        auto outputs = m_wallet->export_outputs();
+        auto outputs = m_wallet->export_outputs(true/*all*/);
         view_wallet->import_outputs(outputs);
 
         // Copy scanned blockchain
@@ -553,7 +553,7 @@ bool WalletImpl::createWatchOnly(const std::string &path, const std::string &pas
 
         // Export/Import key images
         // We already know the spent status from the outputs we exported, thus no need to check them again
-        auto key_images = m_wallet->export_key_images();
+        auto key_images = m_wallet->export_key_images(true/*all*/);
         uint64_t spent = 0;
         uint64_t unspent = 0;
         view_wallet->import_key_images(key_images.second, key_images.first, spent, unspent, false);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -13330,9 +13330,7 @@ size_t wallet2::import_outputs(const std::tuple<uint64_t, uint64_t, std::vector<
   THROW_WALLET_EXCEPTION_IF(offset > m_transfers.size(), error::wallet_internal_error,
       "Imported outputs omit more outputs that we know of");
 
-  THROW_WALLET_EXCEPTION_IF(offset >= num_outputs, error::wallet_internal_error,
-      "Offset is larger than total outputs");
-  THROW_WALLET_EXCEPTION_IF(output_array.size() > num_outputs - offset, error::wallet_internal_error,
+  THROW_WALLET_EXCEPTION_IF(offset + output_array.size() > num_outputs, error::wallet_internal_error,
       "Offset is larger than total outputs");
 
   const size_t original_size = m_transfers.size();
@@ -13412,9 +13410,7 @@ size_t wallet2::import_outputs(const std::tuple<uint64_t, uint64_t, std::vector<
   THROW_WALLET_EXCEPTION_IF(offset > m_transfers.size(), error::wallet_internal_error,
       "Imported outputs omit more outputs that we know of. Try using export_outputs all.");
 
-  THROW_WALLET_EXCEPTION_IF(offset >= num_outputs, error::wallet_internal_error,
-      "Offset is larger than total outputs");
-  THROW_WALLET_EXCEPTION_IF(output_array.size() > num_outputs - offset, error::wallet_internal_error,
+  THROW_WALLET_EXCEPTION_IF(offset + output_array.size() > num_outputs, error::wallet_internal_error,
       "Offset is larger than total outputs");
 
   const size_t original_size = m_transfers.size();


### PR DESCRIPTION
A user can create a view-only wallet from a normal wallet by calling `createWatchOnly()`. The GUI supports this feature. If the user calls this function from:

### 1) A normal wallet with 0 transfers

The result of `export_outputs()` will have a 0 offset and 0 `num_outputs`, which triggers this error in `import_outputs` (reported in #8614):

https://github.com/monero-project/monero/blob/fc907a957078cae2dc68348886a33363848dd089/src/wallet/wallet2.cpp#L13415-L13416

**Fix:** I updated the error logic of the throw.

### 2) a normal wallet with >1 transfer(s)

Since all key images are known in a normal wallet, `export_outputs()` won't export any of the user's transfers into the fresh view-only wallet; the offset will advance past all of the user's transfers when exporting:

https://github.com/monero-project/monero/blob/fc907a957078cae2dc68348886a33363848dd089/src/wallet/wallet2.cpp#L13264-L13267

Then when importing, the view-only wallet won't know of any existing outputs prior to the offset, which triggers this error in `import_outputs`:

https://github.com/monero-project/monero/blob/fc907a957078cae2dc68348886a33363848dd089/src/wallet/wallet2.cpp#L13412-L13413

**Fix:** Call `export_outputs(all=true)` so the normal wallet will export **all** outputs into the fresh view-only wallet. I also added `export_key_images(all=true)` to make sure to get all key images imported as well.