### PR TITLE
common: add missing iomanip include

### DIFF
--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -34,6 +34,7 @@
 #include "easylogging++/easylogging++.h"
 
 #include <stdexcept>
+#include <iomanip>
 #ifdef USE_UNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>


### PR DESCRIPTION
`D:/a/monero/monero/src/common/stack_trace.cpp:154:27: error: 'setw' is not a member of 'std'`

https://github.com/tobtoht/monero/actions/runs/13374416174/job/37350275299#step:6:859