### PR TITLE
fix(trezor-tests): fix trezor tests build, fix integrated addr test

### DIFF
--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -39,6 +39,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
 
+class WalletApiAccessorTest;
 
 namespace Monero {
 class TransactionHistoryImpl;
@@ -248,6 +249,7 @@ private:
     friend class AddressBookImpl;
     friend class SubaddressImpl;
     friend class SubaddressAccountImpl;
+    friend class ::WalletApiAccessorTest;
 
     std::unique_ptr<tools::wallet2> m_wallet;
     mutable boost::mutex m_statusMutex;

--- a/tests/core_tests/wallet_tools.h
+++ b/tests/core_tests/wallet_tools.h
@@ -32,6 +32,7 @@
 
 #include "chaingen.h"
 #include "wallet/wallet2.h"
+#include "wallet/api/wallet.h"
 
 typedef struct {
   tools::wallet2::transfer_details * td;
@@ -55,6 +56,13 @@ public:
   static tools::wallet2::transfer_container & get_transfers(tools::wallet2 * wallet) { return wallet->m_transfers; }
   static subaddresses_t & get_subaddresses(tools::wallet2 * wallet) { return wallet->m_subaddresses; }
   static void process_parsed_blocks(tools::wallet2 * wallet, uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<tools::wallet2::parsed_block> &parsed_blocks, uint64_t& blocks_added);
+};
+
+// Wallet API friend, direct access to required fields and private methods
+class WalletApiAccessorTest
+{
+public:
+  static void allow_mismatched_daemon_version(Monero::WalletImpl * wallet, bool allow_mismatch) { wallet->m_wallet->allow_mismatched_daemon_version(allow_mismatch); }
 };
 
 class wallet_tools

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -313,7 +313,7 @@ void mock_daemon::mine_blocks(size_t num_blocks, const std::string &miner_addres
 {
   bool blocks_mined = false;
   const uint64_t start_height = get_height();
-  const auto mining_timeout = std::chrono::seconds(120);
+  const auto mining_timeout = std::chrono::seconds(360);
   MDEBUG("Current height before mining: " << start_height);
 
   start_mining(miner_address);


### PR DESCRIPTION
- fix integrated address test, it was not testing integrated address suport
- fix trezor test build as dependent classes were changed
- add a friend test class for Monero::WalletImpl to support wallet api tests When using wallet_api in tests, synthetic chain is used. Without being able to set `allow_mismatched_daemon_version` in the underlying wallet, we are not able to use a synthetic chain with the tests 

