### PR TITLE
Fixes tar extract cmd for systems with 16 bit uid_t

### DIFF
--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -78,7 +78,7 @@ $(1)_download_path_fixed=$(subst :,\:,$$($(1)_download_path))
 
 #default commands
 $(1)_fetch_cmds ?= $(call fetch_file,$(1),$(subst \:,:,$$($(1)_download_path_fixed)),$$($(1)_download_file),$($(1)_file_name),$($(1)_sha256_hash))
-$(1)_extract_cmds ?= mkdir -p $$($(1)_extract_dir) && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > $$($(1)_extract_dir)/.$$($(1)_file_name).hash &&  $(build_SHA256SUM) -c $$($(1)_extract_dir)/.$$($(1)_file_name).hash && tar --strip-components=1 -xf $$($(1)_source)
+$(1)_extract_cmds ?= mkdir -p $$($(1)_extract_dir) && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > $$($(1)_extract_dir)/.$$($(1)_file_name).hash &&  $(build_SHA256SUM) -c $$($(1)_extract_dir)/.$$($(1)_file_name).hash && tar --no-same-owner --strip-components=1 -xf $$($(1)_source)
 $(1)_preprocess_cmds ?=
 $(1)_build_cmds ?=
 $(1)_config_cmds ?=


### PR DESCRIPTION
One build dependency tarball, [protobuf-cpp-3.6.1.tar.gz](https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-cpp-3.6.1.tar.gz)) contains file owner uid/gid as 231664/89939. This file fails to extract during the build process with the following error on systems where either uid_t or gid_t is limited to 16 bits (e.g. older kernels, rootless containers etc) i.e. the maximum uid_t/gid_t is 65534:
```
tar: six.BUILD: Cannot change ownership to uid 231664, gid 89939: Invalid argument
```

Since the file ownership is immaterial for the build process, this PR adds the `--no-same-owner` flag to `tar` command. This fixes #8639