### PR TITLE
depends: use staging_prefix_dir where possible

### DIFF
--- a/contrib/depends/packages/darwin_sdk.mk
+++ b/contrib/depends/packages/darwin_sdk.mk
@@ -8,7 +8,7 @@ $(package)_sha256_hash=df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717
 # our own version of readline.
 
 define $(package)_stage_cmds
-  mkdir -p $($(package)_staging_dir)/$(host_prefix)/native/SDK &&\
+  mkdir -p $($(package)_staging_prefix_dir)/SDK &&\
   rm -rf usr/include/readline && \
-  mv * $($(package)_staging_dir)/$(host_prefix)/native/SDK
+  mv * $($(package)_staging_prefix_dir)/SDK
 endef

--- a/contrib/depends/packages/freebsd_base.mk
+++ b/contrib/depends/packages/freebsd_base.mk
@@ -14,7 +14,7 @@ endef
 # statically link our own version of OpenSSL.
 
 define $(package)_stage_cmds
-  mkdir $($(package)_staging_dir)/$(host_prefix)/native &&\
+  mkdir $($(package)_staging_prefix_dir) &&\
   rm -rf usr/include/openssl &&\
-  mv lib usr $($(package)_staging_dir)/$(host_prefix)/native
+  mv lib usr $($(package)_staging_prefix_dir)
 endef


### PR DESCRIPTION
Cleanup. $($(package)_staging_prefix_dir) maps to the same directory.