### PR TITLE
http_client: Add support for virtual servers

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -63,9 +63,9 @@ namespace http
   public:
     abstract_http_client() {}
     virtual ~abstract_http_client() {}
-    bool set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect);
+    bool set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect, const std::string& virtual_host = {});
     virtual bool set_proxy(const std::string& address);
-    virtual void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) = 0;
+    virtual void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect, const std::string& virtual_host = {}) = 0;
     virtual void set_auto_connect(bool auto_connect) = 0;
     virtual bool connect(std::chrono::milliseconds timeout) = 0;
     virtual bool disconnect() = 0;

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -83,7 +83,8 @@ namespace net_utils
 
 
 			net_client_type m_net_client;
-			std::string m_host_buff;
+			std::string m_host_buff;      // Host IP address
+			std::string m_virt_host_buff; // Value of 'Host:' header field
 			std::string m_port;
 			http_client_auth m_auth;
 			std::string m_header_cache;
@@ -102,6 +103,7 @@ namespace net_utils
 				: i_target_handler(), abstract_http_client()
 				, m_net_client()
 				, m_host_buff()
+				, m_virt_host_buff()
 				, m_port()
 				, m_auth()
 				, m_header_cache()
@@ -121,11 +123,12 @@ namespace net_utils
 
 			using abstract_http_client::set_server;
 
-			void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) override
+			void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect, const std::string& virtual_host = {}) override
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				disconnect();
 				m_host_buff = std::move(host);
+				m_virt_host_buff = !virtual_host.empty() ? virtual_host : m_host_buff; // Unless otherwise specified, virtual host matches host
 				m_port = std::move(port);
 				m_auth = user ? http_client_auth{std::move(*user)} : http_client_auth{};
 				m_net_client.set_ssl(std::move(ssl_options));
@@ -202,7 +205,7 @@ namespace net_utils
 				std::string req_buff{};
 				req_buff.reserve(2048);
 				req_buff.append(method.data(), method.size()).append(" ").append(uri.data(), uri.size()).append(" HTTP/1.1\r\n");
-				add_field(req_buff, "Host", m_host_buff);
+				add_field(req_buff, "Host", m_virt_host_buff);
 				add_field(req_buff, "Content-Length", std::to_string(body.size()));
 
 				//handle "additional_params"

--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -130,12 +130,12 @@ namespace net_utils
 namespace http
 {
   //----------------------------------------------------------------------------------------------------
-  bool epee::net_utils::http::abstract_http_client::set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options)
+  bool epee::net_utils::http::abstract_http_client::set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options, const std::string& virtual_host)
   {
     http::url_content parsed{};
     const bool r = parse_url(address, parsed);
     CHECK_AND_ASSERT_MES(r, false, "failed to parse url: " << address);
-    set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), std::move(ssl_options));
+    set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), std::move(ssl_options), virtual_host);
     return true;
   }
 


### PR DESCRIPTION
With this patch, we can make HTTP requests where the value of the `Host:` field is different from the real IP address. I plan on using this feature for community root node load balancing, where the root node doesn't have to be a real `monerod` process but can be a lightweight shared server which serves a JSON response,  directing wallets to other real `monerod` servers. 