### PR TITLE
tests: fix IPv4Success, DNSSECSuccess

### DIFF
--- a/tests/unit_tests/dns_resolver.cpp
+++ b/tests/unit_tests/dns_resolver.cpp
@@ -41,15 +41,11 @@ TEST(DNSResolver, IPv4Success)
 
   auto ips = resolver.get_ipv4("example.com", avail, valid);
 
-  ASSERT_EQ(1, ips.size());
-
-  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+  ASSERT_LE(1, ips.size());
 
   ips = tools::DNSResolver::instance().get_ipv4("example.com", avail, valid);
 
-  ASSERT_EQ(1, ips.size());
-
-  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+  ASSERT_LE(1, ips.size());
 }
 
 TEST(DNSResolver, IPv4Failure)
@@ -76,9 +72,7 @@ TEST(DNSResolver, DNSSECSuccess)
 
   auto ips = resolver.get_ipv4("example.com", avail, valid);
 
-  ASSERT_EQ(1, ips.size());
-
-  //ASSERT_STREQ("93.184.216.119", ips[0].c_str());
+  ASSERT_LE(1, ips.size());
 
   ASSERT_TRUE(avail);
   ASSERT_TRUE(valid);


### PR DESCRIPTION
"example.com" now has more than one A record.

```
;; ANSWER SECTION:
example.com.		43	IN	A	23.192.228.84
example.com.		43	IN	A	96.7.128.175
example.com.		43	IN	A	23.192.228.80
example.com.		43	IN	A	23.215.0.136
example.com.		43	IN	A	23.215.0.138
example.com.		43	IN	A	96.7.128.198
```

 https://github.com/monero-project/monero/actions/runs/12783536409/job/35635533417#step:9:4435