### PR TITLE
win-service: enable auto startup

### DIFF
--- a/src/daemonizer/windows_service.cpp
+++ b/src/daemonizer/windows_service.cpp
@@ -196,7 +196,7 @@ bool install_service(
       , 0
       //, GENERIC_EXECUTE | GENERIC_READ
       , SERVICE_WIN32_OWN_PROCESS
-      , SERVICE_DEMAND_START
+      , SERVICE_AUTO_START
       , SERVICE_ERROR_NORMAL
       , full_command.c_str()
       , nullptr


### PR DESCRIPTION
current behaviour:
1. from a terminal with admin rights `monerod.exe --data-dir G:\\ --install-service`
2. monerod is added to services but not running
3. `monerod.exe --start-service` - runs, and works perfectly
4. restart system - monerod service is "stopped"/not running after boot.

with [SERVICE_AUTO_START:](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/inf-addservice-directive): 
4. restart system - monerod service is running as expected.

notes: (fixed by #8700 )
when service monerod is running, if you `monerod exit` the service gets uninstalled (?). so if e.g. the GUI implements this - clicking 'stop daemon' would uninstall the service, (run time flags will reveal that its in service mode)

