### PR TITLE
Handle case where a command line flag is not allowed in the config file

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -219,6 +219,19 @@ int main(int argc, char const * argv[])
       {
         po::store(po::parse_config_file<char>(config_path.string<std::string>().c_str(), core_settings), vm);
       }
+      catch (const po::unknown_option &e)
+      {
+        std::string unrecognized_option = e.get_option_name();
+        if (all_options.find_nothrow(unrecognized_option, false))
+        {
+          std::cerr << "Option '" << unrecognized_option << "' is not allowed in the config file, please use it as a command line flag." << std::endl;
+        }
+        else
+        {
+          std::cerr << "Unrecognized option '" << unrecognized_option << "' in config file." << std::endl;
+        }
+        return 1;
+      }
       catch (const std::exception &e)
       {
         // log system isn't initialized yet


### PR DESCRIPTION
Relates to issue #8753 