### PR TITLE
Add byte_stream `value_type` and `data()`

### DIFF
--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -74,6 +74,7 @@ namespace epee
   public:
     using char_type = std::uint8_t;
     using Ch = char_type;
+    using value_type = char_type;
 
     //! Increase internal buffer by at least `byte_stream_increase` bytes.
     byte_stream() noexcept
@@ -86,6 +87,7 @@ namespace epee
     ~byte_stream() noexcept = default;
     byte_stream& operator=(byte_stream&& rhs) noexcept;
 
+    std::uint8_t* data() noexcept { return buffer_.get(); }
     const std::uint8_t* data() const noexcept { return buffer_.get(); }
     std::uint8_t* tellp() const noexcept { return next_write_; }
     std::size_t available() const noexcept { return end_ - next_write_; }


### PR DESCRIPTION
Both of these are needed for the new serialization format, but might be useful for other purposes.