### PR TITLE
cryptonote_basic: speedup find_tx_extra_field_by_type

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -112,6 +112,26 @@ namespace cryptonote {
 
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b);
+
+  template <typename T>
+  struct assignment_visitor: public boost::static_visitor<bool>
+  {
+    assignment_visitor(T& target): target(target), boost::static_visitor<bool>() {}
+
+    bool operator()(const T& val) const
+    {
+      target = val;
+      return true;
+    }
+
+    template <typename U>
+    bool operator()(const U&) const
+    {
+      return false;
+    }
+
+    T& target;
+  };
 }
 
 bool parse_hash256(const std::string &str_hash, crypto::hash& hash);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -63,12 +63,10 @@ namespace cryptonote
   template<typename T>
   bool find_tx_extra_field_by_type(const std::vector<tx_extra_field>& tx_extra_fields, T& field, size_t index = 0)
   {
-    auto it = std::find_if(tx_extra_fields.begin(), tx_extra_fields.end(), [&index](const tx_extra_field& f) { return typeid(T) == f.type() && !index--; });
-    if(tx_extra_fields.end() == it)
+    if(index >= tx_extra_fields.size())
       return false;
 
-    field = boost::get<T>(*it);
-    return true;
+    return boost::apply_visitor(assignment_visitor<T>(field), tx_extra_fields[index]);
   }
 
   bool parse_tx_extra(const std::vector<uint8_t>& tx_extra, std::vector<tx_extra_field>& tx_extra_fields);


### PR DESCRIPTION
The savings are pretty small per call, but it gets called multiple times per output per transaction per block per refresh, so it's probably worth it.