### PR TITLE
blockchain_db/core_rpc_server: Get coinbase RCT output distribution

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -274,6 +274,7 @@ uint64_t BlockchainDB::add_block( const std::pair<block, blobdata>& blck
   time1 = epee::misc_utils::get_tick_count();
 
   uint64_t num_rct_outs = 0;
+  const uint64_t num_rct_outs_coinbase = get_num_coinbase_rct_outputs(blck.first);
   blobdata miner_bd = tx_to_blob(blk.miner_tx);
   add_transaction(blk_hash, std::make_pair(blk.miner_tx, blobdata_ref(miner_bd)));
   if (blk.miner_tx.version == 2)
@@ -296,7 +297,7 @@ uint64_t BlockchainDB::add_block( const std::pair<block, blobdata>& blck
 
   // call out to subclass implementation to add the block & metadata
   time1 = epee::misc_utils::get_tick_count();
-  add_block(blk, block_weight, long_term_block_weight, cumulative_difficulty, coins_generated, num_rct_outs, blk_hash);
+  add_block(blk, block_weight, long_term_block_weight, cumulative_difficulty, coins_generated, num_rct_outs, num_rct_outs_coinbase, blk_hash);
   TIME_MEASURE_FINISH(time1);
   time_add_block1 += time1;
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -397,6 +397,8 @@ private:
    * @param long_term_block_weight the long term block weight of the block (transactions and all)
    * @param cumulative_difficulty the accumulated difficulty after this block
    * @param coins_generated the number of coins generated total after this block
+   * @param num_rct_outs the number of total RCT tx outputs, including coinbase, in this block
+   * @param num_rct_outs_coinbase same as num_rct_outs, but ONLY including coinbase RCT outputs
    * @param blk_hash the hash of the block
    */
   virtual void add_block( const block& blk
@@ -405,6 +407,7 @@ private:
                 , const difficulty_type& cumulative_difficulty
                 , const uint64_t& coins_generated
                 , uint64_t num_rct_outs
+                , uint64_t num_rct_outs_coinbase
                 , const crypto::hash& blk_hash
                 ) = 0;
 
@@ -976,6 +979,24 @@ public:
    * @return the cumulative number of rct outputs
    */
   virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const = 0;
+
+  /**
+   * @brief fetch a block's cumulative number of rct *coinbase* outputs
+   *
+   * Same idea as get_block_cumulative_rct_outputs, but we include ONLY outputs from miner txs, and
+   * we perform the fetch on contiguous blocks in range [start_height, end_height).
+   *
+   * The subclass should return the numer of rct coinbase outputs in the blockchain
+   * up to the block with the given height (inclusive).
+   *
+   * If the block does not exist, the subclass should throw BLOCK_DNE
+   *
+   * @param begin_height the start height to fetch (inclusive)
+   * @param end_height the end height to fetch (exclusive)
+   *
+   * @return a list of the cumulative number of rct coinbase outputs per block
+   */
+  virtual std::vector<uint64_t> get_block_cumulative_rct_coinbase_outputs(uint64_t begin_height, uint64_t end_height) const = 0;
 
   /**
    * @brief fetch the top block's timestamp

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -218,6 +218,8 @@ public:
 
   virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const;
 
+  virtual std::vector<uint64_t> get_block_cumulative_rct_coinbase_outputs(uint64_t begin_height, uint64_t end_height) const;
+
   virtual uint64_t get_block_timestamp(const uint64_t& height) const;
 
   virtual uint64_t get_top_block_timestamp() const;
@@ -371,6 +373,7 @@ private:
                 , const difficulty_type& cumulative_difficulty
                 , const uint64_t& coins_generated
                 , uint64_t num_rct_outs
+                , uint64_t num_rct_outs_coinbase
                 , const crypto::hash& block_hash
                 );
 
@@ -442,6 +445,9 @@ private:
 
   // migrate from DB version 4 to 5
   void migrate_4_5();
+
+  // migrate from DB version 5 to 6: add field `bi_cum_rct_coinbase` to block_info table
+  void migrate_5_6();
 
   void cleanup_batch();
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -77,6 +77,7 @@ public:
   virtual cryptonote::block_header get_block_header(const crypto::hash& h) const override { return cryptonote::block_header(); }
   virtual uint64_t get_block_timestamp(const uint64_t& height) const override { return 0; }
   virtual std::vector<uint64_t> get_block_cumulative_rct_outputs(const std::vector<uint64_t> &heights) const override { return {}; }
+  virtual std::vector<uint64_t> get_block_cumulative_rct_coinbase_outputs(uint64_t begin_height, uint64_t end_height) const override { return {}; };
   virtual uint64_t get_top_block_timestamp() const override { return 0; }
   virtual size_t get_block_weight(const uint64_t& height) const override { return 128; }
   virtual std::vector<uint64_t> get_block_weights(uint64_t start_height, size_t count) const override { return {}; }
@@ -144,6 +145,7 @@ public:
                         , const cryptonote::difficulty_type& cumulative_difficulty
                         , const uint64_t& coins_generated
                         , uint64_t num_rct_outs
+                        , uint64_t num_rct_outs_coinbase
                         , const crypto::hash& blk_hash
                         ) override { }
   virtual cryptonote::block get_block_from_height(const uint64_t& height) const override { return cryptonote::block(); }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -183,6 +183,16 @@ namespace cryptonote {
     return true;
   }
   //-----------------------------------------------------------------------
+  uint64_t get_num_coinbase_rct_outputs(const block& b)
+  {
+    if (b.miner_tx.version < 2)
+    {
+      return 0;
+    }
+
+    return b.miner_tx.vout.size();
+  }
+  //-----------------------------------------------------------------------
   bool get_account_address_from_str(
       address_parse_info& info
     , network_type nettype

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -110,6 +110,8 @@ namespace cryptonote {
 
   bool is_coinbase(const transaction& tx);
 
+  uint64_t get_num_coinbase_rct_outputs(const block& b);
+
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b);
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -573,6 +573,19 @@ namespace cryptonote
     bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, uint64_t &start_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
 
     /**
+     * @brief gets per-block distribution of rct coinbase outputs (cumulative)
+     *
+     * @param from_height the height before which we do not care about the data (inclusive)
+     * @param to_height the height after which we do not care about the data (inclusive)
+     * @param[out] start_height the height of the first rct coinbase output
+     * @param[out] distribution the number of rct coinbase outputs in each block starting from start_height (inclusive)
+     * @param[out] base how many rct coinbase outputs are before the stated distribution
+     *
+     * @return false if requested heights are not available or other failure, true for success
+     */
+    bool get_rct_coinbase_output_distribution(uint64_t from_height, uint64_t to_height, uint64_t &start_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
+
+    /**
      * @brief gets the global indices for outputs from a given transaction
      *
      * This function gets the global indices for all outputs belonging

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -285,7 +285,8 @@ private:
     bool use_bootstrap_daemon_if_necessary(const invoke_http_mode &mode, const std::string &command_name, const typename COMMAND_TYPE::request& req, typename COMMAND_TYPE::response& res, bool &r);
     bool get_block_template(const account_public_address &address, const crypto::hash *prev_block, const cryptonote::blobdata &extra_nonce, size_t &reserved_offset, cryptonote::difficulty_type &difficulty, uint64_t &height, uint64_t &expected_reward, block &b, uint64_t &seed_height, crypto::hash &seed_hash, crypto::hash &next_seed_hash, epee::json_rpc::error &error_resp);
     bool check_payment(const std::string &client, uint64_t payment, const std::string &rpc, bool same_ts, std::string &message, uint64_t &credits, std::string &top_hash);
-    
+    bool on_get_output_distribution_generalized(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx, void* tracker_erased);
+
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& m_p2p;
     boost::shared_mutex m_bootstrap_daemon_mutex;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2447,6 +2447,7 @@ namespace cryptonote
       bool cumulative;
       bool binary;
       bool compress;
+      bool get_rct_coinbase;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
@@ -2456,6 +2457,7 @@ namespace cryptonote
         KV_SERIALIZE_OPT(cumulative, false)
         KV_SERIALIZE_OPT(binary, true)
         KV_SERIALIZE_OPT(compress, false)
+        KV_SERIALIZE_OPT(get_rct_coinbase, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -2500,15 +2502,27 @@ namespace cryptonote
           KV_SERIALIZE_N(data.distribution, "distribution")
         KV_SERIALIZE_N(data.base, "base")
       END_KV_SERIALIZE_MAP()
+
+      bool operator==(const distribution& other) const
+      {
+        return data == other.data
+          && amount == other.amount
+          && compressed_data == other.compressed_data
+          && binary == other.binary
+          && compress == other.compress
+        ;
+      }
     };
 
     struct response_t: public rpc_access_response_base
     {
       std::vector<distribution> distributions;
+      distribution rct_coinbase_distribution;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(distributions)
+        KV_SERIALIZE_OPT(rct_coinbase_distribution, decltype(rct_coinbase_distribution)())
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;

--- a/src/rpc/rpc_handler.h
+++ b/src/rpc/rpc_handler.h
@@ -47,6 +47,14 @@ struct output_distribution_data
   std::vector<std::uint64_t> distribution;
   std::uint64_t start_height;
   std::uint64_t base;
+
+  bool operator==(const output_distribution_data& other) const
+  {
+    return distribution == other.distribution
+      && start_height == other.start_height
+      && base == other.base
+    ;
+  }
 };
 
 class RpcHandler

--- a/tests/block_weight/block_weight.cpp
+++ b/tests/block_weight/block_weight.cpp
@@ -65,6 +65,7 @@ public:
                         , const cryptonote::difficulty_type& cumulative_difficulty
                         , const uint64_t& coins_generated
                         , uint64_t num_rct_outs
+                        , uint64_t num_rct_outs_coinbase
                         , const crypto::hash& blk_hash
                         ) override {
     blocks.push_back({block_weight, long_term_block_weight});

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -87,6 +87,7 @@ namespace
         , const cryptonote::difficulty_type& cumulative_difficulty
         , const uint64_t& coins_generated
         , uint64_t num_rct_outs
+        , uint64_t num_rct_outs_coinbase
         , const crypto::hash& blk_hash
     ) override
     {
@@ -174,7 +175,7 @@ static std::unique_ptr<cryptonote::Blockchain> init_blockchain(const std::vector
 
     const block *blk = &boost::get<block>(ev);
     auto blk_hash = get_block_hash(*blk);
-    bdb->add_block(*blk, 1, 1, 1, 0, 0, blk_hash);
+    bdb->add_block(*blk, 1, 1, 1, 0, 0, 0, blk_hash);
   }
 
   bool r = blockchain->init(bdb, nettype, true, test_options, 2, nullptr);

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -41,6 +41,11 @@ using namespace cryptonote;
 #define BLOCKS_PER_YEAR 525960
 #define SECONDS_PER_YEAR 31557600
 
+#define ADD_BLOCK_DEFAULT(db, block)                         \
+  do {                                                       \
+    db.add_block((block), 0, 0, 0, 0, 0, 0, crypto::hash()); \
+  } while (0);                                               \
+
 namespace
 {
 
@@ -53,6 +58,7 @@ public:
                         , const difficulty_type& cumulative_difficulty
                         , const uint64_t& coins_generated
                         , uint64_t num_rct_outs
+                        , uint64_t num_rct_outs_coinbase
                         , const crypto::hash& blk_hash
                         ) override {
     blocks.push_back(blk);
@@ -107,20 +113,20 @@ TEST(major, Only)
   ASSERT_FALSE(hf.add(mkblock(0, 2), 0));
   ASSERT_FALSE(hf.add(mkblock(2, 2), 0));
   ASSERT_TRUE(hf.add(mkblock(1, 2), 0));
-  db.add_block(mkblock(1, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ADD_BLOCK_DEFAULT(db, mkblock(1, 1));
 
   // block height 1, only version 1 is accepted
   ASSERT_FALSE(hf.add(mkblock(0, 2), 1));
   ASSERT_FALSE(hf.add(mkblock(2, 2), 1));
   ASSERT_TRUE(hf.add(mkblock(1, 2), 1));
-  db.add_block(mkblock(1, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ADD_BLOCK_DEFAULT(db, mkblock(1, 1));
 
   // block height 2, only version 2 is accepted
   ASSERT_FALSE(hf.add(mkblock(0, 2), 2));
   ASSERT_FALSE(hf.add(mkblock(1, 2), 2));
   ASSERT_FALSE(hf.add(mkblock(3, 2), 2));
   ASSERT_TRUE(hf.add(mkblock(2, 2), 2));
-  db.add_block(mkblock(2, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ADD_BLOCK_DEFAULT(db, mkblock(2, 1));
 }
 
 TEST(empty_hardforks, Success)
@@ -134,7 +140,7 @@ TEST(empty_hardforks, Success)
   ASSERT_TRUE(hf.get_state(time(NULL) + 3600*24*400) == HardFork::Ready);
 
   for (uint64_t h = 0; h <= 10; ++h) {
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 1));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
   ASSERT_EQ(hf.get(0), 1);
@@ -168,14 +174,14 @@ TEST(check_for_height, Success)
   for (uint64_t h = 0; h <= 4; ++h) {
     ASSERT_TRUE(hf.check_for_height(mkblock(1, 1), h));
     ASSERT_FALSE(hf.check_for_height(mkblock(2, 2), h));  // block version is too high
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 1));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 
   for (uint64_t h = 5; h <= 10; ++h) {
     ASSERT_FALSE(hf.check_for_height(mkblock(1, 1), h));  // block version is too low
     ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), h));
-    db.add_block(mkblock(hf, h, 2), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 2));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 }
@@ -192,19 +198,19 @@ TEST(get, next_version)
 
   for (uint64_t h = 0; h <= 4; ++h) {
     ASSERT_EQ(2, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 1));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 
   for (uint64_t h = 5; h <= 9; ++h) {
     ASSERT_EQ(4, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 2), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 2));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 
   for (uint64_t h = 10; h <= 15; ++h) {
     ASSERT_EQ(4, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 4), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 4));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 }
@@ -245,7 +251,7 @@ TEST(steps_asap, Success)
   hf.init();
 
   for (uint64_t h = 0; h < 10; ++h) {
-    db.add_block(mkblock(hf, h, 9), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, 9));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 
@@ -272,7 +278,7 @@ TEST(steps_1, Success)
   hf.init();
 
   for (uint64_t h = 0 ; h < 10; ++h) {
-    db.add_block(mkblock(hf, h, h+1), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, h+1));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 
@@ -297,7 +303,7 @@ TEST(reorganize, Same)
     //                                 index  0  1  2  3  4  5  6  7  8  9
     static const uint8_t block_versions[] = { 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
     for (uint64_t h = 0; h < 20; ++h) {
-      db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
+      ADD_BLOCK_DEFAULT(db, mkblock(hf, h, block_versions[h]));
       ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
     }
 
@@ -328,7 +334,7 @@ TEST(reorganize, Changed)
   static const uint8_t block_versions[] =    { 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
   static const uint8_t expected_versions[] = { 1, 1, 1, 1, 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9 };
   for (uint64_t h = 0; h < 16; ++h) {
-    db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, block_versions[h]));
     ASSERT_TRUE (hf.add(db.get_block_from_height(h), h));
   }
 
@@ -348,7 +354,7 @@ TEST(reorganize, Changed)
   ASSERT_EQ(db.height(), 3);
   hf.reorganize_from_block_height(2);
   for (uint64_t h = 3; h < 16; ++h) {
-    db.add_block(mkblock(hf, h, block_versions_new[h]), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, block_versions_new[h]));
     bool ret = hf.add(db.get_block_from_height(h), h);
     ASSERT_EQ (ret, h < 15);
   }
@@ -372,7 +378,7 @@ TEST(voting, threshold)
 
     for (uint64_t h = 0; h <= 8; ++h) {
       uint8_t v = 1 + !!(h % 8);
-      db.add_block(mkblock(hf, h, v), 0, 0, 0, 0, 0, crypto::hash());
+      ADD_BLOCK_DEFAULT(db, mkblock(hf, h, v));
       bool ret = hf.add(db.get_block_from_height(h), h);
       if (h >= 8 && threshold == 87) {
         // for threshold 87, we reach the treshold at height 7, so from height 8, hard fork to version 2, but 8 tries to add 1
@@ -406,7 +412,7 @@ TEST(voting, different_thresholds)
     static const uint8_t expected_versions[] = { 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
 
     for (uint64_t h = 0; h < sizeof(block_versions) / sizeof(block_versions[0]); ++h) {
-      db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
+      ADD_BLOCK_DEFAULT(db, mkblock(hf, h, block_versions[h]));
       bool ret = hf.add(db.get_block_from_height(h), h);
       ASSERT_EQ(ret, true);
     }
@@ -459,7 +465,7 @@ TEST(voting, info)
     ASSERT_EQ(expected_thresholds[h], threshold);
     ASSERT_EQ(4, voting);
 
-    db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
+    ADD_BLOCK_DEFAULT(db, mkblock(hf, h, block_versions[h]));
     ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
   }
 }
@@ -522,7 +528,7 @@ TEST(reorganize, changed)
 #define ADD(v, h, a) \
   do { \
     cryptonote::block b = mkblock(hf, h, v); \
-    db.add_block(b, 0, 0, 0, 0, 0, crypto::hash()); \
+    ADD_BLOCK_DEFAULT(db, b); \
     ASSERT_##a(hf.add(b, h)); \
   } while(0)
 #define ADD_TRUE(v, h) ADD(v, h, TRUE)

--- a/tests/unit_tests/long_term_block_weight.cpp
+++ b/tests/unit_tests/long_term_block_weight.cpp
@@ -57,6 +57,7 @@ public:
                         , const cryptonote::difficulty_type& cumulative_difficulty
                         , const uint64_t& coins_generated
                         , uint64_t num_rct_outs
+                        , uint64_t num_rct_outs_coinbase
                         , const crypto::hash& blk_hash
                         ) override {
     blocks.push_back({block_weight, long_term_block_weight});

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -375,7 +375,7 @@ class Daemon(object):
         }
         return self.rpc.send_json_rpc_request(get_coinbase_tx_sum)
 
-    def get_output_distribution(self, amounts = [], from_height = 0, to_height = 0, cumulative = False, binary = False, compress = False, client = ""):
+    def get_output_distribution(self, amounts = [], from_height = 0, to_height = 0, cumulative = False, binary = False, compress = False, client = "", get_rct_coinbase = False):
         get_output_distribution = {
             'method': 'get_output_distribution',
             'params': {
@@ -386,6 +386,7 @@ class Daemon(object):
                 'cumulative': cumulative,
                 'binary': binary,
                 'compress': compress,
+                'get_rct_coinbase': get_rct_coinbase
             },
             'jsonrpc': '2.0',
             'id': '0'


### PR DESCRIPTION
This changes edits `BlockchainLMDB` to add an extra field to the block info structs, and updates the `get_output_distribution` RPC API to allow wallets to obtain the distribution of RCT coinbase outputs per block. This change requires a database migration and will add ~2MB to the database every year.

How to request the information:
1. In the `get_output_distribution[.bin]` RPC command, set a boolean field `get_rct_coinbase` to `true`.
2. The RCT coinbase distribution will be returned in the response field `rct_coinbase_distribution`.

This change will enable extremely fast fetching of the RCT coinbase distribution, which will let wallets efficiently perform decoy selection across only coinbase outputs or only non-coinbase outputs. This PR by itself does **not** affect decoy selection.