### PR TITLE
util: make GMT timestamps explicit for clarity

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -1067,7 +1067,7 @@ std::string get_nix_version_display_string()
     time_t tt = ts;
     struct tm tm;
     misc_utils::get_gmt_time(tt, tm);
-    strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm);
+    strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%SZ", &tm);
     return std::string(buffer);
   }
 


### PR DESCRIPTION
For privacy reasons, time functions use GMT, to avoid logs leaking timezones. It'd make more sense to use localtime for wallet output (which are not logged by default), but that adds inconsistencies which can also be confusing. So add a Z suffix for now to make it clear these are not local time.