### PR TITLE
guix: remove moreutils

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -409,6 +409,5 @@ mv --no-target-directory "$OUTDIR" "$ACTUAL_OUTDIR" \
         find "$ACTUAL_OUTDIR" -type f
     } | xargs realpath --relative-base="$PWD" \
       | xargs sha256sum \
-      | sort -k2 \
-      | sponge "$LOGDIR"/SHA256SUMS.part
+      | sort -k2 -o "$LOGDIR"/SHA256SUMS.part
 )

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -257,7 +257,6 @@ chain for " target " development."))
         patch
         gawk
         sed
-        moreutils ; sponge is used to construct the SHA256SUMS.part file in libexec/build.sh
         patchelf  ; unused, occassionally useful for debugging
 
         ;; Compression and archiving


### PR DESCRIPTION

### Changes to the build environment

| package | old | new |
|---|---|---|
| moreutils | 0.69 | removed |
| perl-io-tty | 1.14 | removed |
| perl-ipc-run | 20180523.0 | removed |
| perl-time-duration | 1.21 | removed |
| perl-timedate | 2.33 | removed |

### Changes to transitive build dependencies

| package | old | new | 
|---|---|---|
| docbook-xml | 4.4 | removed |
| docbook-xsl | 1.79.2-0.fe16c90 | removed |
| perl-archive-zip | 1.68 | removed |
| perl-canary-stability | 2013 | removed |
| perl-capture-tiny | 0.48 | removed |
| perl-common-sense | 3.75 | removed |
| perl-cpan-meta | 2.150010 | removed |
| perl-cpan-meta-requirements | 2.140 | removed |
| perl-cpan-meta-yaml | 0.018 | removed |
| perl-cpanel-json-xs | 4.30 | removed |
| perl-devel-symdump | 2.18 | removed |
| perl-extutils-config | 0.008 | removed |
| perl-extutils-helpers | 0.026 | removed |
| perl-extutils-installpaths | 0.012 | removed |
| perl-file-homedir | 1.004 | removed |
| perl-file-remove | 1.58 | removed |
| perl-file-which | 1.23 | removed |
| perl-json | 4.02 | removed |
| perl-json-maybexs | 1.004003 | removed |
| perl-json-xs | 4.0 | removed |
| perl-module-build | 0.4231 | removed |
| perl-module-build-tiny | 0.039 | removed |
| perl-module-install | 1.19 | removed |
| perl-module-scandeps | 1.27 | removed |
| perl-par-dist | 0.49 | removed |
| perl-parse-cpan-meta | 2.150010 | removed |
| perl-path-tiny | 0.118 | removed |
| perl-pod-coverage | 0.23 | removed |
| perl-pod-parser | 1.65 | removed |
| perl-probe-perl | 0.03 | removed |
| perl-sub-identify | 0.14 | removed |
| perl-super | 1.20190531 | removed |
| perl-test-fatal | 0.016 | removed |
| perl-test-harness | 3.42 | removed |
| perl-test-leaktrace | 0.16 | removed |
| perl-test-mockmodule | 0.177.0 | removed |
| perl-test-needs | 0.002009 | removed |
| perl-test-pod | 1.52 | removed |
| perl-test-pod-coverage | 1.10 | removed |
| perl-test-requires | 0.11 | removed |
| perl-test-script | 1.20 | removed |
| perl-test-warnings | 0.030 | removed |
| perl-try-tiny | 0.31 | removed |
| perl-types-serialiser | 1.0 | removed |
| perl-unicode-utf8 | 0.62 | removed |
| perl-variable-magic | 0.62 | removed |
| perl-xml-parser | 2.46 | removed |
| perl-xml-xpath | 1.44 | removed |
| perl-yaml-tiny | 1.73 | removed |

### Stats

| \# Packages | Old | New |
|--|----|----|
| **Environment** | 85 | 80 |
| **Build** | 117 | 68 |