### PR TITLE
wallet: report exact reason for open_wallet failure.

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3625,7 +3625,7 @@ namespace tools
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to open wallet";
+      er.message = "Failed to open wallet : " + (!er.message.empty() ? er.message : "Unknown.");
       return false;
     }
 


### PR DESCRIPTION
Report exact failure reason in error string when `open_wallet` fails. 