### PR TITLE
miniupnpc: fix build with gcc 14 [RELEASE]

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(Miniupnpc REQUIRED)
 
 message(STATUS "Using in-tree miniupnpc")
 set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
+set(UPNPC_BUILD_SHARED OFF CACHE BOOL "Disable building shared library" FORCE)
 add_subdirectory(miniupnp/miniupnpc)
 set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
 set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This is a quick fix to get development builds working while we work out what to do with miniupnpc.

https://github.com/tobtoht/monero/actions/runs/12653434575/job/35258755783

Fixes #9678, #9359.