### PR TITLE
Allow option 'non-interactive' in monerod config file

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -159,6 +159,7 @@ int main(int argc, char const * argv[])
       command_line::add_arg(core_settings, daemon_args::arg_zmq_rpc_bind_port);
       command_line::add_arg(core_settings, daemon_args::arg_zmq_pub);
       command_line::add_arg(core_settings, daemon_args::arg_zmq_rpc_disabled);
+      command_line::add_arg(core_settings, daemonizer::arg_non_interactive);
 
       daemonizer::init_options(hidden_options, visible_options);
       daemonize::t_executor::init_options(core_settings);

--- a/src/daemonizer/daemonizer.h
+++ b/src/daemonizer/daemonizer.h
@@ -57,6 +57,11 @@ namespace daemonizer
     , T_executor && executor // universal ref
     , boost::program_options::variables_map const & vm
     );
+    
+  const command_line::arg_descriptor<bool> arg_non_interactive = {
+      "non-interactive"
+    , "Run non-interactive"
+    };
 }
 
 #ifdef WIN32

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -47,10 +47,6 @@ namespace daemonizer
       "pidfile"
     , "File path to write the daemon's PID to (optional, requires --detach)"
     };
-    const command_line::arg_descriptor<bool> arg_non_interactive = {
-      "non-interactive"
-    , "Run non-interactive"
-    };
   }
 
   inline void init_options(
@@ -60,7 +56,6 @@ namespace daemonizer
   {
     command_line::add_arg(normal_options, arg_detach);
     command_line::add_arg(normal_options, arg_pidfile);
-    command_line::add_arg(normal_options, arg_non_interactive);
   }
 
   inline boost::filesystem::path get_default_data_dir()

--- a/src/daemonizer/windows_daemonizer.inl
+++ b/src/daemonizer/windows_daemonizer.inl
@@ -61,11 +61,6 @@ namespace daemonizer
       "run-as-service"
     , "Hidden -- true if running as windows service"
     };
-    const command_line::arg_descriptor<bool> arg_non_interactive = {
-      "non-interactive"
-    , "Run non-interactive"
-    };
-
     std::string get_argument_string(int argc, char const * argv[])
     {
       std::string result = "";
@@ -87,7 +82,6 @@ namespace daemonizer
     command_line::add_arg(normal_options, arg_start_service);
     command_line::add_arg(normal_options, arg_stop_service);
     command_line::add_arg(hidden_options, arg_is_service);
-    command_line::add_arg(hidden_options, arg_non_interactive);
   }
 
   inline boost::filesystem::path get_default_data_dir()

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4708,6 +4708,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_prompt_for_password);
   command_line::add_arg(desc_params, arg_rpc_client_secret_key);
   command_line::add_arg(desc_params, arg_no_initial_sync);
+  command_line::add_arg(hidden_options, daemonizer::arg_non_interactive);
 
   daemonizer::init_options(hidden_options, desc_params);
   desc_params.add(hidden_options);


### PR DESCRIPTION
#### Legitimacy
~~Considering that non-interactive and all system flags are allowed in config file of wallet-rpc, I believe the user request is founded.~~
EDIT: jtgrassie has justly pointed out that non-interactive is a dummy option for wallet-rpc, so this becomes a question of whether the user is indulged or not.

#### Accuracy
Only non-interactive is allowed, the system flags are still not allowed in config for monerod.

#### Minimality
The anonymous namespace in Deamonizer.h makes things complicated as well as the fact that wallet_rpc uses the class too. I reworked daemonizer::init_options to accomodate both the new option for monerod and the status quo in wallet_rpc, without breaking encapsulation. Trivial changes either break wallet_rpc or allow all options for monerod. The latter is a one liner, but for the sake of accuracy it cannot be this trivial.

Therefore I submit to you that this is a correct patch as defined in the contributing guidelines regarding minimality and accuracy, I also welcome constructive criticism.

Closes #8753