### PR TITLE
wallet2: speed up pick_preferred_rct_inputs and get_output_relatednes

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6338,29 +6338,25 @@ namespace
 // their ordering, but it could become more murky if we add scores later.
 float wallet2::get_output_relatedness(const transfer_details &td0, const transfer_details &td1) const
 {
-  int dh;
+  const int64_t dh = td0.m_block_height > td1.m_block_height ? td0.m_block_height - td1.m_block_height : td1.m_block_height - td0.m_block_height;
 
-  // expensive test, and same tx will fall onto the same block height below
-  if (td0.m_txid == td1.m_txid)
-    return 1.0f;
+  // don't think these are particularly related
+  if (dh >= 10)
+    return 0.0f;
 
-  // same block height -> possibly tx burst, or same tx (since above is disabled)
-  dh = td0.m_block_height > td1.m_block_height ? td0.m_block_height - td1.m_block_height : td1.m_block_height - td0.m_block_height;
-  if (dh == 0)
-    return 0.9f;
+  // similar block heights
+  if (dh > 1)
+    return 0.2f;
 
   // adjacent blocks -> possibly tx burst
   if (dh == 1)
     return 0.8f;
 
-  // could extract the payment id, and compare them, but this is a bit expensive too
+  // expensive test, and same tx will fall onto the same block height below
+  if (td0.m_txid == td1.m_txid)
+    return 1.0f;
 
-  // similar block heights
-  if (dh < 10)
-    return 0.2f;
-
-  // don't think these are particularly related
-  return 0.0f;
+  return 0.9f;
 }
 //----------------------------------------------------------------------------------------------------
 size_t wallet2::pop_best_value_from(const transfer_container &transfers, std::vector<size_t> &unused_indices, const std::vector<size_t>& selected_transfers, bool smallest) const


### PR DESCRIPTION
Inside of `pick_preferred_rct_inputs`, when we are looking for 1 output which is spendable and fulfills the amount requirement, we create a local `vector` which stores the indices of only the "spendable" transfers (regardless of amounts). Then, when we look for a 2 output combination, we iterate through said list instead of the whole transfers list. This 1) reduces branching and 2) reduces the complexity of the algorithm from `O(T^2)` to `O(max(T, S^2))` where `T = # of total transfers` and `S = # of spendable transfers`. In the case where a large portion of the outputs are already spent, this can be speed up the output picking by quite a bit.

Inside `get_output_relatedness`, the expensive txid check is postponed until after the block height tests.

Co-authored-by: moneromooo-monero <moneromooo-monero@users.noreply.github.com>