### PR TITLE
common: Remove resolved FIXME in pod-class.h

### DIFF
--- a/src/common/pod-class.h
+++ b/src/common/pod-class.h
@@ -30,14 +30,4 @@
 
 #pragma once
 
-// FIXME: Why is this ifdef needed?  Hopefully making it struct won't break things.
-
-/*
-#if defined(_MSC_VER)
-#define POD_CLASS struct
-#else
-#define POD_CLASS class
-#endif
-*/
-
 #define POD_CLASS struct


### PR DESCRIPTION
In src/common/pod-class.h, the POD_CLASS definition contained quite a lot of detritus, including a long-ago resolved FIXME. Delete all the noise.