### PR TITLE
wallet: prevent fee sniping when est. tx weight exceeds realized weight

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10423,7 +10423,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       {
         LOG_PRINT_L2("We made a tx, adjusting fee and saving it, we need " << print_money(needed_fee) << " and we have " << print_money(test_ptx.fee));
         size_t fee_tries;
-        for (fee_tries = 0; fee_tries < 10 && needed_fee > test_ptx.fee; ++fee_tries) {
+        for (fee_tries = 0; fee_tries < 10 && (use_rct ? (needed_fee != test_ptx.fee) : (needed_fee > test_ptx.fee)); ++fee_tries) {
           tx_dsts = tx.get_adjusted_dsts(needed_fee);
 
           if (use_rct)


### PR DESCRIPTION
In some cases `wallet2` can produce a transaction that pays a fee/weight that slightly exceeds a dynamic base fee.

It occurs when [estimate_fee](https://github.com/tobtoht/monero/blob/ef0bf7b51879822c1b60e529aa2a13a31be53632/src/wallet/wallet2.cpp#L10333) exceeds the transaction's [calculated fee](https://github.com/tobtoht/monero/blob/ef0bf7b51879822c1b60e529aa2a13a31be53632/src/wallet/wallet2.cpp#L10392), which skips the [final transaction attempt](https://github.com/tobtoht/monero/blob/ef0bf7b51879822c1b60e529aa2a13a31be53632/src/wallet/wallet2.cpp#L10426-L10439). This reliably happens for multi-destination transactions. To reproduce, try spending a 2-in / 16-out.

This is a transaction uniformity defect that effectively leaks that `wallet2` was used to construct the transaction, because the inputs to `estimate_fee` can be derived from on-chain data. Paying a fee/weight that is slightly higher than a dynamic base fee also unfairly puts the transaction in front of others for block inclusion ("fee sniping").

I'm leaving this as a draft for now to investigate if the accuracy of `estimate_fee` can also be improved.