### PR TITLE
blockchain_export: add checks for args to `blocks.dat` format

### DIFF
--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -113,6 +113,7 @@ int main(int argc, char* argv[])
     return 1;
   }
   bool opt_blocks_dat = command_line::get_arg(vm, arg_blocks_dat);
+  CHECK_AND_ASSERT_MES(!(opt_blocks_dat && block_start), 1, "Can't specify both --block-start and --blocksdat");
 
   std::string m_config_folder;
 


### PR DESCRIPTION
Add 2 checks which help give feedback to user on bad arguments instead of silently doing the wrong thing.
1. The `blocks.dat` format must start from height 0. If the user also gives a `--block-start` option, throw an error.
2. The `blocks.dat` format chunks the data every `HASH_OF_HASHES_STEP` (512) blocks. If the user does not align `--block-stop` with this paramter, align the block stop and give them a warning message.

Before both of these arguments were silently ignored if incorrect, e.g. running with `--blocksdat` and `--block-stop 510` exported no data. Also, running with `--blocksdat`, `--block-start 509`, `--block-stop 511` was the same as if you changed the option to `--block-start 0`.