### PR TITLE
brew: remove unneeded taps

### DIFF
--- a/contrib/brew/Brewfile
+++ b/contrib/brew/Brewfile
@@ -5,9 +5,6 @@
 # execute brew bundle in the directory containing the Brewfile
 
 tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/cask-versions"
-tap "homebrew/core"
 
 brew "autoconf"
 brew "autogen"


### PR DESCRIPTION
```
Tapping homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
Tapping homebrew/cask has failed!
Tapping homebrew/cask-versions
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-versions has failed!
Tapping homebrew/core
Error: Tapping homebrew/core is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
Tapping homebrew/core has failed!
```