### PR TITLE
cmake: lowercase ARCH_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,10 @@ if (NOT ARCH OR ARCH STREQUAL "" OR ARCH STREQUAL "native" OR ARCH STREQUAL "def
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "")
     set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
   endif()
-  set(ARCH_ID "${CMAKE_SYSTEM_PROCESSOR}")
+  # On Windows, CMake sets CMAKE{_HOST,}_SYSTEM_PROCESSOR to the value of the
+  # PROCESSOR_ARCHITECTURE environment variable. On some systems it may be set to
+  # AMD64. Lowercase it to ensure checks for "x86_64" or "amd64" work as expected.
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" ARCH_ID)
 else()
   set(ARCH_ID "${ARCH}")
 endif()


### PR DESCRIPTION
On Windows, CMake sets CMAKE{_HOST,}_SYSTEM_PROCESSOR to the value of the
PROCESSOR_ARCHITECTURE environment variable. On some systems it may be set to
AMD64. Lowercase it to ensure checks for "x86_64" or "amd64" work as expected.

For example: https://github.com/monero-project/monero/blob/master/src/crypto/CMakeLists.txt#L55

https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html