### PR TITLE
depends: unwind: do not build for linux hosts

### DIFF
--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -25,10 +25,6 @@ ifeq ($(build_tests),ON)
 packages += gtest
 endif
 
-ifneq ($(host_arch),riscv64)
-linux_packages += unwind
-endif
-
 mingw32_packages = sodium $(hardware_packages)
 mingw32_native_packages = $(hardware_native_packages)
 


### PR DESCRIPTION
It is unused. easylogging++ [is used instead](https://github.com/monero-project/monero/blob/master/CMakeLists.txt#L537) when building with GCC, which is used for all Linux builds in depends.

We could use libunwind for FreeBSD, so I'm keeping the package definition in case someone wants to fix that build.