### PR TITLE
readme: update msys2 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If you are using the older Raspbian Jessie image, compiling Monero is a bit more
 
 #### On Windows:
 
-Binaries for Windows are built on Windows using the MinGW toolchain within
+Binaries for Windows can be built on Windows using the MinGW toolchain within
 [MSYS2 environment](https://www.msys2.org). The MSYS2 environment emulates a
 POSIX system. The toolchain runs within the environment and *cross-compiles*
 binaries that can run outside of the environment as a regular Windows
@@ -411,22 +411,13 @@ application.
 
 **Preparing the build environment**
 
-* Download and install the [MSYS2 installer](https://www.msys2.org), either the 64-bit or the 32-bit package, depending on your system.
-* Open the MSYS shell via the `MSYS2 Shell` shortcut
+* Download and install the [MSYS2 installer](https://www.msys2.org). Installing MSYS2 requires 64-bit Windows 10 or newer.
+* Open the MSYS shell via the `MSYS2 MSYS` shortcut
 * Update packages using pacman:
 
     ```bash
     pacman -Syu
     ```
-
-* Exit the MSYS shell using Alt+F4
-* Edit the properties for the `MSYS2 Shell` shortcut changing "msys2_shell.bat" to "msys2_shell.cmd -mingw64" for 64-bit builds or "msys2_shell.cmd -mingw32" for 32-bit builds
-* Restart MSYS shell via modified shortcut and update packages again using pacman:
-
-    ```bash
-    pacman -Syu
-    ```
-
 
 * Install dependencies:
 
@@ -442,9 +433,8 @@ application.
     pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium mingw-w64-i686-hidapi mingw-w64-i686-unbound
     ```
 
-* Open the MingW shell via `MinGW-w64-Win64 Shell` shortcut on 64-bit Windows
-  or `MinGW-w64-Win64 Shell` shortcut on 32-bit Windows. Note that if you are
-  running 64-bit Windows, you will have both 64-bit and 32-bit MinGW shells.
+* Open the MingW shell via `MSYS2 MINGW64` shortcut to build for 64-bit Windows
+  or `MSYS2 MINGW32` shortcut to build for 32-bit Windows.
 
 **Cloning**
 
@@ -462,10 +452,10 @@ application.
     cd monero
     ```
 
-* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.18.1.2'. If you don't care about the version and just want binaries from master, skip this step:
+* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.18.3.4'. If you don't care about the version and just want binaries from master, skip this step:
 
     ```bash
-    git checkout v0.18.1.2
+    git checkout v0.18.3.4
     ```
 
 * If you are on a 64-bit system, run:
@@ -474,7 +464,7 @@ application.
     make release-static-win64
     ```
 
-* If you are on a 32-bit system, run:
+* To build for a 32-bit system, run:
 
     ```bash
     make release-static-win32


### PR DESCRIPTION
- The shortcuts were renamed upstream (e.g `MinGW-w64-Win64 Shell` -> `MSYS2 MINGW64`)
- Installing MSYS2 requires a 64-bit system
- Removed an outdated section about manually changing the shortcut
- Updated the Monero tag