### PR TITLE
depends: boost: update to 1.69.0 [0.18]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1108,12 +1108,6 @@ add_definitions(-DBOOST_ASIO_ENABLE_SEQUENTIAL_STRAND_ALLOCATION)
 add_definitions(-DBOOST_NO_AUTO_PTR)
 add_definitions(-DBOOST_UUID_DISABLE_ALIGNMENT) # This restores UUID's std::has_unique_object_representations property
 
-if(FREEBSD AND DEPENDS)
-  # Boost 1.66.0 fails to detect that we have <string_view>, resulting in an incorrect include.
-  # This line can be removed if Boost is upgraded to > 1.66.0.
-  add_definitions(-DBOOST_ASIO_HAS_STD_STRING_VIEW)
-endif()
-
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 if(MINGW)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wa,-mbig-obj")

--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -21,16 +21,22 @@ host_toolchain:=$(HOST)-
 endif
 
 ifneq ($(DEBUG),)
-release_type=Debug
+release_type=debug
 else
-release_type=Release
+release_type=release
 endif
 
 ifneq ($(TESTS),)
 build_tests=ON
-release_type=Debug
+release_type=debug
 else
 build_tests=OFF
+endif
+
+ifeq ($(release_type),debug)
+cmake_release_type=Debug
+else
+cmake_release_type=Release
 endif
 
 base_build_dir=$(BASEDIR)/work/build
@@ -179,7 +185,7 @@ $(host_prefix)/share/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@debug@|$(DEBUG)|' \
-            -e 's|@release_type@|$(release_type)|' \
+            -e 's|@release_type@|$(cmake_release_type)|' \
             -e 's|@build_tests@|$(build_tests)|' \
             -e 's|@depends@|$(host_cmake)|' \
             -e 's|@prefix@|$($(host_arch)_$(host_os)_prefix)|'\

--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,15 +1,15 @@
 package=boost                                                                                                                                                                                                                      
-$(package)_version=1.66.0
+$(package)_version=1.69.0
 $(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
 $(package)_file_name=$(package)_$(subst .,_,$($(package)_version)).tar.gz
-$(package)_sha256_hash=bd0df411efd9a585e5a2212275f8762079fed8842264954675a4fddc46cfcf60
+$(package)_sha256_hash=9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb
 $(package)_dependencies=libiconv
 $(package)_patches=fix_aroptions.patch fix_arm_arch.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
 $(package)_config_opts_debug=variant=debug
-$(package)_config_opts=--layout=tagged --build-type=complete --user-config=user-config.jam
+$(package)_config_opts+=--layout=system --user-config=user-config.jam
 $(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=1
 $(package)_config_opts_linux=threadapi=pthread runtime-link=shared
 $(package)_config_opts_android=threadapi=pthread runtime-link=static target-os=android
@@ -25,7 +25,7 @@ $(package)_archiver_darwin=$($(package)_libtool)
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,date_time,regex,serialization,locale
 $(package)_cxxflags=-std=c++11
 $(package)_cxxflags_linux=-fPIC
-$(package)_cxxflags_freebsd=-fPIC -DBOOST_ASIO_HAS_STD_STRING_VIEW=1
+$(package)_cxxflags_freebsd=-fPIC
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
This should fix a reported crash during sync on Windows that was introduced in #9800.

Context starting here: https://libera.monerologs.net/monero-dev/20250217#c497165

Includes #9457 backport (needed).  