### PR TITLE
ci: print guix hashes to summary

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -98,6 +98,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      - name: print hashes
+        run: |
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          find **/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
       - uses: actions/upload-artifact@v4
         with:
           name: "logs"


### PR DESCRIPTION
To check reproducibility without having to download the log bundle.