### PR TITLE
epee: partially revert c56ee140 to fix linking errors

### DIFF
--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -71,8 +71,6 @@ namespace string_tools
    std::string get_current_module_path();
 #endif
   void set_module_name_and_folder(const std::string& path_to_process_);
-  void trim_left(std::string& str);
-  void trim_right(std::string& str);
   //----------------------------------------------------------------------------
   inline std::string& trim(std::string& str)
   {

--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -1,5 +1,4 @@
 #include "readline_buffer.h"
-#include "string_tools.h"
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <iostream>
@@ -174,7 +173,7 @@ static void handle_line(char* line)
     line_stat = rdln::full;
     the_line = line;
     std::string test_line = line;
-    epee::string_tools::trim_right(test_line);
+    boost::trim_right(test_line);
     if(!test_line.empty())
     {
       if (!same_as_last_line(test_line))

--- a/contrib/epee/src/string_tools.cpp
+++ b/contrib/epee/src/string_tools.cpp
@@ -164,19 +164,6 @@ namespace string_tools
   }
 
 	//----------------------------------------------------------------------------
-  void trim_left(std::string& str)
-  {
-    boost::trim_left(str);
-    return;
-  }
-
-	//----------------------------------------------------------------------------
-  void trim_right(std::string& str)
-  {
-    boost::trim_right(str);
-    return;
-  }
-
   std::string pad_string(std::string s, size_t n, char c, bool prepend)
   {
     if (s.size() < n)


### PR DESCRIPTION
On Linux Mint 21.3, g++ Ubuntu 11.4.0-1ubuntu1~22.04, I get linking error for an undefined reference to `epee::string_tools::trim_right`. This PR reverts the changes to epee_readline.cpp in commit c56ee140, which turns a `boost::trim_right` callsite into an `epee::string_tools::trim_right` callsite.