### PR TITLE
easylogging++: Generalize TERM rule for color-supporting terminals

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -1246,9 +1246,9 @@ std::string OS::currentHost(void) {
 
 bool OS::termSupportsColor(void) {
   std::string term = getEnvironmentVariable("TERM", "");
-  return term == "xterm" || term == "xterm-color" || term == "xterm-256color"
-         || term == "screen" || term == "linux" || term == "cygwin"
-         || term == "screen-256color" || term == "screen.xterm-256color";
+  return term == "xterm" || term == "screen" || term == "linux" || term == "cygwin"
+         || term.find("-color") != std::string::npos
+         || term.find("-256color") != std::string::npos;
 }
 
 // DateTime


### PR DESCRIPTION
With newer versions of tmux, such as version 3.4 packaged by Ubuntu 24.04, `tmux-256color` the default TERM variable value.

Instead of adding it specifically, extend the rule to look for `-color` or `-256color` in TERM, as these can all be assumed to support color.