### PR TITLE
CMake: only set policy CMP0148 to OLD if version >= 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,9 @@ include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 include(CheckLibraryExists)
 include(CheckFunctionExists)
-
-cmake_policy(SET CMP0148 OLD)
+if (POLICY CMP0148)
+    cmake_policy(SET CMP0148 OLD) # https://cmake.org/cmake/help/latest/policy/CMP0148.html
+endif()
 include(FindPythonInterp)
 
 if (IOS)


### PR DESCRIPTION
Allows people to compile if their CMake is older than 3.27

@tobtoht 