### PR TITLE
depends: fix ar zero timestamp for openssl & unbound on android targets

### DIFF
--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -4,9 +4,12 @@ $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
 
+# The bundled ranlib in Android NDK 18b inserts timestamps by default.
+# To prevent reproducibility issues, we must enable [D]eterministic mode.
+
 define $(package)_set_vars
-$(package)_config_env=AR="$($(package)_ar)" ARFLAGS=$($(package)_arflags) RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
-$(package)_config_env_android=ANDROID_NDK_ROOT="$(host_prefix)/native" PATH="$(host_prefix)/native/bin" CC=clang AR=ar RANLIB=ranlib
+$(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
+$(package)_config_env_android=ANDROID_NDK_ROOT="$(host_prefix)/native" PATH="$(host_prefix)/native/bin" CC=clang AR=ar RANLIB="ranlib -D"
 $(package)_build_env_android=ANDROID_NDK_ROOT="$(host_prefix)/native"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl --libdir=$(host_prefix)/lib
 $(package)_config_opts+=no-capieng
@@ -52,7 +55,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./Configure $($(package)_config_opts)
+  ./Configure $($(package)_config_opts) ARFLAGS=$($(package)_arflags)
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -24,7 +24,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) ac_cv_func_getentropy=no
+  $($(package)_autoconf) ac_cv_func_getentropy=no AR_FLAGS=$($(package)_arflags)
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
The Unbound and OpenSSL depends packags are not reproducible when building android targets because the Android NDK's bundled archiver includes timestamps by default. The default options are not overridden properly for these packages.

The archiver lies about zeroing timestamps by default.

>  [D]          - use zero for timestamps and uids/gids (default)

This PR sets the `ARFLAGS` for these packages to the flags defined in the hosts file, [which includes `D` for android](https://github.com/monero-project/monero/blob/master/contrib/depends/hosts/android.mk#L13).

Note for OpenSSL: it only reads `ARFLAGS` (not `AR_FLAGS`) when passed as an argument.