### PR TITLE
depends: {native_,}protobuf: speedup build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: release-all
 
 depends:
 	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
-	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
+	cd build/$(target)/release && USE_DEVICE_TREZOR_MANDATORY=1 cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
 
 cmake-debug:
 	mkdir -p $(builddir)/debug

--- a/contrib/depends/packages/native_protobuf.mk
+++ b/contrib/depends/packages/native_protobuf.mk
@@ -1,4 +1,4 @@
-package=protobuf3
+package=native_protobuf
 $(package)_version=21.12
 $(package)_version_protobuf_cpp=3.21.12
 $(package)_download_path=https://github.com/protocolbuffers/protobuf/releases/download/v$($(package)_version)/
@@ -16,13 +16,13 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) -C src
+  $(MAKE) -C src protoc
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) -C src install
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -C src install-binPROGRAMS install-nobase_dist_protoDATA
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/libprotoc.a
+  rm -rf lib/
 endef

--- a/contrib/depends/packages/protobuf.mk
+++ b/contrib/depends/packages/protobuf.mk
@@ -21,12 +21,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) -C src install-libLTLIBRARIES install-nobase_includeHEADERS &&\
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install-pkgconfigDATA
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -C src install-nobase_includeHEADERS &&\
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install-pkgconfigDATA &&\
+  cp src/.libs/libprotobuf.a $($(package)_staging_prefix_dir)/lib/
 endef
-
-define $(package)_postprocess_cmds
-  rm lib/libprotoc.a &&\
-  rm lib/*.la
-endef
-


### PR DESCRIPTION
- `install-libLTLIBRARIES` triggers builds for `libprotoc.a` and `libprotobuf-lite.a`, which we don't need.
- The make jobserver isn't available in `stage_cmds`, making this slower than necessary.
- This PR reduces build time to ~39s (for `native_protobuf` + `protobuf`) down from 1:50 on my machine.
- Forces Trezor support for depends builds to prevent a silent regression.