### PR TITLE
depends: openssl: update to 3.4.0

### DIFF
--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=3.0.13
-$(package)_download_path=https://www.openssl.org/source
+$(package)_version=3.4.0
+$(package)_download_path=https://github.com/openssl/openssl/releases/download/openssl-$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+$(package)_sha256_hash=e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
 
 # The bundled ranlib in Android NDK 18b inserts timestamps by default.
 # To prevent reproducibility issues, we must enable [D]eterministic mode.
@@ -12,6 +12,7 @@ $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$(
 $(package)_config_env_android=ANDROID_NDK_ROOT="$(host_prefix)/native" PATH="$(host_prefix)/native/bin" CC=clang AR=ar RANLIB="ranlib -D"
 $(package)_build_env_android=ANDROID_NDK_ROOT="$(host_prefix)/native"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl --libdir=$(host_prefix)/lib
+$(package)_config_opts+=no-apps
 $(package)_config_opts+=no-capieng
 $(package)_config_opts+=no-dso
 $(package)_config_opts+=no-dtls1
@@ -28,9 +29,9 @@ $(package)_config_opts+=no-ssl3
 $(package)_config_opts+=no-tests
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
+$(package)_config_opts+=no-winstore
 $(package)_config_opts+=no-zlib
 $(package)_config_opts+=no-zlib-dynamic
-$(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)
 $(package)_config_opts_linux=-fPIC -Wa,--noexecstack
 $(package)_config_opts_freebsd=-fPIC -Wa,--noexecstack
 $(package)_config_opts_x86_64_linux=linux-x86_64
@@ -40,7 +41,7 @@ $(package)_config_opts_aarch64_linux=linux-generic64
 $(package)_config_opts_arm_android=--static android-arm
 $(package)_config_opts_aarch64_android=--static android-arm64
 $(package)_config_opts_aarch64_darwin=darwin64-arm64-cc
-$(package)_config_opts_riscv64_linux=linux-generic64
+$(package)_config_opts_riscv64_linux=linux64-riscv64
 $(package)_config_opts_loongarch64_linux=linux-generic64
 $(package)_config_opts_mipsel_linux=linux-generic32
 $(package)_config_opts_mips_linux=linux-generic32
@@ -52,7 +53,8 @@ $(package)_config_opts_x86_64_freebsd=BSD-x86_64
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old 's|crypto ssl apps util tools fuzz providers doc|crypto ssl util tools providers|' build.info
+  sed -i.old 's|crypto ssl apps util tools fuzz providers doc|crypto ssl util tools providers|' build.info &&\
+  rm -rf doc demos apps test
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
This PR tracks the latest OpenSSL release. It will remain a draft until it is needed. It exists to identify and fix build issues ahead of time.