### PR TITLE
common: add va_args.h

### DIFF
--- a/src/common/va_args.h
+++ b/src/common/va_args.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+// Check for __VA_OPT__ support
+// Apdated from cpplearner's StackOverflow answer: https://stackoverflow.com/a/48045656
+#define PP_THIRD_ARG(a,b,c,...) c
+#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),true,false,)
+#define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
+
+// VA_ARGS_COMMAPREFIX(): VA_ARGS_COMMAPREFIX(__VA_ARGS__) expands to __VA_ARGS__ with a comma in
+// front if more than one argument, else nothing.
+// If __VA_OPT__ supported, use that. Else, use GCC's ,## hack
+#if VA_OPT_SUPPORTED
+#    define VA_ARGS_COMMAPREFIX(...) __VA_OPT__(,) __VA_ARGS__
+#else
+#    define VA_ARGS_COMMAPREFIX(...) , ## __VA_ARGS__
+#endif
+


### PR DESCRIPTION
This PR is upstreaming changes in the Seraphis lib here: https://github.com/UkoeHB/monero/pull/39. This header adds a macro `VA_ARGS_COMMAPREFIX` which, when passed `__VA_ARGS__`, expands to `, __VA_ARGS__` unless the length of `__VA_ARGS__` is 0, in which case it expands to nothing. This macro is useful for passing/declaring optional function arguments.