### PR TITLE
brew: use latest protobuf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,7 @@ jobs:
       - uses: ./.github/actions/set-make-job-count
       - name: install dependencies
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq miniupnpc expat libunwind-headers protobuf@21 ccache
-          brew link protobuf@21 boost
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq miniupnpc expat libunwind-headers protobuf ccache
       - name: build
         run: |
           ${{env.CCACHE_SETTINGS}}

--- a/contrib/brew/Brewfile
+++ b/contrib/brew/Brewfile
@@ -28,5 +28,5 @@ brew "doxygen"
 brew "graphviz"
 brew "libunwind-headers"
 brew "xz"
-brew "protobuf@21", link: true
+brew "protobuf"
 brew "libusb"

--- a/src/device_trezor/README.md
+++ b/src/device_trezor/README.md
@@ -15,10 +15,9 @@ Please, refer to [monero readme](https://github.com/trezor/trezor-firmware/blob/
 
 ## Dependencies
 
-Trezor uses [Protobuf](https://protobuf.dev/) library. Monero is now compiled with C++ 17 by default.
-Protobuf v21 is tested, older versions are not guaranteed to work. Note that Protobuf v23+ requires C++ 17.
+Trezor uses [Protobuf](https://protobuf.dev/) library.
 
-If you are getting Trezor compilation errors, it may be caused by abseil (protobuf dependency) not being compiled with C++17.
+Monero is now compiled with C++17 by default. If you are getting Trezor compilation errors, it may be caused by abseil (protobuf dependency) not being compiled with C++17.
 To fix this try installing protobuf from sources:
 
 ```shell
@@ -29,42 +28,22 @@ cmake --build .
 sudo make install
 ```
 
-If Monero is compiled with C++14, Protobuf v21 is the latest compatible protobuf version for C++ 14.
-If you want to compile Monero with Trezor support with C++14, please make sure the Protobuf v21 is installed.
-
-More about this limitation: [PR #8752](https://github.com/monero-project/monero/pull/8752), 
-[1](https://github.com/monero-project/monero/pull/8752#discussion_r1246174755), [2](https://github.com/monero-project/monero/pull/8752#discussion_r1246480393)
-
-### OSX
-
-To build with installed, but not linked Protobuf v21:
+### macOS
 
 ```bash
-CMAKE_PREFIX_PATH=$(find /opt/homebrew/Cellar/protobuf@21 -maxdepth 1 -type d -name "21.*" -print -quit) \
-make release
-```
-
-or to install and link as a default protobuf version:
-```bash
-# Either install all requirements as
 brew update && brew bundle --file=contrib/brew/Brewfile
-
-# or install protobufv21 specifically
-brew install protobuf@21 && brew link protobuf@21
 ```
 
 ### MSYS32
 
 ```bash
-curl -O https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-protobuf-c-1.4.1-1-any.pkg.tar.zst
-curl -O https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-protobuf-21.9-1-any.pkg.tar.zst
-pacman --noconfirm -U mingw-w64-x86_64-protobuf-c-1.4.1-1-any.pkg.tar.zst mingw-w64-x86_64-protobuf-21.9-1-any.pkg.tar.zst
+pacman -S mingw-w64-x86_64-protobuf
 ```
 
 ### Other systems
 
-- install Protobuf v21
-- point `CMAKE_PREFIX_PATH` environment variable to Protobuf v21 installation.
+- install Protobuf
+- point `CMAKE_PREFIX_PATH` environment variable to Protobuf installation.
 
 ## Troubleshooting
 


### PR DESCRIPTION
No longer needed since #8922.

Resolves two CI annotations:

- protobuf@21 has been deprecated because it is a versioned formula! It will be disabled on 2026-01-08.
- Already linked: /opt/homebrew/Cellar/boost/1.87.0