### PR TITLE
wallet: sign_tx: get tx pubkey from extra

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7287,9 +7287,7 @@ bool wallet2::sign_tx(unsigned_tx_set &exported_txs, std::vector<wallet2::pendin
     crypto::key_derivation derivation;
     std::vector<crypto::key_derivation> additional_derivations;
 
-    // compute public keys from out secret keys
-    crypto::public_key tx_pub_key;
-    crypto::secret_key_to_public_key(txs[n].tx_key, tx_pub_key);
+    crypto::public_key tx_pub_key = get_tx_pub_key_from_extra(tx);
     std::vector<crypto::public_key> additional_tx_pub_keys;
     for (const crypto::secret_key &skey: txs[n].additional_tx_keys)
     {


### PR DESCRIPTION
Fixes an issue where owned output key images are not always [included](https://github.com/monero-project/monero/blob/master/src/wallet/wallet2.cpp#L7324) in the signed transaction.

Tx pub keys for single destination transactions to a subaddress are calculated [differently](https://github.com/monero-project/monero/blob/master/src/cryptonote_core/cryptonote_tx_utils.cpp#L385).