### PR TITLE
trezor: fix protobuf 30 compatibility

### DIFF
--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -63,6 +63,10 @@ if (USE_DEVICE_TREZOR)
         trezor_fatal_msg("Trezor: protobuf library not found")
     endif()
 
+    if (Protobuf_VERSION VERSION_GREATER_EQUAL 22.0)
+        add_definitions(-DPROTOBUF_HAS_ABSEIL)
+    endif()
+
     if(TREZOR_DEBUG)
         set(USE_DEVICE_TREZOR_DEBUG 1)
         message(STATUS "Trezor: debug build enabled")

--- a/src/device_trezor/trezor/messages_map.cpp
+++ b/src/device_trezor/trezor/messages_map.cpp
@@ -132,5 +132,11 @@ namespace trezor
     return res;
   }
 
+#ifdef PROTOBUF_HAS_ABSEIL
+  messages::MessageType MessageMapper::get_message_wire_number(const absl::string_view& msg_name) {
+    return MessageMapper::get_message_wire_number(std::string{msg_name});
+  }
+#endif
+
 }
 }

--- a/src/device_trezor/trezor/messages_map.hpp
+++ b/src/device_trezor/trezor/messages_map.hpp
@@ -44,6 +44,10 @@
 #include <google/protobuf/generated_enum_reflection.h>
 #include "google/protobuf/descriptor.pb.h"
 
+#ifdef PROTOBUF_HAS_ABSEIL
+#include <absl/strings/string_view.h>
+#endif
+
 #include "messages/messages.pb.h"
 
 namespace hw {
@@ -61,6 +65,10 @@ namespace trezor {
     static messages::MessageType get_message_wire_number(const google::protobuf::Message * msg);
     static messages::MessageType get_message_wire_number(const google::protobuf::Message & msg);
     static messages::MessageType get_message_wire_number(const std::string & msg_name);
+
+#ifdef PROTOBUF_HAS_ABSEIL
+    static messages::MessageType get_message_wire_number(const absl::string_view & msg_name); // Protobuf 30 and up
+#endif
 
     template<class t_message=google::protobuf::Message>
     static messages::MessageType get_message_wire_number() {


### PR DESCRIPTION
Fixes builds with Protobuf 30.

See: https://protobuf.dev/news/v30/#descriptor-apis