### PR TITLE
[seraphis] crypto: miscellaneous updates

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -38,7 +38,6 @@ DISABLE_VS_WARNINGS(4146 4244)
 
 /* Predeclarations */
 
-static void fe_mul(fe, const fe, const fe);
 static void fe_sq(fe, const fe);
 static void ge_madd(ge_p1p1 *, const ge_p3 *, const ge_precomp *);
 static void ge_msub(ge_p1p1 *, const ge_p3 *, const ge_precomp *);
@@ -72,7 +71,7 @@ uint64_t load_4(const unsigned char *in)
 h = 0
 */
 
-static void fe_0(fe h) {
+void fe_0(fe h) {
   h[0] = 0;
   h[1] = 0;
   h[2] = 0;
@@ -375,7 +374,7 @@ Can get away with 11 carries, but then data flow is much deeper.
 With tighter constraints on inputs can squeeze carries into int32.
 */
 
-static void fe_mul(fe h, const fe f, const fe g) {
+void fe_mul(fe h, const fe f, const fe g) {
   int32_t f0 = f[0];
   int32_t f1 = f[1];
   int32_t f2 = f[2];

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 /* From fe.h */
 
 typedef int32_t fe[10];
@@ -161,5 +163,7 @@ void ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 void fe_add(fe h, const fe f, const fe g);
 void fe_tobytes(unsigned char *, const fe);
 void fe_invert(fe out, const fe z);
+void fe_mul(fe out, const fe, const fe);
+void fe_0(fe h);
 
 int ge_p3_is_point_at_infinity_vartime(const ge_p3 *p);

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -335,7 +335,15 @@ namespace crypto {
 
   inline bool operator<(const public_key &p1, const public_key &p2) { return memcmp(&p1, &p2, sizeof(public_key)) < 0; }
   inline bool operator>(const public_key &p1, const public_key &p2) { return p2 < p1; }
+  inline bool operator<(const key_image &p1, const key_image &p2) { return memcmp(&p1, &p2, sizeof(key_image)) < 0; }
+  inline bool operator>(const key_image &p1, const key_image &p2) { return p2 < p1; }
 }
+
+// type conversions for easier calls to sc_add(), sc_sub(), hash functions
+inline unsigned char* to_bytes(crypto::ec_scalar &scalar) { return &reinterpret_cast<unsigned char&>(scalar); }
+inline const unsigned char* to_bytes(const crypto::ec_scalar &scalar) { return &reinterpret_cast<const unsigned char&>(scalar); }
+inline unsigned char* to_bytes(crypto::ec_point &point) { return &reinterpret_cast<unsigned char&>(point); }
+inline const unsigned char* to_bytes(const crypto::ec_point &point) { return &reinterpret_cast<const unsigned char&>(point); }
 
 CRYPTO_MAKE_HASHABLE(public_key)
 CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(secret_key)

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -671,7 +671,7 @@ namespace rct {
 
     //Elliptic Curve Diffie Helman: encodes and decodes the amount b and mask a
     // where C= aG + bH
-    static key ecdhHash(const key &k)
+    key genAmountEncodingFactor(const key &k)
     {
         char data[38];
         rct::key hash;
@@ -700,7 +700,7 @@ namespace rct {
         if (v2)
         {
           unmasked.mask = zero();
-          xor8(unmasked.amount, ecdhHash(sharedSec));
+          xor8(unmasked.amount, genAmountEncodingFactor(sharedSec));
         }
         else
         {
@@ -715,7 +715,7 @@ namespace rct {
         if (v2)
         {
           masked.mask = genCommitmentMask(sharedSec);
-          xor8(masked.amount, ecdhHash(sharedSec));
+          xor8(masked.amount, genAmountEncodingFactor(sharedSec));
         }
         else
         {

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -184,6 +184,7 @@ namespace rct {
 
     //Elliptic Curve Diffie Helman: encodes and decodes the amount b and mask a
     // where C= aG + bH
+    key genAmountEncodingFactor(const key &k);
     key genCommitmentMask(const key &sk);
     void ecdhEncode(ecdhTuple & unmasked, const key & sharedSec, bool v2);
     void ecdhDecode(ecdhTuple & masked, const key & sharedSec, bool v2);


### PR DESCRIPTION
This is a PR in my 'upstreaming seraphis_lib project', the changes here are not used anywhere yet.

- Make some `crypto-ops.c` static methods public. These will be used in PR #8662 for recomputing the main ed25519 generator.
- Allow sorting of key images.
- Add `to_bytes()` methods for converting `ec_point` and `ec_scalar` to unsigned char pointers. These methods are SUPER helpful when doing anything with the `sc_*` methods. Note that there is a variant of this in `device_default.cpp`.
- Rename `rct::ecdhHash()` to `rct::genAmountEncodingFactor()` and make it public.