### PR TITLE
serialization: fix infinite loops and clean up dispatching

### DIFF
--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -52,7 +52,7 @@ namespace cryptonote
 
     // load
     template <template <bool> class Archive>
-    bool do_serialize(Archive<false>& ar)
+    bool member_do_serialize(Archive<false>& ar)
     {
       // size - 1 - because of variant tag
       for (size = 1; size <= TX_EXTRA_PADDING_MAX_COUNT; ++size)
@@ -73,7 +73,7 @@ namespace cryptonote
 
     // store
     template <template <bool> class Archive>
-    bool do_serialize(Archive<true>& ar)
+    bool member_do_serialize(Archive<true>& ar)
     {
       if(TX_EXTRA_PADDING_MAX_COUNT < size)
         return false;
@@ -129,7 +129,7 @@ namespace cryptonote
 
     // load
     template <template <bool> class Archive>
-    bool do_serialize(Archive<false>& ar)
+    bool member_do_serialize(Archive<false>& ar)
     {
       std::string field;
       if(!::do_serialize(ar, field))
@@ -142,7 +142,7 @@ namespace cryptonote
 
     // store
     template <template <bool> class Archive>
-    bool do_serialize(Archive<true>& ar)
+    bool member_do_serialize(Archive<true>& ar)
     {
       std::ostringstream oss;
       binary_archive<true> oar(oss);

--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -42,7 +42,7 @@ namespace serialization
     typename std::enable_if<!use_container_varint<T>(), bool>::type
     serialize_container_element(Archive& ar, T& e)
     {
-      return ::do_serialize(ar, e);
+      return do_serialize(ar, e);
     }
 
     template<typename Archive, typename T>
@@ -52,7 +52,7 @@ namespace serialization
       static constexpr const bool previously_varint = std::is_same<uint64_t, T>() || std::is_same<uint32_t, T>();
 
       if (!previously_varint && ar.varint_bug_backward_compatibility_enabled() && !typename Archive::is_saving())
-        return ::do_serialize(ar, e);
+        return do_serialize(ar, e);
       ar.serialize_varint(e);
       return true;
     }

--- a/src/serialization/debug_archive.h
+++ b/src/serialization/debug_archive.h
@@ -42,14 +42,12 @@ struct debug_archive : public json_archive<W> {
 };
 
 template <class T>
-struct serializer<debug_archive<true>, T>
+static inline bool do_serialize(debug_archive<true> &ar, T &v)
 {
-  static void serialize(debug_archive<true> &ar, T &v)
-  {
     ar.begin_object();
     ar.tag(variant_serialization_traits<debug_archive<true>, T>::get_tag());
-    serializer<json_archive<true>, T>::serialize(ar, v);
+    do_serialize(static_cast<json_archive<true>&>(ar), v);
     ar.end_object();
     ar.stream() << std::endl;
-  }
-};
+    return true;
+}

--- a/src/serialization/difficulty_type.h
+++ b/src/serialization/difficulty_type.h
@@ -31,8 +31,6 @@
 #include "cryptonote_basic/difficulty.h"
 #include "serialization.h"
 
-template<> struct is_basic_type<cryptonote::difficulty_type> { typedef boost::true_type type; };
-
 template <template <bool> class Archive>
 inline bool do_serialize(Archive<false>& ar, cryptonote::difficulty_type &diff)
 {

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -47,7 +47,7 @@ namespace serialization
     typename std::enable_if<!use_pair_varint<T>(), bool>::type
     serialize_pair_element(Archive& ar, T& e)
     {
-      return ::do_serialize(ar, e);
+      return do_serialize(ar, e);
     }
 
     template<typename Archive, typename T>
@@ -57,7 +57,7 @@ namespace serialization
       static constexpr const bool previously_varint = std::is_same<uint64_t, T>();
 
       if (!previously_varint && ar.varint_bug_backward_compatibility_enabled() && !typename Archive::is_saving())
-        return ::do_serialize(ar, e);
+        return do_serialize(ar, e);
       ar.serialize_varint(e);
       return true;
     }

--- a/src/serialization/tuple.h
+++ b/src/serialization/tuple.h
@@ -39,7 +39,7 @@ namespace serialization
     template <typename Archive, class T>
     bool serialize_tuple_element(Archive& ar, T& e)
     {
-      return ::do_serialize(ar, e);
+      return do_serialize(ar, e);
     }
 
     template <typename Archive>


### PR DESCRIPTION
Resolves #8687

Before, when you tried to serialize a type which 1) was missing its `do_serialize` free function  and 2) was marked with `is_basic_type<T>`, we would end up calling `do_serialize<Archive, T>(Archive&,T&)`, which called `serializer<Archive, T>::serialize(Archive&, T&)`, which called `serializer<Archive, T>::serialize(Archive&, T&, boost::false_type, boost::false_type, boost::true_type)`, which called `do_serialize<Archive, T>(Archive&,T&)`, so on and so forth.

Now, instead of complicating dispatch by inserting a struct to make function expression calls name-dependent, we just use ADL and function overloading. 