### PR TITLE
Fix lmdb txn commit code

### DIFF
--- a/src/lmdb/database.cpp
+++ b/src/lmdb/database.cpp
@@ -179,9 +179,10 @@ namespace lmdb
     expect<void> database::commit(write_txn txn) noexcept
     {
         MONERO_PRECOND(txn != nullptr);
-        MONERO_LMDB_CHECK(mdb_txn_commit(txn.get()));
-        txn.release();
+        const int err = mdb_txn_commit(txn.release());
         release_context(ctx);
+        if (err)
+          return {lmdb::error(err)};
         return success();
     }
 } // lmdb

--- a/src/lmdb/database.h
+++ b/src/lmdb/database.h
@@ -123,10 +123,13 @@ namespace lmdb
                 const auto wrote = f(*(*txn));
                 if (wrote)
                 {
-                    MONERO_CHECK(commit(std::move(*txn)));
-                    return wrote;
+                    const auto committed = commit(std::move(*txn));
+                    if (committed)
+                      return wrote;
+                    if (committed != lmdb::error(MDB_MAP_FULL))
+                      return committed.error();
                 }
-                if (wrote != lmdb::error(MDB_MAP_FULL))
+                else if (wrote != lmdb::error(MDB_MAP_FULL))
                     return wrote;
 
                 txn->reset();


### PR DESCRIPTION
I added LMDB code to monero core a while ago. The only project (afaik) using it is LWS. I found this bug in the commit code - commit can fail with a resize request too.

If anyone thinks this code should be removed and put into LWS let me know shortly. I thought perhaps this could be used to replace existing LMDB code, but it looks unlikely at this point.