### PR TITLE
cryptonote_protocol: fix handling of pruned blocks during sync

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4260,7 +4260,7 @@ leave:
       {
         tx = std::move(extra_txs_it->second.first);
         txblob = std::move(extra_txs_it->second.second);
-        tx_weight = get_transaction_weight(tx, txblob.size());
+        tx_weight = tx.pruned ? get_pruned_transaction_weight(tx) : get_transaction_weight(tx, txblob.size());
         fee = get_tx_fee(tx);
         pruned = tx.pruned;
         extra_block_txs.txs_by_txid.erase(extra_txs_it);


### PR DESCRIPTION
Resolves [this issue](https://github.com/monero-project/monero/issues/9758#issuecomment-2727447226) when syncing with option `--sync-pruned-blocks` after commit c069c04ede338929c50297558fee15192aa0f67c.