### PR TITLE
cmake: remove obsolete policy setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,10 +462,6 @@ endif()
 
 include_directories(external/rapidjson/include external/easylogging++ src contrib/epee/include external external/supercop/include)
 
-if(APPLE)
-  cmake_policy(SET CMP0042 NEW)
-endif()
-
 if(MSVC OR MINGW)
   set(DEFAULT_STATIC true)
 else()


### PR DESCRIPTION
It already defaults to `NEW` under `cmake_minimum_required(VERSION 3.5)`.