### PR TITLE
ci: consolidate ubuntu 20.04 runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,10 +132,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Oldest supported Ubuntu LTS version
-          - name: Ubuntu 20.04
-            container: ubuntu:20.04
-
           # Most popular Ubuntu LTS version
           - name: Ubuntu 22.04
             container: ubuntu:22.04
@@ -172,11 +168,11 @@ jobs:
 
   test-ubuntu:
     name: "${{ matrix.name }} (tests)"
-    needs: build-ubuntu
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
+          # Oldest supported Ubuntu LTS version
           - name: Ubuntu 20.04
             container: ubuntu:20.04
     container:


### PR DESCRIPTION
The `Ubuntu 20.04 (tests)` job builds a superset of `Ubuntu 20.04`.

- Remove the `Ubuntu 20.04` build
- Don't wait for `build-ubuntu` to finish before building tests

20 minutes of runner time is saved and tests will complete 20 minutes faster as a result of this change.