### PR TITLE
unit_tests: set data dir relative to exe & add log-level arg

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -142,8 +142,6 @@ if (NOT MSVC)
       COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
 endif ()
 
-SET_PROPERTY(SOURCE main.cpp PROPERTY COMPILE_FLAGS -DDEFAULT_DATA_DIR="\\"${CMAKE_SOURCE_DIR}/tests/data\\"")
-
 SET_PROPERTY(SOURCE memwipe.cpp PROPERTY COMPILE_FLAGS -Ofast)
 
 add_test(

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -62,9 +62,14 @@ int main(int argc, char** argv)
 
   ::testing::InitGoogleTest(&argc, argv);
 
+  // the default test data directory is ../data (relative to the executable's directory)
+  const auto default_test_data_dir = boost::filesystem::path(argv[0]).parent_path().parent_path() / "data";
+
   po::options_description desc_options("Command line options");
-  const command_line::arg_descriptor<std::string> arg_data_dir = { "data-dir", "Data files directory", DEFAULT_DATA_DIR };
+  const command_line::arg_descriptor<std::string> arg_data_dir = { "data-dir", "Data files directory", default_test_data_dir.string() };
+  const command_line::arg_descriptor<std::string> arg_log_level = { "log-level",  "0-4 or categories", "" };
   command_line::add_arg(desc_options, arg_data_dir);
+  command_line::add_arg(desc_options, arg_log_level);
 
   po::variables_map vm;
   bool r = command_line::handle_error_helper(desc_options, [&]()
@@ -76,7 +81,12 @@ int main(int argc, char** argv)
   if (! r)
     return 1;
 
-  unit_test::data_dir = command_line::get_arg(vm, arg_data_dir);
+  // set the test data directory
+  unit_test::data_dir = command_line::get_arg(vm, arg_data_dir).c_str();
+
+  // set the log level
+  if (!command_line::is_arg_defaulted(vm, arg_log_level))
+    mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());
 
   CATCH_ENTRY_L0("main", 1);
 


### PR DESCRIPTION
Setting the data directory this way is nice when the unit tests write to files while running (see new `store_to()` PR). Otherwise, files in the data directory will show up on git and you won't be able to have copies for different branches when running tests from root source directory. I also have wanted `--log-level` in the unit tests for a while now.