### PR TITLE
Add ZMQ-PUB json-schemas

### DIFF
--- a/docs/schema/pub_chain_full.json
+++ b/docs/schema/pub_chain_full.json
@@ -1,0 +1,181 @@
+{
+    "definitions": {
+        "binary": {
+            "type": "string",
+            "description": "0+ bytes binary data as hex",
+            "pattern": "^([0-9A-Fa-f]{2})*$"
+        },
+        "binary1": {
+            "type": "string",
+            "description": "1-byte binary data as hex",
+            "minLength": 2,
+            "maxLength": 2,
+            "pattern": "^[0-9A-Fa-f]{2}$"
+        },
+        "binary32": {
+            "type": "string",
+            "description": "32-bytes binary data as hex",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "miner_tx": {
+            "type": "object",
+            "properties": {
+                "extra": { "$ref": "#/definitions/binary" },
+                "inputs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "gen": {
+                                "type": "object",
+                                "properties": {
+                                    "height": { "$ref": "#/definitions/uint64" }
+                                },
+                                "required": ["height"]
+                            }
+                        },
+                        "required": ["gen"]
+                    }
+                },
+                "outputs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/tx_output" }
+                },
+                "ringct": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 0
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "signatures": { "type": "array" }, 
+                "unlock_time": { "$ref": "#/definitions/uint64" },
+                "version": { "$ref": "#/definitions/uint64" }
+            },
+            "required": [
+                "extra",
+                "inputs",
+                "outputs",
+                "ringct",
+                "unlock_time",
+                "version"
+            ]
+        },
+        "tx_output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_key": { "$ref": "#/definitions/tx_output_to_key"}
+                    },
+                    "required": ["amount", "to_key"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_script": { "$ref": "#/definitions/tx_output_to_script"}
+                    },
+                    "required": ["amount", "to_script"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_scripthash": { "$ref": "#/definitions/tx_output_to_scripthash"}
+                    },
+                    "required": ["amount", "to_scripthash"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_tagged_key": { "$ref": "#/definitions/tx_output_to_tagged_key"}
+                    },
+                    "required": ["amount", "to_tagged_key"]
+                }
+            ]
+        },
+        "tx_output_to_key": {
+            "type": "object",
+            "properties": { "key": { "$ref": "#/definitions/binary32" } },
+            "required": ["key"]
+        },
+        "tx_output_to_script": {
+            "type": "object",
+            "properties": {
+                "keys": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/binary32" }
+                },
+                "script": { "$ref": "#/definitions/binary" }
+            },
+            "required": ["keys", "script"]
+        },
+        "tx_output_to_scripthash": {
+            "type": "object",
+            "properties": { "hash": { "$ref": "#/definitions/binary32" } },
+            "required": ["hash"]
+         },
+        "tx_output_to_tagged_key": {
+            "type": "object",
+            "properties": {
+                "key": { "$ref": "#/definitions/binary32" },
+                "view_tag": { "$ref": "#/definitions/binary1" }
+            },
+            "required": ["key", "view_tag"]
+        },
+        "uint8": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "uint32": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "uint64": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+        }
+    },
+    "type": "array",
+    "title": "json-full-chain_main",
+    "description": "Notification of new blocks added to main chain",
+    "minItems": 1,
+    "items": {
+        "type": "object",
+        "properties": {
+            "major_version": { "$ref": "#/definitions/uint8" },
+            "miner_tx": { "$ref": "#/definitions/miner_tx" },
+            "minor_version": { "$ref": "#/definitions/uint8" },
+            "nonce": { "$ref": "#/definitions/uint32" },
+            "prev_id": {
+                "description": "Cryptographic hash of previous block",
+                "$ref": "#/definitions/binary32"
+            },
+            "timestamp": { "$ref": "#/definitions/uint64" },
+            "tx_hashes": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/binary32" }
+            }
+        },
+        "required": [
+            "major_version",
+            "miner_tx",
+            "minor_version",
+            "nonce",
+            "prev_id",
+            "timestamp"
+        ]
+    }
+}

--- a/docs/schema/pub_chain_minimal.json
+++ b/docs/schema/pub_chain_minimal.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+        "binary32": {
+            "type": "string",
+            "description": "32-bytes binary data as hex",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "uint64": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+        }
+    },
+    "title": "json-minimal-chain_main",
+    "description": "Notification of new blocks added to main chain",
+    "type": "object",
+    "properties": {
+        "first_height": {
+            "description": "Height of the first block",
+            "$ref": "#/definitions/uint64"
+        },
+        "first_prev_id": {
+            "description": "The previous hash of the first block",
+            "$ref": "#/definitions/binary32"
+        },
+        "ids": {
+            "type": "array",
+            "description": "The hash of each new block, in order",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/binary32" }
+        }
+    },
+    "required": ["first_height", "first_prev_id", "ids"]
+}

--- a/docs/schema/pub_miner_full.json
+++ b/docs/schema/pub_miner_full.json
@@ -1,0 +1,68 @@
+{
+    "definitions": {
+        "binary32": {
+            "type": "string",
+            "description": "32-bytes binary data as hex",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "uint8": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "uint64": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+        }
+    },
+    "title": "json-full-miner_data",
+    "description": "Notification for a new block template",
+    "type": "object",
+    "properties": {
+        "already_generated_coins": {
+            "description": "The current number of coins previously created",
+            "$ref": "#/definitions/uint64"
+        },
+        "difficulty": {
+            "description": "128-bit PoW difficulty as hex",
+            "type": "string",
+            "pattern": "0x[0-9A-Fa-f]+" 
+        },
+        "height": {
+            "description": "Height of block being mined",
+            "$ref": "#/definitions/uint64"
+        },
+        "major_version": { "$ref": "#/definitions/uint8" },
+        "median_weight": { "$ref": "#/definitions/uint64" },
+        "prev_id": {
+            "description": "The cryptographic hash of the last block",
+            "$ref": "#/definitions/binary32"
+        },
+        "seed_hash": { "$ref": "#/definitions/binary32" },
+        "tx_backlog": {
+            "description": "Transactions waiting in the mempool",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "fee": { "$ref": "#/definitions/uint64" },
+                    "id": { "$ref": "#/definitions/binary32" },
+                    "weight": { "$ref": "#/definitions/uint64" }
+                },
+                "required": ["fee", "id", "weight"]
+            }
+        }
+    },
+    "required": [
+        "already_generated_coins",
+        "difficulty",
+        "height",
+        "major_version",
+        "median_weight",
+        "prev_id",
+        "seed_hash"
+    ]
+}

--- a/docs/schema/pub_txpool_full.json
+++ b/docs/schema/pub_txpool_full.json
@@ -1,0 +1,347 @@
+{
+    "definitions": {
+        "binary": {
+            "type": "string",
+            "description": "0+ bytes binary data as hex",
+            "pattern": "^([0-9A-Fa-f]{2})*$"
+        },
+        "binary1": {
+            "type": "string",
+            "description": "1-byte binary data as hex",
+            "minLength": 2,
+            "maxLength": 2,
+            "pattern": "^[0-9A-Fa-f]{2}$"
+        },
+        "binary32": {
+            "type": "string",
+            "description": "32-bytes binary data as hex",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "binary32_array": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/binary32" }
+        },
+        "binary32_array64": {
+            "type": "array",
+            "minItems": 64,
+            "maxItems": 64,
+            "items": { "$ref": "#/definitions/binary32" }
+        },
+        "ringct_bulletproof": {
+            "properties": {
+                "A": { "$ref": "#/definitions/binary32" },
+                "a": { "$ref": "#/definitions/binary32" },
+                "b": { "$ref": "#/definitions/binary32" },
+                "L": { "$ref": "#/definitions/binary32_array" },
+                "mu": { "$ref": "#/definitions/binary32" },
+                "R": { "$ref": "#/definitions/binary32_array" },
+                "S": { "$ref": "#/definitions/binary32" },
+                "t": { "$ref": "#/definitions/binary32" },
+                "T1": { "$ref": "#/definitions/binary32" },
+                "T2": { "$ref": "#/definitions/binary32" },
+                "taux": { "$ref": "#/definitions/binary32" },
+                "V": { "$ref": "#/definitions/binary32_array" }
+            },
+            "required": [
+                "A", "a", "b", "L", "mu", "R", "S", "t", "T1", "T2", "taux", "V"
+            ]
+        },
+        "ringct_bulletproof_plus": {
+            "properties": {
+                "A": { "$ref": "#/definitions/binary32" },
+                "A1": { "$ref": "#/definitions/binary32" },
+                "B": { "$ref": "#/definitions/binary32" },
+                "d1": { "$ref": "#/definitions/binary32" },
+                "L": { "$ref": "#/definitions/binary32_array" },
+                "R": { "$ref": "#/definitions/binary32_array" },
+                "r1": { "$ref": "#/definitions/binary32" },
+                "s1": { "$ref": "#/definitions/binary32" },
+                "V": { "$ref": "#/definitions/binary32_array" }
+            },
+            "required": ["A", "A1", "B", "d1", "L", "R", "r1", "s1", "V"]
+        },
+        "ringct_clsags": {
+            "properties": {
+                "c1": { "$ref": "#/definitions/binary32" },
+                "D": { "$ref": "#/definitions/binary32" },
+                "s": { "$ref": "#/definitions/binary32_array" }
+            },
+            "required": ["c1", "D", "s"]
+        },
+        "ringct_ecdh_tuple": {
+            "type": "object",
+             "properties": {
+                 "amount": { "$ref": "#/definitions/binary32" },
+                 "mask": { "$ref": "#/definitions/binary32" }
+             },
+             "required": ["amount", "mask"]
+        },
+        "ringct_mlsags": {
+            "properties": {
+                "cc": { "$ref": "#/definitions/binary32" },
+                "ss": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/definitions/binary32_array" }
+                }
+            },
+            "required": ["c1", "D", "s"]
+        },
+        "ringct_prunable": {
+            "type": "object",
+            "properties": {
+                "bulletproofs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/ringct_bulletproof" }
+                },
+                "bulletproofs_plus": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/ringct_bulletproof_plus" }
+                },
+                "clsags": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/ringct_clsags" }
+                },
+                "mlsags": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/ringct_mlsags" }
+                },
+                "pseudo_outs": { "$ref": "#/definitions/binary32_array" },
+                "range_proofs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/ringct_range_proofs" }
+                 }
+            }
+        },
+        "ringct_range_proofs": {
+            "properties": {
+                "ee": { "$ref": "#/definitions/binary32" },
+                "s0": { "$ref": "#/definitions/binary32_array64" },
+                "s1": { "$ref": "#/definitions/binary32_array64" }
+            },
+            "required": ["ee", "s0", "s1"]
+        },
+        "tx": {
+            "type": "object",
+            "properties": {
+                "extra": { "$ref": "#/definitions/binary" },
+                "inputs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/tx_input" }
+                },
+                "outputs": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/tx_output" }
+                },
+                "ringct": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 0
+                                }
+                            },
+                            "required": ["type"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "commitments": {
+                                    "type": "array",
+                                    "items": { "$ref": "#/definitions/binary32" }
+                                },
+                                "encrypted": {
+                                    "type": "array",
+                                    "items": { "$ref": "#/definitions/ringct_ecdh_tuple" }
+                                },
+                                "fee": { "$ref": "#/definitions/uint64" },
+                                "prunable": { "$ref": "#/definitions/ringct_prunable" },
+                                "type": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 6
+                                }
+                            },
+                            "required": [
+                                "commitments",
+                                "encrypted",
+                                "fee",
+                                "prunable",
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                "signatures": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": { "$ref": "#/definitions/binary32" }
+                    }
+                },
+                "unlock_time": { "$ref": "#/definitions/uint64" },
+                "version": { "$ref": "#/definitions/uint64" }
+            },
+            "required": [
+                "extra",
+                "inputs",
+                "outputs",
+                "ringct",
+                "unlock_time",
+                "version"
+            ]
+        },
+        "tx_input": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": { "gen": { "$ref": "#/definitions/tx_input_gen" } },
+                    "required": ["gen"]
+                },
+                {
+                    "type": "object",
+                    "properties": { "to_key": { "$ref": "#/definitions/tx_input_to_key" } },
+                    "required": ["to_key"]
+                },
+                {
+                    "type": "object",
+                    "properties": { "to_script": { "$ref": "#/definitions/tx_input_to_script" } },
+                    "required": ["to_script"]
+                },
+                {
+                    "type": "object",
+                    "properties": { "to_scripthash": { "$ref": "#/definitions/tx_input_to_scripthash" } },
+                    "required": ["to_scripthash"]
+                }
+            ]
+        },
+        "tx_input_gen": {
+            "type": "object",
+            "properties": { "height": { "$ref": "#/definitions/uint64" } },
+            "required": ["height"]
+        },
+        "tx_input_to_key": {
+            "type": "object",
+            "properties": {
+               "amount": { "$ref": "#/definitions/uint64" },
+               "key_image": { "$ref": "#/definitions/binary32" },
+               "key_offsets": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/definitions/uint64" }
+               }
+            },
+            "required": ["amount", "key_image", "key_offsets"]
+        },
+        "tx_input_to_script": {
+            "type": "object",
+            "properties": {
+                "prev": { "$ref": "#/definitions/binary32" },
+                "prevout": { "$ref": "#/definitions/uint64" },
+                "sigset": { "$ref": "#/definitions/binary" }
+            },
+            "required": ["prev", "prevout", "sigset"]
+        },
+        "tx_input_to_scripthash": {
+            "type": "object",
+            "properties": {
+                "prev": { "$ref": "#/definitions/binary32" },
+                "prevout": { "$ref": "#/definitions/uint64" },
+                "script": { "$ref": "#/definitions/tx_output_to_script" },
+                "sigset": { "$ref": "#/definitions/binary" }
+            },
+            "required": ["prev", "prevout", "script", "sigset"]
+        },
+        "tx_output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_key": { "$ref": "#/definitions/tx_output_to_key"}
+                    },
+                    "required": ["amount", "to_key"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_key": { "$ref": "#/definitions/tx_output_to_script"}
+                    },
+                    "required": ["amount", "to_script"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_scripthash": { "$ref": "#/definitions/tx_output_to_scripthash"}
+                    },
+                    "required": ["amount", "to_scripthash"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                         "amount": { "$ref": "#/definitions/uint64" },
+                         "to_tagged_key": { "$ref": "#/definitions/tx_output_to_tagged_key"}
+                    },
+                    "required": ["amount", "to_tagged_key"]
+                }
+            ]
+        },
+        "tx_output_to_key": {
+            "type": "object",
+            "properties": { "key": { "$ref": "#/definitions/binary32" } },
+            "required": ["key"]
+        },
+        "tx_output_to_script": {
+            "type": "object",
+            "properties": {
+                "keys": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/binary32" }
+                },
+                "script": { "$ref": "#/definitions/binary" }
+            },
+            "required": ["keys", "script"]
+        },
+        "tx_output_to_scripthash": {
+            "type": "object",
+            "properties": { "hash": { "$ref": "#/definitions/binary32" } },
+            "required": ["hash"]
+         },
+        "tx_output_to_tagged_key": {
+            "type": "object",
+            "properties": {
+                "key": { "$ref": "#/definitions/binary32" },
+                "view_tag": { "$ref": "#/definitions/binary1" }
+            },
+            "required": ["key", "view_tag"]
+        },
+        "uint8": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "uint32": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "uint64": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+        }
+    },
+    "title": "json-full-txpool_add",
+    "description": "List of newly observed transactions",
+    "type": "array",
+    "description": "New transactions",
+    "items": { "$ref": "#/definitions/tx" }
+}

--- a/docs/schema/pub_txpool_minimal.json
+++ b/docs/schema/pub_txpool_minimal.json
@@ -1,0 +1,34 @@
+{
+    "definitions": {
+        "binary32": {
+            "type": "string",
+            "description": "32-bytes binary data as hex",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "uint64": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+        },
+        "transaction": {
+            "type": "object",
+            "properties": {
+                "blob_size": { "$ref": "#/definitions/uint64" },
+                "fee": { "$ref": "#/definitions/uint64" },
+                "id": {
+                    "description": "Unique (cryptographic hash) identifier",
+                    "$ref": "#/definitions/binary32"
+                },
+                "weight": { "$ref": "#/definitions/uint64" }
+                
+            },
+            "required": ["id", "blob_size", "fee", "weight"]
+        }
+    },
+    "title": "json-minimal-txpool_add",
+    "description": "List of newly observed transactions",
+    "type": "array",
+    "items": { "$ref": "#/definitions/transaction" }
+}


### PR DESCRIPTION
Someone in chat requested information about ZMQ-PUB output, so I decided todo a json schema foreach ZMQ-PUB topic. A few tweaks to our ZMQ read code should be done to match the schemas a bit better. I will hold off on doing that until some comments on this schema are done. 

There are tools for converting from json to markdown, but I did not run them. Reviewers can use those tools, it might be slightly easier to read.