### PR TITLE
CoC: remove 'Monero Maintainer Team'

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,11 +77,6 @@ You should have received a copy of the GNU General Public License along with thi
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
-The "Monero Maintainer Team" is defined in this document as the following users:
-- fluffypony
-- moneromooo
-- hyc
-
 ## Goals
 
 C4 is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:
@@ -146,7 +141,7 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 - To accept or reject a patch, a Maintainer MUST use the Platform interface.
 - Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 30 days) or unless urgent as defined by the Monero Maintainers Team.
 - Maintainers MUST NOT make value judgments on correct patches unless the Maintainer (as may happen in rare circumstances) is a core code developer.
-- Maintainers MUST NOT merge pull requests in less than 168 hours (1 week) unless deemed urgent by at least 2 people from the Monero Maintainer Team.
+- Maintainers MUST NOT merge pull requests in less than 168 hours (1 week) unless deemed urgent by at least 2 Maintainers.
 - The Contributor MAY tag an issue as "Ready" after making a pull request for the issue.
 - The user who created an issue SHOULD close the issue after checking the patch is successful.
 - Maintainers SHOULD ask for improvements to incorrect patches and SHOULD reject incorrect patches if the Contributor does not respond constructively.


### PR DESCRIPTION
Should selsta be on here? Should I be on here?

It's not entirely clear if this is:

- a list of maintainers
- a special team of (non-)maintainers?

I'd like to get some input from others here.