### PR TITLE
epee net tcp server: properly terminate interrupted TCP connection. fixes #8685

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -583,11 +583,8 @@ namespace net_utils
             break;
         }
       }
-      else if (ec.value())
-        terminate();
       else {
-        cancel_timer();
-        on_interrupted();
+        terminate();
       }
     };
     m_strand.post(


### PR DESCRIPTION
See issue https://github.com/monero-project/monero/issues/8685
Specifically the comment/patch by @j-berman https://github.com/monero-project/monero/issues/8685#issuecomment-1396659121

monerod would start using 160-180% CPU after a few days of uptime.
I was consistently running into this issue for multiple months.
With this patch monerod has been running for two weeks already, without high cpu usage.

Related/Same issue https://github.com/monero-project/monero/issues/8550