### PR TITLE
[DRAFT] Caching layer to difficulty calculation of each block.

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -63,6 +63,8 @@
 #define CRYPTONOTE_SHORT_TERM_BLOCK_WEIGHT_SURGE_FACTOR 50
 #define CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE          600
 #define CRYPTONOTE_DISPLAY_DECIMAL_POINT                12
+#define CRYPTONOTE_BLOCKCHAIN_TIMESTAMPS_CACHE_SIZE     200000
+#define CRYPTONOTE_BLOCKCHAIN_DIFFICULTY_CACHE_SIZE     200000
 // COIN - number of smallest units in one coin
 #define COIN                                            ((uint64_t)1000000000000) // pow(10, 12)
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -41,6 +41,7 @@
 #include <boost/multi_index/global_fun.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/compute/detail/lru_cache.hpp>
 #include <atomic>
 #include <functional>
 #include <unordered_map>
@@ -1134,6 +1135,8 @@ namespace cryptonote
 
     typedef std::unordered_map<crypto::hash, block_extended_info> blocks_ext_by_hash;
 
+    boost::compute::detail::lru_cache<uint64_t, uint64_t> timestamps_cache;
+    boost::compute::detail::lru_cache<uint64_t, cryptonote::difficulty_type> difficulties_cache;
 
     BlockchainDB* m_db;
 


### PR DESCRIPTION
The default cache capacity is set by a constant in the cryptonote config file.

In certain cases, it is `20%` improvements. 