### PR TITLE
tests: include <iomanip> where using std::setfill

### DIFF
--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -40,6 +40,7 @@ using namespace cryptonote;
 #include <cmath>
 #include <boost/regex.hpp>
 #include <common/apply_permutation.h>
+#include <iomanip>
 #include "common/util.h"
 #include "common/command_line.h"
 #include "trezor_tests.h"

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -34,6 +34,7 @@
 #include <boost/range/iterator_range.hpp>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <iterator>
 #include <string>
 #include <sstream>

--- a/tests/unit_tests/memwipe.cpp
+++ b/tests/unit_tests/memwipe.cpp
@@ -28,6 +28,7 @@
 
 #include "gtest/gtest.h"
 
+#include <iomanip>
 #include <stdint.h>
 #include "misc_log_ex.h"
 #include "memwipe.h"


### PR DESCRIPTION
Not including this header when using `std::setfill()` has caused compilation errors on some compilers