### PR TITLE
wallet: mark wallet error throwing functions as noreturn

### DIFF
--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -993,7 +993,7 @@ namespace tools
 #if !defined(_MSC_VER)
 
     template<typename TException, typename... TArgs>
-    void throw_wallet_ex(std::string&& loc, const TArgs&... args)
+    [[noreturn]] void throw_wallet_ex(std::string&& loc, const TArgs&... args)
     {
       TException e(std::move(loc), args...);
       LOG_PRINT_L0(e.to_string());
@@ -1006,7 +1006,7 @@ namespace tools
     #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 
     template<typename TException>
-    void throw_wallet_ex(std::string&& loc)
+    [[noreturn]] void throw_wallet_ex(std::string&& loc)
     {
       TException e(std::move(loc));
       LOG_PRINT_L0(e.to_string());
@@ -1015,7 +1015,7 @@ namespace tools
 
 #define GEN_throw_wallet_ex(z, n, data)                                                       \
     template<typename TException, BOOST_PP_ENUM_PARAMS(n, typename TArg)>                     \
-    void throw_wallet_ex(std::string&& loc, BOOST_PP_ENUM_BINARY_PARAMS(n, const TArg, &arg)) \
+    [[noreturn]] void throw_wallet_ex(std::string&& loc, BOOST_PP_ENUM_BINARY_PARAMS(n, const TArg, &arg)) \
     {                                                                                         \
       TException e(std::move(loc), BOOST_PP_ENUM_PARAMS(n, arg));                             \
       LOG_PRINT_L0(e.to_string());                                                            \


### PR DESCRIPTION
Simplifies calling logic where a branch ends but a return value is needed