### PR TITLE
replace deprecated boost copy_option

### DIFF
--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -200,7 +200,7 @@ namespace nodetool
     if (!out)
     {
       // if failed, try reading in unportable mode
-      boost::filesystem::copy_file(path, path + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+      boost::filesystem::copy_file(path, path + ".unportable", boost::filesystem::copy_options::overwrite_existing);
       src_file.close();
       src_file.open( path , std::ios_base::binary | std::ios_base::in);
       if(src_file.fail())

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5664,7 +5664,7 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
           catch (...)
           {
             LOG_PRINT_L0("Failed to open portable binary, trying unportable");
-            if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+            if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_options::overwrite_existing);
             std::stringstream iss;
             iss.str("");
             iss << cache_data;
@@ -5686,7 +5686,7 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
       catch (...)
       {
         LOG_PRINT_L0("Failed to open portable binary, trying unportable");
-        if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+        if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_options::overwrite_existing);
         std::stringstream iss;
         iss.str("");
         iss << cache_file_buf;

--- a/tests/core_tests/chaingen_serialization.h
+++ b/tests/core_tests/chaingen_serialization.h
@@ -110,7 +110,7 @@ namespace tools
     catch(...)
     {
       // if failed, try reading in unportable mode
-      boost::filesystem::copy_file(file_path, file_path + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+      boost::filesystem::copy_file(file_path, file_path + ".unportable", boost::filesystem::copy_options::overwrite_existing);
       data_file.close();
       data_file.open( file_path, std::ios_base::binary | std::ios_base::in);
       if(data_file.fail())


### PR DESCRIPTION
As of boost 1.74.0, `boost::filesystem::copy_option` is deprecated and replaced by `boost::filesystem::copy_options`. See https://www.boost.org/doc/libs/1_75_0/libs/filesystem/doc/release_history.html

I replaced all occurrences with the new `copy_options` to avoid problems in the future when `copy_option` will be removed. 