### PR TITLE
Use amd64 accelerations for scalarmultKey in verify code

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -38,6 +38,7 @@
 #include "cryptonote_config.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
+#include "ringct/accel.h"
 #include "ringct/rctSigs.h"
 
 using namespace epee;
@@ -167,7 +168,7 @@ namespace cryptonote
           CHECK_AND_ASSERT_MES(n_amounts == rv.outPk.size(), false, "Internal error filling out V");
           rv.p.bulletproofs_plus[0].V.resize(n_amounts);
           for (size_t i = 0; i < n_amounts; ++i)
-            rv.p.bulletproofs_plus[0].V[i] = rct::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
+            rv.p.bulletproofs_plus[0].V[i] = rct::accel::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
         }
         else if (bulletproof)
         {
@@ -191,7 +192,7 @@ namespace cryptonote
           CHECK_AND_ASSERT_MES(n_amounts == rv.outPk.size(), false, "Internal error filling out V");
           rv.p.bulletproofs[0].V.resize(n_amounts);
           for (size_t i = 0; i < n_amounts; ++i)
-            rv.p.bulletproofs[0].V[i] = rct::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
+            rv.p.bulletproofs[0].V[i] = rct::accel::scalarmultKey(rv.outPk[i].mask, rct::INV_EIGHT);
         }
       }
     }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -49,6 +49,7 @@ using namespace epee;
 #include "file_io_utils.h"
 #include <csignal>
 #include "checkpoints/checkpoints.h"
+#include "ringct/accel.h"
 #include "ringct/rctTypes.h"
 #include "blockchain_db/blockchain_db.h"
 #include "ringct/rctSigs.h"
@@ -1037,7 +1038,7 @@ namespace cryptonote
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, tokey_in, false);
-      if (!(rct::scalarmultKey(rct::ki2rct(tokey_in.k_image), rct::curveOrder()) == rct::identity()))
+      if (!(rct::accel::scalarmultKey(rct::ki2rct(tokey_in.k_image), rct::curveOrder()) == rct::identity()))
         return false;
     }
     return true;

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -27,6 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(ringct_basic_sources
+  accel.cpp
   rctOps.cpp
   rctTypes.cpp
   rctCryptoOps.c
@@ -45,6 +46,7 @@ target_link_libraries(ringct_basic
   PUBLIC
     common
     cncrypto
+    wallet-crypto
   PRIVATE
     ${OPENSSL_LIBRARIES}
     ${EXTRA_LIBRARIES})

--- a/src/ringct/accel.cpp
+++ b/src/ringct/accel.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2025, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "accel.h"
+#include "misc_log_ex.h"
+
+namespace rct { namespace accel
+{
+  void throw_log_message()
+  {
+    ASSERT_MES_AND_THROW("monero_crypto_ge25519_scalarmult failed (::rct::accel::scalarmultKey)");
+  }
+}}

--- a/src/ringct/accel.h
+++ b/src/ringct/accel.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, Monero
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "crypto/wallet/ops.h"
+#include "ringct/rctOps.h"
+
+namespace rct { namespace accel
+{
+#ifdef monero_crypto_ge25519_scalarmult
+  [[noreturn]] void throw_log_message();
+  inline void scalarmultKey(key &aP, const key &P, const key &a)
+  {
+    const int rc =
+      monero_crypto_ge25519_scalarmult(
+        reinterpret_cast<char*>(aP.bytes),
+        reinterpret_cast<const char*>(P.bytes),
+        reinterpret_cast<const char*>(a.bytes)
+      );
+    if (rc != 0)
+      throw_log_message();
+  }
+
+  inline key scalarmultKey(const key &P, const key &a)
+  {
+    key out;
+    ::rct::accel::scalarmultKey(out, P, a);
+    return out;
+  }
+#else
+  using ::rct::scalarmultKey;
+#endif
+}}


### PR DESCRIPTION
I profiled a post ringct block sync and discovered that `rct::scalarmultKey` took ~60% of CPU time on a Ryzen 3900x. Using amd64 accelerations, already in use by the wallet, dropped this function to ~18% of the CPU time. The same base code has been in use by the wallet for years without issue, so the likelihood of bugs is low. I have **not** done a real-world sync test to determine the difference, if any, this provides. If no community members pick up this kind of testing, I will try to figure this out at some point, as its likely never going to get merged without such analysis.

This same CPU was used to profile the #6337 wallet changes. Each `scalarmultKey` call to the 32-bit code takes ~93 microseconds, whereas the 64-bit code takes ~37 microseconds. There's at least 3 of these calls per transaction, so with 40 transaction blocks this saves about 7 milliseconds per block. However, the remainder of the ringct still uses the other crypto functions, so there may be some CPU cache thrashing effects. Since the transaction verification code does everything in batches, the CPU cache isn't constantly switching between the two libraries, so the penalty of the two libraries is mostly mitigated.

My other recent PRs remove `transaction` copies - after this PR `~transaction` is now fairly high up on the list of "hot spots". I didn't profile _with those changes merged_, so between these patches we are fairly close on reducing the sync time.

This is still marked as draft as this changes consensus code to use a different library depending on build. We could, as a matter of safety, use this only when "expanding" transactions in `cryptonote_format_utils.cpp` (leaving the curve order check to always use the "safer" ref10 code).
