### PR TITLE
wallet: serialization not setting variable correctly when only child is opt

### DIFF
--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2193,7 +2193,7 @@ namespace wallet_rpc
   {
     struct request_t
     {
-      bool autosave_current;
+      bool autosave_current = true;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_OPT(autosave_current, true)


### PR DESCRIPTION
This will fix `close_wallet` not saving the wallet issue, without touching the serialization code [1]. This is a minor fix. The main fix is 9570. 

For a detailed explanation take a look at that PR. 

https://github.com/monero-project/monero/pull/9570