### PR TITLE
ringct: remove inclusion of cryptonote_format_utils.h in rctOps.cpp

### DIFF
--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -30,7 +30,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include "misc_log_ex.h"
-#include "cryptonote_basic/cryptonote_format_utils.h"
 #include "rctOps.h"
 using namespace crypto;
 using namespace std;


### PR DESCRIPTION
This vestigial include line breaks some downstream builds