### PR TITLE
rpc: give reason when sending non-hex raw tx

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1250,6 +1250,7 @@ namespace cryptonote
     {
       LOG_PRINT_L0("[on_send_raw_tx]: Failed to parse tx from hexbuff: " << req.tx_as_hex);
       res.status = "Failed";
+      res.reason = "Hex decoding failed";
       return true;
     }
 


### PR DESCRIPTION
Had an incident where I was trying to send raw transactions, but I got carriage returns in the hex string and the RPC command was failing with no reason provided.