### PR TITLE
[seraphis] cryptonote_base: add account generators

### DIFF
--- a/src/cryptonote_basic/account_generators.h
+++ b/src/cryptonote_basic/account_generators.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2021, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "crypto/crypto.h"
+#include "crypto/generators.h"
+
+
+namespace cryptonote
+{
+
+enum class account_generator_era : unsigned char
+{
+  unknown = 0,
+  cryptonote = 1  //and ringct
+};
+
+struct account_generators
+{
+  crypto::public_key m_primary;    //e.g. for spend key
+  crypto::public_key m_secondary;  //e.g. for view key
+};
+
+inline crypto::public_key get_primary_generator(const account_generator_era era)
+{
+  if (era == account_generator_era::cryptonote)
+    return crypto::get_G();
+  else
+    return crypto::null_pkey;  //error
+}
+
+inline crypto::public_key get_secondary_generator(const account_generator_era era)
+{
+  if (era == account_generator_era::cryptonote)
+    return crypto::get_G();
+  else
+    return crypto::null_pkey;  //error
+}
+
+inline account_generators get_account_generators(const account_generator_era era)
+{
+  return account_generators{get_primary_generator(era), get_secondary_generator(era)};
+}
+
+} //namespace cryptonote


### PR DESCRIPTION
## Summary

This is a PR in my 'upstreaming seraphis_lib project', it is not used anywhere yet.

- Adds `account_generators.h` to `cryptonote_basic`.

## Explanation

Multisig account generation is the same for ringct and seraphis, so it's best to reuse all that code if possible. The only difference is the base generators used. Refactoring multisig accounts to depend on `account_generator_era` will allow seraphis to be easily supported.

## Future PRs
- Refactor multisig accounts to use `account_generator_era`.
- Introduce seraphis generators.