### PR TITLE
Add a size limit for tx_extra in tx pool

### DIFF
--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -53,6 +53,7 @@ namespace cryptonote
     bool m_overspend;
     bool m_fee_too_low;
     bool m_too_few_outputs;
+    bool m_tx_extra_too_big;
   };
 
   struct block_verification_context

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -206,6 +206,11 @@
 
 #define DNS_BLOCKLIST_LIFETIME (86400 * 8)
 
+//The limit is enough for the mandatory transaction content with 16 outputs (547 bytes),
+//a custom tag (1 byte) and up to 32 bytes of custom data for each recipient.
+// (1+32) + (1+1+16*32) + (1+16*32) = 1060
+#define MAX_TX_EXTRA_SIZE                       1060
+
 // New constants are intended to go here
 namespace config
 {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -437,6 +437,8 @@ namespace cryptonote
     if (!sort_tx_extra(tx.extra, tx.extra))
       return false;
 
+    CHECK_AND_ASSERT_MES(tx.extra.size() <= MAX_TX_EXTRA_SIZE, false, "TX extra size (" << tx.extra.size() << ") is greater than max allowed (" << MAX_TX_EXTRA_SIZE << ")");
+
     //check money
     if(summary_outs_money > summary_inputs_money )
     {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -218,6 +218,15 @@ namespace cryptonote
       return false;
     }
 
+    size_t tx_extra_size = tx.extra.size();
+    if (!kept_by_block && tx_extra_size > MAX_TX_EXTRA_SIZE)
+    {
+      LOG_PRINT_L1("transaction tx-extra is too big: " << tx_extra_size << " bytes, the limit is: " << MAX_TX_EXTRA_SIZE);
+      tvc.m_verifivation_failed = true;
+      tvc.m_tx_extra_too_big = true;
+      return false;
+    }
+
     // if the transaction came from a block popped from the chain,
     // don't check if we have its key images as spent.
     // TODO: Investigate why not?

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1275,6 +1275,8 @@ namespace cryptonote
           add_reason(reason, "fee too low");
         if ((res.too_few_outputs = tvc.m_too_few_outputs))
           add_reason(reason, "too few outputs");
+        if ((res.tx_extra_too_big = tvc.m_tx_extra_too_big))
+          add_reason(reason, "tx-extra too big");
         const std::string punctuation = reason.empty() ? "" : ": ";
         if (tvc.m_verifivation_failed)
         {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -88,7 +88,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 3
-#define CORE_RPC_VERSION_MINOR 11
+#define CORE_RPC_VERSION_MINOR 12
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -592,6 +592,7 @@ namespace cryptonote
       bool fee_too_low;
       bool too_few_outputs;
       bool sanity_check_failed;
+      bool tx_extra_too_big;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_response_base)
@@ -606,6 +607,7 @@ namespace cryptonote
         KV_SERIALIZE(fee_too_low)
         KV_SERIALIZE(too_few_outputs)
         KV_SERIALIZE(sanity_check_failed)
+        KV_SERIALIZE(tx_extra_too_big)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
Related to #6668

This patch limits the maximum size of tx_extra that's allowed in the transaction pool. Mined transactions bypass this check, which means this is a non-consensus change.

I set the limit to 1060 bytes. A typical transaction with 16 outputs needs up to 547 bytes for the transaction public keys, which still leaves 32 bytes of space for some custom data to send to each recipient.

Note that Bitcoin also has a [limit](https://github.com/bitcoin/bitcoin/blob/e325e0fccba4981d28053b79473ddaa44355e6e8/src/kernel/mempool_options.h#L47-L54) for arbitrary data payloads that defaults to a much lower value of just 83 bytes per transaction.

The purpose of this change is to make it harder to "upload" large amounts of unprunable data onto the blockchain. [Here](https://xmrchain.net/tx/21d0218ba8141a07048986d9e74ce8a011d9d5fddc3283dce58339da74c4bacd) is an example of a transaction with a tx_extra size of 126 KB containing a PDF file. The limit of ~1 KB should be sufficient for useful content such as the metadata of decentralized exchanges.

Ping @kayabaNerve


