### PR TITLE
depends: native_cctools: don't embed build date

### DIFF
--- a/contrib/depends/packages/native_cctools.mk
+++ b/contrib/depends/packages/native_cctools.mk
@@ -6,12 +6,17 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=70a7189418c2086d20c299c5d59250cf5940782c778892ccc899c66516ed240e
 $(package)_build_subdir=cctools
 $(package)_dependencies=native_clang native_libtapi
+$(package)_patches=no-build-date.patch
 
 define $(package)_set_vars
 $(package)_config_opts=--target=$(host) --disable-lto-support --with-libtapi=$(host_prefix)
 $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
 $(package)_cc=$(host_prefix)/native/bin/clang
 $(package)_cxx=$(host_prefix)/native/bin/clang++
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/no-build-date.patch
 endef
 
 define $(package)_config_cmds

--- a/contrib/depends/patches/native_cctools/no-build-date.patch
+++ b/contrib/depends/patches/native_cctools/no-build-date.patch
@@ -1,0 +1,12 @@
+diff --git a/cctools/ld64/src/ld/Options.cpp b/cctools/ld64/src/ld/Options.cpp
+index 3bb8324..033760d 100644
+--- a/cctools/ld64/src/ld/Options.cpp
++++ b/cctools/ld64/src/ld/Options.cpp
+@@ -4279,7 +4279,6 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+ 			fVerbose = true;
+ 			extern const char ldVersionString[];
+ 			fprintf(stderr, "%s", ldVersionString);
+-			fprintf(stderr, "BUILD "  __TIME__ " "  __DATE__"\n");
+ 			fprintf(stderr, "configured to support archs: %s\n", ALL_SUPPORTED_ARCHS);
+ 			 // if only -v specified, exit cleanly
+ 			 if ( argc == 2 ) {


### PR DESCRIPTION
The `native_cctools` depends package is not reproducible because it embeds the build date. This does not make its way into release binaries, but hinders automated reproducibility scanning.