### PR TITLE
get_block_template_backlog: better sorting logic

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1073,7 +1073,7 @@ namespace cryptonote
 
     // If the total weight is too high, choose the best paying transactions
     if (total_weight > max_backlog_weight)
-      std::sort(tmp.begin(), tmp.end(), [](const auto& a, const auto& b){ return a.fee * b.weight > b.fee * a.weight; });
+      std::stable_sort(tmp.begin(), tmp.end(), [](const auto& a, const auto& b){ return a.fee * b.weight > b.fee * a.weight; });
 
     backlog.clear();
     uint64_t w = 0;


### PR DESCRIPTION
`std::sort` is unstable, so it can return random sets of transactions when mempool has many transactions with the same fee/byte. It can result in p2pool mining empty blocks sometimes because it doesn't pick up "new" transactions immediately.

`std::stable_sort` should preserve the order of transactions that was returned by the DB request.

Example when P2Pool was mining an empty block despite full mempool:
```
NOTICE  2024-03-08 12:34:06.0670 P2Pool new miner data
---------------------------------------------------------------------------------------------------------------
host                    = 127.0.0.1:18081:ZMQ:18083
major_version           = 16
height                  = 3100556
prev_id                 = 93c317bb130f77459a0698d4a86c1bad815ca40a6c3fa513fecfd0d751635213
seed_hash               = 4ec15c377ac3576f49361d2e912ecb2256c438937821e7262508d5995b37c7e6
difficulty              = 248886870954
median_weight           = 329841
already_generated_coins = 18407529506769594824
transactions            = 231
---------------------------------------------------------------------------------------------------------------
NOTICE  2024-03-08 12:34:06.0673 P2Pool median timestamp updated to 1709897381
NOTICE  2024-03-08 12:34:06.0673 P2Pool new main chain block: height = 3100555, id = 93c317bb130f77459a0698d4a86c1bad815ca40a6c3fa513fecfd0d751635213, timestamp = 1709901243, reward = 0.600811880000 XMR
NOTICE  2024-03-08 12:34:06.0682 BlockTemplate mempool has 231 transactions, taking 0 transactions from it
NOTICE  2024-03-08 12:34:06.0682 BlockTemplate base  reward = 0.600000000000 XMR, 0 transactions, fees = 0.000000000000 XMR, weight = 0
NOTICE  2024-03-08 12:34:06.0866 BlockTemplate final reward = 0.600000000000 XMR, weight = 23984, outputs = 616, 0 of 0 transactions included
```