### PR TITLE
Fix ZMQ Tx Pruning

### DIFF
--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -273,7 +273,10 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::t
   {
     INSERT_INTO_JSON_OBJECT(dest, signatures, tx.signatures);
   }
-  INSERT_INTO_JSON_OBJECT(dest, ringct, tx.rct_signatures);
+  {
+    dest.Key("ringct");
+    toJsonValue(dest, tx.rct_signatures, tx.pruned);
+  }
 
   dest.EndObject();
 }
@@ -1111,7 +1114,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResp
   GET_FROM_JSON_OBJECT(val, response.reward, reward);
 }
 
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& sig)
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& sig, const bool prune)
 {
   using boost::adaptors::transform;
 
@@ -1131,7 +1134,7 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& 
   }
 
   // prunable
-  if (!sig.p.bulletproofs.empty() || !sig.p.bulletproofs_plus.empty() || !sig.p.rangeSigs.empty() || !sig.p.MGs.empty() || !sig.get_pseudo_outs().empty())
+  if (!prune && (!sig.p.bulletproofs.empty() || !sig.p.bulletproofs_plus.empty() || !sig.p.rangeSigs.empty() || !sig.p.MGs.empty() || !sig.get_pseudo_outs().empty()))
   {
     dest.Key("prunable");
     dest.StartObject();

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -281,7 +281,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::error& error);
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::BlockHeaderResponse& response);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResponse& response);
 
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& i);
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const rct::rctSig& sig, bool prune);
 void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig);
 
 void fromJsonValue(const rapidjson::Value& val, rct::ctkey& key);


### PR DESCRIPTION
When requesting pruned txes over ZMQ, the txes aren't fully pruned. This is due to a quirk in the unpacking of txes - the pruned elements are still read into the local tx. Fixing this is a bit more involved. The ZMQ output code then has no context/flag for `prune` in the signature portion (because it assumes the signatures wouldn't have been unpacked in. a pruned tx).

This is a simple hack that passes the prune information from the base tx into the next function call. This allows for full pruning, which saves on bandwidth, output time, and read time.

I have verified locally (with LWS) that this output is still valid.