### PR TITLE
cryptonote_protocol: prevent duplicate txs in fluff queue

### DIFF
--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -396,6 +396,8 @@ namespace levin
         for (auto& connection : connections)
         {
           std::sort(connection.first.begin(), connection.first.end()); // don't leak receive order
+          connection.first.erase(std::unique(connection.first.begin(), connection.first.end()),
+                                  connection.first.end());
           make_payload_send_txs(*zone_->p2p, std::move(connection.first), connection.second, zone_->pad_txs, true);
         }
 


### PR DESCRIPTION
Fix duplicate transaction #9335


Thanks @Boog900  for suggesting how it can be done easier.  

There is another (draft) implementation which passes tests based on `std::set` [here](https://github.com/0xFFFC0000/monero/pull/20/files).