### PR TITLE
logging: Generalize terminal color detection

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -1244,11 +1244,19 @@ std::string OS::currentHost(void) {
 #endif  // ELPP_OS_UNIX && !ELPP_OS_ANDROID
 }
 
+static bool endswith(const std::string &s, const std::string &ending)
+{
+    return s.size() >= ending.size() && s.substr(s.size() - ending.size()) == ending;
+}
+
+bool OS::termSupportsColor(std::string& term) {
+  return term == "xterm" || term == "screen" || term == "linux" || term == "cygwin"
+        || endswith(term, "-color") || endswith(term, "-256color");
+}
+
 bool OS::termSupportsColor(void) {
   std::string term = getEnvironmentVariable("TERM", "");
-  return term == "xterm" || term == "xterm-color" || term == "xterm-256color"
-         || term == "screen" || term == "linux" || term == "cygwin"
-         || term == "screen-256color" || term == "screen.xterm-256color";
+  return termSupportsColor(term);
 }
 
 // DateTime

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -1210,7 +1210,9 @@ class OS : base::StaticClass {
   ///
   /// @detail For android systems this is device name with its manufacturer and model seperated by hyphen
   static std::string currentHost(void);
-  /// @brief Whether or not terminal supports colors
+  /// @brief Whether or not the named terminal supports colors
+  static bool termSupportsColor(std::string& term);
+  /// @brief Whether or not the process's current terminal supports colors
   static bool termSupportsColor(void);
 };
 /// @brief Contains utilities for cross-platform date/time. This class make use of el::base::utils::Str

--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -195,6 +195,41 @@ TEST(logging, multiline)
   cleanup();
 }
 
+class LoggingTermSupportsColorSuite : public testing::TestWithParam<std::tuple<std::string, bool>> {};
+
+TEST_P(LoggingTermSupportsColorSuite, Detection)
+{
+  std::tuple<std::string, bool> param = GetParam();
+  auto term = std::get<0>(param);
+  auto is_color = std::get<1>(param);
+  ASSERT_EQ(el::base::utils::OS::termSupportsColor(term), is_color) << term;
+}
+INSTANTIATE_TEST_SUITE_P(
+    TerminalStrings,
+    LoggingTermSupportsColorSuite,
+    testing::Values(
+        std::make_tuple("", false),
+        // unrecognized terminals
+        std::make_tuple("basic", false),
+        std::make_tuple("vt100", false),
+        // known color terminals
+        std::make_tuple("xterm", true),
+        std::make_tuple("screen", true),
+        std::make_tuple("linux", true),
+        std::make_tuple("cygwin", true),
+        std::make_tuple("xterm-color", true),
+        std::make_tuple("xterm-256color", true),
+        std::make_tuple("screen-256color", true),
+        std::make_tuple("screen.xterm-256color", true),
+        // generic color terminal detection by suffix
+        std::make_tuple("unrecognized-color", true),
+        std::make_tuple("unrecognized-256color", true),
+        std::make_tuple("basic-nocolor", false),
+        std::make_tuple("basic-no256color", false),
+        std::make_tuple("basic-color-unsupported", false),
+        std::make_tuple("basic-256color-unsupported", false)
+    ));
+
 // These operations might segfault
 TEST(logging, copy_ctor_segfault)
 {


### PR DESCRIPTION
Assume the terminal supports color codes if TERM ends with `-color` or `-256color`, rather than special-casing a handful of such terminals.

Add tests for terminal color detection.