### PR TITLE
depends: unbound: update to 1.19.1

### DIFF
--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -145,7 +145,7 @@ $(1)_build_env+=PATH="$(build_prefix)/bin:$(PATH)"
 $(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"
 $(1)_autoconf=./configure --host=$($($(1)_type)_host) --prefix=$($($(1)_type)_prefix) $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
 
-ifneq ($(1),libusb)
+ifeq ($(filter $(1),libusb unbound),)
 $(1)_autoconf += --disable-dependency-tracking
 endif
 ifneq ($($(1)_nm),)

--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -1,18 +1,21 @@
 package=unbound
-$(package)_version=1.15.0
+$(package)_version=1.19.1
 $(package)_download_path=https://www.nlnetlabs.nl/downloads/$(package)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
+$(package)_sha256_hash=bc1d576f3dd846a0739adc41ffaa702404c6767d2b6082deb9f2f97cbb24a3a9
 $(package)_dependencies=openssl expat
 $(package)_patches=disable-glibc-reallocarray.patch
 
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --enable-static --without-pyunbound --prefix=$(host_prefix) --with-libexpat=$(host_prefix) --with-ssl=$(host_prefix) --with-libevent=no --without-pythonmodule --disable-flto --with-pthreads --with-libunbound-only
+  $(package)_config_opts=--disable-shared --enable-static --without-pyunbound --prefix=$(host_prefix)
+  $(package)_config_opts+=--with-libexpat=$(host_prefix) --with-ssl=$(host_prefix) --with-libevent=no
+  $(package)_config_opts+=--without-pythonmodule --disable-flto --with-pthreads --with-libunbound-only
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_w64=--enable-static-exe --sysconfdir=/etc --prefix=$(host_prefix) --target=$(host_prefix)
   $(package)_config_opts_x86_64_darwin=ac_cv_func_SHA384_Init=yes
   $(package)_build_opts_mingw32=LDFLAGS="$($(package)_ldflags) -lpthread"
+  $(package)_cflags_mingw32+="-D_WIN32_WINNT=0x600"
 endef
 
 define $(package)_preprocess_cmds
@@ -30,7 +33,4 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
-endef
-
-define $(package)_postprocess_cmds
 endef


### PR DESCRIPTION
Security release: https://github.com/NLnetLabs/unbound/releases/tag/release-1.19.1

- Unbound 1.19.1 uses WSAPoll, which is only defined in winsock2.h if `_WIN32_WINNT >= 0x600` (Windows Vista).
- mingw in the gitian build environment defaults to `0x502` (Windows Server 2003, see: `/usr/share/mingw-w64/include/_mingw.h`), so set it explicitely