### PR TITLE
crypto: remove unused POD classes

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -71,22 +71,6 @@ namespace crypto {
 
   using secret_key = epee::mlocked<tools::scrubbed<ec_scalar>>;
 
-  POD_CLASS public_keyV {
-    std::vector<public_key> keys;
-    int rows;
-  };
-
-  POD_CLASS secret_keyV {
-    std::vector<secret_key> keys;
-    int rows;
-  };
-
-  POD_CLASS public_keyM {
-    int cols;
-    int rows;
-    std::vector<secret_keyV> column_vectors;
-  };
-
   POD_CLASS key_derivation: ec_point {
     friend class crypto_ops;
   };


### PR DESCRIPTION
Remove the following unused classes from the crypto namespace: public_keyV, secret_keyV, and public_keyM.