### PR TITLE
tx_memory_pool: make double spends a no-drop offense

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -246,6 +246,7 @@ namespace cryptonote
         LOG_PRINT_L1("Transaction with id= "<< id << " used already spent key images");
         tvc.m_verifivation_failed = true;
         tvc.m_double_spend = true;
+        tvc.m_no_drop_offense = true;
         return false;
       }
     }


### PR DESCRIPTION
Nodes who see different txs in a double spend attack will drop each other, splitting the network. Issue found by @boog900.