### PR TITLE
serialization: silence warning about shifting `uint8_t` by 8

### DIFF
--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -197,7 +197,7 @@ struct binary_archive<true> : public binary_archive_base<true>
   {
     for (size_t i = 0; i < sizeof(T); i++) {
       stream_.put((char)(v & 0xff));
-      if (1 < sizeof(T)) v >>= 8;
+      if constexpr (1 < sizeof(T)) { v >>= 8; }
     }
   }
 


### PR DESCRIPTION
Some compilers are stupid and give a warning on this line when `T = uint8_t`, even though it will never run