### PR TITLE
guix: remove automake & autoconf

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -270,8 +270,6 @@ chain for " target " development."))
         ;; Build tools
         gnu-make
         libtool
-        autoconf-2.71 ; defaults to 2.69, which does not recognize the aarch64-apple-darwin target
-        automake
         pkg-config
         gperf         ; required to build eudev in depends
         cmake-minimal


### PR DESCRIPTION
A visualization of the build environment for Linux targets (after these changes):

Excludes `bash-minimal`, `glibc` and `gcc-lib` for clarity. 

![graph2](https://github.com/user-attachments/assets/718fd743-3835-466f-8764-b45ec97da754)
