### PR TITLE
bump lmdb sync threshold for performance

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -576,7 +576,11 @@ namespace cryptonote
         else if(options[0] == "fastest")
         {
           db_flags = DBF_FASTEST;
+#ifdef _WIN32
           sync_threshold = 1000; // default to fastest:async:1000
+#else
+          sync_threshold = 100000; // default to fastest:async:100000
+#endif
           sync_mode = db_sync_mode_is_default ? db_defaultsync : db_async;
         }
         else


### PR DESCRIPTION
Force sync every 100k blocks instead of every 1k blocks. Bumping this value is reported to make a big difference in sync performance, eg: https://github.com/monero-project/monero/issues/8189