### PR TITLE
wallet: add no_sync flag to wallet-rpc.

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -60,7 +60,7 @@ using namespace epee;
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
 
 #define DEFAULT_AUTO_REFRESH_PERIOD 20 // seconds
-#define REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
+#define REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
 
 #define CHECK_MULTISIG_ENABLED() \
   do \
@@ -176,7 +176,7 @@ namespace tools
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
-  wallet_rpc_server::wallet_rpc_server():m_wallet(NULL), rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL)
+  wallet_rpc_server::wallet_rpc_server(bool no_initial_sync) : m_wallet(NULL), rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL), m_no_initial_sync(no_initial_sync)
   {
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -202,13 +202,13 @@ namespace tools
       uint64_t blocks_fetched = 0;
       try {
         bool received_money = false;
-        if (m_wallet) m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, blocks_fetched, received_money, true, true, REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE);
+        if (m_wallet) m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, blocks_fetched, received_money, true, true, REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE);
       } catch (const std::exception& ex) {
         LOG_ERROR("Exception at while refreshing, what=" << ex.what());
       }
       // if we got the max amount of blocks, do not set the last refresh time, we did only part of the refresh and will
       // continue asap, and only set the last refresh time once the refresh is actually finished
-      if (blocks_fetched < REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE)
+      if (blocks_fetched < REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE)
         m_last_auto_refresh_time = boost::posix_time::microsec_clock::universal_time();
       return true;
     }, 1000);
@@ -3628,7 +3628,17 @@ namespace tools
       er.message = "Failed to open wallet";
       return false;
     }
-
+    try
+    {
+      if (!get_no_initial_sync() && !req.no_initial_sync)
+        wal->refresh(wal->is_trusted_daemon());
+      else
+        LOG_PRINT_L1("no-initial-sync passed. Not syncing the wallet.");
+    }
+    catch (const std::exception& e)
+    {
+      LOG_ERROR(tools::wallet_rpc_server::tr("Initial refresh failed: ") << e.what());
+    }
     if (m_wallet)
       delete m_wallet;
     m_wallet = wal.release();
@@ -4805,7 +4815,7 @@ public:
       const auto password_file = command_line::get_arg(vm, arg_password_file);
       const auto prompt_for_password = command_line::get_arg(vm, arg_prompt_for_password);
       const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
-      const auto no_initial_sync = command_line::get_arg(vm, arg_no_initial_sync);
+      wrpc->set_no_initial_sync(command_line::get_arg(vm, arg_no_initial_sync));
 
       if(!wallet_file.empty() && !from_json.empty())
       {
@@ -4863,8 +4873,10 @@ public:
 
       try
       {
-        if (!no_initial_sync)
+        if (!wrpc->get_no_initial_sync())
           wal->refresh(wal->is_trusted_daemon());
+        else
+          LOG_PRINT_L1("--no-initial-sync passed. Not syncing the wallet.");
       }
       catch (const std::exception& e)
       {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -59,8 +59,6 @@ using namespace epee;
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
 
-#define DEFAULT_AUTO_REFRESH_PERIOD 20 // seconds
-#define REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
 
 #define CHECK_MULTISIG_ENABLED() \
   do \
@@ -129,6 +127,7 @@ namespace
   const command_line::arg_descriptor<std::string> arg_wallet_dir = {"wallet-dir", "Directory for newly created wallets"};
   const command_line::arg_descriptor<bool> arg_prompt_for_password = {"prompt-for-password", "Prompts for password when not provided", false};
   const command_line::arg_descriptor<bool> arg_no_initial_sync = {"no-initial-sync", "Skips the initial sync before listening for connections", false};
+  const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the wallet with daemon", false};  
 
   constexpr const char default_rpc_username[] = "monero";
 
@@ -195,9 +194,9 @@ namespace tools
   {
     m_stop = false;
     m_net_server.add_idle_handler([this](){
-      if (m_auto_refresh_period == 0) // disabled
+      if (this->auto_refresh_is_disabled())
         return true;
-      if (boost::posix_time::microsec_clock::universal_time() < m_last_auto_refresh_time + boost::posix_time::seconds(m_auto_refresh_period))
+      if (boost::posix_time::microsec_clock::universal_time() < m_last_auto_refresh_time + boost::posix_time::seconds(this->get_auto_refresh_period()))
         return true;
       uint64_t blocks_fetched = 0;
       try {
@@ -320,7 +319,8 @@ namespace tools
       assert(bool(http_login));
     } // end auth enabled
 
-    m_auto_refresh_period = DEFAULT_AUTO_REFRESH_PERIOD;
+    if(!this->auto_refresh_is_disabled())
+      this->set_auto_refresh_period(DEFAULT_AUTO_REFRESH_PERIOD);
     m_last_auto_refresh_time = boost::posix_time::min_date_time;
 
     check_background_mining();
@@ -3339,8 +3339,8 @@ namespace tools
     }
     try
     {
-      m_auto_refresh_period = req.enable ? req.period ? req.period : DEFAULT_AUTO_REFRESH_PERIOD : 0;
-      MINFO("Auto refresh now " << (m_auto_refresh_period ? std::to_string(m_auto_refresh_period) + " seconds" : std::string("disabled")));
+      this->set_auto_refresh_period(req.enable ? req.period ? req.period : DEFAULT_AUTO_REFRESH_PERIOD : 0);
+      MINFO("Auto refresh now " << (!this->auto_refresh_is_disabled() ? std::to_string(this->get_auto_refresh_period()) + " seconds" : std::string("disabled")));
       return true;
     }
     catch (const std::exception& e)
@@ -4815,7 +4815,14 @@ public:
       const auto password_file = command_line::get_arg(vm, arg_password_file);
       const auto prompt_for_password = command_line::get_arg(vm, arg_prompt_for_password);
       const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
-      wrpc->set_no_initial_sync(command_line::get_arg(vm, arg_no_initial_sync));
+      const bool no_sync = command_line::get_arg(vm, arg_no_sync);
+      wrpc->set_no_initial_sync(command_line::get_arg(vm, arg_no_initial_sync)
+                                || no_sync);
+
+      if(no_sync) {
+        LOG_PRINT_L1("--no-sync passed. Disabling the auto_refresh and not syncing the wallet.");
+        wrpc->disable_auto_refresh();
+      }  
 
       if(!wallet_file.empty() && !from_json.empty())
       {
@@ -4986,6 +4993,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_wallet_dir);
   command_line::add_arg(desc_params, arg_prompt_for_password);
   command_line::add_arg(desc_params, arg_no_initial_sync);
+  command_line::add_arg(desc_params, arg_no_sync);
   command_line::add_arg(hidden_options, daemonizer::arg_non_interactive);
 
   daemonizer::init_options(hidden_options, desc_params);

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -41,6 +41,9 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
 
+#define DEFAULT_AUTO_REFRESH_PERIOD 20 // seconds
+#define REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
+
 namespace tools
 {
   /************************************************************************/
@@ -67,6 +70,22 @@ namespace tools
 
     bool get_no_initial_sync() {
       return m_no_initial_sync;
+    }
+
+    bool auto_refresh_is_disabled() {
+      return this->m_auto_refresh_period == 0;
+    }
+
+    void disable_auto_refresh() {
+      this->m_auto_refresh_period = 0;
+    }
+
+    void set_auto_refresh_period(uint32_t auto_refresh){
+      this->m_auto_refresh_period = auto_refresh;
+    }
+
+    uint32_t get_auto_refresh_period() {
+      return this->m_auto_refresh_period;
     }
 
   private:
@@ -294,7 +313,7 @@ namespace tools
       bool m_restricted;
       bool m_no_initial_sync;
       const boost::program_options::variables_map *m_vm;
-      uint32_t m_auto_refresh_period;
+      uint32_t m_auto_refresh_period = DEFAULT_AUTO_REFRESH_PERIOD;
       boost::posix_time::ptime m_last_auto_refresh_time;
   };
 }

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -53,13 +53,21 @@ namespace tools
 
     static const char* tr(const char* str);
 
-    wallet_rpc_server();
+    wallet_rpc_server(bool no_initial_sync = false);
     ~wallet_rpc_server();
 
     bool init(const boost::program_options::variables_map *vm);
     bool run();
     void stop();
     void set_wallet(wallet2 *cr);
+
+    void set_no_initial_sync(bool no_initial_sync){
+      this->m_no_initial_sync = no_initial_sync;
+    }
+
+    bool get_no_initial_sync() {
+      return m_no_initial_sync;
+    }
 
   private:
 
@@ -284,6 +292,7 @@ namespace tools
       tools::private_file rpc_login_file;
       std::atomic<bool> m_stop;
       bool m_restricted;
+      bool m_no_initial_sync;
       const boost::program_options::variables_map *m_vm;
       uint32_t m_auto_refresh_period;
       boost::posix_time::ptime m_last_auto_refresh_time;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2172,11 +2172,13 @@ namespace wallet_rpc
       std::string filename;
       std::string password;
       bool autosave_current;
+      bool no_initial_sync;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(filename)
         KV_SERIALIZE(password)
         KV_SERIALIZE_OPT(autosave_current, true)
+        KV_SERIALIZE_OPT(no_initial_sync, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
wallet: add no_sync flag to wallet-rpc.
        * encapsulate auto_refresh variable.

This PR adds `--no-sync` flag to `monero-wallet-rpc` which will prevent `monero-wallet-rpc` from syncing until user enables it manually via `auto_refresh` RPC call. 

Depends on https://github.com/monero-project/monero/pull/9579