### PR TITLE
wallet2: adjust fee during backlog, fix set priority

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6313,7 +6313,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     local_args.erase(local_args.begin());
   }
 
-  uint32_t priority = 0;
+  uint32_t priority = m_wallet->get_default_priority();
   if (local_args.size() > 0 && parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8118,7 +8118,7 @@ uint32_t wallet2::adjust_priority(uint32_t priority)
       else if (blocks[0].first > 0)
       {
         MINFO("We don't use the low priority because there's a backlog in the tx pool.");
-        return priority;
+        return 2;
       }
 
       // get the current full reward zone
@@ -8163,7 +8163,7 @@ uint32_t wallet2::adjust_priority(uint32_t priority)
       if (P > 80)
       {
         MINFO("We don't use the low priority because recent blocks are quite full.");
-        return priority;
+        return 2;
       }
       MINFO("We'll use the low priority because probably it's safe to do so.");
       return 1;


### PR DESCRIPTION
Resolves #9221

The automatic fee level should switch between slow and normal depending on the current backlog.

https://monero.stackexchange.com/questions/11657/what-are-the-standard-fee-multiplier-levels#comment10765_11658

This behaviour broke at some point, likely during the 2021 fee code changes. This PR restores the previous behaviour.