### PR TITLE
core_tests: fix gcc7 compilation

### DIFF
--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -4,7 +4,6 @@
 
 #include "wallet_tools.h"
 #include <random>
-#include <boost/assign.hpp>
 
 using namespace std;
 using namespace epee;
@@ -39,7 +38,8 @@ void wallet_accessor_test::process_parsed_blocks(tools::wallet2 * wallet, uint64
 
 void wallet_tools::process_transactions(tools::wallet2 * wallet, const std::vector<test_event_entry>& events, const cryptonote::block& blk_head, block_tracker &bt, const boost::optional<crypto::hash>& blk_tail)
 {
-  process_transactions(boost::assign::list_of(wallet), events, blk_head, bt, blk_tail);
+  std::vector<tools::wallet2*> wallet_vector = { wallet };
+  process_transactions(wallet_vector, events, blk_head, bt, blk_tail);
 }
 
 void wallet_tools::process_transactions(const std::vector<tools::wallet2*>& wallets, const std::vector<test_event_entry>& events, const cryptonote::block& blk_head, block_tracker &bt, const boost::optional<crypto::hash>& blk_tail)
@@ -56,7 +56,8 @@ void wallet_tools::process_transactions(const std::vector<tools::wallet2*>& wall
 }
 
 void wallet_tools::process_transactions(tools::wallet2 * wallet, const std::vector<const cryptonote::block*>& blockchain, const map_hash2tx_t & mtx, block_tracker &bt){
-  process_transactions(boost::assign::list_of(wallet), blockchain, mtx, bt);
+  std::vector<tools::wallet2*> wallet_vector = { wallet };
+  process_transactions(wallet_vector, blockchain, mtx, bt);
 }
 
 void wallet_tools::process_transactions(const std::vector<tools::wallet2*>& wallets, const std::vector<const cryptonote::block*>& blockchain, const map_hash2tx_t & mtx, block_tracker &bt)


### PR DESCRIPTION
Reported by @Gingeropolous

```
/home/user/monero/tests/core_tests/wallet_tools.cpp:42:86: error: call of overloaded ‘process_transactions(boost::assign_detail::generic_list<tools::wallet2*>, const std::vector<boost::variant<cryptonote::block, cryptonote::transaction, std::vector<cryptonote::transaction, std::allocator<cryptonote::transaction> >, cryptonote::account_base, callback_entry, serialized_object<cryptonote::block>, serialized_object<cryptonote::transaction>, event_visitor_settings, event_replay_settings> >&, const cryptonote::block&, block_tracker&, const boost::optional<crypto::hash>&)’ is ambiguous
   process_transactions(boost::assign::list_of(wallet), events, blk_head, bt, blk_tail);
                                                                                      ^
/home/user/monero/tests/core_tests/wallet_tools.cpp:40:6: note: candidate: static void wallet_tools::process_transactions(tools::wallet2*, const std::vector<boost::variant<cryptonote::block, cryptonote::transaction, std::vector<cryptonote::transaction, std::allocator<cryptonote::transaction> >, cryptonote::account_base, callback_entry, serialized_object<cryptonote::block>, serialized_object<cryptonote::transaction>, event_visitor_settings, event_replay_settings> >&, const cryptonote::block&, block_tracker&, const boost::optional<crypto::hash>&)
 void wallet_tools::process_transactions(tools::wallet2 * wallet, const std::vector<test_event_entry>& events, const cryptonote::block& blk_head, block_tracker &bt, const boost::optional<crypto::hash>& blk_tail)
      ^~~~~~~~~~~~
In file included from /home/user/monero/tests/core_tests/wallet_tools.cpp:5:0:
/home/user/monero/tests/core_tests/wallet_tools.h:75:15: note: candidate: static void wallet_tools::process_transactions(const std::vector<tools::wallet2*>&, const std::vector<boost::variant<cryptonote::block, cryptonote::transaction, std::vector<cryptonote::transaction, std::allocator<cryptonote::transaction> >, cryptonote::account_base, callback_entry, serialized_object<cryptonote::block>, serialized_object<cryptonote::transaction>, event_visitor_settings, event_replay_settings> >&, const cryptonote::block&, block_tracker&, const boost::optional<crypto::hash>&)
   static void process_transactions(const std::vector<tools::wallet2*>& wallets, const std::vector<test_event_entry>& events, const cryptonote::block& blk_head, block_tracker &bt, const boost::optional<crypto::hash>& blk_tail=boost::none);
               ^~~~~~~~~~~~~~~~~~~~
/home/user/monero/tests/core_tests/wallet_tools.cpp: In static member function ‘static void wallet_tools::process_transactions(tools::wallet2*, const std::vector<const cryptonote::block*>&, const map_hash2tx_t&, block_tracker&)’:
/home/user/monero/tests/core_tests/wallet_tools.cpp:59:75: error: call of overloaded ‘process_transactions(boost::assign_detail::generic_list<tools::wallet2*>, const std::vector<const cryptonote::block*>&, const map_hash2tx_t&, block_tracker&)’ is ambiguous
   process_transactions(boost::assign::list_of(wallet), blockchain, mtx, bt);
                                                                           ^
/home/user/monero/tests/core_tests/wallet_tools.cpp:58:6: note: candidate: static void wallet_tools::process_transactions(tools::wallet2*, const std::vector<const cryptonote::block*>&, const map_hash2tx_t&, block_tracker&)
 void wallet_tools::process_transactions(tools::wallet2 * wallet, const std::vector<const cryptonote::block*>& blockchain, const map_hash2tx_t & mtx, block_tracker &bt){
      ^~~~~~~~~~~~
In file included from /home/user/monero/tests/core_tests/wallet_tools.cpp:5:0:
/home/user/monero/tests/core_tests/wallet_tools.h:77:15: note: candidate: static void wallet_tools::process_transactions(const std::vector<tools::wallet2*>&, const std::vector<const cryptonote::block*>&, const map_hash2tx_t&, block_tracker&)
   static void process_transactions(const std::vector<tools::wallet2*>& wallets, const std::vector<const cryptonote::block*>& blockchain, const map_hash2tx_t & mtx, block_tracker &bt);
               ^~~~~~~~~~~~~~~~~~~~
```