### PR TITLE
validate ip parameter in set_bans rpc call

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2875,6 +2875,12 @@ namespace cryptonote
       }
       else
       {
+        if (!i->ip)
+        {
+          error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+          error_resp.message = "No ip/host supplied";
+          return false;
+        }
         na = epee::net_utils::ipv4_network_address{i->ip, 0};
       }
       if (i->ban)


### PR DESCRIPTION
The `set_bans` method does not validate if there is actually a host or ip passed as a parameter. If a faulty RPC call fails to provide one of those, it falls back to banning `0.0.0.0`:

![image](https://github.com/user-attachments/assets/2a3a7055-6c99-4edd-bf34-26174fed97e2)

IMO the better way to handle this would be to provide an error message upon a missing parameter, which I added here:

![image](https://github.com/user-attachments/assets/291c8272-8df8-4609-b528-8d741fcdb6ad)
