### PR TITLE
Relax static_asserts in src/lmdb

### DIFF
--- a/src/lmdb/key_stream.h
+++ b/src/lmdb/key_stream.h
@@ -133,6 +133,7 @@ namespace lmdb
         //! \pre `!is_end()` \return Current key
         K get_key() const noexcept
         {
+            static_assert(std::is_trivially_copyable<K>(), "key is not memcpy safe");
             assert(!is_end());
             K out;
             std::memcpy(std::addressof(out), key.data(), sizeof(out));

--- a/src/lmdb/table.h
+++ b/src/lmdb/table.h
@@ -55,7 +55,7 @@ namespace lmdb
         static expect<F> get_value(MDB_val value) noexcept
         {
             static_assert(std::is_same<U, V>(), "bad MONERO_FIELD?");
-            static_assert(std::is_pod<F>(), "F must be POD");
+            static_assert(std::is_trivially_copyable<F>(), "F must be memcpy safe");
             static_assert(sizeof(F) + offset <= sizeof(U), "bad field type and/or offset");
 
             if (value.mv_size != sizeof(U))

--- a/src/lmdb/util.h
+++ b/src/lmdb/util.h
@@ -111,6 +111,7 @@ namespace lmdb
     template<typename T, std::size_t offset = 0>
     inline int less(MDB_val const* left, MDB_val const* right) noexcept
     {
+        static_assert(std::is_trivially_copyable<T>(), "memcpy will not work");
         if (!left || !right || left->mv_size < sizeof(T) + offset || right->mv_size < sizeof(T) + offset)
         {
             assert("invalid use of custom comparison" == 0);

--- a/src/lmdb/value_stream.h
+++ b/src/lmdb/value_stream.h
@@ -162,8 +162,8 @@ namespace lmdb
         G get_value() const noexcept
         {
             static_assert(std::is_same<U, T>(), "bad MONERO_FIELD usage?");
-            static_assert(std::is_pod<U>(), "value type must be pod");
-            static_assert(std::is_pod<G>(), "field type must be pod");
+            static_assert(std::is_trivially_copyable<U>(), "value type must be memcpy safe");
+            static_assert(std::is_trivially_copyable<G>(), "field type must be memcpy safe");
             static_assert(sizeof(G) + uoffset <= sizeof(U), "bad field and/or offset");
             assert(sizeof(G) + uoffset <= values.size());
             assert(!is_end());


### PR DESCRIPTION
This allows `boost::uuids::uuid` to be used in the lmdb glue code. LWS currently has this patched until this gets committed.