### PR TITLE
core: do not force sync the db when finding a block in regtest mode

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1563,7 +1563,8 @@ namespace cryptonote
       return false;
     }
     m_blockchain_storage.add_new_block(b, bvc);
-    cleanup_handle_incoming_blocks(true);
+    const bool force_sync = m_nettype != FAKECHAIN;
+    cleanup_handle_incoming_blocks(force_sync);
     //anyway - update miner template
     update_miner_block_template();
     m_miner.resume();


### PR DESCRIPTION
for a slight performance boost in functional tests