### PR TITLE
wallet: fix DNS leak on wallet open

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -880,7 +880,7 @@ std::string get_nix_version_display_string()
     return false;
   }
 
-  bool is_local_address(const std::string &address)
+  bool is_local_address(const std::string &address, bool use_dns)
   {
     // extract host
     epee::net_utils::http::url_content u_c;
@@ -899,6 +899,12 @@ std::string get_nix_version_display_string()
     if (is_privacy_preserving_network(u_c.host))
     {
       MDEBUG("Address '" << address << "' is Tor/I2P, non local");
+      return false;
+    }
+
+    if (!use_dns)
+    {
+      MDEBUG("Couldn't use DNS to determine if address '" << address << "' is local, assuming not");
       return false;
     }
 

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -882,13 +882,6 @@ std::string get_nix_version_display_string()
 
   bool is_local_address(const std::string &address)
   {
-    // always assume Tor/I2P addresses to be untrusted by default
-    if (is_privacy_preserving_network(address))
-    {
-      MDEBUG("Address '" << address << "' is Tor/I2P, non local");
-      return false;
-    }
-
     // extract host
     epee::net_utils::http::url_content u_c;
     if (!epee::net_utils::parse_url(address, u_c))
@@ -899,6 +892,13 @@ std::string get_nix_version_display_string()
     if (u_c.host.empty())
     {
       MWARNING("Failed to determine whether address '" << address << "' is local, assuming not");
+      return false;
+    }
+
+    // always assume Tor/I2P addresses to be untrusted by default
+    if (is_privacy_preserving_network(u_c.host))
+    {
+      MDEBUG("Address '" << address << "' is Tor/I2P, non local");
       return false;
     }
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -227,7 +227,7 @@ namespace tools
   void set_max_concurrency(unsigned n);
   unsigned get_max_concurrency();
 
-  bool is_local_address(const std::string &address);
+  bool is_local_address(const std::string &address, bool use_dns);
   bool is_privacy_preserving_network(const std::string &address);
   int vercmp(const char *v0, const char *v1); // returns < 0, 0, > 0, similar to strcmp, but more human friendly than lexical - does not attempt to validate
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5328,7 +5328,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
       }
     }
 
-    if (!tools::is_privacy_preserving_network(parsed.host) && !tools::is_local_address(parsed.host))
+    if (!tools::is_privacy_preserving_network(parsed.host) && !tools::is_local_address(parsed.host, m_wallet->is_dns_enabled()))
     {
       if (trusted == "untrusted" || trusted == "")
       {
@@ -5353,7 +5353,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
       m_wallet->set_trusted_daemon(false);
       try
       {
-        if (tools::is_local_address(m_wallet->get_daemon_address()))
+        if (tools::is_local_address(m_wallet->get_daemon_address(), m_wallet->is_dns_enabled()))
         {
           MINFO(tr("Daemon is local, assuming trusted"));
           m_wallet->set_trusted_daemon(true);

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -38,10 +38,10 @@ using namespace std;
 namespace Monero {
 namespace Utils {
 
-bool isAddressLocal(const std::string &address)
+bool isAddressLocal(const std::string &address, bool use_dns)
 { 
     try {
-        return tools::is_local_address(address);
+        return tools::is_local_address(address, use_dns);
     } catch (const std::exception &e) {
         MERROR("error: " << e.what());
         return false;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2293,6 +2293,8 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit))
        return false;
 
+    m_wallet->enable_dns(proxy_address.empty());
+
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
     // If daemon isn't synced a calculated block height will be used instead
     if (isNewWallet() && daemonSynced()) {
@@ -2303,7 +2305,7 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     if (m_rebuildWalletCache)
       LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << m_wallet->get_refresh_from_block_height());
 
-    if (Utils::isAddressLocal(daemon_address)) {
+    if (Utils::isAddressLocal(daemon_address, m_wallet->is_dns_enabled())) {
         this->setTrustedDaemon(true);
         m_refreshIntervalMillis = DEFAULT_REFRESH_INTERVAL_MILLIS;
     } else {

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -49,7 +49,7 @@ enum NetworkType : uint8_t {
 };
 
     namespace Utils {
-        bool isAddressLocal(const std::string &hostaddr);
+        bool isAddressLocal(const std::string &hostaddr, bool use_dns = false);
         void onStartup();
     }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -437,6 +437,8 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
       std::string{"Invalid address specified for --"} + opts.proxy.name);
   }
 
+  bool use_dns = !command_line::get_arg(vm, opts.no_dns);
+
   boost::optional<bool> trusted_daemon;
   if (!command_line::is_arg_defaulted(vm, opts.trusted_daemon) || !command_line::is_arg_defaulted(vm, opts.untrusted_daemon))
     trusted_daemon = command_line::get_arg(vm, opts.trusted_daemon) && !command_line::get_arg(vm, opts.untrusted_daemon);
@@ -449,7 +451,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
     try
     {
       trusted_daemon = false;
-      if (tools::is_local_address(daemon_address))
+      if (tools::is_local_address(daemon_address, use_dns))
       {
         MINFO(tools::wallet2::tr("Daemon is local, assuming trusted"));
         trusted_daemon = true;
@@ -468,9 +470,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   wallet->get_message_store().set_options(vm);
   wallet->device_name(device_name);
   wallet->device_derivation_path(device_derivation_path);
-
-  if (command_line::get_arg(vm, opts.no_dns))
-    wallet->enable_dns(false);
+  wallet->enable_dns(use_dns);
 
   if (command_line::get_arg(vm, opts.offline))
     wallet->set_offline();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -437,7 +437,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
       std::string{"Invalid address specified for --"} + opts.proxy.name);
   }
 
-  bool use_dns = !command_line::get_arg(vm, opts.no_dns);
+  bool use_dns = !command_line::get_arg(vm, opts.no_dns) && !use_proxy;
 
   boost::optional<bool> trusted_daemon;
   if (!command_line::is_arg_defaulted(vm, opts.trusted_daemon) || !command_line::is_arg_defaulted(vm, opts.untrusted_daemon))

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1617,6 +1617,7 @@ private:
     uint64_t hash_m_transfers(boost::optional<uint64_t> transfer_height, crypto::hash &hash) const;
     void finish_rescan_bc_keep_key_images(uint64_t transfer_height, const crypto::hash &hash);
     void enable_dns(bool enable) { m_use_dns = enable; }
+    bool is_dns_enabled() { return m_use_dns; }
     void set_offline(bool offline = true);
     bool is_offline() const { return m_offline; }
 


### PR DESCRIPTION
Starting `monero-wallet-cli` with arguments 

```
--daemon-address any_address.onion:18081 --proxy 127.0.0.1:9050
``` 

produces a DNS leak when a wallet is opened (credit to r4v3r23 / pokkst for finding this). A lookup for the .onion daemon address using the system's default DNS resolver is done in `tools::is_local_address`.

The first commit in this PR fixes a bug in `is_local_address` where the full daemon address (including port) is passed to `is_privacy_preserving_network` instead of just the host, which it expects.

In the second commit, changes are made so that `is_local_address` respects the `--no-dns` flag.

Checking if an address is local using DNS does not make sense when a proxy is set, since a daemon behind a proxy can't be considered local in the first place. (We probably shouldn't be using DNS for this at all. Are there any compelling reasons why someone would configure their nameserver to point some arbitrary domain to a loopback address? A simple solution would be to only parse IP addresses for this check and ask that users enter that instead. Maybe parse the hosts file if we're feeling generous). Anyway, the third commit disables DNS for checking if an address is local when a proxy is set. This prevents a leak when a proxy is used in combination with a clearnet daemon address.