### PR TITLE
Fix ZMQ DaemonInfo [0.18 release]

### DIFF
--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -520,6 +520,8 @@ namespace rpc
       res.info.target_height = res.info.height;
     }
 
+    m_core.get_blockchain_top(res.info.top_block_height, res.info.top_block_hash);
+
     auto& chain = m_core.get_blockchain_storage();
 
     res.info.wide_difficulty = chain.get_difficulty_for_next_block();

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -176,6 +176,7 @@ namespace rpc
   {
     uint64_t height;
     uint64_t target_height;
+    uint64_t top_block_height;
     cryptonote::difficulty_type wide_difficulty;
     uint64_t difficulty;
     uint64_t target;

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1423,9 +1423,14 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::r
 {
   dest.StartObject();
 
+  const uint64_t difficulty_top64 = (info.wide_difficulty >> 64).convert_to<std::uint64_t>();
+  const uint64_t cumulative_difficulty_top64 = (info.wide_cumulative_difficulty >> 64).convert_to<std::uint64_t>();
+
   INSERT_INTO_JSON_OBJECT(dest, height, info.height);
   INSERT_INTO_JSON_OBJECT(dest, target_height, info.target_height);
+  INSERT_INTO_JSON_OBJECT(dest, top_block_height, info.top_block_height);
   INSERT_INTO_JSON_OBJECT(dest, difficulty, info.difficulty);
+  INSERT_INTO_JSON_OBJECT(dest, difficulty_top64, difficulty_top64);
   INSERT_INTO_JSON_OBJECT(dest, target, info.target);
   INSERT_INTO_JSON_OBJECT(dest, tx_count, info.tx_count);
   INSERT_INTO_JSON_OBJECT(dest, tx_pool_size, info.tx_pool_size);
@@ -1440,12 +1445,14 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::r
   INSERT_INTO_JSON_OBJECT(dest, nettype, info.nettype);
   INSERT_INTO_JSON_OBJECT(dest, top_block_hash, info.top_block_hash);
   INSERT_INTO_JSON_OBJECT(dest, cumulative_difficulty, info.cumulative_difficulty);
+  INSERT_INTO_JSON_OBJECT(dest, cumulative_difficulty_top64, cumulative_difficulty_top64);
   INSERT_INTO_JSON_OBJECT(dest, block_size_limit, info.block_size_limit);
   INSERT_INTO_JSON_OBJECT(dest, block_weight_limit, info.block_weight_limit);
   INSERT_INTO_JSON_OBJECT(dest, block_size_median, info.block_size_median);
   INSERT_INTO_JSON_OBJECT(dest, block_weight_median, info.block_weight_median);
   INSERT_INTO_JSON_OBJECT(dest, adjusted_time, info.adjusted_time);
   INSERT_INTO_JSON_OBJECT(dest, start_time, info.start_time);
+  INSERT_INTO_JSON_OBJECT(dest, version, info.version);
 
   dest.EndObject();
 }
@@ -1457,9 +1464,14 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& inf
     throw WRONG_TYPE("json object");
   }
 
+  uint64_t difficulty_top64 = 0;
+  uint64_t cumulative_difficulty_top64 = 0;
+
   GET_FROM_JSON_OBJECT(val, info.height, height);
   GET_FROM_JSON_OBJECT(val, info.target_height, target_height);
+  GET_FROM_JSON_OBJECT(val, info.top_block_height, top_block_height);
   GET_FROM_JSON_OBJECT(val, info.difficulty, difficulty);
+  GET_FROM_JSON_OBJECT(val, difficulty_top64, difficulty_top64);
   GET_FROM_JSON_OBJECT(val, info.target, target);
   GET_FROM_JSON_OBJECT(val, info.tx_count, tx_count);
   GET_FROM_JSON_OBJECT(val, info.tx_pool_size, tx_pool_size);
@@ -1474,12 +1486,22 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& inf
   GET_FROM_JSON_OBJECT(val, info.nettype, nettype);
   GET_FROM_JSON_OBJECT(val, info.top_block_hash, top_block_hash);
   GET_FROM_JSON_OBJECT(val, info.cumulative_difficulty, cumulative_difficulty);
+  GET_FROM_JSON_OBJECT(val, cumulative_difficulty_top64, cumulative_difficulty_top64);
   GET_FROM_JSON_OBJECT(val, info.block_size_limit, block_size_limit);
   GET_FROM_JSON_OBJECT(val, info.block_weight_limit, block_weight_limit);
   GET_FROM_JSON_OBJECT(val, info.block_size_median, block_size_median);
   GET_FROM_JSON_OBJECT(val, info.block_weight_median, block_weight_median);
   GET_FROM_JSON_OBJECT(val, info.adjusted_time, adjusted_time);
   GET_FROM_JSON_OBJECT(val, info.start_time, start_time);
+  GET_FROM_JSON_OBJECT(val, info.version, version);
+
+  info.wide_difficulty = difficulty_top64;
+  info.wide_difficulty <<= 64;
+  info.wide_difficulty += info.difficulty;
+
+  info.wide_cumulative_difficulty = cumulative_difficulty_top64;
+  info.wide_cumulative_difficulty <<= 64;
+  info.wide_cumulative_difficulty += info.cumulative_difficulty;
 }
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::rpc::output_distribution& dist)

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -124,6 +124,68 @@ TEST(JsonSerialization, InvalidVectorBytes)
     EXPECT_THROW(cryptonote::json::fromJsonValue(doc, out), cryptonote::json::BAD_INPUT);
 }
 
+TEST(JsonSerialization, DaemonInfo)
+{
+  cryptonote::rpc::DaemonInfo info{};
+  info.height = 154544;
+  info.target_height = 15345435;
+  info.top_block_height = 2344;
+  info.wide_difficulty = cryptonote::difficulty_type{"100000000000000000005443"};
+  info.difficulty = 200376420520695107;
+  info.target = 7657567;
+  info.tx_count = 355;
+  info.tx_pool_size = 45435;
+  info.alt_blocks_count = 43535;
+  info.outgoing_connections_count = 1444;
+  info.incoming_connections_count = 1444;
+  info.white_peerlist_size = 14550;
+  info.grey_peerlist_size = 34324;
+  info.mainnet = true;
+  info.testnet = true;
+  info.stagenet = true;
+  info.nettype = "main";
+  info.top_block_hash = crypto::hash{1};
+  info.wide_cumulative_difficulty = cryptonote::difficulty_type{"200000000000000000005543"};
+  info.cumulative_difficulty = 400752841041384871;
+  info.block_size_limit = 4324234;
+  info.block_weight_limit = 3434;
+  info.block_size_median = 3434;
+  info.adjusted_time = 4535;
+  info.block_weight_median = 43535;
+  info.start_time = 34535;
+  info.version = "1.0";
+
+  const auto info_copy = test_json(info);
+
+  EXPECT_EQ(info.height, info_copy.height);
+  EXPECT_EQ(info.target_height, info_copy.target_height);
+  EXPECT_EQ(info.top_block_height, info_copy.top_block_height);
+  EXPECT_EQ(info.wide_difficulty, info_copy.wide_difficulty);
+  EXPECT_EQ(info.difficulty, info_copy.difficulty);
+  EXPECT_EQ(info.target, info_copy.target);
+  EXPECT_EQ(info.tx_count, info_copy.tx_count);
+  EXPECT_EQ(info.tx_pool_size, info_copy.tx_pool_size);
+  EXPECT_EQ(info.alt_blocks_count, info_copy.alt_blocks_count);
+  EXPECT_EQ(info.outgoing_connections_count, info_copy.outgoing_connections_count);
+  EXPECT_EQ(info.incoming_connections_count, info_copy.incoming_connections_count);
+  EXPECT_EQ(info.white_peerlist_size, info_copy.white_peerlist_size);
+  EXPECT_EQ(info.grey_peerlist_size, info_copy.grey_peerlist_size);
+  EXPECT_EQ(info.mainnet, info_copy.mainnet);
+  EXPECT_EQ(info.testnet, info_copy.testnet);
+  EXPECT_EQ(info.stagenet, info_copy.stagenet);
+  EXPECT_EQ(info.nettype, info_copy.nettype);
+  EXPECT_EQ(info.top_block_hash, info_copy.top_block_hash);
+  EXPECT_EQ(info.wide_cumulative_difficulty, info_copy.wide_cumulative_difficulty);
+  EXPECT_EQ(info.cumulative_difficulty, info_copy.cumulative_difficulty);
+  EXPECT_EQ(info.block_size_limit, info_copy.block_size_limit);
+  EXPECT_EQ(info.block_weight_limit, info_copy.block_weight_limit);
+  EXPECT_EQ(info.block_size_median, info_copy.block_size_median);
+  EXPECT_EQ(info.adjusted_time, info_copy.adjusted_time);
+  EXPECT_EQ(info.block_weight_median, info_copy.block_weight_median);
+  EXPECT_EQ(info.start_time, info_copy.start_time);
+  EXPECT_EQ(info.version, info_copy.version);
+}
+
 TEST(JsonSerialization, MinerTransaction)
 {
     cryptonote::account_base acct;


### PR DESCRIPTION
  * top_block_hash was never set in handler
  * wide_difficulty was never sent in JSON
  * wide_cumulative_difficulty was never sent in JSON