### PR TITLE
[Requires PR 9838 & 9842] Support Elevated Fee Promotion in Automatic adjust_priority.

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -74,6 +74,7 @@
 #include "wallet/wallet_args.h"
 #include "wallet/fee_priority.h"
 #include "wallet/fee_level.h"
+#include "wallet/constants.h"
 #include "version.h"
 #include <stdexcept>
 #include "wallet/message_store.h"
@@ -1028,18 +1029,12 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
   const bool per_byte = m_wallet->use_fork_rules(HF_VERSION_PER_BYTE_FEE);
   const uint64_t base_fee = m_wallet->get_base_fee();
   const char *base = per_byte ? "byte" : "kB";
-  const uint64_t typical_size = per_byte ? 2500 : 13;
+  const uint64_t typical_size = per_byte ? tools::TransactionConstants::TypicalTransactionSizeBytes : 13;
   const uint64_t size_granularity = per_byte ? 1 : 1024;
   message_writer() << (boost::format(tr("Current fee is %s %s per %s")) % print_money(base_fee) % cryptonote::get_unit(cryptonote::get_default_decimal_point()) % base).str();
 
-  std::vector<uint64_t> fees;
-  for (const auto priority : FeePriorityUtilities::GetEnums())
-  {
-    if (priority == FeePriority::Default)
-      continue;
-    uint64_t mult = m_wallet->get_fee_multiplier(priority);
-    fees.push_back(base_fee * typical_size * mult);
-  }
+  std::vector<uint64_t> fees = m_wallet->get_base_fee_by_priority(base_fee, typical_size);
+
   tools::BlockRangeBacklogs blocks;
   blocks.reserve(fees.size());
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1623,7 +1623,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
       
     cryptonote::address_parse_info info;
 
-    uint32_t adjusted_priority = m_wallet->adjust_priority(static_cast<uint32_t>(priority));
+    const auto adjusted_priority = m_wallet->adjust_priority(static_cast<uint32_t>(priority));
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
@@ -1896,7 +1896,7 @@ uint64_t WalletImpl::estimateTransactionFee(const std::vector<std::pair<std::str
         m_wallet->use_fork_rules(HF_VERSION_CLSAG, 0),
         m_wallet->use_fork_rules(HF_VERSION_BULLETPROOF_PLUS, 0),
         m_wallet->use_fork_rules(HF_VERSION_VIEW_TAGS, 0),
-        m_wallet->get_base_fee(priority),
+        m_wallet->get_base_fee(static_cast<uint32_t>(priority)),
         m_wallet->get_fee_quantization_mask());
 }
 

--- a/src/wallet/constants.h
+++ b/src/wallet/constants.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace tools
+{
+    struct TransactionConstants
+    {
+        static inline const uint64_t TypicalTransactionSizeBytes = 2500;
+    };
+}

--- a/src/wallet/fee_algorithm.h
+++ b/src/wallet/fee_algorithm.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace tools
+{
+    enum class FeeAlgorithm : int
+    {
+        Unset = -1,
+        PreHardforkV3, /* Original */
+        HardforkV3,
+        HardforkV5,
+        HardforkV8,
+    };
+
+    class FeeAlgorithmUtilities
+    {
+    public:
+        static int AsIntegral(const FeeAlgorithm algorithm)
+        {
+            return static_cast<int>(algorithm);
+        }
+    };
+}

--- a/src/wallet/fee_level.h
+++ b/src/wallet/fee_level.h
@@ -27,6 +27,7 @@ namespace tools
         // Paying a lower fee requires one to wait longer.
         uint64_t GetMaximumBlocksRemaining() const { return minimum_fee_backlog.blocks_remaining; }
         uint64_t GetMinimumBlocksRemaining() const { return maximum_fee_backlog.blocks_remaining; }
+        uint64_t GetAverageBlocksRemaining() const { (GetMaximumBlocksRemaining() - GetMinimumBlocksRemaining()) / 2 + GetMinimumBlocksRemaining(); }
     };
 
     using BlockRangeBacklogs = std::vector<BlockRangeBacklog>;

--- a/src/wallet/fee_level.h
+++ b/src/wallet/fee_level.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+namespace tools
+{
+    struct FeeLevelRange
+    {
+        double minimum;
+        double maximum;
+    };
+
+    using FeeLevelRanges = std::vector<FeeLevelRange>;
+
+    struct BlockBacklog
+    {
+        double fee;
+        uint64_t blocks_remaining;
+    };
+
+    struct BlockRangeBacklog
+    {
+        BlockBacklog minimum_fee_backlog;
+        BlockBacklog maximum_fee_backlog;
+
+        // Paying a lower fee requires one to wait longer.
+        uint64_t GetMaximumBlocksRemaining() const { return minimum_fee_backlog.blocks_remaining; }
+        uint64_t GetMinimumBlocksRemaining() const { return maximum_fee_backlog.blocks_remaining; }
+    };
+
+    using BlockRangeBacklogs = std::vector<BlockRangeBacklog>;
+}

--- a/src/wallet/fee_priority.cpp
+++ b/src/wallet/fee_priority.cpp
@@ -1,0 +1,9 @@
+#include "fee_priority.h"
+
+namespace tools
+{
+    std::ostream& operator<<(std::ostream& os, const FeePriority priority)
+    {
+        return os << FeePriorityUtilities::ToString(priority);
+    }
+}

--- a/src/wallet/fee_priority.h
+++ b/src/wallet/fee_priority.h
@@ -39,9 +39,23 @@ namespace tools
             }
             else
             {
-                const uint32_t integralValue = static_cast<uint32_t>(priority);
+                const uint32_t integralValue = AsIntegral(priority);
                 const auto decrementedIntegralValue = integralValue - 1u;
-                return static_cast<FeePriority>(decrementedIntegralValue);
+                return FromIntegral(decrementedIntegralValue);
+            }
+        }
+
+        static FeePriority Increase(const FeePriority priority)
+        {
+            if (priority == FeePriority::Priority)
+            {
+                return priority;
+            }
+            else
+            {
+                const uint32_t integralValue = AsIntegral(priority);
+                const auto incrementedIntegralValue = integralValue + 1u;
+                return FromIntegral(incrementedIntegralValue);
             }
         }
 

--- a/src/wallet/fee_priority.h
+++ b/src/wallet/fee_priority.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <array>
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+namespace tools
+{
+    enum class FeePriority : uint32_t
+    {
+        Default = 0,
+        Unimportant, /* Low */
+        Normal, /* Medium */
+        Elevated, /* High */
+        Priority, /* Very High */
+    };
+
+    std::ostream& operator<<(std::ostream& os, const FeePriority priority);
+
+    class FeePriorityUtilities
+    {
+    private:
+        using EnumStringsType = std::array<std::string_view, 5>;
+        using EnumsType = std::array<FeePriority, 5>;
+
+        static inline const EnumStringsType strings_ = { { "default", "unimportant", "normal", "elevated", "priority" } };
+        static inline const EnumsType enums_ = { { FeePriority::Default, FeePriority::Unimportant, FeePriority::Normal, FeePriority::Elevated, FeePriority::Priority } };
+
+    public:
+        static FeePriority Decrease(const FeePriority priority)
+        {
+            if (priority == FeePriority::Default)
+            {
+                return FeePriority::Default;
+            }
+            else
+            {
+                const uint32_t integralValue = static_cast<uint32_t>(priority);
+                const auto decrementedIntegralValue = integralValue - 1u;
+                return static_cast<FeePriority>(decrementedIntegralValue);
+            }
+        }
+
+        static uint32_t AsIntegral(const FeePriority priority)
+        {
+            return static_cast<uint32_t>(priority);
+        }
+
+        static FeePriority FromIntegral(const uint32_t priority)
+        {
+            return static_cast<FeePriority>(priority);
+        }
+
+        static FeePriority Clamp(const FeePriority priority)
+        {
+            /* Map Default to an actionable priority. */
+            if (priority == FeePriority::Default)
+            {
+                return FeePriority::Unimportant;
+            }
+            else
+            {
+                return priority;
+            }
+        }
+
+        static std::string_view ToString(const FeePriority priority)
+        {
+            const auto integralValue = AsIntegral(priority);
+            return strings_.at(integralValue);
+        }
+
+        static std::optional<FeePriority> FromString(const std::string& str)
+        {
+            const auto strIterator = std::find(strings_.begin(), strings_.end(), str);
+            if (strIterator == strings_.end())
+                return std::nullopt;
+
+            const auto distance = std::distance(strings_.begin(), strIterator);
+            return enums_.at(distance);
+        }
+
+        static const EnumStringsType GetFeePriorityStrings() { return strings_; }
+        static const EnumsType GetEnums() { return enums_; }
+    };
+}

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8631,6 +8631,11 @@ uint64_t wallet2::adjust_mixin(uint64_t mixin)
   return mixin;
 }
 //----------------------------------------------------------------------------------------------------
+FeePriority wallet2::adjust_priority(uint32_t priority)
+{
+  return adjust_priority(FeePriorityUtilities::FromIntegral(priority));
+}
+//----------------------------------------------------------------------------------------------------
 FeePriority wallet2::adjust_priority(FeePriority priority)
 {
   if (priority == FeePriority::Default && m_default_priority == FeePriority::Default && auto_low_priority())

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8734,11 +8734,10 @@ FeePriority wallet2::adjust_priority(FeePriority priority)
         if (tx_pool_is_empty)
           return priority;
 
-        const auto default_priority_index = 1;
-        const auto priority_index = tools::FeePriorityUtilities::AsIntegral(priority) - default_priority_index;
         const auto blocks_required_to_elevate = 360;
         auto blocks_to_wait = 0;
-        for (auto i{ priority_index }; i < blocks.size(); ++i)
+        const auto normal_priority_index = 1;
+        for (auto i{ normal_priority_index }; i < blocks.size(); ++i)
         {
           const auto& block_at_priority = blocks.at(i);
           const auto blocks_to_wait_at_priority = block_at_priority.GetAverageBlocksRemaining();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -91,6 +91,7 @@ using namespace epee;
 #include "device/device_cold.hpp"
 #include "device_trezor/device_trezor.hpp"
 #include "net/socks_connect.h"
+#include "constants.h"
 
 extern "C"
 {
@@ -8537,6 +8538,19 @@ uint64_t wallet2::get_base_fee()
 uint64_t wallet2::get_base_fee(uint32_t priority)
 {
   return get_base_fee(FeePriorityUtilities::FromIntegral(priority));
+}
+//----------------------------------------------------------------------------------------------------
+std::vector<uint64_t> wallet2::get_base_fee_by_priority(uint64_t base_fee, uint64_t typical_size)
+{
+  std::vector<uint64_t> fees;
+  for (const auto priority : FeePriorityUtilities::GetEnums())
+  {
+    if (priority == FeePriority::Default)
+      continue;
+    uint64_t mult = get_fee_multiplier(priority);
+    fees.push_back(base_fee * typical_size * mult);
+  }
+  return fees;
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_base_fee(FeePriority priority)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8722,11 +8722,14 @@ FeePriority wallet2::adjust_priority(FeePriority priority)
       {
         /*
           We know the last 10 blocks are relatively full. Let's consider our steps moving forward:
-          1. If the txpool is empty, there is no need to adjust our priority (do nothing).
+          1. If the txpool is empty, or we are at Elevated priority, there is no need to adjust our priority (do nothing).
           2. If the txpool contains transactions, we need to assess our priority relative to those transactions
             a) If the pool is contains over 180 blocks worth of transactions paying as much or more than we are, elevate priority, otherwise
             b) do nothing.
         */
+        if (priority == tools::FeePriority::Elevated)
+          return priority;
+
         const bool tx_pool_is_empty = std::all_of(blocks.begin(), blocks.end(), [](const tools::BlockRangeBacklog& backlog) { return backlog.GetMaximumBlocksRemaining() == 0; });
         if (tx_pool_is_empty)
           return priority;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1198,7 +1198,7 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std
   m_print_ring_members(false),
   m_store_tx_info(true),
   m_default_mixin(0),
-  m_default_priority(0),
+  m_default_priority(FeePriority::Default),
   m_refresh_type(RefreshOptimizeCoinbase),
   m_auto_refresh(true),
   m_first_refresh_done(false),
@@ -4606,7 +4606,7 @@ boost::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const crypt
   value2.SetUint(m_default_mixin);
   json.AddMember("default_mixin", value2, json.GetAllocator());
 
-  value2.SetUint(m_default_priority);
+  value2.SetUint(static_cast<unsigned>(m_default_priority));
   json.AddMember("default_priority", value2, json.GetAllocator());
 
   value2.SetInt(m_auto_refresh ? 1 :0);
@@ -4938,7 +4938,7 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     m_print_ring_members = false;
     m_store_tx_info = true;
     m_default_mixin = 0;
-    m_default_priority = 0;
+    m_default_priority = FeePriority::Default;
     m_auto_refresh = true;
     m_refresh_type = RefreshType::RefreshDefault;
     m_refresh_from_block_height = 0;
@@ -5071,15 +5071,15 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, default_priority, unsigned int, Uint, false, 0);
     if (field_default_priority_found)
     {
-      m_default_priority = field_default_priority;
+      m_default_priority = static_cast<FeePriority>(field_default_priority);
     }
     else
     {
       GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, default_fee_multiplier, unsigned int, Uint, false, 0);
       if (field_default_fee_multiplier_found)
-        m_default_priority = field_default_fee_multiplier;
+        m_default_priority = static_cast<FeePriority>(field_default_fee_multiplier);
       else
-        m_default_priority = 0;
+        m_default_priority = FeePriority::Default;
     }
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, auto_refresh, int, Int, false, true);
     m_auto_refresh = field_auto_refresh;
@@ -8470,42 +8470,43 @@ uint64_t wallet2::estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs
   }
 }
 
-uint64_t wallet2::get_fee_multiplier(uint32_t priority, int fee_algorithm)
+uint64_t wallet2::get_fee_multiplier(FeePriority priority, int fee_algorithm)
 {
   static const struct
   {
-    size_t count;
-    uint64_t multipliers[4];
+    FeePriority maximum_priority; // Determines the maximum priority available for said fee algorithm.
+    uint64_t fee_multipliers[4]; // Determines the fee multiplier applied at various priorities for said fee algorithm.
   }
-  multipliers[] =
+  fee_steps[] =
   {
-    { 3, {1, 2, 3} },
-    { 3, {1, 20, 166} },
-    { 4, {1, 4, 20, 166} },
-    { 4, {1, 5, 25, 1000} },
+    { FeePriority::Elevated, {1, 2, 3} },
+    { FeePriority::Elevated, {1, 20, 166} },
+    { FeePriority::Priority, {1, 4, 20, 166} },
+    { FeePriority::Priority, {1, 5, 25, 1000} },
   };
 
   if (fee_algorithm == -1)
     fee_algorithm = get_fee_algorithm();
 
   // 0 -> default (here, x1 till fee algorithm 2, x4 from it)
-  if (priority == 0)
+  if (priority == FeePriority::Default)
     priority = m_default_priority;
-  if (priority == 0)
+  if (priority == FeePriority::Default)
   {
     if (fee_algorithm >= 2)
-      priority = 2;
+      priority = FeePriority::Normal;
     else
-      priority = 1;
+      priority = FeePriority::Unimportant;
   }
 
   THROW_WALLET_EXCEPTION_IF(fee_algorithm < 0 || fee_algorithm > 3, error::invalid_priority);
 
   // 1 to 3/4 are allowed as priorities
-  const uint32_t max_priority = multipliers[fee_algorithm].count;
-  if (priority >= 1 && priority <= max_priority)
+  const FeePriority max_priority = fee_steps[fee_algorithm].maximum_priority;
+  if (priority >= FeePriority::Unimportant && priority <= max_priority)
   {
-    return multipliers[fee_algorithm].multipliers[priority-1];
+    const FeePriority adjusted_priority = FeePriorityUtilities::Decrease(priority);
+    return fee_steps[fee_algorithm].fee_multipliers[FeePriorityUtilities::AsIntegral(adjusted_priority)];
   }
 
   THROW_WALLET_EXCEPTION_IF (false, error::invalid_priority);
@@ -8532,17 +8533,13 @@ uint64_t wallet2::get_base_fee()
   return get_dynamic_base_fee_estimate();
 }
 //----------------------------------------------------------------------------------------------------
-uint64_t wallet2::get_base_fee(uint32_t priority)
+uint64_t wallet2::get_base_fee(FeePriority priority)
 {
   const bool use_2021_scaling = use_fork_rules(HF_VERSION_2021_SCALING, -30 * 1);
   if (use_2021_scaling)
   {
     // clamp and map to 0..3 indices, mapping 0 (default, but should not end up here) to 0, and 1..4 to 0..3
-    if (priority == 0)
-      priority = 1;
-    else if (priority > 4)
-      priority = 4;
-    --priority;
+    priority = FeePriorityUtilities::Clamp(priority);
 
     std::vector<uint64_t> fees;
     boost::optional<std::string> result = m_node_rpc_proxy.get_dynamic_base_fee_estimate_2021_scaling(FEE_ESTIMATE_GRACE_BLOCKS, fees);
@@ -8551,12 +8548,14 @@ uint64_t wallet2::get_base_fee(uint32_t priority)
       MERROR("Failed to determine base fee, using default");
       return FEE_PER_BYTE;
     }
-    if (priority >= fees.size())
+
+    const auto priority_index = FeePriorityUtilities::AsIntegral(priority);
+    if (priority_index >= fees.size())
     {
-      MERROR("Failed to determine base fee for priority " << priority << ", using default");
+      MERROR("Failed to determine base fee for priority " << priority_index << ", using default");
       return FEE_PER_BYTE;
     }
-    return fees[priority];
+    return fees[priority_index];
   }
   else
   {
@@ -8632,16 +8631,16 @@ uint64_t wallet2::adjust_mixin(uint64_t mixin)
   return mixin;
 }
 //----------------------------------------------------------------------------------------------------
-uint32_t wallet2::adjust_priority(uint32_t priority)
+FeePriority wallet2::adjust_priority(FeePriority priority)
 {
-  if (priority == 0 && m_default_priority == 0 && auto_low_priority())
+  if (priority == FeePriority::Default && m_default_priority == FeePriority::Default && auto_low_priority())
   {
     try
     {
       // check if there's a backlog in the tx pool
       const bool use_per_byte_fee = use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0);
-      const uint64_t base_fee = get_base_fee(1);
-      const double fee_level = base_fee * (use_per_byte_fee ? 1 : (12/(double)13 / (double)1024));
+      const uint64_t base_fee = get_base_fee(FeePriority::Unimportant);
+      const double fee_level = base_fee * (use_per_byte_fee ? 1 : (12. / 13. / 1024.));
       const std::vector<std::pair<uint64_t, uint64_t>> blocks = estimate_backlog({std::make_pair(fee_level, fee_level)});
       if (blocks.size() != 1)
       {
@@ -8651,7 +8650,7 @@ uint32_t wallet2::adjust_priority(uint32_t priority)
       else if (blocks[0].first > 0)
       {
         MINFO("We don't use the low priority because there's a backlog in the tx pool.");
-        return 2;
+        return FeePriority::Normal;
       }
 
       // get the current full reward zone
@@ -8696,10 +8695,10 @@ uint32_t wallet2::adjust_priority(uint32_t priority)
       if (P > 80)
       {
         MINFO("We don't use the low priority because recent blocks are quite full.");
-        return 2;
+        return FeePriority::Normal;
       }
       MINFO("We'll use the low priority because probably it's safe to do so.");
-      return 1;
+      return FeePriority::Unimportant;
     }
     catch (const std::exception &e)
     {
@@ -10420,7 +10419,7 @@ static uint32_t get_count_above(const std::vector<wallet2::transfer_details> &tr
 // This system allows for sending (almost) the entire balance, since it does
 // not generate spurious change in all txes, thus decreasing the instantaneous
 // usable balance.
-std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
 {
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
@@ -11188,7 +11187,7 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
   return true;
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
@@ -11261,7 +11260,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
   return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra)
 {
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
@@ -11282,7 +11281,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypt
   return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra)
 {
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
@@ -11751,7 +11750,7 @@ std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()
   const bool hf1_rules = use_fork_rules(2, 10); // first hard fork has version 2
   tx_dust_policy dust_policy(hf1_rules ? 0 : ::config::DEFAULT_DUST_THRESHOLD);
 
-  const uint64_t base_fee  = get_base_fee(1);
+  const uint64_t base_fee  = get_base_fee(FeePriority::Unimportant);
 
   // may throw
   std::vector<size_t> unmixable_outputs = select_available_unmixable_outputs();
@@ -11772,7 +11771,7 @@ std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()
       unmixable_transfer_outputs.push_back(n);
   }
 
-  return create_transactions_from(m_account_public_address, false, 1, unmixable_transfer_outputs, unmixable_dust_outputs, 0 /*fake_outs_count */, 1 /*priority */, std::vector<uint8_t>());
+  return create_transactions_from(m_account_public_address, false, 1, unmixable_transfer_outputs, unmixable_dust_outputs, 0 /*fake_outs_count */, FeePriority::Unimportant, std::vector<uint8_t>());
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::discard_unmixable_outputs()

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8533,6 +8533,11 @@ uint64_t wallet2::get_base_fee()
   return get_dynamic_base_fee_estimate();
 }
 //----------------------------------------------------------------------------------------------------
+uint64_t wallet2::get_base_fee(uint32_t priority)
+{
+  return get_base_fee(FeePriorityUtilities::FromIntegral(priority));
+}
+//----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_base_fee(FeePriority priority)
 {
   const bool use_2021_scaling = use_fork_rules(HF_VERSION_2021_SCALING, -30 * 1);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8744,7 +8744,7 @@ FeePriority wallet2::adjust_priority(FeePriority priority)
           const auto blocks_to_wait_at_priority = block_at_priority.GetAverageBlocksRemaining();
           blocks_to_wait += blocks_to_wait_at_priority;
           if (blocks_to_wait >= blocks_required_to_elevate)
-            return tools::FeePriorityUtilities::Increase(priority);
+            return tools::FeePriority::Elevated;
         }
         return priority;
       }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -71,6 +71,7 @@
 #include "common/password.h"
 #include "node_rpc_proxy.h"
 #include "message_store.h"
+#include "fee_priority.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.wallet2"
@@ -1190,10 +1191,10 @@ private:
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
     bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
-    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
-    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra);
-    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra);
+    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
+    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
+    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra);
+    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, FeePriority priority, const std::vector<uint8_t>& extra);
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, const std::vector<cryptonote::tx_destination_entry>& dsts, const unique_index_container& subtract_fee_from_outputs = {}) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
     void cold_sign_tx(const std::vector<pending_tx>& ptx_vector, signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::vector<std::string> & tx_device_aux);
@@ -1432,8 +1433,8 @@ private:
     void store_tx_info(bool store) { m_store_tx_info = store; }
     uint32_t default_mixin() const { return m_default_mixin; }
     void default_mixin(uint32_t m) { m_default_mixin = m; }
-    uint32_t get_default_priority() const { return m_default_priority; }
-    void set_default_priority(uint32_t p) { m_default_priority = p; }
+    FeePriority get_default_priority() const { return m_default_priority; }
+    void set_default_priority(FeePriority p) { m_default_priority = p; }
     bool auto_refresh() const { return m_auto_refresh; }
     void auto_refresh(bool r) { m_auto_refresh = r; }
     AskPasswordType ask_password() const { return m_ask_password; }
@@ -1652,15 +1653,15 @@ private:
     std::vector<std::pair<uint64_t, uint64_t>> estimate_backlog(uint64_t min_tx_weight, uint64_t max_tx_weight, const std::vector<uint64_t> &fees);
 
     static uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags, uint64_t base_fee, uint64_t fee_quantization_mask);
-    uint64_t get_fee_multiplier(uint32_t priority, int fee_algorithm = -1);
-    uint64_t get_base_fee(uint32_t priority);
+    uint64_t get_fee_multiplier(FeePriority priority, int fee_algorithm = -1);
+    uint64_t get_base_fee(FeePriority priority);
     uint64_t get_base_fee();
     uint64_t get_fee_quantization_mask();
     uint64_t get_min_ring_size();
     uint64_t get_max_ring_size();
     uint64_t adjust_mixin(uint64_t mixin);
 
-    uint32_t adjust_priority(uint32_t priority);
+    FeePriority adjust_priority(FeePriority priority);
 
     bool is_unattended() const { return m_unattended; }
 
@@ -1959,7 +1960,7 @@ private:
     bool m_print_ring_members;
     bool m_store_tx_info; /*!< request txkey to be returned in RPC, and store in the wallet cache file */
     uint32_t m_default_mixin;
-    uint32_t m_default_priority;
+    FeePriority m_default_priority;
     RefreshType m_refresh_type;
     bool m_auto_refresh;
     bool m_first_refresh_done;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1661,10 +1661,14 @@ private:
     uint64_t get_max_ring_size();
     uint64_t adjust_mixin(uint64_t mixin);
     
-    // The overload taking in an integer is kept for backwards compatibility, as this is called from wallet.cpp
-    // after casting from a type (PendingTransaction::FeePriority) which I don't want to touch.
-    FeePriority adjust_priority(uint32_t priority); 
     FeePriority adjust_priority(FeePriority priority);
+
+    /* 
+      The overloads taking in an integer is kept for backwards compatibility, as this is called from wallet.cpp
+      after casting from a type (PendingTransaction::FeePriority) which I don't want to touch.
+    */
+    FeePriority adjust_priority(uint32_t priority); 
+    uint64_t get_base_fee(uint32_t);
 
     bool is_unattended() const { return m_unattended; }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -73,6 +73,7 @@
 #include "message_store.h"
 #include "fee_priority.h"
 #include "fee_algorithm.h"
+#include "fee_level.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.wallet2"
@@ -1650,8 +1651,8 @@ private:
 
     bool is_synced();
 
-    std::vector<std::pair<uint64_t, uint64_t>> estimate_backlog(const std::vector<std::pair<double, double>> &fee_levels);
-    std::vector<std::pair<uint64_t, uint64_t>> estimate_backlog(uint64_t min_tx_weight, uint64_t max_tx_weight, const std::vector<uint64_t> &fees);
+    BlockRangeBacklogs estimate_backlog(const FeeLevelRanges &fee_levels);
+    BlockRangeBacklogs estimate_backlog(uint64_t min_tx_weight, uint64_t max_tx_weight, const std::vector<uint64_t> &fees);
 
     static uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags, uint64_t base_fee, uint64_t fee_quantization_mask);
     uint64_t get_fee_multiplier(FeePriority priority, FeeAlgorithm fee_algorithm = FeeAlgorithm::Unset);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1660,7 +1660,10 @@ private:
     uint64_t get_min_ring_size();
     uint64_t get_max_ring_size();
     uint64_t adjust_mixin(uint64_t mixin);
-
+    
+    // The overload taking in an integer is kept for backwards compatibility, as this is called from wallet.cpp
+    // after casting from a type (PendingTransaction::FeePriority) which I don't want to touch.
+    FeePriority adjust_priority(uint32_t priority); 
     FeePriority adjust_priority(FeePriority priority);
 
     bool is_unattended() const { return m_unattended; }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -72,6 +72,7 @@
 #include "node_rpc_proxy.h"
 #include "message_store.h"
 #include "fee_priority.h"
+#include "fee_algorithm.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.wallet2"
@@ -1540,7 +1541,7 @@ private:
     uint8_t get_current_hard_fork();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
     bool use_fork_rules(uint8_t version, int64_t early_blocks = 0);
-    int get_fee_algorithm();
+    FeeAlgorithm get_fee_algorithm();
 
     std::string get_wallet_file() const;
     std::string get_keys_file() const;
@@ -1653,7 +1654,7 @@ private:
     std::vector<std::pair<uint64_t, uint64_t>> estimate_backlog(uint64_t min_tx_weight, uint64_t max_tx_weight, const std::vector<uint64_t> &fees);
 
     static uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags, uint64_t base_fee, uint64_t fee_quantization_mask);
-    uint64_t get_fee_multiplier(FeePriority priority, int fee_algorithm = -1);
+    uint64_t get_fee_multiplier(FeePriority priority, FeeAlgorithm fee_algorithm = FeeAlgorithm::Unset);
     uint64_t get_base_fee(FeePriority priority);
     uint64_t get_base_fee();
     uint64_t get_fee_quantization_mask();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1658,6 +1658,7 @@ private:
     uint64_t get_fee_multiplier(FeePriority priority, FeeAlgorithm fee_algorithm = FeeAlgorithm::Unset);
     uint64_t get_base_fee(FeePriority priority);
     uint64_t get_base_fee();
+    std::vector<uint64_t> get_base_fee_by_priority(uint64_t base_fee, uint64_t typical_size);
     uint64_t get_fee_quantization_mask();
     uint64_t get_min_ring_size();
     uint64_t get_max_ring_size();

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -85,7 +85,7 @@ bool do_send_money(tools::wallet2& w1, tools::wallet2& w2, size_t mix_in_factor,
   try
   {
     std::vector<tools::wallet2::pending_tx> ptx;
-    ptx = w1.create_transactions_2(dsts, mix_in_factor, 0, std::vector<uint8_t>(), 0, {});
+    ptx = w1.create_transactions_2(dsts, mix_in_factor, tools::FeePriority::Default, std::vector<uint8_t>(), 0, {});
     for (auto &p: ptx)
       w1.commit_tx(p);
     return true;


### PR DESCRIPTION
**The following PR requires https://github.com/monero-project/monero/pull/9838 (code clean-up) and https://github.com/monero-project/monero/pull/9842 (bug fix)**
**The following PR addresses issue https://github.com/monero-project/monero/issues/9799**

**Before this PR**

`adjust_priority` in `wallet2` does not support `FeePriority::Elevated`. 

**Change in this PR**

After speaking to @nahuhh it was determined that, if the past 10 blocks are relatively full, and the transaction pool contains 360 blocks (12 hours of wait time) at a similar or higher fee level than Normal (L2), then we should promote the priority to Elevated.

**Should you look at this PR now?**

Wait until the afformentioned PRs are merged, I'll then rebase this branch.




