### PR TITLE
cryptonote_config: include cstdint [RELEASE]

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <boost/uuid/uuid.hpp>


### PR DESCRIPTION
Header was using `uint64_t` without including `<cstdint>` which caused some issues downstream for windows builds