### PR TITLE
wallet2: ensure transfers and sweeps use same fee calc logic

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9911,7 +9911,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       else
       {
         LOG_PRINT_L2("We made a tx, adjusting fee and saving it, we need " << print_money(needed_fee) << " and we have " << print_money(test_ptx.fee));
-        while (needed_fee > test_ptx.fee) {
+        do {
           if (use_rct)
             transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time, needed_fee, extra,
               test_tx, test_ptx, rct_config, use_view_tags);
@@ -9922,7 +9922,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
           needed_fee = calculate_fee(use_per_byte_fee, test_ptx.tx, txBlob.size(), base_fee, fee_quantization_mask);
           LOG_PRINT_L2("Made an attempt at a  final " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(test_ptx.fee) <<
             " fee  and " << print_money(test_ptx.change_dts.amount) << " change");
-        }
+        } while (needed_fee > test_ptx.fee);
 
         LOG_PRINT_L2("Made a final " << get_weight_string(test_ptx.tx, txBlob.size()) << " tx, with " << print_money(test_ptx.fee) <<
           " fee  and " << print_money(test_ptx.change_dts.amount) << " change");
@@ -10318,7 +10318,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       THROW_WALLET_EXCEPTION_IF(needed_fee > available_for_fee, error::wallet_internal_error, "Transaction cannot pay for itself");
 
       do {
-        LOG_PRINT_L2("We made a tx, adjusting fee and saving it");
+        LOG_PRINT_L2("We made a tx, adjusting fee and saving it, we need " << print_money(needed_fee) << " and we have " << print_money(test_ptx.fee));
         // distribute total transferred amount between outputs
         uint64_t amount_transferred = available_for_fee - needed_fee;
         uint64_t dt_amount = amount_transferred / outputs;


### PR DESCRIPTION
Though highly unlikely today, it's theoretically possible to distinguish transfers from sweeps by the tx fee.

This PR ensures transfers and sweeps both use the result of `calculate_fee` as the tx fee (calculated using the tx's weight).

### Details

In a **sweep**: wallet2 first uses `estimate_fee` to get a baseline guess for the amount(s) to send, but will then use the result of `calculate_fee` as the tx fee.

In a **transfer**: wallet2 first uses `estimate_fee` as the tx fee. **If and only if** `calculate_fee` is larger than the result of `estimate_fee`, then it will use `calculate_fee`. Note that in practice today, the estimate is extremely likely to *under*-estimate the fee, therefore transfers are very likely to use `calculate_fee`, the same as sweeps today.

### The fix

Modify transfers to use the fee from `calculate_fee` as the tx fee always, just like sweeps.

This approach is easier to reason through than the other way around imo (modifying sweeps to be like transfers). With this change, *all* txs created by wallet2 should have a fee that is calculated from the ~~final~~ weight of the tx, rather than have bifurcated logic using either an estimate or calculated.

Edit 1: always using `calculate_fee` would also use a lower fee compared to using `estimate_fee` iff it's greater than `calculate_fee`.
Edit 2: in some theoretical cases wallet2 can end up using a fee that is not calculated using the **final** weight of the tx, but *is still* calculated from the tx's weight rather than an estimate.