### PR TITLE
guix: add rust

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -11,6 +11,7 @@
              (gnu packages mingw)
              (gnu packages perl)
              (gnu packages pkg-config)
+             (gnu packages rust)
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system gnu)
              (guix build-system trivial)
@@ -259,6 +260,8 @@ chain for " target " development."))
         gnu-make
         pkg-config
         cmake-minimal
+        rust
+        (list rust "cargo")
 
         ;; Scripting
         perl ; required to build openssl in depends


### PR DESCRIPTION
**This change introduces cross-architecture non-determinism**. This means that cross-compiling using Rust from a different host architectures to a common target will not produce bit-identical output. 

This effectively means that participants in the [verified reproduction process](https://github.com/monero-project/guix.sigs) must build on a `x86_64` host. This mainly affects users on ARM64 Apple devices and users on experimental RISC-V boards.

---

Rust is [self-hosted](https://en.wikipedia.org/wiki/Self-hosting_(compilers)#Compilers) and because the compiler typically uses new language features as soon as they become available it can only be built with the previous minor version of Rust. This makes Rust notoriously hard to bootstrap.

Its bootstrap graph looks like this:

```
Rust 1.93.0
↓
Rust 1.92.0
↓
Rust 1.91.0
↓
Rust 1.90.0
↓
Rust 1.89.0
↓
Rust 1.88.0
↓
Rust 1.87.0
↓
Rust 1.86.0
↓
Rust 1.85.1
↓
Rust 1.84.1
↓
Rust 1.83.0
↓
Rust 1.82.0
↓
Rust 1.81.0
↓
Rust 1.80.1
↓
Rust 1.79.0
↓
Rust 1.78.0
↓
Rust 1.77.1
↓
Rust 1.76.0
↓
Rust 1.75.0
↓
mrustc 1.74.0
↓
llvm 17.0.6
```

You can obtain this graph locally by running `guix graph rust | xdot -`

Note: `mrustc` can now bootstrap Rust `1.90` which would again greatly decrease the build time for a full source bootstrap. This will land in Guix sooner or later.

#### Changes to the build environment

| package | old | new |
|---|---|---|
| llvm | n/a | 21.1.8 |
| python-minimal-wrapper | n/a | 3.12.12 |
| rust | n/a | 1.93.0 |

#### Changes to transitive build dependencies

Excluding the Rust bootstrap chain shown above.

| package | old | new |
|---|---|---|
| boost | n/a | 1.83.0 |
| dejagnu | n/a | 1.6.3 |
| expect | n/a | 5.45.4 |
| gdb | n/a | 17.1 |
| git-minimal | n/a | 2.50.0 |
| icu4c | n/a | 73.1 |
| llvm | n/a | 17.0.6 |
| procps | n/a | 4.0.3 |
| source-highlight | n/a | 3.1.9 |
| tcsh | n/a | 6.24.15 |
