### PR TITLE
ci: remove obsolete sdk cache

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -84,13 +84,6 @@ jobs:
         restore-keys: |
           depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
           depends-${{ matrix.toolchain.host }}-
-# Static cache
-    - name: OSX SDK cache
-      uses: actions/cache@v4
-      with:
-        path: contrib/depends/sdk-sources
-        key: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
-        restore-keys: sdk-${{ matrix.toolchain.host }}-${{ matrix.toolchain.osx_sdk }}
     - name: set apt conf
       run: ${{env.APT_SET_CONF}}
     - name: install dependencies


### PR DESCRIPTION
Serves no purpose since https://github.com/monero-project/monero/pull/8312/commits/7ea1e214c5db6c48e405f8bb3ede8f5ec9b876db.