### PR TITLE
guix: bump time-machine to 9d09b0cf841fb657a1aec12e9bab68e00c2b493c

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -68,7 +68,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/monero-project/guix.git \
-                      --commit=53396a22afc04536ddf75d8f82ad2eafa5082725 \
+                      --commit=9d09b0cf841fb657a1aec12e9bab68e00c2b493c \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -193,7 +193,8 @@ chain for " target " development."))
                 "0azpb9cvnbv25zg8019rqz48h8i2257ngyjg566dlnp74ivrs9vq"))
               (patches (search-our-patches "glibc-2.27-riscv64-Use-__has_include-to-include-asm-syscalls.h.patch"
                                            "glibc-2.27-guix-prefix.patch"
-                                           "glibc-2.27-no-librt.patch"))))
+                                           "glibc-2.27-no-librt.patch"
+                                           "glibc-2.27-riscv64-fix-incorrect-jal-with-HIDDEN_JUMPTARGET.patch"))))
     (arguments
       (substitute-keyword-arguments (package-arguments glibc)
         ((#:configure-flags flags)

--- a/contrib/guix/patches/glibc-2.27-riscv64-fix-incorrect-jal-with-HIDDEN_JUMPTARGET.patch
+++ b/contrib/guix/patches/glibc-2.27-riscv64-fix-incorrect-jal-with-HIDDEN_JUMPTARGET.patch
@@ -1,0 +1,41 @@
+Backported from: https://sourceware.org/git/?p=glibc.git;a=commit;h=68389203832ab39dd0dbaabbc4059e7fff51c29b
+Context: https://sourceware.org/bugzilla/show_bug.cgi?id=28509
+
+Resolves a build failure with glibc 2.27 + binutils >=2.40.
+Patch can be removed if we update glibc to >= 2.35.
+
+diff --git a/sysdeps/riscv/setjmp.S b/sysdeps/riscv/setjmp.S
+index cfbd276fc3..e2f8088a6e 100644
+--- a/sysdeps/riscv/setjmp.S
++++ b/sysdeps/riscv/setjmp.S
+@@ -21,7 +21,7 @@
+ 
+ ENTRY (_setjmp)
+   li	a1, 0
+-  j	__sigsetjmp
++  j	HIDDEN_JUMPTARGET (__sigsetjmp)
+ END (_setjmp)
+ ENTRY (setjmp)
+   li	a1, 1
+diff --git a/sysdeps/unix/sysv/linux/riscv/setcontext.S b/sysdeps/unix/sysv/linux/riscv/setcontext.S
+index 9f1c7b41fd..a0d9575a08 100644
+--- a/sysdeps/unix/sysv/linux/riscv/setcontext.S
++++ b/sysdeps/unix/sysv/linux/riscv/setcontext.S
+@@ -95,6 +95,7 @@ LEAF (__setcontext)
+ 99:	j	__syscall_error
+ 
+ PSEUDO_END (__setcontext)
++libc_hidden_def (__setcontext)
+ weak_alias (__setcontext, setcontext)
+ 
+ LEAF (__start_context)
+@@ -108,7 +109,7 @@ LEAF (__start_context)
+ 	/* Invoke subsequent context if present, else exit(0).  */
+ 	mv	a0, s2
+ 	beqz	s2, 1f
+-	jal	__setcontext
+-1:	j	exit
++	jal	HIDDEN_JUMPTARGET (__setcontext)
++1:	j	HIDDEN_JUMPTARGET (exit)
+ 
+ PSEUDO_END (__start_context)


### PR DESCRIPTION
- bumps binutils from 2.38 to 2.41, needed for #9440

### Changes to the build environment

Includes packages that are available in the guix container that we use to build Monero.

| package | old | new | rationale |
|---|---|---|---|
| **binutils** | 2.38 | 2.41 | |
| **binutils-cross** | 2.38 | 2.41 | |
| curl | 8.5.0 | 8.6.0 | |
| diffutils | 3.8 | 3.10 | |
| ed | 1.18 | 1.20.1 | |
| file | 5.44 | 5.45 | |
| gawk | 5.2.1 | 5.3.0 | |
| git-minimal | 2.45.2 | 2.46.0 | |
| **glibc**\* | 2.35 | 2.39 | |
| glibc-utf8-locales | 2.35 | removed | Use C.UTF-8 instead of ‘glibc-utf8-locales’ where possible<br>(949ee85019b242d29a1065cde27c491af57b657b) |
| gmp | 6.2.1 | 6.3.0 | |
| grep | 3.8 | 3.11 | |
| gzip | 1.12 | 1.13 | |
| libarchive | 3.6.1 | 3.7.7 | |
| libgc | 8.2.2 | 8.2.4 | |
| libpsl | n/a | 0.21.1 | curl: Update to 8.6.0<br> (f9e761bf138f8d8d80084149b0c3a4388e6af70c)<br>[Link](https://github.com/curl/curl/commit/2998874bb61ac6ef3b72d6a61467cd2aaf6e53ea)|
| libsigsegv | 2.14 | removed | gawk: Update to 5.3.0<br>(da26b34b0f3cf2883a4cb01e11971aad84f2ef6a).<br>[Link](https://git.savannah.gnu.org/cgit/gawk.git/tree/NEWS?h=gawk-5.3.0&id=5efd1487e16e68a1bb52fa5ca997d2d51182bff2#n10) |
| libstdc++ | n/a | 11.4.0 | binutils: Update to 2.41<br>(e7fdcffc73690c675477a3e48ecdb16f8fb5dd01) |
| libunistring | 1.0 | 1.1 | |
| libxcrypt | n/a | 4.4.36 | python: Add libxcrypt dependency<br>(239868c8e9b57ac92efd82558cef7ef04ad6a612) |
| linux-libre-headers-cross | 6.1.106 | 6.1.119 | |
| make | 4.3 | 4.4.1 | |
| mpfr | 4.2.0 | 4.2.1 | |
| nettle | 3.8.1 | 3.9.1 | |
| patchelf | 0.11 | 0.18.0 | |
| pcre2 | n/a | 10.42 | grep: Fix PCRE matches<br>(968c6da422997d795c8601cbbd89b3b308553e8c) |
| xz | 5.2.8 | 5.4.5 | |
| zlib | 1.2.13 | 1.3 | |

\* this does not affect run-time requirements of release binaries.

### Changes to transitive build dependencies

Includes (transitive) build dependencies that are not included in the build environment.

| package | old | new | rationale |
|---|---|---|---|
| datefudge | 1.23 | 1.26 | |
| hwdata | 0.365 | 0.374 | |
| hwloc | 2.11.1 | 2.11.2 | |
| iproute2 | 6.0.0 | 6.4.0 | |
| libgpg-error | 1.45 | 1.47 | |
| libpng | 1.6.37 | 1.6.39 | |
| libxft | 2.3.4 | 2.3.8 | |
| meson | 1.1.0 | 1.5.2 | |
| pcre | 8.45 | removed | grep: Fix PCRE matches<br>(968c6da422997d795c8601cbbd89b3b308553e8c) |
| perl-xml-xpath | 1.44 | 1.48 | |
| socat | 1.7.4.3 | 1.7.4.4 | |
| tzdata | 2022a | 2023d | |

### Changes to commencement

Only includes changes to bootstrap packages.

| package | old | new | rationale |
|---|---|---|---|
| binutils-cross-boot0 | 2.38 | 2.41 | |
| bootstrap-seeds | 1.0.0 | removed | stage0-posix: Update to 1.6.0<br>(129b07dbf34e2c17ba07d8048af88e8f100ef89c) |
| diffutils-boot0 | 3.8 | 3.10 | |
| doxygen | 1.9.5 | 1.9.8 | |
| file-boot0 | 5.44 | 5.45 | |
| gawk-boot0 | 5.2.1 | 5.3.0 | |
| gcc-cross-boot0 | 11.3.0 | 11.4.0 | |
| gcc-cross-boot0-wrapped | 11.3.0 | 11.4.0 | |
| glibc-intermediate | 2.35 | 2.39 | |
| grep-mesboot | 3.8 | 3.11 | |
| libdrm | 2.4.120 | 2.4.123 | |
| libstdc++-headers | 11.3.0 | 11.4.0 | |
| make-boot0 | 4.3 | 4.4.1 | |
| mes-boot | 0.24.2 | 0.25.1 | |
| mesboot-headers | 0.24.2 | 0.25.1 | |
| nss | 3.88.1 | 3.99 | |
| python-boot0 | n/a | 3.5.9 | |
| stage0-posix | 1.4 | 1.6.0 | |
| tcc-boot0 | 0.9.26-1136-g5bba73cc | 0.9.26-1149-g46a75d0c | |
| xz-mesboot | 5.2.8 | 5.4.5 | |

### Stats

| \# Packages | Old | New |
|--|----|----|
| **Environment** | 85 | 87 |
| **Build** | 119 | 118 |
| **Bootstrap** | 90 | 90 |

This bump spans a Guix `core-updates` merge, which results in a larger number of updated packages than is typical.  