### PR TITLE
depends: add command to print variables

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -1,5 +1,9 @@
 .NOTPARALLEL :
 
+# Pattern rule to print variables, e.g. make print-all_packages
+print-%: FORCE
+	@echo '$($*)'
+
 SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 FALLBACK_DOWNLOAD_PATH ?= https://downloads.getmonero.org/depends-sources
@@ -184,3 +188,4 @@ download: download-osx download-linux download-win download-freebsd download-and
  $(foreach package,$(all_packages),$(eval $(call ext_add_stages,$(package))))
 
 .PHONY: install cached download-one download-osx download-linux download-win download-freebsd download-android download check-packages check-sources
+.PHONY: FORCE


### PR DESCRIPTION
```
$ make -C contrib/depends --no-print-directory HOST="i686-w64-mingw32" print-all_packages
boost openssl zeromq expat unbound  sodium hidapi protobuf libusb  native_protobuf
```

A part of #8929.