### PR TITLE
ci: don't fail-fast on matrix jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       CCACHE_TEMPDIR: /tmp/.ccache-temp
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
     steps:


### PR DESCRIPTION
Don't cancel the 22.04 build if 20.04 fails, or vice versa.