### PR TITLE
ci: common: remove duplicated definition

### DIFF
--- a/src/common/variant.h
+++ b/src/common/variant.h
@@ -214,35 +214,4 @@ public:
     bool is_empty() const noexcept { return this->index() == 0; }
 };
 
-template <typename... Types>
-class optional_variant: public variant<boost::blank, Types...>
-{
-public:
-//constructors
-    /// default constructor
-    optional_variant() = default;
-
-    /// construct from variant type (use enable_if to avoid issues with copy/move constructor)
-    template <typename T,
-        typename std::enable_if<
-                !std::is_same<
-                        std::remove_cv_t<std::remove_reference_t<T>>,
-                        optional_variant<Types...>
-                    >::value,
-                bool
-            >::type = true>
-    optional_variant(T &&value) : variant<boost::blank, Types...>(std::forward<T>(value)) {}
-
-    // construct like boost::optional
-    optional_variant(boost::none_t) {}
-
-//overloaded operators
-    /// boolean operator: true if the variant isn't empty/uninitialized
-    explicit operator bool() const noexcept { return !this->is_empty(); }
-
-//member functions
-    /// check if empty/uninitialized
-    bool is_empty() const noexcept { return this->index() == 0; }
-};
-
 } //namespace tools


### PR DESCRIPTION
It is identical to the block above. Introduced by #9336 and #9176, which are essentially the same PR. Not sure why this wasn't a merge conflict.

This fixes CI.

https://github.com/monero-project/monero/actions/runs/12469150712/job/34801715003#step:8:513