### PR TITLE
epee: Change Color Contrast On Magenta (Console Color)

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -441,12 +441,13 @@ void set_console_color(int color, bool bright)
     {
 #ifdef WIN32
       HANDLE h_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-      SetConsoleTextAttribute(h_stdout, FOREGROUND_BLUE | FOREGROUND_RED | (bright ? FOREGROUND_INTENSITY:0));
+      int colorblindMagentaCode = 13;
+      SetConsoleTextAttribute(h_stdout, colorblindMagentaCode | (bright ? FOREGROUND_INTENSITY:0));
 #else
       if(bright)
-        std::cout << "\033[1;35m";
+        std::cout << "\033[38;2;245;176;236m";
       else
-        std::cout << "\033[0;35m";
+        std::cout << "\033[38;2;180;0;158m";
 #endif
     }
     break;


### PR DESCRIPTION
**Description**
I use the monero-wallet-cli, and I have trouble reading a lot of the information, simply because the colors do not have enough contrast. For example, you can see here that the magenta blends in with the background. 

![image](https://github.com/user-attachments/assets/dd71bd77-d0dd-4a72-a411-365d1196b66f)

Even my non-colorblind friend has a hard time reading this.

![image](https://github.com/user-attachments/assets/fce92545-75f6-4fca-8991-ffa5655c0916)

I looked at the API and noticed that there are better colors that can be used. For example, all these color values would be preferred over the current color scheme. 

![image](https://github.com/user-attachments/assets/99af3cce-5521-4a54-bf7a-a57da3d8bbc4)

Have a look at the **spent** transation.

### Before
![image](https://github.com/user-attachments/assets/0c1d1a2a-9c23-42f5-8a5b-9b07286ab009)

### After

**Windows**
![image](https://github.com/user-attachments/assets/3f4eaf77-a5a2-4438-9313-e7a10dc0d46a)

**Linux**
![image](https://github.com/user-attachments/assets/ef7a9b49-a628-464a-9c8f-ea5b5487a179)



