### PR TITLE
monero-wallet-rpc - Changed default cryptonote port

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <string>
 #include <tuple>
 #include <queue>
 #include <boost/format.hpp>
@@ -1359,6 +1360,10 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options, const std::string& proxy)
 {
   boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
+
+  if(daemon_address.empty()) {
+    daemon_address.append("http://localhost:" + std::to_string(get_config(m_nettype).RPC_DEFAULT_PORT));
+  }
 
   if(m_http_client->is_connected())
     m_http_client->disconnect();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -991,13 +991,13 @@ private:
     uint64_t max_reorg_depth() const {return m_max_reorg_depth;}
 
     bool deinit();
-    bool init(std::string daemon_address = "http://localhost:8080",
+    bool init(std::string daemon_address,
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none,
       const std::string &proxy = "",
       uint64_t upper_transaction_weight_limit = 0,
       bool trusted_daemon = true,
       epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
-    bool set_daemon(std::string daemon_address = "http://localhost:8080",
+    bool set_daemon(std::string daemon_address,
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none, bool trusted_daemon = true,
       epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
       const std::string &proxy = "");


### PR DESCRIPTION
- Removed `localhost:8080` default value to address string in wallet rpc
- If `set_daemon` rpc address string is empty, mwr will return an error and explicit message