### PR TITLE
Add compile-time check for input iterators in ::wire array writing

### DIFF
--- a/contrib/epee/include/serialization/wire/write.h
+++ b/contrib/epee/include/serialization/wire/write.h
@@ -30,6 +30,7 @@
 #include <boost/utility/string_ref.hpp>
 #include <boost/range/size.hpp>
 #include <cstdint>
+#include <iterator>
 #include <system_error>
 #include <type_traits>
 
@@ -188,7 +189,13 @@ namespace wire_write
 
   template<typename T>
   inline std::size_t array_size(std::true_type, const T& source)
-  { return boost::size(source); }
+  {
+    static_assert(
+      !std::is_same<typename std::iterator_traits<typename T::const_iterator>::iterator_category, std::input_iterator_tag>{},
+      "Input iterators must use json (or similar) derived classes directly"
+    );
+    return boost::size(source);
+  }
 
   template<typename T>
   inline constexpr std::size_t array_size(std::false_type, const T&) noexcept


### PR DESCRIPTION
I was going to "fix" this with C++17 `std::size`, but instead decided to continue using `boost::size` with a compile-time check.

Background:
Getting the size/count of a "range" of elements is tricky if the range iterator is _not_ random access. `std::size` fails on such ranges, and `boost::size` uses `std::distance` on such ranges. The problem with the boost approach is that input iterators are single-pass, and therefore the `std::distance` invalidates/exhausts the range before it is written!

This check simply verifies that the range is using `std::forward_iterator` tag or better when `boost::size` is called. Input iterators can still be used, but only with the `json_writer` class directly (i.e. not through base class, `epee_writer`, or `msgpack_writer`). Also (a theoretical) `cbor_writer` and `protobuf_writer` could also work with input iterators (since they have a streaming array type).