### PR TITLE
common: support boost filesystem copy_options.

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -114,6 +114,24 @@ static int flock_exnb(int fd)
 
 namespace tools
 {
+
+  void copy_file(const std::string& from, const std::string& to)
+  {
+    using boost::filesystem::path;
+  #if BOOST_VERSION < 107400
+    // Remove this preprocessor if/else when we are bumping the boost version.
+    boost::filesystem::copy_file(
+        path(from),
+        path(to),
+        boost::filesystem::copy_option::overwrite_if_exists);
+  #else
+    boost::filesystem::copy_file(
+        path(from),
+        path(to),
+        boost::filesystem::copy_options::overwrite_existing);
+  #endif
+  }
+
   std::function<void(int)> signal_handler::m_handler;
 
   private_file::private_file() noexcept : m_handle(), m_filename() {}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -67,6 +67,8 @@ namespace tools
     }
   };
 
+  void copy_file(const std::string& from, const std::string& to);
+
   //! A file restricted to process owner AND process. Deletes file on destruction.
   class private_file {
     std::unique_ptr<std::FILE, close_file> m_handle;

--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -42,6 +42,7 @@
 #include <boost/serialization/version.hpp>
 
 #include "net_peerlist_boost_serialization.h"
+#include "common/util.h"
 
 
 namespace nodetool
@@ -200,7 +201,7 @@ namespace nodetool
     if (!out)
     {
       // if failed, try reading in unportable mode
-      boost::filesystem::copy_file(path, path + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+      tools::copy_file(path, path + ".unportable");
       src_file.close();
       src_file.open( path , std::ios_base::binary | std::ios_base::in);
       if(src_file.fail())

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6136,7 +6136,7 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
           catch (...)
           {
             LOG_PRINT_L0("Failed to open portable binary, trying unportable");
-            if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+            if (use_fs) tools::copy_file(m_wallet_file, m_wallet_file + ".unportable");
             std::stringstream iss;
             iss.str("");
             iss << cache_data;
@@ -6158,7 +6158,7 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
       catch (...)
       {
         LOG_PRINT_L0("Failed to open portable binary, trying unportable");
-        if (use_fs) boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+        if (use_fs) tools::copy_file(m_wallet_file, m_wallet_file + ".unportable");
         std::stringstream iss;
         iss.str("");
         iss << cache_file_buf;

--- a/tests/core_tests/chaingen_serialization.h
+++ b/tests/core_tests/chaingen_serialization.h
@@ -35,6 +35,7 @@
 #include <boost/archive/portable_binary_iarchive.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#include "common/util.h"
 
 namespace tools
 {
@@ -110,7 +111,7 @@ namespace tools
     catch(...)
     {
       // if failed, try reading in unportable mode
-      boost::filesystem::copy_file(file_path, file_path + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+      tools::copy_file(file_path, file_path + ".unportable");
       data_file.close();
       data_file.open( file_path, std::ios_base::binary | std::ios_base::in);
       if(data_file.fail())

--- a/tests/unit_tests/wallet_storage.cpp
+++ b/tests/unit_tests/wallet_storage.cpp
@@ -33,6 +33,7 @@
 
 #include "file_io_utils.h"
 #include "wallet/wallet2.h"
+#include "common/util.h"
 
 using namespace boost::filesystem;
 using namespace epee::file_io_utils;
@@ -52,8 +53,8 @@ TEST(wallet_storage, store_to_file2file)
     ASSERT_TRUE(is_file_exist(source_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(source_wallet_file.string() + ".keys"));
 
-    copy_file(source_wallet_file, interm_wallet_file, copy_option::overwrite_if_exists);
-    copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys", copy_option::overwrite_if_exists);
+    tools::copy_file(source_wallet_file.string(), interm_wallet_file.string());
+    tools::copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys");
 
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string() + ".keys"));
@@ -143,8 +144,8 @@ TEST(wallet_storage, change_password_same_file)
     ASSERT_TRUE(is_file_exist(source_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(source_wallet_file.string() + ".keys"));
 
-    copy_file(source_wallet_file, interm_wallet_file, copy_option::overwrite_if_exists);
-    copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys", copy_option::overwrite_if_exists);
+    tools::copy_file(source_wallet_file.string(), interm_wallet_file.string());
+    tools::copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys");
 
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string() + ".keys"));
@@ -182,8 +183,8 @@ TEST(wallet_storage, change_password_different_file)
     ASSERT_TRUE(is_file_exist(source_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(source_wallet_file.string() + ".keys"));
 
-    copy_file(source_wallet_file, interm_wallet_file, copy_option::overwrite_if_exists);
-    copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys", copy_option::overwrite_if_exists);
+    tools::copy_file(source_wallet_file.string(), interm_wallet_file.string());
+    tools::copy_file(source_wallet_file.string() + ".keys", interm_wallet_file.string() + ".keys");
 
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string()));
     ASSERT_TRUE(is_file_exist(interm_wallet_file.string() + ".keys"));


### PR DESCRIPTION
Update [8751](https://github.com/monero-project/monero/pull/8751) to have support for both the older version and the newer version of boost.