### PR TITLE
depends: remove archiver flags

### DIFF
--- a/contrib/depends/builders/default.mk
+++ b/contrib/depends/builders/default.mk
@@ -17,4 +17,4 @@ define add_build_flags_func
 build_$(build_arch)_$(build_os)_$1 += $(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)
 endef
-$(foreach flags, CFLAGS CXXFLAGS ARFLAGS LDFLAGS, $(eval $(call add_build_flags_func,$(flags))))
+$(foreach flags, CFLAGS CXXFLAGS LDFLAGS, $(eval $(call add_build_flags_func,$(flags))))

--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -12,8 +12,6 @@ $(1)_cflags=$$($$($(1)_type)_CFLAGS) \
             $$($$($(1)_type)_$$(release_type)_CFLAGS)
 $(1)_cxxflags=$$($$($(1)_type)_CXXFLAGS) \
               $$($$($(1)_type)_$$(release_type)_CXXFLAGS)
-$(1)_arflags=$$($$($(1)_type)_ARFLAGS) \
-             $$($$($(1)_type)_$(release_type)_ARFLAGS)
 $(1)_ldflags=$$($$($(1)_type)_LDFLAGS) \
              $$($$($(1)_type)_$$(release_type)_LDFLAGS) \
              -L$$($($(1)_type)_prefix)/lib
@@ -111,11 +109,6 @@ $(1)_cxxflags+=$($(1)_cxxflags_$(host_arch)) $($(1)_cxxflags_$(host_arch)_$(rele
 $(1)_cxxflags+=$($(1)_cxxflags_$(host_os)) $($(1)_cxxflags_$(host_os)_$(release_type))
 $(1)_cxxflags+=$($(1)_cxxflags_$(host_arch)_$(host_os)) $($(1)_cxxflags_$(host_arch)_$(host_os)_$(release_type))
 
-$(1)_arflags+=$($(1)_arflags_$(release_type))
-$(1)_arflags+=$($(1)_arflags_$(host_arch)) $($(1)_arflags_$(host_arch)_$(release_type))
-$(1)_arflags+=$($(1)_arflags_$(host_os)) $($(1)_arflags_$(host_os)_$(release_type))
-$(1)_arflags+=$($(1)_arflags_$(host_arch)_$(host_os)) $($(1)_arflags_$(host_arch)_$(host_os)_$(release_type))
-
 $(1)_cppflags+=$($(1)_cppflags_$(release_type))
 $(1)_cppflags+=$($(1)_cppflags_$(host_arch)) $($(1)_cppflags_$(host_arch)_$(release_type))
 $(1)_cppflags+=$($(1)_cppflags_$(host_os)) $($(1)_cppflags_$(host_os)_$(release_type))
@@ -169,9 +162,6 @@ $(1)_autoconf += RANLIB="$$($(1)_ranlib)"
 endif
 ifneq ($($(1)_ar),)
 $(1)_autoconf += AR="$$($(1)_ar)"
-endif
-ifneq ($($(1)_arflags),)
-$(1)_autoconf += ARFLAGS="$$($(1)_arflags)"
 endif
 ifneq ($($(1)_cflags),)
 $(1)_autoconf += CFLAGS="$$($(1)_cflags)"

--- a/contrib/depends/hosts/android.mk
+++ b/contrib/depends/hosts/android.mk
@@ -10,7 +10,6 @@ android_RANLIB=:
 
 android_CFLAGS=-pipe
 android_CXXFLAGS=$(android_CFLAGS)
-android_ARFLAGS=crsD
 
 android_release_CFLAGS=-O2
 android_release_CXXFLAGS=$(android_release_CFLAGS)

--- a/contrib/depends/hosts/darwin.mk
+++ b/contrib/depends/hosts/darwin.mk
@@ -54,7 +54,6 @@ darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
 
 darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)
-darwin_ARFLAGS=cr
 
 darwin_release_CFLAGS=-O2
 darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)

--- a/contrib/depends/hosts/freebsd.mk
+++ b/contrib/depends/hosts/freebsd.mk
@@ -15,7 +15,6 @@ freebsd_NM=nm
 
 freebsd_CFLAGS=-pipe
 freebsd_CXXFLAGS=$(freebsd_CFLAGS)
-freebsd_ARFLAGS=cr
 
 freebsd_release_CFLAGS=-O2
 freebsd_release_CXXFLAGS=$(freebsd_release_CFLAGS)

--- a/contrib/depends/hosts/linux.mk
+++ b/contrib/depends/hosts/linux.mk
@@ -1,6 +1,5 @@
 linux_CFLAGS=-pipe
 linux_CXXFLAGS=$(linux_CFLAGS)
-linux_ARFLAGS=cr
 
 linux_release_CFLAGS=-O2
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)

--- a/contrib/depends/hosts/mingw32.mk
+++ b/contrib/depends/hosts/mingw32.mk
@@ -1,6 +1,5 @@
 mingw32_CFLAGS=-pipe
 mingw32_CXXFLAGS=$(mingw32_CFLAGS)
-mingw32_ARFLAGS=cr
 
 mingw32_release_CFLAGS=-O2
 mingw32_release_CXXFLAGS=$(mingw32_release_CFLAGS)

--- a/contrib/depends/packages/eudev.mk
+++ b/contrib/depends/packages/eudev.mk
@@ -9,7 +9,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmd

--- a/contrib/depends/packages/hidapi.mk
+++ b/contrib/depends/packages/hidapi.mk
@@ -21,7 +21,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/packages/libusb.mk
+++ b/contrib/depends/packages/libusb.mk
@@ -18,7 +18,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmd

--- a/contrib/depends/packages/protobuf.mk
+++ b/contrib/depends/packages/protobuf.mk
@@ -13,7 +13,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -17,7 +17,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -24,7 +24,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) ac_cv_func_getentropy=no AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf) ac_cv_func_getentropy=no
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -12,7 +12,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
Archivers for all targets now default to deterministic mode. Requires #9456. Compare Guix hashes before merge.