### PR TITLE
readme: update msys2 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If you are using the older Raspbian Jessie image, compiling Monero is a bit more
 
 #### On Windows:
 
-Binaries for Windows are built on Windows using the MinGW toolchain within
+Binaries for Windows can be built on Windows using the MinGW toolchain within
 [MSYS2 environment](https://www.msys2.org). The MSYS2 environment emulates a
 POSIX system. The toolchain runs within the environment and *cross-compiles*
 binaries that can run outside of the environment as a regular Windows
@@ -411,40 +411,21 @@ application.
 
 **Preparing the build environment**
 
-* Download and install the [MSYS2 installer](https://www.msys2.org), either the 64-bit or the 32-bit package, depending on your system.
-* Open the MSYS shell via the `MSYS2 Shell` shortcut
+* Download and install the [MSYS2 installer](https://www.msys2.org). Installing MSYS2 requires 64-bit Windows 10 or newer.
+* Open the MSYS shell via the `MSYS2 MSYS` shortcut
 * Update packages using pacman:
 
     ```bash
     pacman -Syu
     ```
 
-* Exit the MSYS shell using Alt+F4
-* Edit the properties for the `MSYS2 Shell` shortcut changing "msys2_shell.bat" to "msys2_shell.cmd -mingw64" for 64-bit builds or "msys2_shell.cmd -mingw32" for 32-bit builds
-* Restart MSYS shell via modified shortcut and update packages again using pacman:
-
-    ```bash
-    pacman -Syu
-    ```
-
-
 * Install dependencies:
-
-    To build for 64-bit Windows:
 
     ```bash
     pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-unbound
     ```
 
-    To build for 32-bit Windows:
-
-    ```bash
-    pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium mingw-w64-i686-hidapi mingw-w64-i686-unbound
-    ```
-
-* Open the MingW shell via `MinGW-w64-Win64 Shell` shortcut on 64-bit Windows
-  or `MinGW-w64-Win64 Shell` shortcut on 32-bit Windows. Note that if you are
-  running 64-bit Windows, you will have both 64-bit and 32-bit MinGW shells.
+* Open the MingW shell via `MSYS2 MINGW64` shortcut.
 
 **Cloning**
 
@@ -462,39 +443,28 @@ application.
     cd monero
     ```
 
-* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.18.1.2'. If you don't care about the version and just want binaries from master, skip this step:
+* If you would like a specific [version/tag](https://github.com/monero-project/monero/tags), do a git checkout for that version. eg. 'v0.18.3.4'. If you don't care about the version and just want binaries from master, skip this step:
 
     ```bash
-    git checkout v0.18.1.2
+    git checkout v0.18.3.4
     ```
 
-* If you are on a 64-bit system, run:
+* To build Monero, run:
 
     ```bash
     make release-static-win64
     ```
 
-* If you are on a 32-bit system, run:
+   The resulting executables can be found in `build/release/bin`
 
-    ```bash
-    make release-static-win32
-    ```
 
-* The resulting executables can be found in `build/release/bin`
-
-* **Optional**: to build Windows binaries suitable for debugging on a 64-bit system, run:
+* **Optional**: to build Windows binaries suitable for debugging, run:
 
     ```bash
     make debug-static-win64
     ```
 
-* **Optional**: to build Windows binaries suitable for debugging on a 32-bit system, run:
-
-    ```bash
-    make debug-static-win32
-    ```
-
-* The resulting executables can be found in `build/debug/bin`
+   The resulting executables can be found in `build/debug/bin`
 
 ### On FreeBSD:
 


### PR DESCRIPTION
- This PR replaces #9534
- Remove Windows 32-bit instructions: MSYS2 no longer packages `mingw-w64-i686-{libsodium,unbound,zeromq}`