### PR TITLE
epee: span::operator[] allow mut ref from const span

### DIFF
--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -109,8 +109,7 @@ namespace epee
     constexpr std::size_t size() const noexcept { return len; }
     constexpr std::size_t size_bytes() const noexcept { return size() * sizeof(value_type); }
 
-    T &operator[](size_t idx) noexcept { return ptr[idx]; }
-    const T &operator[](size_t idx) const noexcept { return ptr[idx]; }
+    constexpr T &operator[](size_t idx) const noexcept { return ptr[idx]; }
 
   private:
     T* ptr;


### PR DESCRIPTION
Changes the `operator[]` method so we can get mutable references to elements even if the span is `const`. The operator is now also `constexpr`. This behavior matches `std::span`.

C++ standard reference: https://en.cppreference.com/w/cpp/container/span/operator_at