### PR TITLE
Fix memcpy in byte_slice constructor

### DIFF
--- a/contrib/epee/src/byte_slice.cpp
+++ b/contrib/epee/src/byte_slice.cpp
@@ -152,7 +152,11 @@ namespace epee
   {
     std::size_t space_needed = 0;
     for (const auto& source : sources)
+    {
+      if (std::numeric_limits<std::size_t>::max() - space_needed < source.size())
+        throw std::bad_alloc{};
       space_needed += source.size();
+    }
 
     if (space_needed)
     {
@@ -162,9 +166,9 @@ namespace epee
 
       for (const auto& source : sources)
       {
+        assert(source.size() <= out.size()); // see check above
         std::memcpy(out.data(), source.data(), source.size());
-        if (out.remove_prefix(source.size()) < source.size())
-          throw std::bad_alloc{}; // size_t overflow on space_needed
+        out.remove_prefix(source.size());
       }
       storage_ = std::move(storage);
     }


### PR DESCRIPTION
There's _technically_ an overflow in `byte_slice.cpp` that I caught while simply scanning the code. This can occur if the total memory being copied exceeds `size_t`. This is unlikely to ever trigger, because the platform probably needs `sizeof(size_t) == 4 && sizeof(void*) == 8` (or similar) to occur. And somehow a `malloc` to copy all of this data needs to succeed too. Therefore, this is primarily just defensive programming to be strictly standards compliant.