### PR TITLE
wallet2: fix `scan_tx` custom compare function incorrectly throwing on some envs

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1715,21 +1715,26 @@ void wallet2::sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_
     else // l.tx_entry.block_height == r.tx_entry.block_height
     {
       // coinbase tx is the first tx in a block
+      if (cryptonote::is_coinbase(r.tx))
+        return false;
       if (cryptonote::is_coinbase(l.tx))
         return true;
-      if (cryptonote::is_coinbase(r.tx))
+
+      // in case std::sort is comparing elem to itself
+      if (l.tx_hash == r.tx_hash)
         return false;
 
       // see which tx hash comes first in the block
       THROW_WALLET_EXCEPTION_IF(parsed_blocks.find(l.tx_entry.block_height) == parsed_blocks.end(),
-          error::wallet_internal_error, "Expected block not returned by daemon");
+          error::wallet_internal_error, std::string("Expected block not returned by daemon, ") +
+          "left tx: " + string_tools::pod_to_hex(l.tx_hash) + ", right tx: " + string_tools::pod_to_hex(r.tx_hash));
       const auto &blk = parsed_blocks[l.tx_entry.block_height];
       for (const auto &tx_hash : blk.tx_hashes)
       {
-        if (tx_hash == l.tx_hash)
-          return true;
         if (tx_hash == r.tx_hash)
           return false;
+        if (tx_hash == l.tx_hash)
+          return true;
       }
       THROW_WALLET_EXCEPTION(error::wallet_internal_error, "Tx hashes not found in block");
       return false;


### PR DESCRIPTION
Fixes #8951

On some envs, `scan_tx` throws when a synced wallet scans a tx older than the wallet's most recent tx and the wallet has lots of txs between those 2 txs.

### The bug

Essentially it's possible for this to throw:

```cpp
std::vector<int> v;
for (int i = 0; i < 32; ++i) v.push_back(i);
std::sort(v.begin(), v.end(), [](const int l, const int r) {
    if (l == r) throw std::runtime_error("Compared elem with itself");
    return l < r;
});
```

I incorrectly assumed this was not possible ([reasoning](https://stackoverflow.com/questions/38966516/should-sorting-algorithm-pass-same-element-in-the-comparison-function) for why an `std::sort` implementation chooses to compare an element against itself).

### The fix

Return false when comparing equal elems in the custom comparator; the comparator must meet the following specification:

> returns ​true if the first argument is less than (i.e. is ordered before) the second [and false otherwise]

> For all a, comp(a, a) == false

https://en.cppreference.com/w/cpp/algorithm/sort
https://en.cppreference.com/w/cpp/named_req/Compare

EDIT: clearer reasoning for the bug.