### PR TITLE
storages: add missing return

### DIFF
--- a/contrib/epee/include/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/storages/portable_storage_from_bin.h
@@ -231,6 +231,7 @@ namespace epee
       default: 
         CHECK_AND_ASSERT_THROW_MES(false, "unknown entry_type code = " << type);
       }
+      return read_ae<int8_t>(); // unreachable, dummy return to avoid compiler warning
     }
 
     inline 
@@ -322,6 +323,7 @@ namespace epee
       default: 
         CHECK_AND_ASSERT_THROW_MES(false, "unknown entry_type code = " << ent_type);
       }
+      return read_se<int8_t>(); // unreachable, dummy return to avoid compiler warning
     }
     inline 
     void throwable_buffer_reader::read(section& sec)


### PR DESCRIPTION
Fixes compilation as we treat some warnings as errors as of https://github.com/monero-project/monero/pull/7481.

Closes #8622