### PR TITLE
removed definition of `refreshed` bool

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3474,7 +3474,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   // "I had to reorder some code to fix... a timing info leak IIRC. In turn, this undid something I had fixed before, ... a subtle race condition with the txpool.
   // It was pretty subtle IIRC, and so I needed time to think about how to refix it after the move, and I never got to it."
   // https://github.com/monero-project/monero/pull/6097
-  bool refreshed = false;
+  bool refreshed;
   std::shared_ptr<std::map<std::pair<uint64_t, uint64_t>, size_t>> output_tracker_cache;
   hw::device &hwdev = m_account.get_device();
 


### PR DESCRIPTION
/usr/src/git/salsa/cryptocoin-team/monero/src/wallet/wallet2.cpp:3427:8: warning: variable ‘refreshed’ set but not used [-Wunused-but-set-variable]
 3427 |   bool refreshed = false;

Fails to build from source.