### PR TITLE
OpenBSD: node server fix IP localhost by aliasing

### DIFF
--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -306,8 +306,8 @@ TEST(node_server, bind_same_p2p_port)
     Relevant part about REUSEADDR from man:
     https://www.man7.org/linux/man-pages/man7/ip.7.html
 
-    For Mac OSX, set the following alias, before running the test, or else it will fail:
-    sudo ifconfig lo0 alias 127.0.0.2
+    For Mac OSX and OpenBSD, set the following alias (by running the command as root), before running the test, or else it will fail:
+    ifconfig lo0 alias 127.0.0.2
     */
     vm.find(nodetool::arg_p2p_bind_ip.name)->second   = boost::program_options::variable_value(std::string("127.0.0.2"), false);
     vm.find(nodetool::arg_p2p_bind_port.name)->second = boost::program_options::variable_value(std::string(port), false);


### PR DESCRIPTION
The test node_server.bind_same_p2p_port fails by default on OpenBSD for at least the debug build. Using the same ifconfig command as described for MacOS results in the test passing.

Submitted on IRC