### PR TITLE
Fix get_database_size on Windows

### DIFF
--- a/contrib/epee/include/file_io_utils.h
+++ b/contrib/epee/include/file_io_utils.h
@@ -38,7 +38,6 @@ namespace file_io_utils
     bool is_file_exist(const std::string& path);
     bool save_string_to_file(const std::string& path_to_file, const std::string& str);
     bool load_file_to_string(const std::string& path_to_file, std::string& target_str, size_t max_size = 1000000000);
-    bool get_file_size(const std::string& path_to_file, uint64_t &size);
 }
 }
 

--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -149,40 +149,5 @@ namespace file_io_utils
 		}
 #endif
 	}
-
-
-	bool get_file_size(const std::string& path_to_file, uint64_t &size)
-	{
-#ifdef _WIN32
-                std::wstring wide_path;
-                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-                if (file_handle == INVALID_HANDLE_VALUE)
-                    return false;
-                LARGE_INTEGER file_size;
-                BOOL result = GetFileSizeEx(file_handle, &file_size);
-                CloseHandle(file_handle);
-                if (result) {
-                    size = file_size.QuadPart;
-                }
-                return size;
-#else
-		try
-		{
-			std::ifstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::in | std::ios::ate);
-			size = fstream.tellg();
-			fstream.close();
-			return true;
-		}
-
-		catch(...)
-		{
-			return false;
-		}
-#endif
-	}
-
 }
 }

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -34,7 +34,6 @@
 #include <cstring>  // memcpy
 
 #include "string_tools.h"
-#include "file_io_utils.h"
 #include "common/util.h"
 #include "common/pruning.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
@@ -4536,12 +4535,11 @@ bool BlockchainLMDB::is_read_only() const
 
 uint64_t BlockchainLMDB::get_database_size() const
 {
-  uint64_t size = 0;
   boost::filesystem::path datafile(m_folder);
   datafile /= CRYPTONOTE_BLOCKCHAINDATA_FILENAME;
-  if (!epee::file_io_utils::get_file_size(datafile.string(), size))
-    size = 0;
-  return size;
+  boost::system::error_code ec{};
+  const boost::uintmax_t size = boost::filesystem::file_size(datafile, ec);
+  return (ec ? 0 : static_cast<uint64_t>(size));
 }
 
 void BlockchainLMDB::fixup()

--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -30,7 +30,6 @@
 #include <atomic>
 #include <boost/filesystem.hpp>
 #include <boost/thread/thread.hpp>
-#include "file_io_utils.h"
 #include "net/http_client.h"
 #include "download.h"
 
@@ -73,8 +72,11 @@ namespace tools
     {
       boost::unique_lock<boost::mutex> lock(control->mutex);
       std::ios_base::openmode mode = std::ios_base::out | std::ios_base::binary;
-      uint64_t existing_size = 0;
-      if (epee::file_io_utils::get_file_size(control->path, existing_size) && existing_size > 0)
+      boost::system::error_code ec{};
+      uint64_t existing_size = static_cast<uint64_t>(boost::filesystem::file_size(control->path, ec));
+      if (ec)
+        existing_size = 0;
+      if (existing_size > 0)
       {
         MINFO("Resuming downloading " << control->uri << " to " << control->path << " from " << existing_size);
         mode |= std::ios_base::app;


### PR DESCRIPTION
Replace all calls to epee::file_io::get_file_size with boost::filesystem::file_size in order to avoid lossy conversions from paths to strings, which tend to break filename resolution. This commit fixes a bug on Windows where the get_info RPC call reported a zero database size because BlockchainLMBD::get_database_size returned zero.