### PR TITLE
tests: Add Virtualenv Recommendation and Version the Python Testing Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,7 @@ nbproject
 __pycache__/
 *.pyc
 *.log
+
+# virtualenv
+venv/
+.venv/

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,9 +48,23 @@ To run the same tests on a release build, replace `debug` with `release`.
 [TODO]
 Functional tests are located under the `tests/functional_tests` directory.
 
-Building all the tests requires installing the following dependencies:
+Building all the tests requires the versioned-dependencies listed in the `requirements.txt` file.
+
+To install said dependencies, you must have the python package `virtualenv` installed. 
+
+To read more on how to install `virtualenv` please read [this](https://virtualenv.pypa.io/en/latest/installation.html) short guide.
+
+After `virtualenv` is installed, create your own virtual environment with:
+
 ```bash
-pip install requests psutil monotonic zmq deepdiff
+virtualenv venv
+```
+
+**Note**: You can name your virtual environment anything you want; but, this repository is configured to ignore the contents of venv.
+
+After activiating your virtual environment, as detailed in the afformentioned fuide, install the required dependencies:
+```bash
+pip install -r requirements.txt
 ```
 
 First, run a regtest daemon in the offline mode and with a fixed difficulty:

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,11 +48,11 @@ To run the same tests on a release build, replace `debug` with `release`.
 [TODO]
 Functional tests are located under the `tests/functional_tests` directory.
 
-Building all the tests requires the versioned-dependencies listed in the `requirements.txt` file.
+Building all the tests requires the versioned dependencies listed in the `requirements.txt` file.
 
 To install said dependencies, you must have the python package `virtualenv` installed. 
 
-To read more on how to install `virtualenv` please read [this](https://virtualenv.pypa.io/en/latest/installation.html) short guide.
+To learn more about how to install `virtualenv`, please read [this](https://virtualenv.pypa.io/en/latest/installation.html) short guide.
 
 After `virtualenv` is installed, create your own virtual environment with:
 
@@ -60,7 +60,7 @@ After `virtualenv` is installed, create your own virtual environment with:
 virtualenv venv
 ```
 
-**Note**: You can name your virtual environment anything you want; but, this repository is configured to ignore the contents of venv.
+**Note**: You can name your virtual environment anything you want; but, this repository is only configured to ignore the contents of `venv` and `.venv`.
 
 After activiating your virtual environment, as detailed in the afformentioned fuide, install the required dependencies:
 ```bash

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2025.1.31
+charset-normalizer==3.4.1
+deepdiff==8.4.2
+idna==3.10
+monotonic==1.6
+orderly-set==5.3.0
+psutil==7.0.0
+pyzmq==26.3.0
+requests==2.32.3
+urllib3==2.3.0
+zmq==0.0.0


### PR DESCRIPTION
The versions used to run the Python tests were not frozen (`pip install library` just pulls the latest version). It's best practice to 'freeze' these versions to those you know work with your current test-suit / application. I froze them at the latest version of each library. I ran the tests with these libraries after creating a virtual environment. I updated the documentation to instruct the user to create a virtual environment before pip installing, and informed them to install said dependencies with the requirements.txt file. 

Using a virtual environment is better than messing with the root system. Static library versions also help improve reproducibility and prevent later version conflicts down the line.

I also added the contents of `venv` and `.venv` commonly-named virtualenv folders to the gitignore.