### PR TITLE
CoC: do not allow Maintainers to tag releases, unless core is not available within a reasonable time

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -179,3 +179,4 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 - A new Contributor who makes a correct patch MUST be invited to become a Maintainer.
 - Administrators MAY remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
 - Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
+- Maintainers MUST NOT tag releases unless the Administrators are not available within a reasonable time.


### PR DESCRIPTION
The intent of this rule is to set the expectation that releases are tagged by a member of the Monero Core Team unless there are extraordinary circumstances which warrant expedited tagging.

Tagging initiates the [verified reproduction](https://github.com/monero-project/gitian.sigs?tab=readme-ov-file#gitian-assertions-and-signatures) process, which requires multiple independent builds from contributors. A release is not finalized until hashes are signed by a member of the core team.

What constitutes '[reasonable time](https://en.wikipedia.org/wiki/Reasonable_time)' should be discussed with other maintainers and developers when such circumstances arise. Misjudgment or abuse can obviously result in the removal of write privileges at the discretion of the core team.

For a release that fixes or mitigates an actively exploited Denial of Service attack against the network, a few days to a week would seem like a reasonable time (depending on severity). For a critical problem that affects the entire network (e.g. a chain halt) this might be on the order of hours.

I'm open to suggestions on how to word this rule better. If there is opposition to allowing maintainers to tag a release under any circumstances, I'm fine with changing this to "Maintainers MUST NOT tag releases unless they are also an Administrator".

Drafted for now awaiting initial feedback.