### PR TITLE
tx_pool: fix old never-mined txs

### DIFF
--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -72,8 +72,7 @@ namespace cryptonote
       else if (a.first.first < b.first.first) return false;
       else if (a.first.second < b.first.second) return true;
       else if (a.first.second > b.first.second) return false;
-      else if (a.second != b.second) return true;
-      else return false;
+      else return memcmp(a.second.data, b.second.data, HASH_SIZE) < 0;
     }
   };
 


### PR DESCRIPTION
`cryptonote::txCompare::operator()` is malformed when two entries have the same fee/weight ratio AND same receive time (within 1 second). It's possible that for those really old txs sticking out, not getting mined, there was another tx with the same fee/weight ratio and receive time. Then, when inserting into `tx_memory_pool::m_txs_by_fee_and_receive_time`, the `std::set` sorting algorithm counts these 2 entries as equivalent since `!(x < y)` and `!(y < x)` and deleted one of the entries. `tx_memory_pool::fill_block_template` uses `tx_memory_pool::m_txs_by_fee_and_receive_time` to determine the priority to mine the transactions, but since these entries got deleted, they will never get mined, unless the daemon is restarted.

To fix, we simply make `cryptonote::txCompare::operator()` actually comply with the `Compare` concept requirements.