### PR TITLE
Added Alpine Linux to list of packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,12 @@ More info and versions in the [Debian package tracker](https://tracker.debian.or
     emerge net-p2p/monero
     ```
 
+* Alpine Linux:
+
+    ```bash
+    apk add monero
+    ```
+
 * macOS [(homebrew)](https://brew.sh/)
     ```bash
     brew install monero


### PR DESCRIPTION
Alpine Linux has a package for monero: https://pkgs.alpinelinux.org/package/edge/community/x86/monero    
You can also view the APKBUILD source here: https://git.alpinelinux.org/aports/tree/community/monero/APKBUILD    