### PR TITLE
guix: drop 32-bit android target

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -48,7 +48,6 @@ jobs:
           - target: "x86_64-apple-darwin"
           - target: "aarch64-apple-darwin"
           - target: "aarch64-linux-android"
-          - target: "arm-linux-androideabi"
 
     name: ${{ matrix.toolchain.target }}
     steps:

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -88,8 +88,7 @@ export HOSTS="${HOSTS:-x86_64-linux-gnu
                        x86_64-unknown-freebsd
                        x86_64-apple-darwin
                        aarch64-apple-darwin
-                       aarch64-linux-android
-                       arm-linux-androideabi}"
+                       aarch64-linux-android}"
 
 # Usage: distsrc_for_host HOST
 #


### PR DESCRIPTION
According to @nahuhh these binaries haven't worked in years (see also: https://github.com/monero-project/monero/issues/8889#issuecomment-1583469451).

Android has mostly moved on to 64-bit: https://android.stackexchange.com/questions/253596

In [a 2020 blog post](https://newsroom.arm.com/blog/android-64bit-future-mobile) ARM stated that "nearly 90 percent of today’s Android devices deploy a 64-bit capable version of the OS."