### PR TITLE
cmake: silence FindPythonInterp warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@
 #
 # Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+cmake_minimum_required(VERSION 3.5)
+message(STATUS "CMake version ${CMAKE_VERSION}")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(INSERT CMAKE_MODULE_PATH 0
@@ -37,14 +40,13 @@ include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 include(CheckLibraryExists)
 include(CheckFunctionExists)
+
+cmake_policy(SET CMP0148 OLD)
 include(FindPythonInterp)
 
 if (IOS)
     INCLUDE(CmakeLists_IOS.txt)
 endif()
-
-cmake_minimum_required(VERSION 3.5)
-message(STATUS "CMake version ${CMAKE_VERSION}")
 
 project(monero)
 
@@ -219,7 +221,7 @@ function(forbid_undefined_symbols)
     file(MAKE_DIRECTORY "${TEST_PROJECT}")
     file(WRITE "${TEST_PROJECT}/CMakeLists.txt"
       [=[
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(test)
 option(EXPECT_SUCCESS "" ON)
 file(WRITE "${CMAKE_SOURCE_DIR}/incorrect_source.cpp" "void undefined_symbol(); void symbol() { undefined_symbol(); }")


### PR DESCRIPTION
`FindPythonInterp` no longer works by default with CMake 3.27 and produces the following warning:

> CMake Warning (dev) at CMakeLists.txt:40 (include):
>   Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
>   are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
>   the cmake_policy command to set the policy and suppress this warning.

https://cmake.org/cmake/help/latest/module/FindPythonInterp.html

`cmake_minimum_required` [resets](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings) policy settings, so we need to move it to the top. `FindPythonInterp` is used elsewhere.

Alternatively, we could change it to `FindPython3`, but this would [require](https://cmake.org/cmake/help/latest/module/FindPython3.html) setting the minimum CMake to 3.12.