### PR TITLE
RingCT cache (huge block propagation speedup)

### DIFF
--- a/src/common/data_cache.h
+++ b/src/common/data_cache.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2014-2022, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once 
+
+#include <unordered_set>
+#include <mutex>
+
+namespace tools
+{
+  template<typename T, size_t MAX_SIZE>
+  class data_cache
+  {
+  public:
+    void add(const T& value)
+    {
+      std::lock_guard<std::mutex> lock(m);
+      if (data.insert(value).second)
+      {
+        T& old_value = buf[counter++ % MAX_SIZE];
+        data.erase(old_value);
+        old_value = value;
+      }
+    }
+
+    bool has(const T& value) const
+    {
+      std::lock_guard<std::mutex> lock(m);
+      return (data.find(value) != data.end());
+    }
+
+  private:
+    mutable std::mutex m;
+    std::unordered_set<T> data;
+    T buf[MAX_SIZE] = {};
+    size_t counter = 0;
+  };
+}

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3613,7 +3613,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
         }
       }
 
-      if (!rct::verRctNonSemanticsSimple(rv))
+      if (!rct::verRctNonSemanticsSimpleCached(rv))
       {
         MERROR_VER("Failed to check ringct signatures!");
         return false;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -30,6 +30,7 @@
 
 #include "misc_log_ex.h"
 #include "misc_language.h"
+#include "common/data_cache.h"
 #include "common/perf_timer.h"
 #include "common/threadpool.h"
 #include "common/util.h"
@@ -1576,6 +1577,42 @@ namespace rct {
         LOG_PRINT_L1("Error in verRctNonSemanticsSimple, but not an actual exception");
         return false;
       }
+    }
+
+    bool verRctNonSemanticsSimpleCached(const rctSig & rv)
+    {
+      // Hello future Monero dev! If you got this assert, read the following carefully:
+      //
+      // RCT cache assumes that this function will serialize and hash all rv's fields used for RingCT verification
+      // If you're about to add a new RCTType here, first you must check that binary_archive serialization writes all rv's fields to the binary blob
+      // If it's not the case, rewrite this function to serialize everything, even some "temporary" fields which are not serialized normally
+      CHECK_AND_ASSERT_MES_L1(rv.type <= RCTTypeBulletproofPlus, false, "Unknown RCT type. Make sure RCT cache works correctly with this type and then enable it in the code here.");
+
+      // Don't cache older (or newer) rctSig types
+      // This cache only makes sense when it caches data from mempool first,
+      // so only "current fork version-enabled" RCT types need to be cached
+      if (rv.type != RCTTypeBulletproofPlus)
+        return verRctNonSemanticsSimple(rv);
+
+      // Get the hash of rv
+      std::stringstream ss;
+      binary_archive<true> ar(ss);
+
+      ::do_serialize(ar, const_cast<rctSig&>(rv));
+
+      crypto::hash h;
+      cryptonote::get_blob_hash(ss.str(), h);
+
+      static tools::data_cache<crypto::hash, 8192> cache;
+
+      if (cache.has(h))
+        return true;
+
+      const bool res = verRctNonSemanticsSimple(rv);
+      if (res)
+        cache.add(h);
+
+      return res;
     }
 
     //RingCT protocol

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -132,6 +132,7 @@ namespace rct {
     bool verRctSemanticsSimple(const rctSig & rv);
     bool verRctSemanticsSimple(const std::vector<const rctSig*> & rv);
     bool verRctNonSemanticsSimple(const rctSig & rv);
+    bool verRctNonSemanticsSimpleCached(const rctSig & rv);
     static inline bool verRctSimple(const rctSig & rv) { return verRctSemanticsSimple(rv) && verRctNonSemanticsSimple(rv); }
     xmr_amount decodeRct(const rctSig & rv, const key & sk, unsigned int i, key & mask, hw::device &hwdev);
     xmr_amount decodeRct(const rctSig & rv, const key & sk, unsigned int i, hw::device &hwdev);


### PR DESCRIPTION
The problem: block propagation takes up to 1.5 seconds even on a fast 6-core Ryzen with 64 GB RAM and an NVMe SSD because monerod must check all transactions before adding them to the new block. This affects mining pools (including P2Pool) and solo miners the most by increasing block orphan rate.

I discovered it when trying to optimize my P2Pool nodes. What I found is each transaction can be checked by monerod up to 3 times:

- when it's added to the mempool
- when it's added to the new block
- when it's sent via ZMQ to connected P2Pool nodes

Each check does exactly the same calculations, so it can be cached. The main offender here is `verRctNonSemanticsSimple` which doesn't have side effects, so if it gets the same input more than one time, it will return the same result each time. This PR adds a cache of last 8192 `rctSig` values that passed the check. It doesn't store the values themselves, but their keccak (`cryptonote::get_blob_hash`) hashes to save memory. Using keccak should be safe from collision attacks since it's a cryptographically secure hash.

I've been running this code on my nodes for a few days and here is a comparison between 2 nodes with the same hardware (6 core CPU, 64 GB RAM, NVMe SSD):
|Block|tx count|propagation delay|optimized delay|speedup
|-|-|-|-|-
|2772901|117|0.6696 s|0.1059 s|6.3x
|2772903|45|0.2905 s|0.059 s|4.9x
|2772907|75|0.5127 s|0.0926 s|5.5x
|2773001|3|0.0766 s|0.0406 s|1.9x
|2773021|112|1.2886 s|0.1713 s|7.5x
|2773043|159|0.8643 s|0.1359 s|6.3x

Raw data: https://paste.debian.net/hidden/cefbf13b/

@UkoeHB and @kayabaNerve - one of you guys should review this.