### PR TITLE
ci: add arch linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,22 @@ jobs:
         ${{env.CCACHE_SETTINGS}}
         make release-static-win64 -j4
 
+  build-arch:
+    name: 'Arch Linux'
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: install dependencies
+        run: pacman -Syyu --noconfirm base-devel git cmake boost openssl zeromq unbound libsodium readline expat gtest python3 doxygen graphviz hidapi libusb protobuf
+      - name: configure git
+        run: git config --global --add safe.directory '*'
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: build
+        run: ${{env.BUILD_DEFAULT_LINUX}}
+
   build-debian:
     name: 'Debian 10'
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't currently have a rolling release Linux distro in our CI. Arch Linux is a common development environment.

This would help us catch and fix issues like #9359 early.