### PR TITLE
daemon: Add log-level arg description

### DIFF
--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -79,7 +79,7 @@ namespace daemon_args
   };
   const command_line::arg_descriptor<std::string> arg_log_level = {
     "log-level"
-  , ""
+  , "0-4 or categories"
   , ""
   };
   const command_line::arg_descriptor<std::vector<std::string>> arg_command = {


### PR DESCRIPTION
This same description is listed in the other cli tools. I saw this argument in the daemon's help menu and didn't know how to set it, which is why I made this PR.