### PR TITLE
depends: native_libtapi: don't embed git hash

### DIFF
--- a/contrib/depends/packages/native_libtapi.mk
+++ b/contrib/depends/packages/native_libtapi.mk
@@ -6,6 +6,11 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=62e419c12d1c9fad67cc1cd523132bc00db050998337c734c15bc8d73cc02b61
 $(package)_build_subdir=build
 $(package)_dependencies=native_clang
+$(package)_patches=no_embed_git_rev.patch
+
+define $(package)_preprocess_cmds
+  patch -p1 -i $($(package)_patch_dir)/no_embed_git_rev.patch
+endef
 
 define $(package)_config_cmds
   echo -n $(build_prefix) > INSTALLPREFIX; \

--- a/contrib/depends/patches/native_libtapi/no_embed_git_rev.patch
+++ b/contrib/depends/patches/native_libtapi/no_embed_git_rev.patch
@@ -1,0 +1,31 @@
+diff --git a/src/llvm/CMakeLists.txt b/src/llvm/CMakeLists.txt
+index ab92717c8..4ad621ea3 100644
+--- a/src/llvm/CMakeLists.txt
++++ b/src/llvm/CMakeLists.txt
+@@ -752,9 +752,10 @@ set(LLVM_SRPM_USER_BINARY_SPECFILE ${CMAKE_CURRENT_SOURCE_DIR}/llvm.spec.in
+ set(LLVM_SRPM_BINARY_SPECFILE ${CMAKE_CURRENT_BINARY_DIR}/llvm.spec)
+ set(LLVM_SRPM_DIR "${CMAKE_CURRENT_BINARY_DIR}/srpm")
+ 
+-# SVN_REVISION and GIT_COMMIT get set by the call to add_version_info_from_vcs.
+-# DUMMY_VAR contains a version string which we don't care about.
+-add_version_info_from_vcs(DUMMY_VAR)
++# A call to add_version_info_from_vcs() was removed, leaving SVN_REVISION
++# and GIT_COMMIT unset. Accordingly, LLVM_RPM_SPEC_REVISION is left empty.
++# This variable appears to be unused. Since it may be used in a future
++# update of native_libtapi this change serves as a precautionairy measure.
+ if ( SVN_REVISION )
+   set(LLVM_RPM_SPEC_REVISION "r${SVN_REVISION}")
+ elseif ( GIT_COMMIT )
+diff --git a/src/llvm/cmake/modules/GenerateVersionFromCVS.cmake b/src/llvm/cmake/modules/GenerateVersionFromCVS.cmake
+index 6b1c71983..e16326ed6 100644
+--- a/src/llvm/cmake/modules/GenerateVersionFromCVS.cmake
++++ b/src/llvm/cmake/modules/GenerateVersionFromCVS.cmake
+@@ -24,7 +24,7 @@ include(VersionFromVCS)
+ set(ENV{TERM} "dumb")
+ 
+ function(append_info name path)
+-  add_version_info_from_vcs(REVISION ${path})
++  set(REVISION "git-0000000")
+   string(STRIP "${REVISION}" REVISION)
+   file(APPEND "${HEADER_FILE}.txt"
+     "#define ${name} \"${REVISION}\"\n")


### PR DESCRIPTION
The `native_libtapi` depends package is not reproducible because it embeds the checked out git hash of whatever git repository it happens to have been extracted to, which is that of the monero repo in our case. If the `native_libtapi` package is cached, runs for different monero commits that otherwise do not invalidate the cache will use a `native_libtapi` package with a hash that does not match the hash of a clean build.

This does not make its way into release binaries, but hinders automated reproducibility scanning.