### PR TITLE
Fix  #8708

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -1232,7 +1232,7 @@ namespace net_utils
       }
     }
 
-    if (use_ipv6)
+    if (use_ipv6 && address_ipv6 != "")
     {
       try
       {


### PR DESCRIPTION
When using `anonymous-inbound`, we create new network zones:

https://github.com/monero-project/monero/blob/50aa0e8b7f11680be3954c176f2daa9ccf77b7dd/src/p2p/net_node.inl#L605

Meanwhile Monero assume that if we has set `p2p-use-ipv6`, then all inbounds should use IPv6. This lead to try to resolve the empty chain in:

https://github.com/monero-project/monero/blob/50aa0e8b7f11680be3954c176f2daa9ccf77b7dd/contrib/epee/include/net/abstract_tcp_server2.inl#L1184

This simple fix prevent an exception when using `anonymous-inbound` with a local Tor instance listening on 127.0.0.1 and `p2p-use-ipv6` together.

Fixing #8708