### PR TITLE
ci: disable guix commit authentication

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -83,7 +83,7 @@ jobs:
           sudo aa-enforce guix || true
           sudo apt purge apparmor
       - name: build
-        run: SUBSTITUTE_URLS='http://bordeaux.guix.gnu.org' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
+        run: ADDITIONAL_GUIX_TIMEMACHINE_FLAGS="--disable-authentication" SUBSTITUTE_URLS='http://bordeaux.guix.gnu.org' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.toolchain.target }}


### PR DESCRIPTION
This speeds up Guix CI by TBD minutes. We don't need to authenticate every commit on every CI run, because we [pin](https://github.com/monero-project/monero/blob/master/contrib/guix/libexec/prelude.bash#L71) the `time-machine` commit hash. 

Reviewers are expected to run a full Guix build and post their hashes when the pinned hash is updated. This way only an authenticated commit is committed to the repo.

https://guix.gnu.org/manual/en/html_node/Invoking-guix-pull.html