### PR TITLE
Failed to build for FreeBSD using GCC

### DIFF
--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -26,7 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__ || defined __FreeBSD__
+#if !defined __GNUC__ || defined __clang__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__
 #define USE_UNWIND
 #else
 #define ELPP_FEATURE_CRASH_LOG 1


### PR DESCRIPTION
My **cmake(1)** command line is:
```sh
CPP="gcc -E" CC=gcc CFLAGS="-Wall -Os -g" CXX=g++ CXXFLAGS="-Wall -Os -g" cmake -D CMAKE_SKIP_RPATH=TRUE ..
```

Failure is similar to:
```
[ 90%] Linking CXX executable ../../bin/monero-gen-ssl-cert
/usr/local/bin/ld: ../common/libcommon.a(stack_trace.cpp.o): in function `tools::log_stack_trace(char const*) [clone .localalias]':
stack_trace.cpp:(.text+0x2f4): undefined reference to `_Ux86_64_getcontext'
/usr/local/bin/ld: stack_trace.cpp:(.text+0x315): undefined reference to `_ULx86_64_init_local'
/usr/local/bin/ld: stack_trace.cpp:(.text+0x32e): undefined reference to `_ULx86_64_step'
/usr/local/bin/ld: stack_trace.cpp:(.text+0x354): undefined reference to `_ULx86_64_get_reg'
/usr/local/bin/ld: stack_trace.cpp:(.text+0x37e): undefined reference to `_ULx86_64_get_proc_name'
collect2: error: ld returned 1 exit status
--- bin/monero-gen-ssl-cert ---
*** [bin/monero-gen-ssl-cert] Error code 1
```

By reading `CMakeList.txt`, easylogging++ should be used instead of libunwind for stack tracing, in case GCC is being used:
```cmake
elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
  set(DEFAULT_STACK_TRACE ON)
  set(STACK_TRACE_LIB "easylogging++") # for diag output only
  set(LIBUNWIND_LIBRARIES "")
```

Source file `src/common/stack_trace.cpp` however, hardcoded to use libunwind for FreeBSD, using `__FreeBSD__` macro.

Since the useability of easylogging++ stack tracing is mostly compiler-depended (requires GCC), and `CMakeList.txt` especially contains a comment saying `When possible, avoid stack tracing using libunwind in favor of using easylogging++`, hardcoding the FreeBSD case here looks unreasonable.

Because Clang also defines macro `__GNUC__` to declare some degrees of compatibility with GCC 4.2, this macro checking has been changed so that uses of non-GCC compilers including Clang (or under a few other conditions such as Android), will enable the use of libunwind; otherwise easylogging++ will be used. This matches `CMakeList.txt` logic better.

