### PR TITLE
contrib: force (de)serialization to create params section incase there is none.

### DIFF
--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -165,6 +165,7 @@
       epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \
       return true; \
     } \
+    ps.open_section("params", nullptr, true); \
     if(false) return true; //just a stub to have "else if"
 
 


### PR DESCRIPTION
This is another solution to `close_wallet` not able to store the wallet due to serialization issues. 

For a detailed explanation look at https://github.com/monero-project/monero/pull/9568 .