### PR TITLE
build: make libsodium an optional build dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,11 +1193,6 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND ARCH_WIDTH EQUAL "32" AND NOT IOS AND
   endif()
 endif()
 
-if(STATIC)
-  set(sodium_USE_STATIC_LIBS ON)
-endif()
-find_package(Sodium REQUIRED)
-
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libzmq REQUIRED IMPORTED_TARGET libzmq)
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ library archives (`.a`).
 | OpenSSL      | basically any | NO       | `libssl-dev`         | `openssl`    | `openssl-devel`    | `openssl-devel`     | NO       | sha256 sum      |
 | libzmq       | 4.2.0         | NO       | `libzmq3-dev`        | `zeromq`     | `zeromq-devel`     | `zeromq-devel`      | NO       | ZeroMQ library  |
 | libunbound   | 1.4.16        | NO       | `libunbound-dev`     | `unbound`    | `unbound-devel`    | `unbound-devel`     | NO       | DNS resolver    |
-| libsodium    | ?             | NO       | `libsodium-dev`      | `libsodium`  | `libsodium-devel`  | `libsodium-devel`   | NO       | cryptography    |
+| libsodium    | ?             | NO       | `libsodium-dev`      | `libsodium`  | `libsodium-devel`  | `libsodium-devel`   | YES      | cryptography    |
 | libunwind    | any           | NO       | `libunwind8-dev`     | `libunwind`  | `libunwind-devel`  | `libunwind-devel`   | YES      | Stack traces    |
 | liblzma      | any           | NO       | `liblzma-dev`        | `xz`         | `liblzma-devel`    | `xz-devel`          | YES      | For libunwind   |
 | libreadline  | 6.3.0         | NO       | `libreadline6-dev`   | `readline`   | `readline-devel`   | `readline-devel`    | YES      | Input editing   |

--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -63,6 +63,11 @@ if (USE_DEVICE_TREZOR)
         trezor_fatal_msg("Trezor: protobuf library not found")
     endif()
 
+    if(STATIC)
+        set(sodium_USE_STATIC_LIBS ON)
+    endif()
+    find_package(Sodium REQUIRED)
+
     if(TREZOR_DEBUG)
         set(USE_DEVICE_TREZOR_DEBUG 1)
         message(STATUS "Trezor: debug build enabled")

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -50,7 +50,8 @@ set(crypto_sources
   slow-hash.c
   rx-slow-hash.c
   CryptonightR_JIT.c
-  tree-hash.c)
+  tree-hash.c
+  verify.c)
 
 if(ARCH_ID STREQUAL "i386" OR ARCH_ID STREQUAL "x86_64" OR ARCH_ID STREQUAL "x86-64" OR ARCH_ID STREQUAL "amd64")
 list(APPEND crypto_sources CryptonightR_template.S)
@@ -73,7 +74,6 @@ target_link_libraries(cncrypto
     epee
     randomx
     ${Boost_SYSTEM_LIBRARY}
-    ${sodium_LIBRARIES}
   PRIVATE
     ${EXTRA_LIBRARIES})
 

--- a/src/crypto/generic-ops.h
+++ b/src/crypto/generic-ops.h
@@ -33,7 +33,7 @@
 #include <cstddef>
 #include <cstring>
 #include <functional>
-#include <sodium/crypto_verify_32.h>
+#include "verify.h"
 
 #define CRYPTO_MAKE_COMPARABLE(type) \
 namespace crypto { \

--- a/src/crypto/verify.c
+++ b/src/crypto/verify.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: ISC
+// SPDX-FileCopyrightText: 2013-2024 Frank Denis <j at pureftpd dot org>
+
+#include <stdint.h>
+
+#include "verify.h"
+
+#define crypto_verify_32_BYTES 32U
+
+#if defined(__x86_64__) && defined(__SSE2__)
+
+# ifdef __GNUC__
+#  pragma GCC target("sse2")
+# endif
+# include <emmintrin.h>
+
+static inline int
+crypto_verify_n(const unsigned char *x_, const unsigned char *y_,
+                const int n)
+{
+    const    __m128i zero = _mm_setzero_si128();
+    volatile __m128i v1, v2, z;
+    volatile int     m;
+    int              i;
+
+    const volatile __m128i *volatile x =
+        (const volatile __m128i *volatile) (const void *) x_;
+    const volatile __m128i *volatile y =
+        (const volatile __m128i *volatile) (const void *) y_;
+    v1 = _mm_loadu_si128((const __m128i *) &x[0]);
+    v2 = _mm_loadu_si128((const __m128i *) &y[0]);
+    z = _mm_xor_si128(v1, v2);
+    for (i = 1; i < n / 16; i++) {
+        v1 = _mm_loadu_si128((const __m128i *) &x[i]);
+        v2 = _mm_loadu_si128((const __m128i *) &y[i]);
+        z = _mm_or_si128(z, _mm_xor_si128(v1, v2));
+    }
+    m = _mm_movemask_epi8(_mm_cmpeq_epi32(z, zero));
+    v1 = zero; v2 = zero; z = zero;
+
+    return (int) (((uint32_t) m + 1U) >> 16) - 1;
+}
+
+#else
+
+static inline int
+crypto_verify_n(const unsigned char *x_, const unsigned char *y_,
+                const int n)
+{
+  const volatile unsigned char *volatile x =
+          (const volatile unsigned char *volatile) x_;
+  const volatile unsigned char *volatile y =
+          (const volatile unsigned char *volatile) y_;
+  volatile uint_fast16_t d = 0U;
+  int i;
+
+  for (i = 0; i < n; i++) {
+    d |= x[i] ^ y[i];
+  }
+  return (1 & ((d - 1) >> 8)) - 1;
+}
+
+#endif
+
+int
+crypto_verify_32(const unsigned char *x, const unsigned char *y)
+{
+  return crypto_verify_n(x, y, crypto_verify_32_BYTES);
+}

--- a/src/crypto/verify.h
+++ b/src/crypto/verify.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: ISC
+// SPDX-FileCopyrightText: 2013-2024 Frank Denis <j at pureftpd dot org>
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// fix naming collision with libsodium
+#define crypto_verify_32 monero_crypto_verify_32
+
+int crypto_verify_32(const unsigned char *x, const unsigned char *y)
+            __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -36,12 +36,11 @@
 #include <common/apply_permutation.h>
 #include <common/json_util.h>
 #include <crypto/hmac-keccak.h>
+#include <crypto/verify.h>
 #include <ringct/rctSigs.h>
 #include <ringct/bulletproofs.h>
 #include <ringct/bulletproofs_plus.h>
 #include "cryptonote_config.h"
-#include <sodium.h>
-#include <sodium/crypto_verify_32.h>
 #include <sodium/crypto_aead_chacha20poly1305.h>
 
 #define GET_FIELD_STRING(name, type, jtype) field_##name = std::string(json[#name].GetString(), json[#name].GetStringLength())

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -36,7 +36,6 @@
 #include <vector>
 #include <iostream>
 #include <cinttypes>
-#include <sodium/crypto_verify_32.h>
 
 extern "C" {
 #include "crypto/crypto-ops.h"

--- a/tests/performance_tests/equality.h
+++ b/tests/performance_tests/equality.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include <string.h>
-#include <sodium/crypto_verify_32.h>
+#include "crypto/verify.h"
 
 struct memcmp32
 {


### PR DESCRIPTION
This PR is a step towards removing libsodium as a release build dependency.

We don't need to pull in libsodium for one evergreen function (`crypto_verify_32`). This PR vendors that function in `src/crypto`. Libsodium is now only required when building with Trezor support.

The code was copied from: `src/libsodium/include/crypto_verify_32.h` and `src/libsodium/crypto_verify/verify.c` in the libsodium repo checked out at `1.0.20-RELEASE`, with minor (non-functional) changes.

Trezor uses `crypto_aead_chacha20poly1305_ietf_decrypt` from libsodium in `src/device_trezor/protocol.cpp` which is a bit more complicated to vendor. We may want to consider using the [upstream implementation](https://github.com/trezor/trezor-firmware/tree/main/crypto/chacha20poly1305) or OpenSSL rather than libsodium's.