### PR TITLE
Respect CMake install paths

### DIFF
--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -51,7 +51,7 @@ if (BUILD_GUI_DEPS)
     if(IOS)
         set(lib_folder lib-${ARCH})
     else()
-        set(lib_folder lib)
+        set(lib_folder ${CMAKE_INSTALL_LIBDIR})
     endif()
     install(TARGETS epee
         ARCHIVE DESTINATION ${lib_folder})

--- a/external/db_drivers/liblmdb/CMakeLists.txt
+++ b/external/db_drivers/liblmdb/CMakeLists.txt
@@ -56,7 +56,7 @@ if (BUILD_GUI_DEPS)
     if(IOS)
         set(lib_folder lib-${ARCH})
     else()
-        set(lib_folder lib)
+        set(lib_folder ${CMAKE_INSTALL_LIBDIR})
     endif()
     install(TARGETS lmdb
         ARCHIVE DESTINATION ${lib_folder}

--- a/external/easylogging++/CMakeLists.txt
+++ b/external/easylogging++/CMakeLists.txt
@@ -58,7 +58,7 @@ if (BUILD_GUI_DEPS)
     if(IOS)
         set(lib_folder lib-${ARCH})
     else()
-        set(lib_folder lib)
+        set(lib_folder ${CMAKE_INSTALL_LIBDIR})
     endif()
     install(TARGETS easylogging
         ARCHIVE DESTINATION ${lib_folder}

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 set_property(TARGET blockchain_import
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-import")
-install(TARGETS blockchain_import DESTINATION bin)
+install(TARGETS blockchain_import DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_export
   ${blockchain_export_sources}
@@ -179,7 +179,7 @@ target_link_libraries(blockchain_export
 set_property(TARGET blockchain_export
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-export")
-install(TARGETS blockchain_export DESTINATION bin)
+install(TARGETS blockchain_export DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_blackball
   ${blockchain_blackball_sources}
@@ -201,7 +201,7 @@ target_link_libraries(blockchain_blackball
 set_property(TARGET blockchain_blackball
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-mark-spent-outputs")
-install(TARGETS blockchain_blackball DESTINATION bin)
+install(TARGETS blockchain_blackball DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 
 monero_add_executable(blockchain_usage
@@ -223,7 +223,7 @@ target_link_libraries(blockchain_usage
 set_property(TARGET blockchain_usage
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-usage")
-install(TARGETS blockchain_usage DESTINATION bin)
+install(TARGETS blockchain_usage DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_ancestry
   ${blockchain_ancestry_sources}
@@ -244,7 +244,7 @@ target_link_libraries(blockchain_ancestry
 set_property(TARGET blockchain_ancestry
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-ancestry")
-install(TARGETS blockchain_ancestry DESTINATION bin)
+install(TARGETS blockchain_ancestry DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_depth
   ${blockchain_depth_sources}
@@ -265,7 +265,7 @@ target_link_libraries(blockchain_depth
 set_property(TARGET blockchain_depth
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-depth")
-install(TARGETS blockchain_depth DESTINATION bin)
+install(TARGETS blockchain_depth DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_stats
   ${blockchain_stats_sources}
@@ -286,7 +286,7 @@ target_link_libraries(blockchain_stats
 set_property(TARGET blockchain_stats
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-stats")
-install(TARGETS blockchain_stats DESTINATION bin)
+install(TARGETS blockchain_stats DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_prune_known_spent_data
   ${blockchain_prune_known_spent_data_sources}
@@ -308,7 +308,7 @@ target_link_libraries(blockchain_prune_known_spent_data
 set_property(TARGET blockchain_prune_known_spent_data
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-prune-known-spent-data")
-install(TARGETS blockchain_prune_known_spent_data DESTINATION bin)
+install(TARGETS blockchain_prune_known_spent_data DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 monero_add_executable(blockchain_prune
   ${blockchain_prune_sources}
@@ -317,7 +317,7 @@ monero_add_executable(blockchain_prune
 set_property(TARGET blockchain_prune
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-prune")
-install(TARGETS blockchain_prune DESTINATION bin)
+install(TARGETS blockchain_prune DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 target_link_libraries(blockchain_prune
   PRIVATE

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -72,4 +72,4 @@ target_link_libraries(daemon
 set_property(TARGET daemon
   PROPERTY
     OUTPUT_NAME "monerod")
-install(TARGETS daemon DESTINATION bin)
+install(TARGETS daemon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/gen_multisig/CMakeLists.txt
+++ b/src/gen_multisig/CMakeLists.txt
@@ -51,4 +51,4 @@ add_dependencies(gen_multisig
 set_property(TARGET gen_multisig
   PROPERTY
     OUTPUT_NAME "monero-gen-trusted-multisig")
-install(TARGETS gen_multisig DESTINATION bin)
+install(TARGETS gen_multisig DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/gen_ssl_cert/CMakeLists.txt
+++ b/src/gen_ssl_cert/CMakeLists.txt
@@ -46,4 +46,4 @@ add_dependencies(gen_ssl_cert
 set_property(TARGET gen_ssl_cert
   PROPERTY
     OUTPUT_NAME "monero-gen-ssl-cert")
-install(TARGETS gen_ssl_cert DESTINATION bin)
+install(TARGETS gen_ssl_cert DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -62,4 +62,4 @@ target_link_libraries(simplewallet
 set_property(TARGET simplewallet
   PROPERTY
     OUTPUT_NAME "monero-wallet-cli")
-install(TARGETS simplewallet DESTINATION bin)
+install(TARGETS simplewallet DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -100,7 +100,7 @@ if(NOT IOS)
   set_property(TARGET wallet_rpc_server
     PROPERTY
       OUTPUT_NAME "monero-wallet-rpc")
-  install(TARGETS wallet_rpc_server DESTINATION bin)
+  install(TARGETS wallet_rpc_server DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 add_subdirectory(api)


### PR DESCRIPTION
There are a lot of CMakeLists.txt files with absolute installation paths like:

`install(TARGETS wallet_rpc_server DESTINATION bin)`

where `bin` usually points to `/usr/local/bin`.

It works well, but if some build system attempts to produce a package, it will fail since a user might not have root privileges. Such build systems usually place artifacts in a dedicated directory, like `~/my-package/usr/local/bin/`. As an example, FreeBSD's Makefile and Poudriere always fail during the insufficient access rights. I believe this is not the only case.

So I just changed the install paths to respect CMake prefixes according to [CMake documentation](https://cmake.org/cmake/help/latest/command/install.html#targets):

`install(TARGETS wallet_rpc_server DESTINATION ${CMAKE_INSTALL_BINDIR})`

And now the produced executables and libraries can be placed to the right directory.