### PR TITLE
depends: remove option from toolchain file

### DIFF
--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -3,10 +3,6 @@ SET(CMAKE_SYSTEM_NAME @cmake_system_name@)
 SET(CMAKE_SYSTEM_PROCESSOR @arch@)
 SET(CMAKE_BUILD_TYPE @release_type@)
 
-OPTION(STATIC "Link libraries statically" ON)
-OPTION(TREZOR_DEBUG "Main trezor debugging switch" OFF)
-OPTION(BUILD_TESTS "Build tests." OFF)
-
 SET(STATIC ON)
 SET(UNBOUND_STATIC ON)
 SET(ARCH "default")


### PR DESCRIPTION
`option` doesn't belong in a toolchain file. These options exist, and are documented in, the (root) `CMakeLists.txt`. All variables here are overridden later on in the toolchain file.