### PR TITLE
Blockchain: remove skip for pruned txs in `check_tx_inputs()`

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3268,10 +3268,6 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   if(pmax_used_block_height)
     *pmax_used_block_height = 0;
 
-  // pruned txes are skipped, as they're only allowed in sync-pruned-blocks mode, which is within the builtin hashes
-  if (tx.pruned)
-    return true;
-
   crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
 
   const uint8_t hf_version = m_hardfork->get_current_version();


### PR DESCRIPTION
I can't see how this would trigger in the current codebase, so it's not a *current* safety issue, but I can very well see it becoming on in the future if downstream code doesn't handle the passing of pruned transactions correctly. I think the safe/good choice would be to remove this skip now that all transactions that pass into the mempool are supposed to be unpruned. And for all in-block txs, `check_tx_inputs()` isn't called for checkpointed blocks, and we sync pruned blocks only if syncing checkpointed blocks.