### PR TITLE
Allow option 'non-interactive' in monerod config file [release-v0.18]

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char const * argv[])
       command_line::add_arg(core_settings, daemon_args::arg_zmq_pub);
       command_line::add_arg(core_settings, daemon_args::arg_zmq_rpc_disabled);
 
-      daemonizer::init_options(hidden_options, visible_options);
+      daemonizer::init_options(hidden_options, visible_options, core_settings);
       daemonize::t_executor::init_options(core_settings);
 
       // Hidden options

--- a/src/daemonizer/daemonizer.h
+++ b/src/daemonizer/daemonizer.h
@@ -36,6 +36,7 @@ namespace daemonizer
 {
   void init_options(
       boost::program_options::options_description & hidden_options
+    , boost::program_options::options_description & system_options
     , boost::program_options::options_description & normal_options
     );
 

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -55,11 +55,12 @@ namespace daemonizer
 
   inline void init_options(
       boost::program_options::options_description & hidden_options
+    , boost::program_options::options_description & system_options
     , boost::program_options::options_description & normal_options
     )
   {
-    command_line::add_arg(normal_options, arg_detach);
-    command_line::add_arg(normal_options, arg_pidfile);
+    command_line::add_arg(system_options, arg_detach);
+    command_line::add_arg(system_options, arg_pidfile);
     command_line::add_arg(normal_options, arg_non_interactive);
   }
 

--- a/src/daemonizer/windows_daemonizer.inl
+++ b/src/daemonizer/windows_daemonizer.inl
@@ -79,15 +79,16 @@ namespace daemonizer
 
   inline void init_options(
       boost::program_options::options_description & hidden_options
+    , boost::program_options::options_description & system_options
     , boost::program_options::options_description & normal_options
     )
   {
-    command_line::add_arg(normal_options, arg_install_service);
-    command_line::add_arg(normal_options, arg_uninstall_service);
-    command_line::add_arg(normal_options, arg_start_service);
-    command_line::add_arg(normal_options, arg_stop_service);
+    command_line::add_arg(system_options, arg_install_service);
+    command_line::add_arg(system_options, arg_uninstall_service);
+    command_line::add_arg(system_options, arg_start_service);
+    command_line::add_arg(system_options, arg_stop_service);
     command_line::add_arg(hidden_options, arg_is_service);
-    command_line::add_arg(hidden_options, arg_non_interactive);
+    command_line::add_arg(normal_options, arg_non_interactive);
   }
 
   inline boost::filesystem::path get_default_data_dir()

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4701,7 +4701,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_prompt_for_password);
   command_line::add_arg(desc_params, arg_rpc_client_secret_key);
 
-  daemonizer::init_options(hidden_options, desc_params);
+  daemonizer::init_options(hidden_options, desc_params, desc_params);
   desc_params.add(hidden_options);
 
   boost::optional<po::variables_map> vm;


### PR DESCRIPTION
On the basis that it's cross-platform and not really a hidden option anymore; with some care not to impact wallet-rpc.

Closes #8753