### PR TITLE
cryptonote_protocol: prevent duplicate txs in fluff queue [RELEASE] 

### DIFF
--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -396,6 +396,8 @@ namespace levin
         for (auto& connection : connections)
         {
           std::sort(connection.first.begin(), connection.first.end()); // don't leak receive order
+          connection.first.erase(std::unique(connection.first.begin(), connection.first.end()),
+                                  connection.first.end());
           make_payload_send_txs(*zone_->p2p, std::move(connection.first), connection.second, zone_->pad_txs, true);
         }
 


### PR DESCRIPTION
Release for [9353]( https://github.com/monero-project/monero/pull/9353)

```
1. Fix duplicate transaction #9335
2. Add test for cases where there are duplicate transaction in fluff
```