### PR TITLE
packages: add freebsd base mirror

### DIFF
--- a/contrib/depends/packages/freebsd_base.mk
+++ b/contrib/depends/packages/freebsd_base.mk
@@ -1,6 +1,6 @@
 package=freebsd_base
 $(package)_version=11.3
-$(package)_download_path=https://download.freebsd.org/ftp/releases/amd64/$($(package)_version)-RELEASE/
+$(package)_download_path=https://archive.freebsd.org/old-releases/amd64/$($(package)_version)-RELEASE/
 $(package)_download_file=base.txz
 $(package)_file_name=freebsd-base-$($(package)_version).txz
 $(package)_sha256_hash=4599023ac136325b86f2fddeec64c1624daa83657e40b00b2ef944c81463a4ff


### PR DESCRIPTION
11.3 no longer @ https://download.freebsd.org/ftp/releases/amd64/11.3-RELEASE/

moved to their old-releases archive mirror https://archive.freebsd.org/old-releases/amd64/ 
