### PR TITLE
fuzz: fix `make fuzz`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ release-static-win32:
 
 fuzz:
 	mkdir -p $(builddir)/fuzz
-	cd $(builddir)/fuzz && cmake -D STATIC=ON -D SANITIZE=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-gcc -D CMAKE_CXX_COMPILER=afl-g++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" $(topdir) && $(MAKE)
+	cd $(builddir)/fuzz && cmake -D STATIC=ON -D OSSFUZZ=ON -D SANITIZE=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-gcc -D CMAKE_CXX_COMPILER=afl-g++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" $(topdir) && $(MAKE)
 
 clean:
 	@echo "WARNING: Back-up your wallet if it exists within ./"$(deldirs)"!" ; \


### PR DESCRIPTION
Set CMake variable `OSSFUZZ=ON` in Makefile `fuzz` target

Thanks @ACK-J for bringing up the issue that `make fuzz` was broken