### PR TITLE
CoC: only allow Administrators to merge changes to the CoC

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -179,3 +179,4 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 - A new Contributor who makes a correct patch MUST be invited to become a Maintainer.
 - Administrators MAY remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
 - Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
+- Maintainers MUST NOT merge changes to this specification unless they are also Administrators.


### PR DESCRIPTION
The Monero Core Team should have the final say on changes to the CoC.