### PR TITLE
ea_config: define ELPP_FEATURE_CRASH_LOG for freebsd

### DIFF
--- a/external/easylogging++/ea_config.h
+++ b/external/easylogging++/ea_config.h
@@ -11,7 +11,7 @@
 #define ELPP_UTC_DATETIME
 
 #ifdef EASYLOGGING_CC
-#if !(!defined __GLIBC__ || !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__ || defined __NetBSD__)
+#if !(!defined __GLIBC__ || !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__ || defined __NetBSD__) || (defined __FreeBSD__)
 #define ELPP_FEATURE_CRASH_LOG
 #endif
 #endif


### PR DESCRIPTION
Relates to [this comment](https://github.com/monero-project/monero-gui/issues/3034#issuecomment-1149216693) in monero-project/monero-gui#3034. This commit allows monero-gui to compile successfully on FreeBSD.

![image](https://github.com/monero-project/monero/assets/40285364/63d4ba1c-36e8-4810-8cff-ae8450023e95)

Note: I tried putting `!defined __FreeBSD__` within the existing parentheses in the if statement, but it would never work. The way I have done it at least preserves the existing part. If there's a better way, it would be nice to know!