### PR TITLE
wallet: shortchain history should include base block

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3013,6 +3013,8 @@ void wallet2::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t gra
   size_t sz = blockchain_size - m_blockchain.offset();
   if(!sz)
   {
+    if(m_blockchain.size() > m_blockchain.offset())
+      ids.push_back(m_blockchain[m_blockchain.offset()]);
     ids.push_back(m_blockchain.genesis());
     return;
   }


### PR DESCRIPTION
# ELI5: The Problem

Your wallet keeps track of part of the blockchain, starting from a specific point (called the "offset"). Sometimes, the wallet might only have one block stored (the "base block") or no blocks at all.

The bug is that when the wallet has just the "base block" (and no newer ones), this block wasn't being included in the list of blocks that the wallet sends to check its history with the blockchain. This makes the wallet’s history incomplete and can break synchronization.

## Example
Buggy Code:
1. Wallet starts at block 1000 (offset = 1000), with no newer blocks (sz == 0).
2. The code only adds the genesis block (block 0).
3. Result: The list looks like this:

`ids = [block_0]`

*Missing block 1000!*

## Fixed Code:
1. Wallet starts at block 1000, with no newer blocks (sz == 0).
2. The fix correctly adds the base block (block 1000) and the genesis block.
3. Result: The list looks like this:

`ids = [block_1000, block_0]`

Now both blocks are included, and the history is accurate!

# Short Summary of the Fix

The original get_short_chain_history method in the wallet2 class contained a bug where the base block (the block at m_blockchain.offset()) was not included in the ids list when sz == 0 (i.e., no blocks exist beyond the offset). This caused an incomplete short chain history in edge cases where the wallet had a minimal or empty blockchain view.

The fixed code ensures the correct behavior by:

1. Adding the base block (m_blockchain[m_blockchain.offset()]) to the ids list if the wallet has valid data at or beyond the offset (m_blockchain.size() > m_blockchain.offset()).
4.  Always including the Genesis block (m_blockchain.genesis()), which is crucial for synchronization.

# Impact of the Fix 

The updated code properly includes the base block when sz == 0, ensuring the short chain history is accurate and complete in all scenarios. This fix resolves potential synchronization issues, particularly for wallets with minimal or partially synced blockchain data. It improves reliability during wallet synchronization and avoids missing critical blocks.