### PR TITLE
p2p: `--tx-proxy` is not required to use `--anonymous-inbound` [RELEASE]

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -639,8 +639,7 @@ namespace nodetool
 
       if (zone.m_connect == nullptr && tx_relay_zones <= 1)
       {
-        MERROR("Listed --" << arg_anonymous_inbound.name << " without listing any --" << arg_tx_proxy.name << ". The latter is necessary for sending local txes over anonymity networks");
-        return false;
+        MLOG_YELLOW(el::Level::Warning, "Listed --" << arg_anonymous_inbound.name << " without listing any --" << arg_tx_proxy.name << ". The latter is recommended for sending local txes over anonymity networks.");
       }
 
       zone.m_bind_ip = std::move(inbound.local_ip);


### PR DESCRIPTION
https://github.com/monero-project/monero/pull/9551