### PR TITLE
monerod.service: use network-online.target

### DIFF
--- a/utils/systemd/monerod.service
+++ b/utils/systemd/monerod.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Monero Full Node
-After=network.target
+After=network-online.target
 
 [Service]
 User=monero


### PR DESCRIPTION
### Problem
For certain configuration options like `add-priority-node`, the network needs to be online before the systemd service can start. See issue [here](https://github.com/monero-project/monero/issues/9419).

### Solution
Update `monerod.service` to use `After=network-online.target`.