### PR TITLE
depends: freebsd_base: update to 12.3

### DIFF
--- a/contrib/depends/packages/freebsd_base.mk
+++ b/contrib/depends/packages/freebsd_base.mk
@@ -1,9 +1,9 @@
 package=freebsd_base
-$(package)_version=11.3
+$(package)_version=12.3
 $(package)_download_path=https://archive.freebsd.org/old-releases/amd64/$($(package)_version)-RELEASE/
 $(package)_download_file=base.txz
 $(package)_file_name=freebsd-base-$($(package)_version).txz
-$(package)_sha256_hash=4599023ac136325b86f2fddeec64c1624daa83657e40b00b2ef944c81463a4ff
+$(package)_sha256_hash=e85b256930a2fbc04b80334106afecba0f11e52e32ffa197a88d7319cf059840
 
 define $(package)_extract_cmds
   echo $($(package)_sha256_hash) $($(1)_source_dir)/$($(package)_file_name) | sha256sum -c &&\


### PR DESCRIPTION
- 11.3 is missing execinfo, which is needed for rust std library build (#9440)
- bump does not violate #9446