### PR TITLE
Make it possible to exit cli wallet when locked

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -10702,7 +10702,9 @@ int main(int argc, char* argv[])
     tools::signal_handler::install([&w](int type) {
       if (tools::password_container::is_prompting.load())
       {
-        // must be prompting for password so return and let the signal stop prompt
+        w.stop();
+        w.deinit();
+        _exit(0);
         return;
       }
 #ifdef WIN32

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -10702,6 +10702,8 @@ int main(int argc, char* argv[])
     tools::signal_handler::install([&w](int type) {
       if (tools::password_container::is_prompting.load())
       {
+        // Runs the full exit routine after receiving Ctrl-C
+        // In current state we're incapable of gracefully exiting from here without major redesign, hence the blunt approach
         w.stop();
         w.deinit();
         _exit(0);


### PR DESCRIPTION
### Fixes the 4 year old issue #6192
### This is a significant UX hindrance and should have been fixed long ago.

I attempted to find the root cause for segfault that happens if we just `w.stop()` in the handler but it appears to happen in the libstdc++ at_exit handlers resulted from corrupted state and further investigation with valgrind shows multiple data races which I don't see a way of solving.

It might not be an "ideal" solution but it's definitely due.

From what I gathered the architecture around simplewallet cli is poor and mostly patchworked with threading primitives.
The terminal is being read asynchronously from many places, such as "contrib/epee/include/console_handler.h" and "src/common/password.cpp", maybe if it was designed around a main synchronous thread reading stdin it would've been easier to fix but without a rewrite this will have to suffice.

I believe this solution to be the easiest, most painless way to exit the wallet after it inevitably locks itself.
Retires #7722 as well