### PR TITLE
depends: unbound: update to 1.22.0

### DIFF
--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -1,10 +1,9 @@
 package=unbound
-$(package)_version=1.19.1
+$(package)_version=1.22.0
 $(package)_download_path=https://www.nlnetlabs.nl/downloads/$(package)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=bc1d576f3dd846a0739adc41ffaa702404c6767d2b6082deb9f2f97cbb24a3a9
+$(package)_sha256_hash=c5dd1bdef5d5685b2cedb749158dd152c52d44f65529a34ac15cd88d4b1b3d43
 $(package)_dependencies=openssl expat
-
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --enable-static --without-pyunbound --prefix=$(host_prefix)
@@ -17,6 +16,12 @@ define $(package)_set_vars
   $(package)_cflags_mingw32+="-D_WIN32_WINNT=0x600"
 endef
 
+# Remove blobs
+define $(package)_preprocess_cmds
+  rm configure~ doc/*.odp doc/*.pdf contrib/*.tar.gz contrib/*.tar.bz2 &&\
+  rm -rf testdata dnscrypt/testdata
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf) ac_cv_func_getentropy=no AR_FLAGS=$($(package)_arflags)
 endef
@@ -27,4 +32,8 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share
 endef


### PR DESCRIPTION
- https://nvd.nist.gov/vuln/detail/CVE-2024-1931
- https://nvd.nist.gov/vuln/detail/CVE-2024-8508

#### Supply chain security

- ☑ The tarball was signed with the same GPG key as the [previous update](https://github.com/NLnetLabs/unbound/releases/tag/release-1.19.1) (1.19.1)
  - `EDFAA3F2CA4E6EB05681AF8E9F6F1C2D7E045F8D`
- ☑ The repository has not changed ownership since the previous update
- ☑ The git [tag](https://github.com/NLnetLabs/unbound/releases/tag/release-1.22.0) was GPG signed by the maintainer
- ☑ Blobs were removed from the source in `preprocess_cmds`
- ☑ The tarball [is used by](https://whatsrc.org/artifact/sha256:c5dd1bdef5d5685b2cedb749158dd152c52d44f65529a34ac15cd88d4b1b3d43) 5 or more distributions.
- ⚠ The source archive does **not** match the contents of the git repo. The following files remain after cleanup:

```
util/configlexer.c
util/configparser.c
util/configparser.h
```
