### PR TITLE
wallet2: fix `on_reorg` callback location

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4252,9 +4252,6 @@ wallet2::detached_blockchain_data wallet2::detach_blockchain(uint64_t height, st
       ++it;
   }
 
-  if (m_callback)
-    m_callback->on_reorg(height, blocks_detached, transfers_detached);
-
   LOG_PRINT_L0("Detached blockchain on height " << height << ", transfers detached " << transfers_detached << ", blocks detached " << blocks_detached);
   return dbd;
 }
@@ -4266,7 +4263,10 @@ void wallet2::handle_reorg(uint64_t height, std::map<std::pair<uint64_t, uint64_
   //               C
   THROW_WALLET_EXCEPTION_IF(height < m_blockchain.offset() && m_blockchain.size() > m_blockchain.offset(),
       error::wallet_internal_error, "Daemon claims reorg below last checkpoint");
-  detach_blockchain(height, output_tracker_cache);
+  detached_blockchain_data dbd = detach_blockchain(height, output_tracker_cache);
+
+  if (m_callback)
+    m_callback->on_reorg(height, dbd.detached_blockchain.size(), dbd.detached_tx_hashes.size());
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::deinit()


### PR DESCRIPTION
Calls the `on_reorg` callback inside `handle_reorg`, instead of inside `detach_blockchain`.

`detach_blockchain` can be called even where there isn't a reorg (see how `scan_tx` uses `detach_blockchain`). `handle_reorg` should be called every time there is a reorg.