### PR TITLE
tx_extra limitation fix [release-v0.18]

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1099,7 +1099,7 @@ namespace cryptonote
       else if(tvc[i].m_verifivation_impossible)
       {MERROR_VER("Transaction verification impossible: " << results[i].hash);}
 
-      if(tvc[i].m_added_to_pool)
+      if(tvc[i].m_added_to_pool && (results[i].tx.extra.size() <= MAX_TX_EXTRA_SIZE))
       {
         MDEBUG("tx added: " << results[i].hash);
         valid_events = true;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1022,8 +1022,18 @@ namespace cryptonote
       tx_verification_context tvc{};
       if (!m_core.handle_incoming_tx({tx, crypto::null_hash}, tvc, tx_relay, true))
       {
-        LOG_PRINT_CCONTEXT_L1("Tx verification failed, dropping connection");
-        drop_connection(context, false, false);
+        // Don't drop connections which send transactions with too big tx_extra
+        // It will only cause updated nodes to isolate themselves from the rest of the network
+        // This check can be removed as soon as updated nodes are the majority (both by hashrate and by total count)
+        if (tvc.m_tx_extra_too_big)
+        {
+          LOG_PRINT_CCONTEXT_L1("Tx verification failed (too big tx_extra)");
+        }
+        else
+        {
+          LOG_PRINT_CCONTEXT_L1("Tx verification failed, dropping connection");
+          drop_connection(context, false, false);
+        }
         return 1;
       }
 


### PR DESCRIPTION
- Fixed connection drop when a big tx_extra is received from another node
- Double check for MAX_TX_EXTRA_SIZE before sending out ZMQ txpool_event notifications to properly mark them as `invalid`

The second fix (ZMQ notifications) is to stop the notification spam when a new block with big tx_extra transactions is received - it brings unneccessary load to p2pool miners.