### PR TITLE
build: fix BUILD_DEBUG_UTILITIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else()
   set(DEFAULT_BUILD_DEBUG_UTILITIES OFF)
 endif()
-option(BUILD_DEBUG_UTILITIES "Build debug utilities." DEFAULT_BUILD_DEBUG_UTILITIES)
+option(BUILD_DEBUG_UTILITIES "Build debug utilities." ${DEFAULT_BUILD_DEBUG_UTILITIES})
 
 if(OSSFUZZ)
   message(STATUS "Using OSS-Fuzz fuzzing system")


### PR DESCRIPTION
As you can see in [this post](https://stackoverflow.com/questions/44719963/cmake-default-value-for-options-doesnt-work), CMake options are cached and the values are not updated with the `option` command if they already exist in the cache. The effect of this for debug builds is that when a debug build is run after a release build, the debug utilities are not built. This PR makes it so that the debug utilities are build always during and only during debug builds.