### PR TITLE
depends: eudev: update to 3.2.14

### DIFF
--- a/contrib/depends/packages/eudev.mk
+++ b/contrib/depends/packages/eudev.mk
@@ -1,9 +1,8 @@
 package=eudev
-$(package)_version=v3.2.6
-$(package)_download_path=https://github.com/gentoo/eudev/archive/
-$(package)_download_file=$($(package)_version).tar.gz
+$(package)_version=3.2.14
+$(package)_download_path=https://github.com/eudev-project/eudev/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=a96ecb8637667897b8bd4dee4c22c7c5f08b327be45186e912ce6bc768385852
+$(package)_sha256_hash=8da4319102f24abbf7fff5ce9c416af848df163b29590e666d334cc1927f006f
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-gudev --disable-introspection --disable-hwdb --disable-manpages --disable-shared


### PR DESCRIPTION
- Repo was moved to https://github.com/eudev-project/eudev (old repo redirects)
- Changelog: https://github.com/eudev-project/eudev/releases