### PR TITLE
ringct: remove unused range proof types and fix serialization bug

### DIFF
--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -413,8 +413,6 @@ namespace tx {
   static unsigned get_rsig_type(const rct::RCTConfig &rct_config, size_t num_outputs){
     if (rct_config.range_proof_type == rct::RangeProofBorromean){
       return rct::RangeProofBorromean;
-    } else if (num_outputs > BULLETPROOF_MAX_OUTPUTS){
-      return rct::RangeProofMultiOutputBulletproof;
     } else {
       return rct::RangeProofPaddedBulletproof;
     }
@@ -424,7 +422,7 @@ namespace tx {
     size_t amount_batched = 0;
 
     while(amount_batched < num_outputs){
-      if (rsig_type == rct::RangeProofBorromean || rsig_type == rct::RangeProofBulletproof) {
+      if (rsig_type == rct::RangeProofBorromean) {
         batches.push_back(1);
         amount_batched += 1;
 
@@ -434,15 +432,6 @@ namespace tx {
         }
         batches.push_back(num_outputs);
         amount_batched += num_outputs;
-
-      } else if (rsig_type == rct::RangeProofMultiOutputBulletproof){
-        size_t batch_size = 1;
-        while (batch_size * 2 + amount_batched <= num_outputs && batch_size * 2 <= BULLETPROOF_MAX_OUTPUTS){
-          batch_size *= 2;
-        }
-        batch_size = std::min(batch_size, num_outputs - amount_batched);
-        batches.push_back(batch_size);
-        amount_batched += batch_size;
 
       } else {
         throw std::invalid_argument("Unknown rsig type");

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -305,7 +305,7 @@ namespace rct {
       RCTTypeCLSAG = 5,
       RCTTypeBulletproofPlus = 6,
     };
-    enum RangeProofType { RangeProofBorromean, RangeProofBulletproof, RangeProofMultiOutputBulletproof, RangeProofPaddedBulletproof };
+    enum RangeProofType { RangeProofBorromean, RangeProofPaddedBulletproof };
     struct RCTConfig {
       RangeProofType range_proof_type;
       int bp_version;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -2509,7 +2509,7 @@ namespace boost
         bool use_bulletproofs = x.rct_config.range_proof_type != rct::RangeProofBorromean;
         a & use_bulletproofs;
         if (!typename Archive::is_saving())
-          x.rct_config = { use_bulletproofs ? rct::RangeProofBulletproof : rct::RangeProofBorromean, 0 };
+          x.rct_config = { use_bulletproofs ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean, 0 };
         return;
       }
       a & x.rct_config;

--- a/tests/core_tests/bulletproof_plus.cpp
+++ b/tests/core_tests/bulletproof_plus.cpp
@@ -228,14 +228,6 @@ bool gen_bpp_tx_valid_at_fork::generate(std::vector<test_event_entry>& events) c
   return generate_with(events, mixin, 1, amounts_paid, true, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bpp(tx, tx_idx, bp_sizes, "gen_bpp_tx_valid_at_fork"); });
 }
 
-bool gen_bpp_tx_invalid_1_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {5000, 5000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof , 4 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, NULL);
-}
-
 bool gen_bpp_tx_valid_2::generate(std::vector<test_event_entry>& events) const
 {
   const size_t mixin = 10;
@@ -263,22 +255,6 @@ bool gen_bpp_tx_valid_16::generate(std::vector<test_event_entry>& events) const
   return generate_with(events, mixin, 1, amounts_paid, true, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bpp(tx, tx_idx, bp_sizes, "gen_bpp_tx_valid_16"); });
 }
 
-bool gen_bpp_tx_invalid_4_2_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofMultiOutputBulletproof , 4 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, NULL);
-}
-
-bool gen_bpp_tx_invalid_16_16::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofMultiOutputBulletproof , 4 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, NULL);
-}
-
 bool gen_bpp_txs_valid_2_and_2::generate(std::vector<test_event_entry>& events) const
 {
   const size_t mixin = 10;
@@ -286,14 +262,6 @@ bool gen_bpp_txs_valid_2_and_2::generate(std::vector<test_event_entry>& events) 
   const size_t bp_sizes[] = {2, (size_t)-1, 2, (size_t)-1};
   const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 4 }, {rct::RangeProofPaddedBulletproof, 4 } };
   return generate_with(events, mixin, 2, amounts_paid, true, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bpp(tx, tx_idx, bp_sizes, "gen_bpp_txs_valid_2_and_2"); });
-}
-
-bool gen_bpp_txs_invalid_2_and_8_2_and_16_16_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, (uint64_t)-1, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = {{rct::RangeProofMultiOutputBulletproof, 4}, {rct::RangeProofMultiOutputBulletproof, 4}, {rct::RangeProofMultiOutputBulletproof, 4}};
-  return generate_with(events, mixin, 3, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, NULL);
 }
 
 bool gen_bpp_txs_valid_2_and_3_and_2_and_4::generate(std::vector<test_event_entry>& events) const
@@ -305,27 +273,12 @@ bool gen_bpp_txs_valid_2_and_3_and_2_and_4::generate(std::vector<test_event_entr
   return generate_with(events, mixin, 4, amounts_paid, true, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx) { return check_bpp(tx, tx_idx, bp_sizes, "gen_bpp_txs_valid_2_and_3_and_2_and_4"); });
 }
 
-bool gen_bpp_tx_invalid_not_enough_proofs::generate(std::vector<test_event_entry>& events) const
-{
-  DEFINE_TESTS_ERROR_CONTEXT("gen_bpp_tx_invalid_not_enough_proofs");
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {5000, 5000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 4 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](cryptonote::transaction &tx, size_t idx){
-    CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
-    CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs_plus.empty());
-    tx.rct_signatures.p.bulletproofs_plus.pop_back();
-    CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs_plus.empty());
-    return true;
-  });
-}
-
 bool gen_bpp_tx_invalid_empty_proofs::generate(std::vector<test_event_entry>& events) const
 {
   DEFINE_TESTS_ERROR_CONTEXT("gen_bpp_tx_invalid_empty_proofs");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {50000, 50000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 4 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 4 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
     tx.rct_signatures.p.bulletproofs_plus.clear();
@@ -338,7 +291,7 @@ bool gen_bpp_tx_invalid_too_many_proofs::generate(std::vector<test_event_entry>&
   DEFINE_TESTS_ERROR_CONTEXT("gen_bpp_tx_invalid_too_many_proofs");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {10000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 4 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 4 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
     CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs_plus.empty());
@@ -352,7 +305,7 @@ bool gen_bpp_tx_invalid_wrong_amount::generate(std::vector<test_event_entry>& ev
   DEFINE_TESTS_ERROR_CONTEXT("gen_bpp_tx_invalid_wrong_amount");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {10000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 4 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 4 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_BULLETPROOF_PLUS, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproofPlus);
     CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs_plus.empty());

--- a/tests/core_tests/bulletproof_plus.h
+++ b/tests/core_tests/bulletproof_plus.h
@@ -121,12 +121,6 @@ struct gen_bpp_tx_valid_at_fork : public gen_bpp_tx_validation_base
 };
 template<> struct get_test_options<gen_bpp_tx_valid_at_fork>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
 
-struct gen_bpp_tx_invalid_1_1 : public gen_bpp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bpp_tx_invalid_1_1>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
-
 struct gen_bpp_tx_valid_2 : public gen_bpp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
@@ -145,41 +139,17 @@ struct gen_bpp_tx_valid_16 : public gen_bpp_tx_validation_base
 };
 template<> struct get_test_options<gen_bpp_tx_valid_16>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
 
-struct gen_bpp_tx_invalid_4_2_1 : public gen_bpp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bpp_tx_invalid_4_2_1>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
-
-struct gen_bpp_tx_invalid_16_16 : public gen_bpp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bpp_tx_invalid_16_16>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
-
 struct gen_bpp_txs_valid_2_and_2 : public gen_bpp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
 };
 template<> struct get_test_options<gen_bpp_txs_valid_2_and_2>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
 
-struct gen_bpp_txs_invalid_2_and_8_2_and_16_16_1 : public gen_bpp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bpp_txs_invalid_2_and_8_2_and_16_16_1>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
-
 struct gen_bpp_txs_valid_2_and_3_and_2_and_4 : public gen_bpp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
 };
 template<> struct get_test_options<gen_bpp_txs_valid_2_and_3_and_2_and_4>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
-
-struct gen_bpp_tx_invalid_not_enough_proofs : public gen_bpp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bpp_tx_invalid_not_enough_proofs>: public get_bpp_versioned_test_options<HF_VERSION_BULLETPROOF_PLUS> {};
 
 struct gen_bpp_tx_invalid_empty_proofs : public gen_bpp_tx_validation_base
 {

--- a/tests/core_tests/bulletproofs.cpp
+++ b/tests/core_tests/bulletproofs.cpp
@@ -228,14 +228,6 @@ bool gen_bp_tx_invalid_1_from_12::generate(std::vector<test_event_entry>& events
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, 12, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bp(tx, tx_idx, bp_sizes, "gen_bp_tx_invalid_1_from_12"); });
 }
 
-bool gen_bp_tx_invalid_1_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {5000, 5000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof , 3 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, NULL);
-}
-
 bool gen_bp_tx_valid_2::generate(std::vector<test_event_entry>& events) const
 {
   const size_t mixin = 10;
@@ -263,22 +255,6 @@ bool gen_bp_tx_valid_16::generate(std::vector<test_event_entry>& events) const
   return generate_with(events, mixin, 1, amounts_paid, true, rct_config, HF_VERSION_CLSAG, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bp(tx, tx_idx, bp_sizes, "gen_bp_tx_valid_16"); });
 }
 
-bool gen_bp_tx_invalid_4_2_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofMultiOutputBulletproof, 3 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, NULL);
-}
-
-bool gen_bp_tx_invalid_16_16::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofMultiOutputBulletproof, 3 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, NULL);
-}
-
 bool gen_bp_txs_valid_2_and_2::generate(std::vector<test_event_entry>& events) const
 {
   const size_t mixin = 10;
@@ -286,14 +262,6 @@ bool gen_bp_txs_valid_2_and_2::generate(std::vector<test_event_entry>& events) c
   const size_t bp_sizes[] = {2, (size_t)-1, 2, (size_t)-1};
   const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 3 }, {rct::RangeProofPaddedBulletproof, 3 } };
   return generate_with(events, mixin, 2, amounts_paid, true, rct_config, HF_VERSION_CLSAG, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx){ return check_bp(tx, tx_idx, bp_sizes, "gen_bp_txs_valid_2_and_2"); });
-}
-
-bool gen_bp_txs_invalid_2_and_8_2_and_16_16_1::generate(std::vector<test_event_entry>& events) const
-{
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {1000, 1000, (uint64_t)-1, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = {{rct::RangeProofMultiOutputBulletproof, 3}, {rct::RangeProofMultiOutputBulletproof, 3}, {rct::RangeProofMultiOutputBulletproof, 3}};
-  return generate_with(events, mixin, 3, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, NULL);
 }
 
 bool gen_bp_txs_valid_2_and_3_and_2_and_4::generate(std::vector<test_event_entry>& events) const
@@ -305,27 +273,12 @@ bool gen_bp_txs_valid_2_and_3_and_2_and_4::generate(std::vector<test_event_entry
   return generate_with(events, mixin, 4, amounts_paid, true, rct_config, HF_VERSION_CLSAG, NULL, [&](const cryptonote::transaction &tx, size_t tx_idx) { return check_bp(tx, tx_idx, bp_sizes, "gen_bp_txs_valid_2_and_3_and_2_and_4"); });
 }
 
-bool gen_bp_tx_invalid_not_enough_proofs::generate(std::vector<test_event_entry>& events) const
-{
-  DEFINE_TESTS_ERROR_CONTEXT("gen_bp_tx_invalid_not_enough_proofs");
-  const size_t mixin = 10;
-  const uint64_t amounts_paid[] = {5000, 5000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 3 } };
-  return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, [&](cryptonote::transaction &tx, size_t idx){
-    CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproof || tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG);
-    CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs.empty());
-    tx.rct_signatures.p.bulletproofs.pop_back();
-    CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs.empty());
-    return true;
-  });
-}
-
 bool gen_bp_tx_invalid_empty_proofs::generate(std::vector<test_event_entry>& events) const
 {
   DEFINE_TESTS_ERROR_CONTEXT("gen_bp_tx_invalid_empty_proofs");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {50000, 50000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 3 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 3 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproof || tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG);
     tx.rct_signatures.p.bulletproofs.clear();
@@ -338,7 +291,7 @@ bool gen_bp_tx_invalid_too_many_proofs::generate(std::vector<test_event_entry>& 
   DEFINE_TESTS_ERROR_CONTEXT("gen_bp_tx_invalid_too_many_proofs");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {10000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 3 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 3 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproof || tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG);
     CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs.empty());
@@ -352,7 +305,7 @@ bool gen_bp_tx_invalid_wrong_amount::generate(std::vector<test_event_entry>& eve
   DEFINE_TESTS_ERROR_CONTEXT("gen_bp_tx_invalid_wrong_amount");
   const size_t mixin = 10;
   const uint64_t amounts_paid[] = {10000, (uint64_t)-1};
-  const rct::RCTConfig rct_config[] = { { rct::RangeProofBulletproof, 3 } };
+  const rct::RCTConfig rct_config[] = { { rct::RangeProofPaddedBulletproof, 3 } };
   return generate_with(events, mixin, 1, amounts_paid, false, rct_config, HF_VERSION_CLSAG, NULL, [&](cryptonote::transaction &tx, size_t idx){
     CHECK_TEST_CONDITION(tx.rct_signatures.type == rct::RCTTypeBulletproof || tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG);
     CHECK_TEST_CONDITION(!tx.rct_signatures.p.bulletproofs.empty());

--- a/tests/core_tests/bulletproofs.h
+++ b/tests/core_tests/bulletproofs.h
@@ -122,12 +122,6 @@ struct gen_bp_tx_invalid_1_from_12 : public gen_bp_tx_validation_base
 };
 template<> struct get_test_options<gen_bp_tx_invalid_1_from_12>: public get_bp_versioned_test_options<12> {};
 
-struct gen_bp_tx_invalid_1_1 : public gen_bp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bp_tx_invalid_1_1>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
-
 struct gen_bp_tx_valid_2 : public gen_bp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
@@ -146,41 +140,17 @@ struct gen_bp_tx_valid_16 : public gen_bp_tx_validation_base
 };
 template<> struct get_test_options<gen_bp_tx_valid_16>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
 
-struct gen_bp_tx_invalid_4_2_1 : public gen_bp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bp_tx_invalid_4_2_1>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
-
-struct gen_bp_tx_invalid_16_16 : public gen_bp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bp_tx_invalid_16_16>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
-
 struct gen_bp_txs_valid_2_and_2 : public gen_bp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
 };
 template<> struct get_test_options<gen_bp_txs_valid_2_and_2>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
 
-struct gen_bp_txs_invalid_2_and_8_2_and_16_16_1 : public gen_bp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bp_txs_invalid_2_and_8_2_and_16_16_1>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
-
 struct gen_bp_txs_valid_2_and_3_and_2_and_4 : public gen_bp_tx_validation_base
 {
   bool generate(std::vector<test_event_entry>& events) const;
 };
 template<> struct get_test_options<gen_bp_txs_valid_2_and_3_and_2_and_4>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
-
-struct gen_bp_tx_invalid_not_enough_proofs : public gen_bp_tx_validation_base
-{
-  bool generate(std::vector<test_event_entry>& events) const;
-};
-template<> struct get_test_options<gen_bp_tx_invalid_not_enough_proofs>: public get_bp_versioned_test_options<HF_VERSION_CLSAG> {};
 
 struct gen_bp_tx_invalid_empty_proofs : public gen_bp_tx_validation_base
 {

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -265,16 +265,11 @@ int main(int argc, char* argv[])
 
     GENERATE_AND_PLAY(gen_bp_tx_valid_1_before_12);
     GENERATE_AND_PLAY(gen_bp_tx_invalid_1_from_12);
-    GENERATE_AND_PLAY(gen_bp_tx_invalid_1_1);
     GENERATE_AND_PLAY(gen_bp_tx_valid_2);
     GENERATE_AND_PLAY(gen_bp_tx_valid_3);
     GENERATE_AND_PLAY(gen_bp_tx_valid_16);
-    GENERATE_AND_PLAY(gen_bp_tx_invalid_4_2_1);
-    GENERATE_AND_PLAY(gen_bp_tx_invalid_16_16);
     GENERATE_AND_PLAY(gen_bp_txs_valid_2_and_2);
-    GENERATE_AND_PLAY(gen_bp_txs_invalid_2_and_8_2_and_16_16_1);
     GENERATE_AND_PLAY(gen_bp_txs_valid_2_and_3_and_2_and_4);
-    GENERATE_AND_PLAY(gen_bp_tx_invalid_not_enough_proofs);
     GENERATE_AND_PLAY(gen_bp_tx_invalid_empty_proofs);
     GENERATE_AND_PLAY(gen_bp_tx_invalid_too_many_proofs);
     GENERATE_AND_PLAY(gen_bp_tx_invalid_wrong_amount);
@@ -284,16 +279,11 @@ int main(int argc, char* argv[])
 
     GENERATE_AND_PLAY(gen_bpp_tx_invalid_before_fork);
     GENERATE_AND_PLAY(gen_bpp_tx_valid_at_fork);
-    GENERATE_AND_PLAY(gen_bpp_tx_invalid_1_1);
     GENERATE_AND_PLAY(gen_bpp_tx_valid_2);
     GENERATE_AND_PLAY(gen_bpp_tx_valid_3);
     GENERATE_AND_PLAY(gen_bpp_tx_valid_16);
-    GENERATE_AND_PLAY(gen_bpp_tx_invalid_4_2_1);
-    GENERATE_AND_PLAY(gen_bpp_tx_invalid_16_16);
     GENERATE_AND_PLAY(gen_bpp_txs_valid_2_and_2);
-    GENERATE_AND_PLAY(gen_bpp_txs_invalid_2_and_8_2_and_16_16_1);
     GENERATE_AND_PLAY(gen_bpp_txs_valid_2_and_3_and_2_and_4);
-    GENERATE_AND_PLAY(gen_bpp_tx_invalid_not_enough_proofs);
     GENERATE_AND_PLAY(gen_bpp_tx_invalid_empty_proofs);
     GENERATE_AND_PLAY(gen_bpp_tx_invalid_too_many_proofs);
     GENERATE_AND_PLAY(gen_bpp_tx_invalid_wrong_amount);

--- a/tests/performance_tests/check_tx_signature.h
+++ b/tests/performance_tests/check_tx_signature.h
@@ -102,7 +102,7 @@ private:
   crypto::hash m_tx_prefix_hash;
 };
 
-template<size_t a_ring_size, size_t a_outputs, size_t a_num_txes, size_t extra_outs = 0>
+template<size_t a_ring_size, size_t a_outputs, size_t a_num_txes>
 class test_check_tx_signature_aggregated_bulletproofs : private multi_tx_test_base<a_ring_size>
 {
   static_assert(0 < a_ring_size, "ring_size must be greater than 0");
@@ -133,21 +133,10 @@ public:
     std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
     subaddresses[this->m_miners[this->real_source_idx].get_keys().m_account_address.m_spend_public_key] = {0,0};
 
-    m_txes.resize(a_num_txes + (extra_outs > 0 ? 1 : 0));
+    m_txes.resize(a_num_txes);
     for (size_t n = 0; n < a_num_txes; ++n)
     {
       if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::account_public_address{}, std::vector<uint8_t>(), m_txes[n], tx_key, additional_tx_keys, true, {rct::RangeProofPaddedBulletproof, 2}))
-        return false;
-    }
-
-    if (extra_outs)
-    {
-      destinations.clear();
-      destinations.push_back(tx_destination_entry(this->m_source_amount - extra_outs + 1, m_alice.get_keys().m_account_address, false));
-      for (size_t n = 1; n < extra_outs; ++n)
-        destinations.push_back(tx_destination_entry(1, m_alice.get_keys().m_account_address, false));
-
-      if (!construct_tx_and_get_tx_key(this->m_miners[this->real_source_idx].get_keys(), subaddresses, this->m_sources, destinations, cryptonote::account_public_address{}, std::vector<uint8_t>(), m_txes.back(), tx_key, additional_tx_keys, true, {rct::RangeProofMultiOutputBulletproof, 2}))
         return false;
     }
 

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -171,23 +171,14 @@ int main(int argc, char** argv)
   TEST_PERFORMANCE4(filter, p, test_check_tx_signature, 2, 10, true, rct::RangeProofBorromean);
 
   TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 2, 2, true, rct::RangeProofPaddedBulletproof, 2);
-  TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 2, 2, true, rct::RangeProofMultiOutputBulletproof, 2);
   TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 10, 2, true, rct::RangeProofPaddedBulletproof, 2);
-  TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 10, 2, true, rct::RangeProofMultiOutputBulletproof, 2);
   TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 100, 2, true, rct::RangeProofPaddedBulletproof, 2);
-  TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 100, 2, true, rct::RangeProofMultiOutputBulletproof, 2);
   TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 2, 10, true, rct::RangeProofPaddedBulletproof, 2);
-  TEST_PERFORMANCE5(filter, p, test_check_tx_signature, 2, 10, true, rct::RangeProofMultiOutputBulletproof, 2);
 
   TEST_PERFORMANCE3(filter, p, test_check_tx_signature_aggregated_bulletproofs, 2, 2, 64);
   TEST_PERFORMANCE3(filter, p, test_check_tx_signature_aggregated_bulletproofs, 10, 2, 64);
   TEST_PERFORMANCE3(filter, p, test_check_tx_signature_aggregated_bulletproofs, 100, 2, 64);
   TEST_PERFORMANCE3(filter, p, test_check_tx_signature_aggregated_bulletproofs, 2, 10, 64);
-
-  TEST_PERFORMANCE4(filter, p, test_check_tx_signature_aggregated_bulletproofs, 2, 2, 62, 4);
-  TEST_PERFORMANCE4(filter, p, test_check_tx_signature_aggregated_bulletproofs, 10, 2, 62, 4);
-  TEST_PERFORMANCE4(filter, p, test_check_tx_signature_aggregated_bulletproofs, 2, 2, 56, 16);
-  TEST_PERFORMANCE4(filter, p, test_check_tx_signature_aggregated_bulletproofs, 10, 2, 56, 16);
 
   TEST_PERFORMANCE4(filter, p, test_check_hash, 0, 1, 0, 1);
   TEST_PERFORMANCE4(filter, p, test_check_hash, 0, 0xffffffffffffffff, 0, 0xffffffffffffffff);

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -78,7 +78,7 @@ namespace test
         std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
         subaddresses[from.m_account_address.m_spend_public_key] = {0,0};
 
-        if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, tx_key, extra_keys, rct, { bulletproof ? rct::RangeProofBulletproof : rct::RangeProofBorromean, bulletproof ? 2 : 0 }))
+        if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, tx_key, extra_keys, rct, { bulletproof ? rct::RangeProofPaddedBulletproof : rct::RangeProofBorromean, bulletproof ? 2 : 0 }))
             throw std::runtime_error{"transaction construction error"};
 
         return tx;


### PR DESCRIPTION
Remove unused Rangeproof types `RangeProofBulletproof `, and `RangeProofMultiOutputBulletproof`. In the prove code, if the `RangeProofBulletproof` enum was passed, then one bulletproof was created per output. If `RangeProofMultiOutputBulletproof` was passed, then K bulletproofs were produced, where K is the number of one bits in the count of the outputs, Neither of these are allowed by consensus: https://github.com/monero-project/monero/blob/2226d4f7e0bf316aa0d4241b9b498f928add4b8b/src/cryptonote_basic/cryptonote_format_utils.cpp#L150-L154 and https://github.com/monero-project/monero/blob/2226d4f7e0bf316aa0d4241b9b498f928add4b8b/src/cryptonote_basic/cryptonote_format_utils.cpp#L174-L178.

Also fixes an actual bug with the boost serialization of type `tools::wallet2::signed_tx_set`. If the serialized payload has a version < 4, then the range proof type is assumed to be `RangeProofBulletproof`, which is incorrect. 