### PR TITLE
MMS: Ignore 2 more API errors thrown by latest PyBitmessage

### DIFF
--- a/src/wallet/message_transporter.cpp
+++ b/src/wallet/message_transporter.cpp
@@ -273,15 +273,28 @@ bool message_transporter::post_request(const std::string &request, std::string &
   {
     if ((string_value.find("API Error 0021") == 0) && (request.find("joinChan") != std::string::npos))
     {
+      // "API Error 0021: Unexpected API Failure"
       // Error that occurs if one tries to join an already joined chan, which can happen
       // if several auto-config participants share one PyBitmessage instance: As a little
       // hack simply ignore the error. (A clean solution would be to check for the chan
       // with 'listAddresses2', but parsing the returned array is much more complicated.)
     }
+    else if ((string_value.find("API Error 0024") == 0) && (request.find("joinChan") != std::string::npos))
+    {
+      // "API Error 0024: Chan address is already present."
+      // Maybe a result of creating the chan in a slightly different way i.e. not with
+      // 'createChan'; everything works by just ignoring this error
+    }
     else if ((string_value.find("API Error 0013") == 0) && (request.find("leaveChan") != std::string::npos))
     {
+      // "API Error 0013: Could not find your fromAddress in the keys.dat file."
       // Error that occurs if one tries to leave an already left / deleted chan, which can happen
       // if several auto-config participants share one PyBitmessage instance: Also ignore.
+    }
+    else if ((string_value.find("API Error 0025") == 0) && (request.find("leaveChan") != std::string::npos))
+    {
+      // "API Error 0025: Specified address is not a chan address. Use deleteAddress API call instead."
+      // Error does not really make sense, but everything works by just ignoring
     }
     else
     {


### PR DESCRIPTION
The MMS had some problems with the latest version of PyBitmessage that you can download [here](https://appimage.bitmessage.org/releases/20230116/) as an appimage when doing auto-config. Simply ignoring 2 errors more does the trick, as can be seen in the simple changes of this PR.

-------

Note that the development of PyBitmessage currently goes forward only very slowly, if at all, and that is still runs on Python 2, which is a problem because that's "end of life" and does not receive security updates anymore. The appimage mitigates that a bit, because you don't have to add that unsafe Python 2 permanently to your system, but still.

The MMS encrypts all messages before it hands them over to PyBitmessage, so it should be hard to break into the MMS by using a PyBitmessage exploit.