### PR TITLE
tests: remove unlock_time argument from trezor_tests

### DIFF
--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -1708,7 +1708,7 @@ tsx_builder * tsx_builder::construct_pending_tx(tools::wallet2::pending_tx &ptx,
   auto sources_copy = m_sources;
   auto change_addr = m_from->get_account().get_keys().m_account_address;
   bool r = construct_tx_and_get_tx_key(m_from->get_account().get_keys(), subaddresses, m_sources, destinations_copy,
-                                       change_addr, extra ? extra.get() : std::vector<uint8_t>(), tx, 0, tx_key,
+                                       change_addr, extra ? extra.get() : std::vector<uint8_t>(), tx, tx_key,
                                        additional_tx_keys, true, m_rct_config, this->m_tester->cur_hf() >= HF_VERSION_VIEW_TAGS);
   CHECK_AND_ASSERT_THROW_MES(r, "Transaction construction failed");
 


### PR DESCRIPTION
`unlock_time` argument has been removed. With this PR `trezor_tests` will compile without any issue. 

https://github.com/monero-project/monero/pull/9151