### PR TITLE
cryptonote_basic: remove unused to_script[_hash] vin/vout

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -53,26 +53,7 @@
 
 namespace cryptonote
 {
-  typedef std::vector<crypto::signature> ring_signature;
-
-
   /* outputs */
-
-  struct txout_to_script
-  {
-    std::vector<crypto::public_key> keys;
-    std::vector<uint8_t> script;
-
-    BEGIN_SERIALIZE_OBJECT()
-      FIELD(keys)
-      FIELD(script)
-    END_SERIALIZE()
-  };
-
-  struct txout_to_scripthash
-  {
-    crypto::hash hash;
-  };
 
   // outputs <= HF_VERSION_VIEW_TAGS
   struct txout_to_key
@@ -107,34 +88,6 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
-  struct txin_to_script
-  {
-    crypto::hash prev;
-    size_t prevout;
-    std::vector<uint8_t> sigset;
-
-    BEGIN_SERIALIZE_OBJECT()
-      FIELD(prev)
-      VARINT_FIELD(prevout)
-      FIELD(sigset)
-    END_SERIALIZE()
-  };
-
-  struct txin_to_scripthash
-  {
-    crypto::hash prev;
-    size_t prevout;
-    txout_to_script script;
-    std::vector<uint8_t> sigset;
-
-    BEGIN_SERIALIZE_OBJECT()
-      FIELD(prev)
-      VARINT_FIELD(prevout)
-      FIELD(script)
-      FIELD(sigset)
-    END_SERIALIZE()
-  };
-
   struct txin_to_key
   {
     uint64_t amount;
@@ -148,12 +101,19 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
+  //! @brief A placeholder for types in variants which aren't currently used
+  // You can replace instances of reserved<X> in a variant with no meaningful difference
+  template <int TAG>
+  struct reserved
+  {
+    BEGIN_SERIALIZE()
+    END_SERIALIZE()
+  };
 
-  typedef boost::variant<txin_gen, txin_to_script, txin_to_scripthash, txin_to_key> txin_v;
+  typedef boost::variant<txin_gen, reserved<0>, reserved<1>, txin_to_key> txin_v;
 
-  typedef boost::variant<txout_to_script, txout_to_scripthash, txout_to_key, txout_to_tagged_key> txout_target_v;
+  typedef boost::variant<reserved<0>, reserved<1>, txout_to_key, txout_to_tagged_key> txout_target_v;
 
-  //typedef std::pair<uint64_t, txout> out_t;
   struct tx_out
   {
     uint64_t amount;
@@ -441,8 +401,8 @@ namespace cryptonote
     struct txin_signature_size_visitor : public boost::static_visitor<size_t>
     {
       size_t operator()(const txin_gen& txin) const{return 0;}
-      size_t operator()(const txin_to_script& txin) const{return 0;}
-      size_t operator()(const txin_to_scripthash& txin) const{return 0;}
+      size_t operator()(const reserved<0>&) const { return 0; }
+      size_t operator()(const reserved<1>&) const { return 0; }
       size_t operator()(const txin_to_key& txin) const {return txin.key_offsets.size();}
     };
 
@@ -567,37 +527,30 @@ namespace std {
 }
 
 BLOB_SERIALIZER(cryptonote::txout_to_key);
-BLOB_SERIALIZER(cryptonote::txout_to_scripthash);
 
 VARIANT_TAG(binary_archive, cryptonote::txin_gen, 0xff);
-VARIANT_TAG(binary_archive, cryptonote::txin_to_script, 0x0);
-VARIANT_TAG(binary_archive, cryptonote::txin_to_scripthash, 0x1);
 VARIANT_TAG(binary_archive, cryptonote::txin_to_key, 0x2);
-VARIANT_TAG(binary_archive, cryptonote::txout_to_script, 0x0);
-VARIANT_TAG(binary_archive, cryptonote::txout_to_scripthash, 0x1);
 VARIANT_TAG(binary_archive, cryptonote::txout_to_key, 0x2);
 VARIANT_TAG(binary_archive, cryptonote::txout_to_tagged_key, 0x3);
 VARIANT_TAG(binary_archive, cryptonote::transaction, 0xcc);
 VARIANT_TAG(binary_archive, cryptonote::block, 0xbb);
+VARIANT_TAG(binary_archive, cryptonote::reserved<0>, 0x00);
+VARIANT_TAG(binary_archive, cryptonote::reserved<1>, 0x01);
 
 VARIANT_TAG(json_archive, cryptonote::txin_gen, "gen");
-VARIANT_TAG(json_archive, cryptonote::txin_to_script, "script");
-VARIANT_TAG(json_archive, cryptonote::txin_to_scripthash, "scripthash");
 VARIANT_TAG(json_archive, cryptonote::txin_to_key, "key");
-VARIANT_TAG(json_archive, cryptonote::txout_to_script, "script");
-VARIANT_TAG(json_archive, cryptonote::txout_to_scripthash, "scripthash");
 VARIANT_TAG(json_archive, cryptonote::txout_to_key, "key");
 VARIANT_TAG(json_archive, cryptonote::txout_to_tagged_key, "tagged_key");
 VARIANT_TAG(json_archive, cryptonote::transaction, "tx");
 VARIANT_TAG(json_archive, cryptonote::block, "block");
+VARIANT_TAG(json_archive, cryptonote::reserved<0>, "reserved_0");
+VARIANT_TAG(json_archive, cryptonote::reserved<1>, "reserved_1");
 
 VARIANT_TAG(debug_archive, cryptonote::txin_gen, "gen");
-VARIANT_TAG(debug_archive, cryptonote::txin_to_script, "script");
-VARIANT_TAG(debug_archive, cryptonote::txin_to_scripthash, "scripthash");
 VARIANT_TAG(debug_archive, cryptonote::txin_to_key, "key");
-VARIANT_TAG(debug_archive, cryptonote::txout_to_script, "script");
-VARIANT_TAG(debug_archive, cryptonote::txout_to_scripthash, "scripthash");
 VARIANT_TAG(debug_archive, cryptonote::txout_to_key, "key");
 VARIANT_TAG(debug_archive, cryptonote::txout_to_tagged_key, "tagged_key");
 VARIANT_TAG(debug_archive, cryptonote::transaction, "tx");
 VARIANT_TAG(debug_archive, cryptonote::block, "block");
+VARIANT_TAG(debug_archive, cryptonote::reserved<0>, "reserved_0");
+VARIANT_TAG(debug_archive, cryptonote::reserved<1>, "reserved_1");

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -93,14 +93,6 @@ namespace boost
   }
 
   template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txout_to_script &x, const boost::serialization::version_type ver)
-  {
-    a & x.keys;
-    a & x.script;
-  }
-
-
-  template <class Archive>
   inline void serialize(Archive &a, cryptonote::txout_to_key &x, const boost::serialization::version_type ver)
   {
     a & x.key;
@@ -114,32 +106,9 @@ namespace boost
   }
 
   template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txout_to_scripthash &x, const boost::serialization::version_type ver)
-  {
-    a & x.hash;
-  }
-
-  template <class Archive>
   inline void serialize(Archive &a, cryptonote::txin_gen &x, const boost::serialization::version_type ver)
   {
     a & x.height;
-  }
-
-  template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txin_to_script &x, const boost::serialization::version_type ver)
-  {
-    a & x.prev;
-    a & x.prevout;
-    a & x.sigset;
-  }
-
-  template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txin_to_scripthash &x, const boost::serialization::version_type ver)
-  {
-    a & x.prev;
-    a & x.prevout;
-    a & x.script;
-    a & x.sigset;
   }
 
   template <class Archive>
@@ -421,6 +390,10 @@ namespace boost
       a & v;
     }
   }
+
+  template <class Archive, int TAG>
+  inline void serialize(Archive &a, cryptonote::reserved<TAG> &x, const boost::serialization::version_type ver)
+  {}
 
 }
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2921,11 +2921,11 @@ bool Blockchain::check_for_double_spend(const transaction& tx, key_images_contai
     {
       return true;
     }
-    bool operator()(const txin_to_script& tx) const
+    bool operator()(const reserved<0>&) const
     {
       return false;
     }
-    bool operator()(const txin_to_scripthash& tx) const
+    bool operator()(const reserved<1>&) const
     {
       return false;
     }

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -353,13 +353,13 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::t
     {
       INSERT_INTO_JSON_OBJECT(dest, gen, input);
     }
-    void operator()(cryptonote::txin_to_script const& input) const
+    void operator()(cryptonote::reserved<0> const&) const
     {
-      INSERT_INTO_JSON_OBJECT(dest, to_script, input);
+      ASSERT_MES_AND_THROW("attemping to serialize reserved variant to JSON");
     }
-    void operator()(cryptonote::txin_to_scripthash const& input) const
+    void operator()(cryptonote::reserved<1> const&) const
     {
-      INSERT_INTO_JSON_OBJECT(dest, to_scripthash, input);
+      ASSERT_MES_AND_THROW("attemping to serialize reserved variant to JSON");
     }
   };
   boost::apply_visitor(add_input{dest}, txin);
@@ -393,18 +393,6 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin)
       fromJsonValue(elem.value, tmpVal);
       txin = std::move(tmpVal);
     }
-    else if (elem.name == "to_script")
-    {
-      cryptonote::txin_to_script tmpVal;
-      fromJsonValue(elem.value, tmpVal);
-      txin = std::move(tmpVal);
-    }
-    else if (elem.name == "to_scripthash")
-    {
-      cryptonote::txin_to_scripthash tmpVal;
-      fromJsonValue(elem.value, tmpVal);
-      txin = std::move(tmpVal);
-    }
   }
 }
 
@@ -425,57 +413,6 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_gen& txin)
   }
 
   GET_FROM_JSON_OBJECT(val, txin.height, height);
-}
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_script& txin)
-{
-  dest.StartObject();
-
-  INSERT_INTO_JSON_OBJECT(dest, prev, txin.prev);
-  INSERT_INTO_JSON_OBJECT(dest, prevout, txin.prevout);
-  INSERT_INTO_JSON_OBJECT(dest, sigset, txin.sigset);
-
-  dest.EndObject();
-}
-
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, txin.prev, prev);
-  GET_FROM_JSON_OBJECT(val, txin.prevout, prevout);
-  GET_FROM_JSON_OBJECT(val, txin.sigset, sigset);
-}
-
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_scripthash& txin)
-{
-  dest.StartObject();
-
-  INSERT_INTO_JSON_OBJECT(dest, prev, txin.prev);
-  INSERT_INTO_JSON_OBJECT(dest, prevout, txin.prevout);
-  INSERT_INTO_JSON_OBJECT(dest, script, txin.script);
-  INSERT_INTO_JSON_OBJECT(dest, sigset, txin.sigset);
-
-  dest.EndObject();
-}
-
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& txin)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, txin.prev, prev);
-  GET_FROM_JSON_OBJECT(val, txin.prevout, prevout);
-  GET_FROM_JSON_OBJECT(val, txin.script, script);
-  GET_FROM_JSON_OBJECT(val, txin.sigset, sigset);
 }
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_key& txin)
@@ -500,49 +437,6 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin)
   GET_FROM_JSON_OBJECT(val, txin.key_offsets, key_offsets);
   GET_FROM_JSON_OBJECT(val, txin.k_image, key_image);
 }
-
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout)
-{
-  dest.StartObject();
-
-  INSERT_INTO_JSON_OBJECT(dest, keys, txout.keys);
-  INSERT_INTO_JSON_OBJECT(dest, script, txout.script);
-
-  dest.EndObject();
-}
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, txout.keys, keys);
-  GET_FROM_JSON_OBJECT(val, txout.script, script);
-}
-
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout)
-{
-  dest.StartObject();
-
-  INSERT_INTO_JSON_OBJECT(dest, hash, txout.hash);
-
-  dest.EndObject();
-}
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, txout.hash, hash);
-}
-
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_key& txout)
 {
@@ -603,13 +497,13 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::t
     {
       INSERT_INTO_JSON_OBJECT(dest, to_tagged_key, output);
     }
-    void operator()(cryptonote::txout_to_script const& output) const
+    void operator()(cryptonote::reserved<0> const&) const
     {
-      INSERT_INTO_JSON_OBJECT(dest, to_script, output);
+      ASSERT_MES_AND_THROW("attemping to serialize reserved variant to JSON");
     }
-    void operator()(cryptonote::txout_to_scripthash const& output) const
+    void operator()(cryptonote::reserved<1> const&) const
     {
-      INSERT_INTO_JSON_OBJECT(dest, to_scripthash, output);
+      ASSERT_MES_AND_THROW("attemping to serialize reserved variant to JSON");
     }
   };
   boost::apply_visitor(add_output{dest}, txout.target);
@@ -644,18 +538,6 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout)
     else if (elem.name == "to_tagged_key")
     {
       cryptonote::txout_to_tagged_key tmpVal;
-      fromJsonValue(elem.value, tmpVal);
-      txout.target = std::move(tmpVal);
-    }
-    else if (elem.name == "to_script")
-    {
-      cryptonote::txout_to_script tmpVal;
-      fromJsonValue(elem.value, tmpVal);
-      txout.target = std::move(tmpVal);
-    }
-    else if (elem.name == "to_scripthash")
-    {
-      cryptonote::txout_to_scripthash tmpVal;
       fromJsonValue(elem.value, tmpVal);
       txout.target = std::move(tmpVal);
     }

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -209,23 +209,11 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin);
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_gen& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_gen& txin);
 
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_script& txin);
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin);
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_scripthash& txin);
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& txin);
-
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_key& txin);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin);
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_target_v& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_target_v& txout);
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout);
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout);
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout);
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout);
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_key& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_key& txout);

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -276,10 +276,10 @@ bool gen_tx_input_is_not_txin_to_key::generate(std::vector<test_event_entry>& ev
   };
 
   DO_CALLBACK(events, "mark_invalid_tx");
-  events.push_back(make_tx_with_input(txin_to_script()));
+  events.push_back(make_tx_with_input(reserved<0>()));
 
   DO_CALLBACK(events, "mark_invalid_tx");
-  events.push_back(make_tx_with_input(txin_to_scripthash()));
+  events.push_back(make_tx_with_input(reserved<1>()));
 
   return true;
 }
@@ -706,7 +706,7 @@ bool gen_tx_output_is_not_txout_to_key::generate(std::vector<test_event_entry>& 
 
   builder.m_tx.vout.push_back(tx_out());
   builder.m_tx.vout.back().amount = 1;
-  builder.m_tx.vout.back().target = txout_to_script();
+  builder.m_tx.vout.back().target = reserved<0>();
 
   builder.step4_calc_hash();
   builder.step5_sign(sources);
@@ -719,7 +719,7 @@ bool gen_tx_output_is_not_txout_to_key::generate(std::vector<test_event_entry>& 
 
   builder.m_tx.vout.push_back(tx_out());
   builder.m_tx.vout.back().amount = 1;
-  builder.m_tx.vout.back().target = txout_to_scripthash();
+  builder.m_tx.vout.back().target = reserved<1>();
 
   builder.step4_calc_hash();
   builder.step5_sign(sources);


### PR DESCRIPTION
Structs were added 9 years ago and have yet to be used