### PR TITLE
epee: fix mlog filename compare bug.

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -176,11 +176,12 @@ void mlog_configure(const std::string &filename_base, bool console, const std::s
       std::vector<boost::filesystem::path> found_files;
       const boost::filesystem::directory_iterator end_itr;
       const boost::filesystem::path filename_base_path(filename_base);
+      const std::string filename_base_name = filename_base_path.filename().string();
       const boost::filesystem::path parent_path = filename_base_path.has_parent_path() ? filename_base_path.parent_path() : ".";
       for (boost::filesystem::directory_iterator iter(parent_path); iter != end_itr; ++iter)
       {
-        const std::string filename = iter->path().string();
-        if (filename.size() >= filename_base.size() && std::memcmp(filename.data(), filename_base.data(), filename_base.size()) == 0)
+        const std::string filename = iter->path().filename().string();
+        if (filename.size() >= filename_base_name.size() && std::memcmp(filename.data(), filename_base_name.data(), filename_base_name.size()) == 0)
         {
           found_files.push_back(iter->path());
         }


### PR DESCRIPTION
When using a relative path for the log filename,
since the iteration on files adds "./" to the beginning of the filename monero-wallet-rpc and monero-wallet-cli	cannot find already written log files and therefore rotate indefinitely  (causing unlimited storage usage).


Thanks to [@ofrnxmr](https://github.com/nahuhh) for reporting this bug to me.