### PR TITLE
build: drop support for 32-bit windows target

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -38,9 +38,6 @@ jobs:
           - name: "ARM v8"
             host: "aarch64-linux-gnu"
             packages: "g++-aarch64-linux-gnu"
-          - name: "i686 Win"
-            host: "i686-w64-mingw32"
-            packages: "g++-mingw-w64-i686"
           - name: "i686 Linux"
             host: "i686-pc-linux-gnu"
             packages: "g++-multilib"
@@ -85,7 +82,7 @@ jobs:
     - name: install dependencies
       run: sudo apt update; sudo apt -y install build-essential libtool cmake autotools-dev automake pkg-config python3 gperf bsdmainutils curl git ca-certificates ccache ${{ matrix.toolchain.packages }}
     - name: prepare w64-mingw32
-      if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'i686-w64-mingw32' }}
+      if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' }}
       run: |
         sudo update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
         sudo update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)


### PR DESCRIPTION
Discussion: https://libera.monerologs.net/monero-research-lab/20240904#c422227-c422235
Context: https://github.com/monero-project/monero/pull/9436#pullrequestreview-2278670854

The last commercially available x86 processors were released [over 18 years ago](https://en.wikipedia.org/wiki/List_of_Intel_processors#Intel_Core). Windows 11 [requires 64-bit](https://www.microsoft.com/en-us/windows/windows-11-specifications).

Article from Nov 2021:

>The first 32-bit Windows version in the charts is Windows 7 with a share of 0.22 percent, followed by its Windows 10 sibling with 0.09 percent.

https://news.softpedia.com/news/new-data-shows-windows-32-bit-is-becoming-a-thing-of-the-past-534336.shtml