### PR TITLE
depends: android_ndk: update to 18b

### DIFF
--- a/contrib/depends/packages/android_ndk.mk
+++ b/contrib/depends/packages/android_ndk.mk
@@ -1,8 +1,9 @@
 package=android_ndk
-$(package)_version=17b
+$(package)_version=18b
 $(package)_download_path=https://dl.google.com/android/repository/
 $(package)_file_name=android-ndk-r$($(package)_version)-linux-x86_64.zip
-$(package)_sha256_hash=5dfbbdc2d3ba859fed90d0e978af87c71a91a5be1f6e1c40ba697503d48ccecd
+$(package)_sha256_hash=4f61cbe4bbf6406aa5ef2ae871def78010eed6271af72de83f8bd0b07a9fd3fd
+$(package)_patches=api_definition.patch
 
 define $(package)_set_vars
 $(package)_config_opts_arm=--arch arm
@@ -12,6 +13,11 @@ endef
 define $(package)_extract_cmds
   echo $($(package)_sha256_hash) $($(1)_source_dir)/$($(package)_file_name) | sha256sum -c &&\
   unzip -q $($(1)_source_dir)/$($(package)_file_name)
+endef
+
+define $(package)_preprocess_cmds
+  cd android-ndk-r$($(package)_version) && \
+  patch -p1 < $($(package)_patch_dir)/api_definition.patch
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/patches/android_ndk/api_definition.patch
+++ b/contrib/depends/patches/android_ndk/api_definition.patch
@@ -1,0 +1,15 @@
+CMake 3.10.2 compatibility, see:
+https://github.com/Kitware/CMake/blob/c1e087a9d3af74299d7681c9f9de59e5977a1539/Modules/Platform/Android-Determine.cmake#L105
+
+diff --git a/build/tools/make_standalone_toolchain.py b/build/tools/make_standalone_toolchain.py
+index b8172b2..1984595 100755
+--- a/build/tools/make_standalone_toolchain.py
++++ b/build/tools/make_standalone_toolchain.py
+@@ -208,6 +208,7 @@ def make_clang_scripts(install_dir, triple, api, windows):
+ 
+     target = '-'.join([arch, 'none', os_name, env])
+     common_flags = '-target {}{}'.format(target, api)
++    common_flags += ' -D__ANDROID_API__={}'.format(api)
+ 
+     # We only need mstackrealign to fix issues on 32-bit x86 pre-24. After 24,
+     # this consumes an extra register unnecessarily, which can cause issues for


### PR DESCRIPTION
Splitting this out of #9162, since it also resolves an Android depends build issue here: https://github.com/seraphis-migration/monero/pull/16.

See related CI run: https://github.com/tobtoht/monero/commits/pr-16/