### PR TITLE
wallet: store watch-only wallet correctly when `change_password()` is called [RELEASE]

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4460,7 +4460,7 @@ boost::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const epee:
   value2.SetInt(m_key_device_type);
   json.AddMember("key_on_device", value2, json.GetAllocator());
 
-  value2.SetInt(watch_only ? 1 :0); // WTF ? JSON has different true and false types, and not boolean ??
+  value2.SetInt((watch_only || m_watch_only) ? 1 :0); // WTF ? JSON has different true and false types, and not boolean ??
   json.AddMember("watch_only", value2, json.GetAllocator());
 
   value2.SetInt(m_multisig ? 1 :0);
@@ -6395,7 +6395,7 @@ void wallet2::store_to(const std::string &path, const epee::wipeable_string &pas
 
   if (!same_file || force_rewrite_keys)
   {
-    bool r = store_keys(m_keys_file, password, false);
+    bool r = store_keys(m_keys_file, password, m_watch_only);
     THROW_WALLET_EXCEPTION_IF(!r, error::file_save_error, m_keys_file);
   }
 


### PR DESCRIPTION
The Monero GUI code was calling `Monero::wallet::setPassword()` on every open/close for some reason, and the old `store_to()` code called `store_keys()` with `watch_only=false`, even for watch-only wallets. This caused a bug where the watch-only keys file got saved with with the JSON field `watch_only` set to 0, and after saving a watch-only wallet once, a user could never open it back up against because `load()` errored out. This never got brought up before this because you would have to change the file location of the watch-only wallet to see this bug, and I guess that didn't happen often, but calling the new `store_to()` function with the new `force_rewrite` parameter set to `true` triggers key restoring and the bug appeared.