### PR TITLE
unit tests: fix running from pwd and ctest selected location

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MONERO_WALLET_CRYPTO_BENCH "auto" CACHE STRING "Select wallet crypto librari
 
 # The docs say this only affects grouping in IDEs
 set(folder "tests")
-set(TEST_DATA_DIR "${CMAKE_CURRENT_LIST_DIR}/data")
+set(TEST_DATA_DIR "${CMAKE_CURRENT_BINARY_DIR}/data")
 
 if (WIN32 AND STATIC)
   add_definitions(-DSTATICLIB)

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
   ::testing::InitGoogleTest(&argc, argv);
 
   // the default test data directory is ../data (relative to the executable's directory)
-  const auto default_test_data_dir = boost::filesystem::path(argv[0]).parent_path().parent_path() / "data";
+  const auto default_test_data_dir = boost::filesystem::canonical(argv[0]).parent_path().parent_path() / "data";
 
   po::options_description desc_options("Command line options");
   const command_line::arg_descriptor<std::string> arg_data_dir = { "data-dir", "Data files directory", default_test_data_dir.string() };


### PR DESCRIPTION
Fixes #8987

Instead of using raw `argv[0]`, first we resolve `argv[0]` then get parent's parent for test root dir. Also, the ctest suite was using the wrong tests/data folder: the one at the source root, not inside the build dir. 