### PR TITLE
Prevent tx broadcasts from using Tor circuit twice

### DIFF
--- a/contrib/epee/include/math_helper.h
+++ b/contrib/epee/include/math_helper.h
@@ -299,5 +299,7 @@ namespace math_helper
   class once_a_time_milliseconds: public once_a_time<get_constant_interval<default_interval * (uint64_t)1000>, start_immediate> {};
   template<typename get_interval, bool start_immediate = true>
   class once_a_time_seconds_range: public once_a_time<get_interval, start_immediate> {};
+  template<typename get_interval, bool start_immediate = false>
+  class once_a_time_range: public once_a_time<get_interval, start_immediate> {};
 }
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -214,6 +214,15 @@ namespace config
   uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)2000000000); // 2 * pow(10, 9)
   uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)
 
+  // Both below are in nanoseconds. Onion connections are randomly dropped within this
+  // range and successive onion connections are delayed within this range
+  time_t const RANDOM_CONNECTION_DROP_LOWER = 2 * 60 * 1000000;
+  time_t const RANDOM_CONNECTION_DROP_UPPER = 4 * 60 * 1000000;
+  uint8_t const ACQUIRE_PEERS_RECONNECT_SCALING_FACTOR = 4;
+
+  // Onion circuit will expire after not being used for this many minutes
+  uint8_t const DEFAULT_ONION_CIRCUIT_EXPIRY = 10;
+
   uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 18;
   uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 19;
   uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 42;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -113,13 +113,15 @@ namespace nodetool
     p2p_connection_context_t()
       : peer_id(0),
         support_flags(0),
-        m_in_timedsync(false)
+        m_in_timedsync(false),
+        can_broadcast_txs_to_peer(true)
     {}
 
     peerid_type peer_id;
     uint32_t support_flags;
     bool m_in_timedsync;
     std::set<epee::net_utils::network_address> sent_addresses;
+    bool can_broadcast_txs_to_peer;
   };
 
   template<class t_payload_net_handler>
@@ -147,12 +149,14 @@ namespace nodetool
       config_t()
         : m_net_config(),
           m_peer_id(1),
-          m_support_flags(0)
+          m_support_flags(0),
+          can_broadcast_txs_to_peer(true)
       {}
 
       network_config m_net_config;
       uint64_t m_peer_id;
       uint32_t m_support_flags;
+      bool can_broadcast_txs_to_peer;
     };
     typedef epee::misc_utils::struct_init<config_t> config;
 
@@ -256,7 +260,8 @@ namespace nodetool
         is_closing(false),
         m_network_id(),
         m_enable_dns_seed_nodes(true),
-        max_connections(1)
+        max_connections(1),
+        m_make_next_tor_connection_after(0)
     {}
     virtual ~node_server();
 
@@ -281,6 +286,8 @@ namespace nodetool
     size_t get_public_gray_peers_count();
     void get_public_peerlist(std::vector<peerlist_entry>& gray, std::vector<peerlist_entry>& white);
     void get_peerlist(std::vector<peerlist_entry>& gray, std::vector<peerlist_entry>& white);
+
+    void extend_make_next_connection_after(epee::net_utils::zone zone, bool acquire_peers);
 
     void change_max_out_public_peers(size_t count);
     uint32_t get_max_out_public_peers() const;
@@ -420,6 +427,8 @@ namespace nodetool
     bool gray_peerlist_housekeeping();
     bool check_incoming_connections();
 
+    bool drop_random_outgoing_tor_connection();
+
     void kill() { ///< will be called e.g. from deinit()
       _info("Killing the net_node");
       is_closing = true;
@@ -475,6 +484,10 @@ namespace nodetool
     epee::math_helper::once_a_time_seconds<3600, false> m_incoming_connections_interval;
     epee::math_helper::once_a_time_seconds<7000> m_dns_blocklist_interval;
 
+    template<uint64_t mini, uint64_t maxi> struct get_random_interval { public: uint64_t operator()() const { return crypto::rand_range(mini, maxi); } };
+    epee::math_helper::once_a_time_range<get_random_interval<::config::RANDOM_CONNECTION_DROP_LOWER, ::config::RANDOM_CONNECTION_DROP_UPPER>> m_drop_random_outgoing_tor_connection_interval;
+    time_t m_make_next_tor_connection_after;
+
     std::list<epee::net_utils::network_address>   m_priority_peers;
     std::vector<epee::net_utils::network_address> m_exclusive_peers;
     std::atomic_flag m_fallback_seed_nodes_added;
@@ -517,6 +530,7 @@ namespace nodetool
     bool m_enable_dns_blocklist;
 
     uint32_t max_connections;
+
   };
 
     const int64_t default_limit_up = P2P_DEFAULT_LIMIT_RATE_UP;      // kB/s

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1350,6 +1350,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::try_to_connect_and_handshake_with_new_peer(const epee::net_utils::network_address& na, bool just_take_peerlist, uint64_t last_seen_stamp, PeerType peer_type, uint64_t first_seen_stamp)
   {
+    bool one_conn_below_max = false;
+
     network_zone& zone = m_network_zones.at(na.get_zone());
     if (zone.m_connect == nullptr) // outgoing connections in zone not possible
       return false;
@@ -1361,6 +1363,10 @@ namespace nodetool
     {
       return false;
     }
+    else if (zone.m_current_number_of_out_peers == zone.m_config.m_net_config.max_out_connection_count - 1)
+    {
+      one_conn_below_max = true;
+    }
     else if (zone.m_current_number_of_out_peers > zone.m_config.m_net_config.max_out_connection_count)
     {
       zone.m_net_server.get_config_object().del_out_connections(1);
@@ -1368,6 +1374,9 @@ namespace nodetool
       return false;
     }
 
+    if (na.get_zone() == epee::net_utils::zone::tor && time(nullptr) < m_make_next_tor_connection_after) {
+      return false;
+    }
 
     MDEBUG("Connecting to " << na.str() << "(peer_type=" << peer_type << ", last_seen: "
         << (last_seen_stamp ? epee::misc_utils::get_time_interval_string(time(NULL) - last_seen_stamp):"never")
@@ -1424,6 +1433,17 @@ namespace nodetool
     zone.m_peerlist.append_with_peer_anchor(ape);
     zone.m_notifier.on_handshake_complete(con->m_connection_id, con->m_is_income);
     zone.m_notifier.new_out_connection();
+
+    if (na.get_zone() == epee::net_utils::zone::tor) {
+      if (one_conn_below_max)
+      {
+        extend_make_next_connection_after(na.get_zone(), false);
+      }
+      else
+      {
+        extend_make_next_connection_after(na.get_zone(), true);
+      }
+    }
 
     LOG_DEBUG_CC(*con, "CONNECTION HANDSHAKED OK.");
     return true;
@@ -1788,6 +1808,35 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
+  void node_server<t_payload_net_handler>::extend_make_next_connection_after(epee::net_utils::zone zone,
+                                                                             bool acquire_peers) {
+    if (zone == epee::net_utils::zone::public_) {
+      return;
+    }
+
+    auto scaling_factor = 1;
+    if (acquire_peers)
+    {
+      scaling_factor = ::config::ACQUIRE_PEERS_RECONNECT_SCALING_FACTOR;
+    }
+    auto offset = crypto::rand_range<time_t>(::config::RANDOM_CONNECTION_DROP_LOWER / scaling_factor,
+                                             ::config::RANDOM_CONNECTION_DROP_UPPER / scaling_factor) / 1000000;
+
+    if (zone == epee::net_utils::zone::tor)
+    {
+      if (m_make_next_tor_connection_after > time(nullptr))
+      {
+        return;
+      }
+      m_make_next_tor_connection_after = time(nullptr) + offset;
+    }
+    else if (zone == epee::net_utils::zone::i2p)
+    {
+      ; // not implemented
+    }
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::connections_maker()
   {
     using zone_type = epee::net_utils::zone;
@@ -1800,6 +1849,10 @@ namespace nodetool
     bool one_succeeded = false;
     for(auto& zone : m_network_zones)
     {
+      if (zone.first == zone_type::tor && m_make_next_tor_connection_after > time(nullptr)) {
+        continue;
+      }
+
       size_t start_conn_count = get_outgoing_connections_count(zone.second);
       if(!zone.second.m_peerlist.get_white_peers_count() && !connect_to_seed(zone.first))
       {
@@ -1811,7 +1864,6 @@ namespace nodetool
       size_t base_expected_white_connections = (zone.second.m_config.m_net_config.max_out_connection_count*P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT)/100;
 
       // carefully avoid `continue` in nested loop
-      
       size_t conn_count = get_outgoing_connections_count(zone.second);
       while(conn_count < zone.second.m_config.m_net_config.max_out_connection_count)
       {
@@ -1849,12 +1901,30 @@ namespace nodetool
         conn_count = new_conn_count;
       }
 
-      if (start_conn_count == get_outgoing_connections_count(zone.second) && start_conn_count < zone.second.m_config.m_net_config.max_out_connection_count)
+      // extend when no connection is made, prevents immediate new connection after peer drop
+      if (get_outgoing_connections_count(zone.second) <= start_conn_count)
       {
-        MINFO("Failed to connect to any, trying seeds");
-        if (!connect_to_seed(zone.first))
-          continue;
+        if (start_conn_count < zone.second.m_config.m_net_config.max_out_connection_count)
+        {
+          // add check if tor and not yet ready to connecct, if so avoid trying seeds.
+          MINFO("Failed to connect to any, trying seeds");
+          if (!connect_to_seed(zone.first))
+          {
+            // maybe made connection
+            extend_make_next_connection_after(zone.first, true);
+            continue;
+          }
+          // maybe made connection
+          extend_make_next_connection_after(zone.first, true);
+        }
+        else
+        {
+          // usually maximum connections reached
+          extend_make_next_connection_after(zone.first, false);
+        }
       }
+
+      // not always accurate when using seeds
       one_succeeded = true;
     }
 
@@ -2001,6 +2071,43 @@ namespace nodetool
     m_peerlist_store_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::store_config, this));
     m_incoming_connections_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::check_incoming_connections, this));
     m_dns_blocklist_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::update_dns_blocklist, this));
+    m_drop_random_outgoing_tor_connection_interval.do_call(boost::bind(
+            &node_server<t_payload_net_handler>::drop_random_outgoing_tor_connection, this));
+    return true;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::drop_random_outgoing_tor_connection()
+  {
+    std::vector<p2p_connection_context> outgoing_tor_connections;
+    auto tor_zone = m_network_zones.find(epee::net_utils::zone::tor);
+
+    if (tor_zone != m_network_zones.end()) {
+        tor_zone->second.m_net_server.get_config_object().foreach_connection([&](p2p_connection_context &cntx) {
+            if (!cntx.m_is_income) {
+                outgoing_tor_connections.push_back(cntx);
+            }
+            return true;
+        });
+    }
+
+    for (auto &cntx : outgoing_tor_connections) {
+      if (!cntx.can_broadcast_txs_to_peer) {
+        drop_connection(cntx);
+        // should use random auth for each connection but no socks5
+        // possible to use same circuit twice if drop initiated by remote
+        block_host(cntx.m_remote_address, (::config::DEFAULT_ONION_CIRCUIT_EXPIRY + 1) * 60, true);
+        return true;
+      }
+    }
+
+    if (auto len = outgoing_tor_connections.size()) {
+        auto index_to_drop = crypto::rand_idx(len);
+        drop_connection(outgoing_tor_connections[index_to_drop]);
+        block_host(outgoing_tor_connections[index_to_drop].m_remote_address,
+                   (::config::DEFAULT_ONION_CIRCUIT_EXPIRY + 1) * 60, true);
+    }
+
     return true;
   }
   //-----------------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md
Addresses "Tor Stream Used Twice" by preventing same connection from broadcasting more than one local tx.
Drops onion connections with random delay and makes new connections with random delay. Parameters/strategy for dropping/reconnecting are arbitrary. Need review. 
I could not find a timestamp in peer timed sync, has it been removed?
Need to implement socks5 to improve solution.
Exclusive peer handling not final.
Small changes and it will work for I2P, I left it because I don't know how I2P works.
No tests written, good results in debug output "on my system".
This is a "rough draft"/"conversation starter". I have not done much C++.