### PR TITLE
ci: Parallelize Arch Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: ./.github/actions/set-make-job-count
       - name: build
-        run: ${{env.BUILD_DEFAULT_LINUX}}
+        run: ${{env.BUILD_DEFAULT_LINUX}} --parallel ${{env.MAKE_JOB_COUNT}}
 
   build-debian:
     name: 'Debian 10'


### PR DESCRIPTION
The "--parallel" flag got dropped from the Arch Linux build due to unidentified, logical commit conflicts.