### PR TITLE
contrib: smaller and more reasonable log size.

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -38,7 +38,7 @@
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
 
 #define MAX_LOG_FILE_SIZE 104850000 // 100 MB - 7600 bytes
-#define MAX_LOG_FILES 50
+#define MAX_LOG_FILES 10
 
 #define MCLOG_TYPE(level, cat, color, type, x) do { \
     if (el::Loggers::allowed(level, cat)) { \


### PR DESCRIPTION
The default log size is roughly 5 GB, which is huge. Particularly for handheld devices. Setting the default size to 1GB is more reasonable IMHO.