### PR TITLE
daemonizer: don't uninstall windows service on exit

### DIFF
--- a/src/daemonizer/windows_service_runner.h
+++ b/src/daemonizer/windows_service_runner.h
@@ -146,9 +146,6 @@ namespace windows {
       m_handler.run();
 
       on_state_change_request_(SERVICE_CONTROL_STOP);
-
-      // Ensure that the service is uninstalled
-      uninstall_service(m_name);
     }
 
     static void WINAPI on_state_change_request(DWORD control_code)


### PR DESCRIPTION
Issue mentioned by @plowsof in #8697

>when service monerod is running, if you monerod exit the service gets uninstalled (?). so if e.g. the GUI implements this - clicking 'stop daemon' would uninstall the service, (run time flags will reveal that its in service mode)