### PR TITLE
Replace deprecated result_of with decltype

### DIFF
--- a/src/lmdb/database.h
+++ b/src/lmdb/database.h
@@ -111,7 +111,7 @@ namespace lmdb
             \return The result of calling `f`.
         */
         template<typename F>
-        typename std::result_of<F(MDB_txn&)>::type try_write(F f, unsigned attempts = 3)
+        auto try_write(F f, unsigned attempts = 3) -> decltype(f(std::declval<MDB_txn&>()))
         {
             for (unsigned i = 0; i < attempts; ++i)
             {


### PR DESCRIPTION
This is primarily used by LWS. `std::result_of` has been deprecated in C++17, so this silences those warnings.