### PR TITLE
unit_tests: fix strtoul unit test

### DIFF
--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -1899,7 +1899,6 @@ TEST(parsing, strtoul)
   p = "q";
   endp = nullptr;
   ul = std::strtoul(p, const_cast<char**>(&endp), 10);
-  EXPECT_EQ(0, errno);
   EXPECT_EQ(0, ul);
   EXPECT_EQ(p, endp);
 


### PR DESCRIPTION
`errno` not guaranteed to be anything according to C standard, except on range error