### PR TITLE
wallet2: fix version check at hf version 1

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3299,7 +3299,7 @@ void check_block_hard_fork_version(cryptonote::network_type nettype, uint8_t hf_
     if (wallet_hard_forks[fork_index].version == hf_version)
       break;
   THROW_WALLET_EXCEPTION_IF(fork_index == wallet_num_hard_forks, error::wallet_internal_error, "Fork not found in table");
-  uint64_t start_height = wallet_hard_forks[fork_index].height;
+  uint64_t start_height = hf_version == 1 ? 0 : wallet_hard_forks[fork_index].height;
   uint64_t end_height = fork_index == wallet_num_hard_forks - 1
     ? std::numeric_limits<uint64_t>::max()
     : wallet_hard_forks[fork_index + 1].height;


### PR DESCRIPTION
Fixes:
- create a new wallet
- set restore height to 0
- wallet fails to sync with `Error: refresh failed: refresh error: Unexpected hard fork version v1 at height 0. Make sure the node you are connected to is running the latest version. Blocks received: 0`

Synced a wallet restored from 0 with this change.