### PR TITLE
readline_buffer: disable bracketed paste escape sequences

### DIFF
--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -238,6 +238,10 @@ static char** attempted_completion(const char* text, int start, int end)
 
 static void install_line_handler()
 {
+#if RL_READLINE_VERSION >= 0x0801
+  rl_variable_bind("enable-bracketed-paste", "off");
+#endif
+
   rl_attempted_completion_function = attempted_completion;
   rl_callback_handler_install("", handle_line);
   stifle_history(500);


### PR DESCRIPTION
As of libreadline >= 8.1, bracketed paste sequences are enabled by default. This turns them off. This along with #8693, should mean that with environment variable `NO_COLOR` present, no escape sequences are generated in the output, just plain text. 