### PR TITLE
Fix dandelion++ fluff/stem bug with local txes

### DIFF
--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -542,6 +542,7 @@ namespace levin
       i_core_events* core_;
       std::vector<blobdata> txs_;
       boost::uuids::uuid source_;
+      relay_method tx_relay;
 
       //! \pre Called in `zone_->strand`
       void operator()()
@@ -549,7 +550,7 @@ namespace levin
         if (!zone_ || !core_ || txs_.empty())
           return;
 
-        if (!zone_->fluffing)
+        if (!zone_->fluffing || tx_relay == relay_method::local)
         {
           core_->on_transactions_relayed(epee::to_span(txs_), relay_method::stem);
           for (int tries = 2; 0 < tries; tries--)
@@ -589,7 +590,7 @@ namespace levin
 
       change_channels(change_channels&&) = default;
       change_channels(const change_channels& source)
-        : zone_(source.zone_), map_(source.map_.clone())
+        : zone_(source.zone_), map_(source.map_.clone()), fluffing_(source.fluffing_)
       {}
 
       //! \pre Called within `zone_->strand`.
@@ -871,7 +872,7 @@ namespace levin
           {
             // this will change a local/forward tx to stem or fluff ...
             zone_->strand.dispatch(
-              dandelionpp_notify{zone_, core_, std::move(txs), source}
+              dandelionpp_notify{zone_, core_, std::move(txs), source, tx_relay}
             );
             break;
           }


### PR DESCRIPTION
An IRC user reported a Dandelion++ bug - the `monerod` Dandelion++ implementation does not match the paper exactly. When a user submits their transaction to their `monerod` for broadcasting, if their local daemon is in "fluff" mode their transaction must still be broadcast in "stem" mode. Our current implementation "fluffs" in this situation; now the implementation will "stem" in this situation.

The fallout from this is a potential targeted attack on a user - an attacker tries to fill up a users incoming table, thereby increasing the chances of knowing whether a particular transaction is received over "stem" (or not). If an attacker fills the incoming table, a fluffed transaction either originated at the victim node or 1+ outgoing links from the victim are in fluff mode. The attacker would then have to do _additional_ trace analysis on the victim's outgoing connections to determine who initiated the fluffing. The randomized delays in fluffing should make this difficult (compared to pre-dandelion++ implementation).

This IRC user also pointed out that following the paper has a similar issue - if an attacker can determine whether a node is in fluff vs stem, and get the victim to make an outgoing connection to them, there's a chance they can identify with high probability that the victim node is the origin for the transaction. However, this should more difficult to perform, assuming it is difficult to spam the peerlist aggressively (which is a whole other topic).

Users should upgrade immediately at next point release, but also not panic because mass surveillance should still be difficult.