### PR TITLE
ci: containerize depends jobs

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -12,9 +12,11 @@ on:
 
 env:
   APT_SET_CONF: |
-        echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
+    tee -a /etc/apt/apt.conf.d/80-custom << EOF
+    Acquire::Retries "3";
+    Acquire::http::Timeout "120";
+    Acquire::ftp::Timeout "120";
+    EOF
   CCACHE_SETTINGS: |
         ccache --max-size=150M
         ccache --set-config=compression=true
@@ -22,9 +24,12 @@ env:
 
 jobs:
   build-cross:
-    runs-on: ubuntu-20.04
-    env:
-      CCACHE_TEMPDIR: /tmp/.ccache-temp
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        CCACHE_TEMPDIR: /tmp/.ccache-temp
     strategy:
       fail-fast: false
       matrix:
@@ -48,17 +53,25 @@ jobs:
             host: "x86_64-unknown-linux-gnu"
           - name: "Cross-Mac x86_64"
             host: "x86_64-apple-darwin"
+            packages: "clang"
           - name: "Cross-Mac aarch64"
-            host: "aarch64-apple-darwin"
+            host: "arm64-apple-darwin"
+            packages: "clang"
           - name: "x86_64 Freebsd"
             host: "x86_64-unknown-freebsd"
-            packages: "clang-8"
+            packages: "clang"
           - name: "ARMv7 Android"
             host: "arm-linux-android"
           - name: "ARMv8 Android"
             host: "aarch64-linux-android"
     name: ${{ matrix.toolchain.name }}
     steps:
+    - name: set apt conf
+      run: ${{env.APT_SET_CONF}}
+    - name: install dependencies
+      run: apt update; apt -y install build-essential libtool cmake autotools-dev automake pkg-config python3 gperf bsdmainutils curl git ca-certificates unzip ccache ${{ matrix.toolchain.packages }}
+    - name: configure git
+      run: git config --global --add safe.directory '*'
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -79,24 +92,20 @@ jobs:
         restore-keys: |
           depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
           depends-${{ matrix.toolchain.host }}-
-    - uses: ./.github/actions/set-make-job-count
-    - name: set apt conf
-      run: ${{env.APT_SET_CONF}}
-    - name: install dependencies
-      run: sudo apt update; sudo apt -y install build-essential libtool cmake autotools-dev automake pkg-config python3 gperf bsdmainutils curl git ca-certificates ccache ${{ matrix.toolchain.packages }}
     - name: prepare w64-mingw32
       if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' }}
       run: |
-        sudo update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
-        sudo update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
+        update-alternatives --set ${{ matrix.toolchain.host }}-g++ $(which ${{ matrix.toolchain.host }}-g++-posix)
+        update-alternatives --set ${{ matrix.toolchain.host }}-gcc $(which ${{ matrix.toolchain.host }}-gcc-posix)
+    - uses: ./.github/actions/set-make-job-count
     - name: build
       run: |
         ${{env.CCACHE_SETTINGS}}
         make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
     - uses: actions/upload-artifact@v4
-      if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'x86_64-apple-darwin' || matrix.toolchain.host == 'aarch64-apple-darwin' || matrix.toolchain.host == 'x86_64-unknown-linux-gnu' }}
+      if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'x86_64-apple-darwin' || matrix.toolchain.host == 'arm64-apple-darwin' || matrix.toolchain.host == 'x86_64-unknown-linux-gnu' }}
       with:
         name: ${{ matrix.toolchain.name }}
         path: |
-          /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/build/${{ matrix.toolchain.host }}/release/bin/monero-wallet-cli*
-          /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/build/${{ matrix.toolchain.host }}/release/bin/monerod*
+          build/${{ matrix.toolchain.host }}/release/bin/monero-wallet-cli*
+          build/${{ matrix.toolchain.host }}/release/bin/monerod*

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -48,7 +48,7 @@ jobs:
           - target: "x86_64-w64-mingw32"
           - target: "x86_64-unknown-freebsd"
           - target: "x86_64-apple-darwin"
-          - target: "aarch64-apple-darwin"
+          - target: "arm64-apple-darwin"
           - target: "aarch64-linux-android"
 
     name: ${{ matrix.toolchain.target }}

--- a/contrib/depends/packages/hidapi.mk
+++ b/contrib/depends/packages/hidapi.mk
@@ -5,8 +5,17 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd
 $(package)_linux_dependencies=libusb
 
+# -DHIDAPI_NO_ICONV=ON
+#
+#   `FindIconv.cmake` in CMake 3.16 fails to detect iconv for riscv64, arm, and aarch64 linux targets.
+#   Disable it if we're not building in a release environment.
+
 define $(package)_set_vars
-  $(package)_config_opts+=-DBUILD_SHARED_LIBS=OFF -DHIDAPI_WITH_HIDRAW=OFF
+  $(package)_config_opts := -DBUILD_SHARED_LIBS=OFF
+  $(package)_config_opts += -DHIDAPI_WITH_HIDRAW=OFF
+  ifeq ($(GUIX_ENVIRONMENT),)
+  $(package)_config_opts += -DHIDAPI_NO_ICONV=ON
+  endif
 endef
 
 # Remove blobs

--- a/contrib/depends/packages/native_cctools.mk
+++ b/contrib/depends/packages/native_cctools.mk
@@ -16,10 +16,7 @@ $(package)_cxx=$(clangxx_prog)
 endef
 
 define $(package)_preprocess_cmds
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools
-endef
-
-define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools && \
   patch -p1 < $($(package)_patch_dir)/no-build-date.patch
 endef
 

--- a/contrib/depends/packages/ncurses.mk
+++ b/contrib/depends/packages/ncurses.mk
@@ -46,6 +46,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . && \
   cp $($(package)_patch_dir)/fallback.c ncurses
 endef
 

--- a/contrib/depends/packages/readline.mk
+++ b/contrib/depends/packages/readline.mk
@@ -15,6 +15,10 @@ define $(package)_set_vars
   $(package)_build_opts=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub support
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -9,6 +9,10 @@ $(package)_config_opts=--enable-static --disable-shared
 $(package)_config_opts+=--prefix=$(host_prefix)
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
 endef

--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -9,6 +9,10 @@ define $(package)_set_vars
   $(package)_cxxflags=-std=c++11
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
 endef

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -50,11 +50,30 @@ set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER) # Find programs on host
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY) # Find libs in target
 set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY) # Find includes in target
 
+function(split_program input_string program arguments)
+  # CMake < 3.19 only understands setting CMAKE_<LANG>_COMPILER using "<program>" "<arguments>".
+  # https://cmake.org/cmake/help/v3.19/variable/CMAKE_LANG_COMPILER.html#variable:CMAKE_%3CLANG%3E_COMPILER
+
+  string(FIND "${input_string}" " " space_index)
+
+  if(space_index EQUAL -1)
+      set(${program} "${input_string}" PARENT_SCOPE)
+      set(${arguments} "" PARENT_SCOPE)
+  else()
+      string(SUBSTRING "${input_string}" 0 ${space_index} _program)
+      math(EXPR args_index "${space_index} + 1")
+      string(SUBSTRING "${input_string}" ${args_index} -1 _arguments)
+
+      set(${program} "${_program}" PARENT_SCOPE)
+      set(${arguments} "${_arguments}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # specify the cross compiler to be used. Darwin uses clang provided by the SDK.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   if(ARCHITECTURE STREQUAL "aarch64")
     SET(CLANG_TARGET "arm64-apple-darwin")
-    SET(CONF_TRIPLE "aarch64-apple-darwin")
+    SET(CONF_TRIPLE "arm64-apple-darwin")
     SET(BUILD_TAG "mac-armv8")
     SET(CMAKE_OSX_ARCHITECTURES "arm64")
     set(ARM ON)
@@ -66,10 +85,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     SET(CMAKE_OSX_ARCHITECTURES "x86_64")
   endif()
   SET(_CMAKE_TOOLCHAIN_PREFIX @prefix@/native/bin/${CONF_TRIPLE}-)
-  SET(CMAKE_C_COMPILER @CC@)
+  split_program("@CC@" CC_DARWIN CC_DARWIN_ARGS)
+  SET(CMAKE_C_COMPILER "${CC_DARWIN}" "${CC_DARWIN_ARGS}")
   SET(CMAKE_C_COMPILER_TARGET ${CLANG_TARGET})
   SET(CMAKE_C_FLAGS_INIT -B${_CMAKE_TOOLCHAIN_PREFIX})
-  SET(CMAKE_CXX_COMPILER @CXX@ -stdlib=libc++)
+  split_program("@CXX@" CXX_DARWIN CXX_DARWIN_ARGS)
+  SET(CMAKE_CXX_COMPILER "${CXX_DARWIN}" "${CXX_DARWIN_ARGS}")
   SET(CMAKE_CXX_COMPILER_TARGET ${CLANG_TARGET})
   SET(CMAKE_CXX_FLAGS_INIT -B${_CMAKE_TOOLCHAIN_PREFIX})
   SET(CMAKE_ASM_COMPILER clang)
@@ -87,14 +108,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   SET(LLVM_ENABLE_PIE OFF)
 elseif(TARGET_OS STREQUAL "android")
   SET(ANDROID TRUE)
-  SET(CMAKE_C_COMPILER @CC@)
-  SET(CMAKE_CXX_COMPILER @CXX@)
-else()
-  if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    SET(CMAKE_ASM_COMPILER clang)
-    SET(CMAKE_ASM-ATT_COMPILER as)
-  endif()
 
+  split_program("@CC@" CC_ANDROID CC_ANDROID_ARGS)
+  SET(CMAKE_C_COMPILER "${CC_ANDROID}" "${CC_ANDROID_ARGS}")
+
+  split_program("@CXX@" CXX_ANDROID CXX_ANDROID_ARGS)
+  SET(CMAKE_CXX_COMPILER "${CXX_ANDROID}" "${CXX_ANDROID_ARGS}")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  split_program("@CC@" CC_FREEBSD CC_FREEBSD_ARGS)
+  SET(CMAKE_C_COMPILER "${CC_FREEBSD}" "${CC_FREEBSD_ARGS}")
+
+  split_program("@CXX@" CXX_FREEBSD CXX_FREEBSD_ARGS)
+  SET(CMAKE_CXX_COMPILER "${CXX_FREEBSD}" "${CXX_FREEBSD_ARGS}")
+
+  SET(CMAKE_ASM_COMPILER clang)
+  SET(CMAKE_ASM-ATT_COMPILER as)
+else()
   SET(CMAKE_C_COMPILER @CC@)
   SET(CMAKE_CXX_COMPILER @CXX@)
 endif()

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -173,7 +173,7 @@ details.
 
   _(defaults to "x86\_64-linux-gnu aarch64-linux-gnu arm-linux-gnueabihf
   riscv64-linux-gnu i686-linux-gnu x86\_64-w64-mingw32 x86\_64-unknown-freebsd
-  x86\_64-apple-darwin aarch64-apple-darwin aarch64-linux-android")_
+  x86\_64-apple-darwin arm64-apple-darwin aarch64-linux-android")_
 
 * _**SOURCES_PATH**_
 

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -87,7 +87,7 @@ export HOSTS="${HOSTS:-x86_64-linux-gnu
                        x86_64-w64-mingw32
                        x86_64-unknown-freebsd
                        x86_64-apple-darwin
-                       aarch64-apple-darwin
+                       arm64-apple-darwin
                        aarch64-linux-android}"
 
 # Usage: distsrc_for_host HOST


### PR DESCRIPTION
Clang 10.0 [does not recognize](https://phabricator.services.mozilla.com/D87052) the `aarch64-apple-darwin` target. The release branch hacks around this by automatically [renaming the target](https://github.com/monero-project/monero/blob/release-v0.18/contrib/depends/hosts/darwin.mk#L3-L7).

This approach is less straightforward on master due to the [introduction of CMake](https://github.com/monero-project/monero/pull/9640) in depends. We would also need to inform CMake about the updated target to prevent it from passing `--target=aarch64-apple-darwin` to the compiler.

It's less messy to just rename the target to whatever clang expects.