### PR TITLE
Speed up perf_timer init on x86

### DIFF
--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -62,7 +62,7 @@ namespace tools
     while (1)
     {
       t1 = epee::misc_utils::get_ns_count();
-      if (t1 - t0 > 1*1000000000) break; // work one second
+      if (t1 - t0 > 1*100000000) break; // work 0.1 seconds
     }
 
     uint64_t r1 = get_tick_count();


### PR DESCRIPTION
All Monero binaries have 1 second startup delay because of this code. This is especially noticeable and affects UX in Monero GUI wallet with local node where it often starts another monerod instance to run commands and query node status.