### PR TITLE
Add <cstdint> to aligned test

### DIFF
--- a/tests/unit_tests/aligned.cpp
+++ b/tests/unit_tests/aligned.cpp
@@ -29,6 +29,7 @@
 
 #include "gtest/gtest.h"
 
+#include <cstdint>
 #include "common/aligned.h"
 
 TEST(aligned, large_null) { ASSERT_TRUE(aligned_malloc((size_t)-1, 1) == NULL); }


### PR DESCRIPTION
Compilation with gcc 13 failed on my Gentoo test box.