### PR TITLE
Daemon RPC: high_height_ok req boolean field /getblocks.bin

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -702,12 +702,20 @@ namespace cryptonote
     if (get_blocks)
     {
       // quick check for noop
-      if (!req.block_ids.empty())
+      if (req.start_height > 0 || !req.block_ids.empty())
       {
         uint64_t last_block_height;
         crypto::hash last_block_hash;
         m_core.get_blockchain_top(last_block_height, last_block_hash);
-        if (last_block_hash == req.block_ids.front())
+
+        if (!req.high_height_ok && req.start_height > last_block_height)
+        {
+          res.status = "Failed";
+          return true;
+        }
+
+        if (req.start_height > last_block_height ||
+           (!req.block_ids.empty() && last_block_hash == req.block_ids.front()))
         {
           res.start_height = 0;
           res.current_height = last_block_height + 1;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -88,7 +88,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 3
-#define CORE_RPC_VERSION_MINOR 14
+#define CORE_RPC_VERSION_MINOR 15
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -176,6 +176,7 @@ namespace cryptonote
       uint64_t    start_height;
       bool        prune;
       bool        no_miner_tx;
+      bool        high_height_ok;
       uint64_t    pool_info_since;
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
@@ -184,6 +185,7 @@ namespace cryptonote
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(prune)
         KV_SERIALIZE_OPT(no_miner_tx, false)
+        KV_SERIALIZE_OPT(high_height_ok, false) // default false maintains backwards compatibility for clients that relied on failure on high height
         KV_SERIALIZE_OPT(pool_info_since, (uint64_t)0)
       END_KV_SERIALIZE_MAP()
     };


### PR DESCRIPTION
Behavior before: when `req.start_height > chain tip`, response fails and the client is dropped and blocked

Behavior after: when `req.high_height_ok && req.start_height > chain tip`, the server returns a successful empty block response that includes the chain height

This is useful when firing parallel requests to scan the chain and the client doesn't initially know what the chain tip is. This avoids the client getting itself dropped when firing too high of a request.

The reason I implemented this new optional `high_height_ok` field rather than changing the default behavior to return a successful response when the request includes too high of a height is to maintain backwards compatibility with clients that perhaps currently rely on a failure response when requesting too high a height. Perhaps this is overkill and I could be convinced that making "high height ok" the server's default behavior (and not implementing the request field) is the better call.

Used in the Seraphis lib async scanner: https://github.com/UkoeHB/monero/pull/23