### PR TITLE
Blockchain: speed up get_output_distribution for RCT by about ~15%

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -971,11 +971,13 @@ public:
    *
    * If the block does not exist, the subclass should throw BLOCK_DNE
    *
-   * @param height the height requested
+   * @param start_height the first height to start accumulating (inclusive)
+   * @param end_height the last height to accumulatate (inclusive)
+   * @param[out] base the cumulative number of rct outputs for all blocks with height < start_height
    *
    * @return the cumulative number of rct outputs
    */
-  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const = 0;
+  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(uint64_t start_height, uint64_t end_height, uint64_t& base) const = 0;
 
   /**
    * @brief fetch the top block's timestamp

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -216,7 +216,7 @@ public:
 
   virtual cryptonote::blobdata get_block_blob_from_height(const uint64_t& height) const;
 
-  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const;
+  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(uint64_t start_height, uint64_t end_height, uint64_t& base) const;
 
   virtual uint64_t get_block_timestamp(const uint64_t& height) const;
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -76,7 +76,7 @@ public:
   virtual uint64_t get_block_height(const crypto::hash& h) const override { return 0; }
   virtual cryptonote::block_header get_block_header(const crypto::hash& h) const override { return cryptonote::block_header(); }
   virtual uint64_t get_block_timestamp(const uint64_t& height) const override { return 0; }
-  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const override { return {}; }
+  virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(uint64_t start_height, uint64_t end_height, uint64_t& base) const override { base = 0; return {}; }
   virtual uint64_t get_top_block_timestamp() const override { return 0; }
   virtual size_t get_block_weight(const uint64_t& height) const override { return 128; }
   virtual std::vector<uint64_t> get_block_weights(uint64_t start_height, size_t count) const override { return {}; }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2391,17 +2391,7 @@ bool Blockchain::get_output_distribution(uint64_t amount, uint64_t from_height, 
     return false;
   if (amount == 0)
   {
-    std::vector<uint64_t> heights;
-    heights.reserve(to_height + 1 - start_height);
-    const uint64_t real_start_height = start_height > 0 ? start_height-1 : start_height;
-    for (uint64_t h = real_start_height; h <= to_height; ++h)
-      heights.push_back(h);
-    distribution = m_db->get_block_cumulative_rct_outputs(heights);
-    if (start_height > 0)
-    {
-      base = distribution[0];
-      distribution.erase(distribution.begin());
-    }
+    distribution = m_db->get_block_cumulative_rct_outputs(start_height, to_height, base);
     return true;
   }
   else

--- a/tests/unit_tests/output_distribution.cpp
+++ b/tests/unit_tests/output_distribution.cpp
@@ -50,15 +50,20 @@ public:
   TestDB(size_t bc_height = test_distribution_size): blockchain_height(bc_height) { m_open = true; }
   virtual uint64_t height() const override { return blockchain_height; }
 
-  std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const override
+  std::vector<uint64_t> get_block_cumulative_rct_outputs(uint64_t start_height, uint64_t end_height, uint64_t& base) const
   {
+    base = 0;
     std::vector<uint64_t> d;
-    for (uint64_t h: heights)
+    const uint64_t base_height = start_height == 0 ? 0 : start_height - 1;
+    for (uint64_t h = base_height; h <= end_height; ++h)
     {
       uint64_t c = 0;
       for (uint64_t i = 0; i <= h; ++i)
         c += test_distribution[i];
-      d.push_back(c);
+      if (h < start_height)
+        base = c;
+      else
+        d.push_back(c);
     }
     return d;
   }


### PR DESCRIPTION
Note: this does make the `BlockchainDB::get_block_cumulative_rct_outputs()` method less flexible for one invocation, but I can't think of a good use case where it would need random arbitrary access to different heights. 