### PR TITLE
contrib: force (de)serialization to create params section incase there is none.

### DIFF
--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -165,6 +165,13 @@
       epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \
       return true; \
     } \
+    epee::serialization::storage_entry params_; \
+    params_ = epee::serialization::storage_entry(epee::serialization::section()); \
+    if(!ps.get_value("params", params_, nullptr)) \
+    { \
+      epee::serialization::section params_section; \
+      ps.set_value("params", std::move(params_section), nullptr); \
+    } \
     if(false) return true; //just a stub to have "else if"
 
 

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -77,6 +77,67 @@ struct ObjOfInts
     KV_SERIALIZE(x)
   END_KV_SERIALIZE_MAP()
 };
+
+template<typename t_param>
+struct ParentObjWithOptChild
+{
+  t_param     params;
+
+  ParentObjWithOptChild(): params{} {}
+
+  BEGIN_KV_SERIALIZE_MAP()
+    KV_SERIALIZE(params)
+  END_KV_SERIALIZE_MAP()
+};
+
+struct ObjWithOptChild
+{
+  bool test_value;
+
+  BEGIN_KV_SERIALIZE_MAP()
+    KV_SERIALIZE_OPT(test_value, true);
+  END_KV_SERIALIZE_MAP()
+};
+}
+
+TEST(epee_binary, serialize_deserialize)
+{
+  ParentObjWithOptChild<ObjWithOptChild> o;
+  std::string o_json;
+  o.params.test_value = true;
+
+  EXPECT_TRUE(epee::serialization::store_t_to_json(o, o_json));
+  EXPECT_TRUE(o.params.test_value);
+
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o, o_json));
+  EXPECT_TRUE(o.params.test_value);
+
+  ParentObjWithOptChild<ObjWithOptChild> o2;
+  std::string o2_json;
+  o.params.test_value = false;
+
+  EXPECT_TRUE(epee::serialization::store_t_to_json(o2, o2_json));
+  EXPECT_FALSE(o2.params.test_value);
+
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o2, o2_json));
+  EXPECT_FALSE(o2.params.test_value);
+
+  // compiler sets default value of test_value to false
+  ParentObjWithOptChild<ObjWithOptChild> o3;
+  std::string o3_json;
+
+  EXPECT_TRUE(epee::serialization::store_t_to_json(o3, o3_json));
+  EXPECT_FALSE(o3.params.test_value);
+
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o3, o3_json));
+  EXPECT_FALSE(o3.params.test_value);
+
+  // test optional field default initialization.
+  ParentObjWithOptChild<ObjWithOptChild> o4;
+  std::string o4_json = "{\"params\": {}}";
+
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o4, o4_json));
+  EXPECT_TRUE(o4.params.test_value);
 }
 
 TEST(epee_binary, any_empty_seq)


### PR DESCRIPTION
The problem is `monero-wallet-rpc` does not save the state of the wallet when closing the wallet.

As you can see in the image below, the value of `autosave_current` is `false`. When in fact it should be `true` \[1\]. ( The command I am running is default command ` curl http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"close_wallet"}' -H 'Content-Type: application/json'` )

![image](https://github.com/user-attachments/assets/10f547ae-d29b-4f11-a7a1-7f66094ada61)

The reason for this bug is when the _only_ child of the key-value serialization object is optional ( as is the case with the `close_wallet` ), we don't call the function `_load` of the object. This line \[2\] returns `null` and therefore we don't call `_load` method, which initializes the object.  Whether the child section is null or not, we want to call `_load` method, to make sure the correct initialization.

1. https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/wallet/wallet_rpc_server_commands_defs.h#L2199
2. https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h#L80