### PR TITLE
readme: Update minimal dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,15 +164,15 @@ library archives (`.a`).
 
 | Dep          | Min. version  | Vendored | Debian/Ubuntu pkg    | Arch pkg     | Void pkg           | Fedora pkg          | Optional | Purpose         |
 | ------------ | ------------- | -------- | -------------------- | ------------ | ------------------ | ------------------- | -------- | --------------- |
-| GCC          | 7             | NO       | `build-essential`    | `base-devel` | `base-devel`       | `gcc`               | NO       |                 |
+| GCC          | 12            | NO       | `build-essential`    | `base-devel` | `base-devel`       | `gcc`               | NO       |                 |
 | CMake        | 3.5           | NO       | `cmake`              | `cmake`      | `cmake`            | `cmake`             | NO       |                 |
 | pkg-config   | any           | NO       | `pkg-config`         | `base-devel` | `base-devel`       | `pkgconf`           | NO       |                 |
 | Boost        | 1.58          | NO       | `libboost-all-dev`   | `boost`      | `boost-devel`      | `boost-devel`       | NO       | C++ libraries   |
 | OpenSSL      | basically any | NO       | `libssl-dev`         | `openssl`    | `openssl-devel`    | `openssl-devel`     | NO       | sha256 sum      |
-| libzmq       | 4.2.0         | NO       | `libzmq3-dev`        | `zeromq`     | `zeromq-devel`     | `zeromq-devel`      | NO       | ZeroMQ library  |
+| libzmq       | 4.3.4         | NO       | `libzmq3-dev`        | `zeromq`     | `zeromq-devel`     | `zeromq-devel`      | NO       | ZeroMQ library  |
 | OpenPGM      | ?             | NO       | `libpgm-dev`         | `libpgm`     |                    | `openpgm-devel`     | NO       | For ZeroMQ      |
 | libnorm[2]   | ?             | NO       | `libnorm-dev`        |              |                    |                     | YES      | For ZeroMQ      |
-| libunbound   | 1.4.16        | NO       | `libunbound-dev`     | `unbound`    | `unbound-devel`    | `unbound-devel`     | NO       | DNS resolver    |
+| libunbound   | 1.13.1        | NO       | `libunbound-dev`     | `unbound`    | `unbound-devel`    | `unbound-devel`     | NO       | DNS resolver    |
 | libsodium    | ?             | NO       | `libsodium-dev`      | `libsodium`  | `libsodium-devel`  | `libsodium-devel`   | NO       | cryptography    |
 | libunwind    | any           | NO       | `libunwind8-dev`     | `libunwind`  | `libunwind-devel`  | `libunwind-devel`   | YES      | Stack traces    |
 | liblzma      | any           | NO       | `liblzma-dev`        | `xz`         | `liblzma-devel`    | `xz-devel`          | YES      | For libunwind   |


### PR DESCRIPTION
Monero should keep minimal versions of dependencies updated to reasonable and secure versions to avoid introducing vulnerabilities in third-party builds and stay coherent with its current building process.

The following packages have been updated in this PR:
- GCC (7 -> 12): GCC 7 is outdated since 2022 and set C++17 templates behind an experimental flag. I'm doubtful about its ability to compile monerod. Moved to 12 because most distributions are shipping 13 and transitioning to 14 ([monerod issue with gcc14](https://github.com/monero-project/monero/issues/9359) / [Fix PR](https://github.com/monero-project/monero/pull/9367)).
- Libunbound (1.4.16 -> 1.13.1): A lot of memory corruption as well as non memory related vulnerabilities have been reported since version 1.4.16. Latest version is 1.21.0 and latest package on ubuntu 22.04 repository is 1.13.1, I updated it to 1.13.1.
- Libzmq (4.2.0 -> 4.3.4): Same as libunbound, [lot of security vulnerabilities reported](https://www.cvedetails.com/vulnerability-list/vendor_id-14186/product_id-52489/version_id-1616705/Zeromq-Libzmq-4.2.0.html?page=1&order=1&trc=6&sha=ae6b688fb48903dc3a072a0ea241a16922c27d9a) since this version. Some can be mitigated with exploit mitigations at build time but it is unreasonable to recommend such an old version. Updated to its latest version without known vulnerability