### PR TITLE
DNSResolver: fix not handling hostnames without dot characters

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -326,11 +326,6 @@ std::vector<std::string> DNSResolver::get_record(const std::string& url, int rec
   dnssec_available = false;
   dnssec_valid = false;
 
-  if (!check_address_syntax(url.c_str()))
-  {
-    return addresses;
-  }
-
   // destructor takes care of cleanup
   ub_result_ptr result;
 
@@ -411,16 +406,6 @@ DNSResolver& DNSResolver::instance()
 DNSResolver DNSResolver::create()
 {
   return DNSResolver();
-}
-
-bool DNSResolver::check_address_syntax(const char *addr) const
-{
-  // if string doesn't contain a dot, we won't consider it a url for now.
-  if (strchr(addr,'.') == NULL)
-  {
-    return false;
-  }
-  return true;
 }
 
 namespace dns_utils

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -159,15 +159,6 @@ private:
   // TODO: modify this to accommodate DNSSEC
   std::vector<std::string> get_record(const std::string& url, int record_type, boost::optional<std::string> (*reader)(const char *,size_t), bool& dnssec_available, bool& dnssec_valid);
 
-  /**
-   * @brief Checks a string to see if it looks like a URL
-   *
-   * @param addr the string to be checked
-   *
-   * @return true if it looks enough like a URL, false if not
-   */
-  bool check_address_syntax(const char *addr) const;
-
   DNSResolverData *m_data;
 }; // class DNSResolver
 

--- a/tests/unit_tests/dns_resolver.cpp
+++ b/tests/unit_tests/dns_resolver.cpp
@@ -158,6 +158,17 @@ TEST(DNSResolver, GetTXTRecord)
   EXPECT_STREQ("donate.getmonero.org", addr.c_str());
 }
 
+TEST(DNSResolver, Localhost)
+{
+  tools::DNSResolver resolver = tools::DNSResolver::create();
+
+  bool avail, valid;
+  std::vector<std::string> ips = resolver.get_ipv4("localhost", avail, valid);
+
+  ASSERT_EQ(1, ips.size());
+  ASSERT_EQ("127.0.0.1", ips[0]);
+}
+
 bool is_equal(const char *s, const std::vector<std::string> &v) { return v.size() == 1 && v[0] == s; }
 
 TEST(DNS_PUBLIC, empty) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("").empty()); }


### PR DESCRIPTION
Unrelated, but similar code-wise to #8643. There is a check in `DNSResolver` which automatically fails to resolve hostnames which do not contain the `.` character. This PR removes that check.