### PR TITLE
depends: expat: update to 2.6.4

### DIFF
--- a/contrib/depends/packages/expat.mk
+++ b/contrib/depends/packages/expat.mk
@@ -1,17 +1,20 @@
 package=expat
-$(package)_version=2.6.0
+$(package)_version=2.6.4
 $(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=ff60e6a6b6ce570ae012dc7b73169c7fdf4b6bf08c12ed0ec6f55736b78d85ba
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=fd03b7172b3bd7427a3e7a812063f74754f24542429b634e0db6511b53fb2278
+$(package)_build_subdir=build
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
-$(package)_config_opts+=--enable-option-checking --without-xmlwf --with-pic
-$(package)_config_opts+=--prefix=$(host_prefix)
+  $(package)_config_opts := -DEXPAT_BUILD_TOOLS=OFF
+  $(package)_config_opts += -DEXPAT_BUILD_EXAMPLES=OFF
+  $(package)_config_opts += -DEXPAT_BUILD_TESTS=OFF
+  $(package)_config_opts += -DBUILD_SHARED_LIBS=OFF
+  $(package)_config_opts += -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  $($(package)_cmake) -S .. -B .
 endef
 
 define $(package)_build_cmds
@@ -23,6 +26,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf share lib/cmake lib/*.la
+  rm -rf share lib/cmake
 endef
-


### PR DESCRIPTION
- https://nvd.nist.gov/vuln/detail/CVE-2024-45490
- https://nvd.nist.gov/vuln/detail/CVE-2024-45491
- https://nvd.nist.gov/vuln/detail/CVE-2024-45492

Requires #9640.