### PR TITLE
ci: brew: pin boost to 1.85

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
         restore-keys: ccache-${{ runner.os }}-build-
     - name: install dependencies
       run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf@21 ccache
-        brew link protobuf@21
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost@1.85 hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf@21 ccache
+        brew link protobuf@21 boost@1.85
     - name: build
       run: |
         ${{env.CCACHE_SETTINGS}}

--- a/contrib/brew/Brewfile
+++ b/contrib/brew/Brewfile
@@ -16,7 +16,7 @@ brew "binutils"
 brew "coreutils"
 brew "cmake"
 brew "pkg-config"
-brew "boost"
+brew "boost@1.85", link: true
 brew "openssl"
 brew "hidapi"
 brew "zmq"


### PR DESCRIPTION
- Boost >= 1.87.0 breaks builds (#9596)
- Brew ships Boost 1.87.0 by default
- Temporary downgrade to get CI to pass until a proper fix is in place
- https://formulae.brew.sh/formula/boost