### PR TITLE
Remove instructions for Void Linux, add NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,10 +626,10 @@ More info and versions in the [Debian package tracker](https://tracker.debian.or
     sudo pacman -S monero
     ```
 
-* Void Linux:
+* NixOS:
 
     ```bash
-    xbps-install -S monero
+    nix-shell -p monero-cli
     ```
 
 * GuixSD


### PR DESCRIPTION
Void Linux decided to remove all cryptocurrency related packages including Monero from their official repositories. See https://github.com/void-linux/void-packages/pull/44422

Added instructions for NixOS: https://search.nixos.org/packages?channel=23.11&show=monero-cli&type=packages&query=monero