### PR TITLE
[seraphis] ringct: adjust multiexp

### DIFF
--- a/src/ringct/multiexp.h
+++ b/src/ringct/multiexp.h
@@ -35,9 +35,15 @@
 #define MULTIEXP_H
 
 #include <vector>
+extern "C"
+{
+#include "crypto/crypto-ops.h"
+}
 #include "crypto/crypto.h"
 #include "rctTypes.h"
 #include "misc_log_ex.h"
+
+#include <boost/align/aligned_allocator.hpp>
 
 namespace rct
 {
@@ -55,17 +61,19 @@ struct MultiexpData {
 };
 
 struct straus_cached_data;
-struct pippenger_cached_data;
+using pippenger_cached_data = std::vector<ge_cached, boost::alignment::aligned_allocator<ge_cached, 4096>>;
 
 rct::key bos_coster_heap_conv(std::vector<MultiexpData> data);
 rct::key bos_coster_heap_conv_robust(std::vector<MultiexpData> data);
 std::shared_ptr<straus_cached_data> straus_init_cache(const std::vector<MultiexpData> &data, size_t N =0);
 size_t straus_get_cache_size(const std::shared_ptr<straus_cached_data> &cache);
+ge_p3 straus_p3(const std::vector<MultiexpData> &data, const std::shared_ptr<straus_cached_data> &cache = NULL, size_t STEP = 0);
 rct::key straus(const std::vector<MultiexpData> &data, const std::shared_ptr<straus_cached_data> &cache = NULL, size_t STEP = 0);
 std::shared_ptr<pippenger_cached_data> pippenger_init_cache(const std::vector<MultiexpData> &data, size_t start_offset = 0, size_t N =0);
 size_t pippenger_get_cache_size(const std::shared_ptr<pippenger_cached_data> &cache);
 size_t get_pippenger_c(size_t N);
-rct::key pippenger(const std::vector<MultiexpData> &data, const std::shared_ptr<pippenger_cached_data> &cache = NULL, size_t cache_size = 0, size_t c = 0);
+ge_p3 pippenger_p3(const std::vector<MultiexpData> &data, const std::shared_ptr<pippenger_cached_data> &cache = NULL, size_t cache_size = 0, size_t c = 0);
+rct::key pippenger(const std::vector<MultiexpData> &data, const std::shared_ptr<pippenger_cached_data> &cache = NULL, const size_t cache_size = 0, const size_t c = 0);
 
 }
 


### PR DESCRIPTION
This is a PR in my 'upstreaming seraphis_lib project', the changes here are not used anywhere yet.

- Refactors `pippenger_cached_data` to use a vector of `ge_cached` directly. This makes `pippenger_cached_data` reusable (I use it in a multiexp utility in the `seraphis_lib`).
- Exposes `ge_p3` versions of the multiexp functions for efficiency when desired.
- Replaces tabs with spaces in the multiexp notes, so they are legible in text editors that don't render tabs consistently (mine shows all the whitespace in the multiexp notes as single spaces).