### PR TITLE
Cleanup extra memory allocation, and port boost to std shared_ptr

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -74,10 +74,10 @@ namespace misc_utils
 
   struct call_befor_die_base
   {
-    virtual ~call_befor_die_base(){}
+    virtual ~call_befor_die_base() = default;
   };
 
-  typedef boost::shared_ptr<call_befor_die_base> auto_scope_leave_caller;
+  typedef std::shared_ptr<call_befor_die_base> auto_scope_leave_caller;
 
 
   template<class t_scope_leave_handler>
@@ -96,7 +96,7 @@ namespace misc_utils
   template<class t_scope_leave_handler>
   auto_scope_leave_caller create_scope_leave_handler(t_scope_leave_handler f)
   {
-    auto_scope_leave_caller slc(new call_befor_die<t_scope_leave_handler>(f));
+    auto_scope_leave_caller slc = std::make_shared<call_befor_die<t_scope_leave_handler>>(f);
     return slc;
   }
 


### PR DESCRIPTION
a) Use `make_shared` which removes one extra allocation [1]. 
b) Port from `boost::shared_ptr` to `std::shared_ptr`.
c) use `= default` syntax instead of ` {} `. Which is cleaner.

1. https://stackoverflow.com/a/20895705