### PR TITLE
[DRAFT] 10x improvement to `pop_blocks` operation with flag denoting txis are already verified

### DIFF
--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -31,6 +31,7 @@
 #pragma once
 #include <boost/asio/io_service.hpp>
 #include <boost/function/function_fwd.hpp>
+#include <cstdint>
 #if BOOST_VERSION >= 107400
 #include <boost/serialization/library_version_type.hpp>
 #endif
@@ -205,6 +206,16 @@ namespace cryptonote
      */
     size_t get_alternative_blocks_count() const;
 
+    /**
+     * @brief get maximum used block height and id of transaction 
+     *  
+     *  @param tx the transaction to get maximum input height
+     *  @param version version of the hardfork
+     *  @max_used_block_id return-by-reference block hash of most recent input
+     *  @max_used_block_height return-by-reference return-by-reference block hash of most recent input
+     */
+    bool get_maximum_block_id_height(transaction& tx, uint8_t version, uint64_t* pmax_used_block_height, crypto::hash* pmax_used_block_id); 
+    
     /**
      * @brief gets a block's hash given a height
      *
@@ -617,6 +628,7 @@ namespace cryptonote
      */
     bool check_tx_inputs(transaction& tx, uint64_t& pmax_used_block_height, crypto::hash& max_used_block_id, tx_verification_context &tvc, bool kept_by_block = false) const;
 
+   
     /**
      * @brief get fee quantization mask
      *

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -104,7 +104,7 @@ namespace cryptonote
      * @tx_relay how the transaction was received
      * @param tx_weight the transaction's weight
      */
-    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed, uint8_t version);
+    bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed, uint8_t version, bool already_verified = false);
 
     /**
      * @brief add a transaction to the transaction pool
@@ -122,7 +122,7 @@ namespace cryptonote
      *
      * @return true if the transaction passes validations, otherwise false
      */
-    bool add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed, uint8_t version);
+    bool add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed, uint8_t version, bool already_verified = false);
 
     /**
      * @brief takes a transaction with the given hash from the pool


### PR DESCRIPTION
Add `already_verified` flag to add transaction operation of the `txpool`. This is very useful when we are popping block, and `txis` are already verified in that situation, which prevents verifying transactions again.

Numbers on my machine:

popping 500 blocks: `master` branch ~50 seconds, with this PR ~6 seconds.
popping 2000 blocks: `master` branch ~210 seconds, with this PR ~29 seconds.

Profiling information of `monerod` on `master` branch. As you can see, 80-90% of computation is happening in `check_tx_inputs` function. The profiling output is attached to this message. 

[monerod-master-branch-pop_blocks-profile.pdf](https://github.com/monero-project/monero/files/14127104/monerod-master-branch-pop_blocks-profile.pdf)
