### PR TITLE
RandomX: print VM allocation warnings only once

### DIFF
--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -246,7 +246,11 @@ static void rx_init_full_vm(randomx_flags flags, randomx_vm** vm)
 
   *vm = randomx_create_vm((flags | RANDOMX_FLAG_LARGE_PAGES | RANDOMX_FLAG_FULL_MEM) & ~disabled_flags(), NULL, main_dataset);
   if (!*vm) {
-    mwarning(RX_LOGCAT, "Couldn't allocate RandomX full VM using large pages");
+    static int shown = 0;
+    if (!shown) {
+        shown = 1;
+        mwarning(RX_LOGCAT, "Couldn't allocate RandomX full VM using large pages (will print only once)");
+    }
     *vm = randomx_create_vm((flags | RANDOMX_FLAG_FULL_MEM) & ~disabled_flags(), NULL, main_dataset);
     if (!*vm) {
       merror(RX_LOGCAT, "Couldn't allocate RandomX full VM");
@@ -269,7 +273,11 @@ static void rx_init_light_vm(randomx_flags flags, randomx_vm** vm, randomx_cache
 
   *vm = randomx_create_vm((flags | RANDOMX_FLAG_LARGE_PAGES) & ~disabled_flags(), cache, NULL);
   if (!*vm) {
-    mwarning(RX_LOGCAT, "Couldn't allocate RandomX light VM using large pages");
+    static int shown = 0;
+    if (!shown) {
+        shown = 1;
+        mwarning(RX_LOGCAT, "Couldn't allocate RandomX light VM using large pages (will print only once)");
+    }
     *vm = randomx_create_vm(flags & ~disabled_flags(), cache, NULL);
     if (!*vm) local_abort("Couldn't allocate RandomX light VM");
   }

--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -43,6 +43,9 @@
 
 #define RX_LOGCAT	"randomx"
 
+// Report large page allocation failures as debug messages
+#define alloc_err_msg(x) mdebug(RX_LOGCAT, x);
+
 static CTHR_RWLOCK_TYPE main_dataset_lock = CTHR_RWLOCK_INIT;
 static CTHR_RWLOCK_TYPE main_cache_lock = CTHR_RWLOCK_INIT;
 
@@ -212,7 +215,7 @@ static void rx_alloc_dataset(randomx_flags flags, randomx_dataset** dataset, int
 
   *dataset = randomx_alloc_dataset((flags | RANDOMX_FLAG_LARGE_PAGES) & ~disabled_flags());
   if (!*dataset) {
-    mwarning(RX_LOGCAT, "Couldn't allocate RandomX dataset using large pages");
+    alloc_err_msg("Couldn't allocate RandomX dataset using large pages");
     *dataset = randomx_alloc_dataset(flags & ~disabled_flags());
     if (!*dataset) {
       merror(RX_LOGCAT, "Couldn't allocate RandomX dataset");
@@ -228,7 +231,7 @@ static void rx_alloc_cache(randomx_flags flags, randomx_cache** cache)
 
   *cache = randomx_alloc_cache((flags | RANDOMX_FLAG_LARGE_PAGES) & ~disabled_flags());
   if (!*cache) {
-    mwarning(RX_LOGCAT, "Couldn't allocate RandomX cache using large pages");
+    alloc_err_msg("Couldn't allocate RandomX cache using large pages");
     *cache = randomx_alloc_cache(flags & ~disabled_flags());
     if (!*cache) local_abort("Couldn't allocate RandomX cache");
   }
@@ -249,7 +252,7 @@ static void rx_init_full_vm(randomx_flags flags, randomx_vm** vm)
     static int shown = 0;
     if (!shown) {
         shown = 1;
-        mwarning(RX_LOGCAT, "Couldn't allocate RandomX full VM using large pages (will print only once)");
+        alloc_err_msg("Couldn't allocate RandomX full VM using large pages (will print only once)");
     }
     *vm = randomx_create_vm((flags | RANDOMX_FLAG_FULL_MEM) & ~disabled_flags(), NULL, main_dataset);
     if (!*vm) {
@@ -276,7 +279,7 @@ static void rx_init_light_vm(randomx_flags flags, randomx_vm** vm, randomx_cache
     static int shown = 0;
     if (!shown) {
         shown = 1;
-        mwarning(RX_LOGCAT, "Couldn't allocate RandomX light VM using large pages (will print only once)");
+        alloc_err_msg("Couldn't allocate RandomX light VM using large pages (will print only once)");
     }
     *vm = randomx_create_vm(flags & ~disabled_flags(), cache, NULL);
     if (!*vm) local_abort("Couldn't allocate RandomX light VM");


### PR DESCRIPTION
See #8705