### PR TITLE
tests: Speed up p2p reorg test

### DIFF
--- a/tests/functional_tests/p2p.py
+++ b/tests/functional_tests/p2p.py
@@ -150,15 +150,18 @@ class P2PTest():
         # reconnect and wait for sync
         daemon2.out_peers(8)
         daemon3.out_peers(8)
-        loops = 100
-        while True:
+        deadline = time.monotonic() + 240
+        result = None
+        while result is None:
             res2 = daemon2.get_info()
             res3 = daemon3.get_info()
             if res2.top_block_hash == res3.top_block_hash:
-                break
-            time.sleep(10)
-            loops -= 1
-            assert loops >= 0
+                result = True
+            elif time.monotonic() >= deadline:
+                result = False
+            else:
+                time.sleep(.25)
+        assert result, 'Sync timed out'
 
     def test_p2p_tx_propagation(self):
         print('Testing P2P tx propagation')


### PR DESCRIPTION
Use a fixed, 240s deadline for the daemons to reach agreement and poll with a suitable frequency (.25s), rather than polling up to 100 times at roughly 10s intervals.