### PR TITLE
cmake: fix readline find_path call.

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -23,8 +23,7 @@
 
 find_path(Readline_ROOT_DIR
     NAMES include/readline/readline.h
-    PATHS /usr/local/opt/readline/ /opt/homebrew/opt/readline/ /opt/local/ /usr/local/ /usr/
-    NO_DEFAULT_PATH
+    HINTS /usr/local/opt/readline/ /opt/homebrew/opt/readline/ /opt/local/ /usr/local/ /usr/
 )
 
 find_path(Readline_INCLUDE_DIR


### PR DESCRIPTION
When passing `PATHS` and `NO_DEFAULT_PATH` to `find_path` in CMake, `find_path` will not look into any other location. This will make building on non-canonical *ix based system hard. For example `GUIX` package solves this by passing argument: 

Search for `DReadline_ROOT_DIR=` in 
https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/finance.scm