### PR TITLE
CoC: remove 'creating stable releases' section

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -153,14 +153,6 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 - Any Contributor who has value judgments on a correct patch SHOULD express these via their own patches.
 - Maintainers MAY commit changes to non-source documentation directly to the project.
 
-### Creating stable releases
-
-- The project MUST have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
-- The project MUST NOT use topic branches for any reason. Personal forks MAY use topic branches.
-- To make a stable release someone MUST fork the repository by copying it and thus become maintainer of this repository.
-- Forking a project for stabilization MAY be done unilaterally and without agreement of project maintainers.
-- A patch to a stabilization project declared "stable" MUST be accompanied by a reproducible test case.
-
 ### Evolution of public contracts
 
 - All Public Contracts (APIs or protocols) MUST be documented.


### PR DESCRIPTION
This section was forgotten to be removed. This project does not have "stable" releases.

https://github.com/monero-project/monero/pull/2174#discussion_r127844693