### PR TITLE
performance_tests: framework updates

### DIFF
--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -101,12 +101,14 @@ int main(int argc, char** argv)
 
   const std::string filter = tools::glob_to_regex(command_line::get_arg(vm, arg_filter));
   const std::string timings_database = command_line::get_arg(vm, arg_timings_database);
-  Params p;
+  Params core_params;
   if (!timings_database.empty())
-    p.td = TimingsDatabase(timings_database);
-  p.verbose = command_line::get_arg(vm, arg_verbose);
-  p.stats = command_line::get_arg(vm, arg_stats);
-  p.loop_multiplier = command_line::get_arg(vm, arg_loop_multiplier);
+    core_params.td = TimingsDatabase(timings_database);
+  core_params.verbose = command_line::get_arg(vm, arg_verbose);
+  core_params.stats = command_line::get_arg(vm, arg_stats);
+  core_params.loop_multiplier = command_line::get_arg(vm, arg_loop_multiplier);
+
+  ParamsShuttle p{core_params};
 
   performance_timer timer;
   timer.start();


### PR DESCRIPTION
This is a PR in my 'upstreaming `seraphis_lib` project', the changes here are not used anywhere yet.

- Allow custom parameter packs for tests. This enables changing parameters programmatically and reduces the number of test templates you need to compile.
- Improve error reporting for failed tests.
