### PR TITLE
upnp: add support for miniupnpc API version 18

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2985,7 +2985,12 @@ namespace nodetool
     UPNPUrls urls;
     IGDdatas igdData;
     char lanAddress[64];
+#if MINIUPNPC_API_VERSION < 18
     result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress);
+#else
+    char wanAddress[64];
+    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress, wanAddress, sizeof wanAddress);
+#endif
     freeUPNPDevlist(deviceList);
     if (result > 0) {
       if (result == 1) {
@@ -3053,7 +3058,12 @@ namespace nodetool
     UPNPUrls urls;
     IGDdatas igdData;
     char lanAddress[64];
+#if MINIUPNPC_API_VERSION < 18
     result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress);
+#else
+    char wanAddress[64];
+    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress, wanAddress, sizeof wanAddress);
+#endif
     freeUPNPDevlist(deviceList);
     if (result > 0) {
       if (result == 1) {


### PR DESCRIPTION
miniupnpc 2.2.8 updated API to version 18, with breaking change to UPNP_GetValidIGD().

See: https://github.com/miniupnp/miniupnp/commit/c0a50ce33e3b99ce8a96fd43049bb5b53ffac62f
See: http://miniupnp.free.fr/files/changelog.php?file=miniupnpc-2.2.8.tar.gz
