### PR TITLE
depends: boost: update to 1.66.0 [RELEASE]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1108,6 +1108,12 @@ add_definitions(-DBOOST_ASIO_ENABLE_SEQUENTIAL_STRAND_ALLOCATION)
 add_definitions(-DBOOST_NO_AUTO_PTR)
 add_definitions(-DBOOST_UUID_DISABLE_ALIGNMENT) # This restores UUID's std::has_unique_object_representations property
 
+if(FREEBSD AND DEPENDS)
+  # Boost 1.66.0 fails to detect that we have <string_view>, resulting in an incorrect include.
+  # This line can be removed if Boost is upgraded to > 1.66.0.
+  add_definitions(-DBOOST_ASIO_HAS_STD_STRING_VIEW)
+endif()
+
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 if(MINGW)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wa,-mbig-obj")

--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost                                                                                                                                                                                                                      
-$(package)_version=1_64_0
-$(package)_download_path=https://downloads.sourceforge.net/project/boost/boost/1.64.0/
-$(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_version=1.66.0
+$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
+$(package)_file_name=$(package)_$(subst .,_,$($(package)_version)).tar.gz
+$(package)_sha256_hash=bd0df411efd9a585e5a2212275f8762079fed8842264954675a4fddc46cfcf60
 $(package)_dependencies=libiconv
 $(package)_patches=fix_aroptions.patch fix_arm_arch.patch
 
@@ -25,7 +25,7 @@ $(package)_archiver_darwin=$($(package)_libtool)
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,date_time,regex,serialization,locale
 $(package)_cxxflags=-std=c++11
 $(package)_cxxflags_linux=-fPIC
-$(package)_cxxflags_freebsd=-fPIC
+$(package)_cxxflags_freebsd=-fPIC -DBOOST_ASIO_HAS_STD_STRING_VIEW=1
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
`-DBOOST_ASIO_HAS_STD_STRING_VIEW=1` fixes:

```
/monero/contrib/depends/x86_64-unknown-freebsd/native/usr/include/c++/v1/experimental/string_view:18:3: 
warning: "<experimental/string_view> has been removed. Use <string_view> instead." [-W#warnings]

/monero/contrib/depends/x86_64-unknown-freebsd/include/boost/asio/detail/string_view.hpp:32:12: 
error: no member named 'experimental' in namespace 'std' using std::experimental::basic_string_view;
```

https://github.com/monero-project/monero/pull/9162#issuecomment-2574034170

Needs successful Gitian build and testing.