### PR TITLE
Blockchain: fix temp fails causing alt blocks to be permanently invalid

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1209,12 +1209,7 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
       // just the latter (because the rollback was done above).
       rollback_blockchain_switching(disconnected_chain, split_height);
 
-      // FIXME: Why do we keep invalid blocks around?  Possibly in case we hear
-      // about them again so we can immediately dismiss them, but needs some
-      // looking into.
       const crypto::hash blkid = cryptonote::get_block_hash(bei.bl);
-      add_block_as_invalid(bei, blkid);
-      MERROR("The block was inserted as invalid while connecting new alternative chain, block_id: " << blkid);
       m_db->remove_alt_block(blkid);
       alt_ch_iter++;
 
@@ -1222,7 +1217,6 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
       {
         const auto &bei = *alt_ch_to_orph_iter++;
         const crypto::hash blkid = cryptonote::get_block_hash(bei.bl);
-        add_block_as_invalid(bei, blkid);
         m_db->remove_alt_block(blkid);
       }
       return false;


### PR DESCRIPTION
Issue appeared in stressnet where nodes would never switch to the valid chain with longest proof of work, but instead log a message like so:

```
INFO    global  src/cryptonote_core/blockchain.cpp:2125 ###### REORGANIZE on height: 2534772 of 2534772 with cum_difficulty 1072308428953
INFO    global  src/cryptonote_core/blockchain.cpp:2125  alternative blockchain size: 2 with cum_difficulty 1072309197139
ERROR   txpool  src/cryptonote_core/tx_pool.cpp:596     Failed to find tx_meta in txpool
ERROR   verify  src/cryptonote_core/blockchain.cpp:4239 Block with id: <BLKID> has at least one unknown transaction with id: <TXID>
ERROR   blockchain      src/cryptonote_core/blockchain.cpp:1205 Failed to switch to alternative blockchain
ERROR   blockchain      src/cryptonote_core/blockchain.cpp:1217 The block was inserted as invalid while connecting new alternative chain, block_id: <BLKID>
```

What I believe was happening is this chain of events:
    1. Transaction T is added to mempool
    2. Block B1, which contains T, is added as an alt block
    3. Mempool conditions cause T to be pushed out
    4. Block B2, with previous block B1, is added as an alt block 
    5. Cumulative difficulty of B2 relative to the main chain triggers a reorg attempt
    6. Tx validation of B1 begins, but T is not present in the mempool
    7. Method `handle_block_to_main_chain` returns false
    8. As a result, method `switch_to_alternative_blockchain` adds B1 and B2 to `m_invalid_blocks` list permanently
    9. Peer gets blocked, and node never reaches consensus with other nodes because B1 and B2 stay in the invalid blocks list

I could be wrong about the exact trigger, but regardless, `handle_block_to_main_chain` returns `false` for many reasons, some of which are non-deterministic (i.e. the node not having a transaction in the mempool). As such, we should not add blocks to the invalid blocks list every time `handle_block_to_main_chain` returns false. Additionally, `handle_block_to_main_chain` already adds blocks to the invalid blocks list for transaction input consensus failures (which should be deterministic). The other big type of failure that could occur s a PoW check, but in that case, we shouldn't add those blocks to the invalid blocks list either, since it is 100% free for a peer to create a block that fails the PoW check, and doing so would cause the list to be filled up with garbage quickly.

There is a discussion to be had whether we should have any invalid blocks cache in the first place...

Thanks to @Rucknium for finding this issue, and to everyone running a stressnet node!