### PR TITLE
cryptonote_basic: remove unused struct

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -39,15 +39,6 @@ namespace cryptonote {
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
-  template<class t_array>
-  struct array_hasher: std::unary_function<t_array&, std::size_t>
-  {
-    std::size_t operator()(const t_array& val) const
-    {
-      return boost::hash_range(&val.data[0], &val.data[sizeof(val.data)]);
-    }
-  };
-
 
 #pragma pack(push, 1)
   struct public_address_outer_blob


### PR DESCRIPTION
It's spamming build logs with: 

```
monero/src/cryptonote_basic/cryptonote_basic_impl.h:43:29: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
   43 |   struct array_hasher: std::unary_function<t_array&, std::size_t>
      |                             ^~~~~~~~~~~~~~
```