### PR TITLE
Daemon RPC: add max_block_count field to /getblocks.bin

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -725,12 +725,13 @@ namespace cryptonote
         }
       }
 
-      size_t max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
+      size_t max_blocks = req.max_block_count > 0
+        ? std::min(req.max_block_count, (uint64_t)COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT)
+        : COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
+
       if (m_rpc_payment)
       {
-        max_blocks = res.credits / COST_PER_BLOCK;
-        if (max_blocks > COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT)
-          max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
+        max_blocks = std::min((size_t)(res.credits / COST_PER_BLOCK), max_blocks);
         if (max_blocks == 0)
         {
           res.status = CORE_RPC_STATUS_PAYMENT_REQUIRED;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -191,6 +191,8 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       bool        no_miner_tx;
       bool        high_height_ok;
       uint64_t    pool_info_since;
+      uint64_t    max_block_count;
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_OPT(requested_info, (uint8_t)0)
@@ -200,6 +202,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE_OPT(no_miner_tx, false)
         KV_SERIALIZE_OPT(high_height_ok, false) // default false maintains backwards compatibility for clients that relied on failure on high height
         KV_SERIALIZE_OPT(pool_info_since, (uint64_t)0)
+        KV_SERIALIZE_OPT(max_block_count, (uint64_t)0)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -99,6 +99,7 @@ BEGIN_RPC_MESSAGE_CLASS(GetBlocksFast);
     RPC_MESSAGE_MEMBER(uint64_t, current_height);
     RPC_MESSAGE_MEMBER(crypto::hash, top_block_hash);
     RPC_MESSAGE_MEMBER(std::vector<cryptonote::rpc::block_output_indices>, output_indices);
+    RPC_MESSAGE_MEMBER(uint64_t, max_block_count);
   END_RPC_MESSAGE_RESPONSE;
 END_RPC_MESSAGE_CLASS;
 


### PR DESCRIPTION
Enables making parallel requests for a small number of blocks. When scanning the chain using parallel requests, setting this request param to a small number (e.g. 10) can speed up progress feedback to the user significantly (compared to leaving the default to 1000 as is).

Used in the Seraphis lib async scanner: https://github.com/UkoeHB/monero/pull/23