### PR TITLE
fix: added key correspondence check to monero-wallet-rpc generate_from_keys

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3891,7 +3891,20 @@ namespace tools
       er.message = "Failed to parse view key secret key";
       return false;
     }
-
+    
+    crypto::public_key pkey;
+    if (!crypto::secret_key_to_public_key(viewkey, pkey)) {
+          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+          er.message = "failed to verify view key secret key";
+          return false;
+        }
+        
+    if (info.address.m_view_public_key != pkey) {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "view key does not match standard address";
+      return false;
+    }
+      
     if (m_wallet && req.autosave_current)
     {
       try
@@ -3918,6 +3931,20 @@ namespace tools
           er.message = "Failed to parse spend key secret key";
           return false;
         }
+
+        crypto::public_key spkey;
+        if (!crypto::secret_key_to_public_key(spendkey, spkey)) {
+          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+          er.message ="failed to verify spend key secret key";
+          return false;
+        }
+        if (info.address.m_spend_public_key != spkey) {
+          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+          er.message = "spend key does not match standard address";
+          return false;
+        }
+
+
         wal->generate(wallet_file, std::move(rc.second).password(), info.address, spendkey, viewkey, false);
         res.info = "Wallet has been generated successfully.";
       }


### PR DESCRIPTION
I created this pull request to propose fixing the error handling in monero-wallet-rpc generate_from_keys where the key correspondence is not checked.

Missing checks lets users create malformed wallets. There was no checks to make sure the entered address, viewkey and spendkey are actually corresponding to each other when creating a wallet via RPC with generate_from_keys, so this adds error handling for it.

Without this, if the keys are not corresponding to each other generate_from_keys still returns "Wallet has been generated successfully" but open_wallet will error with "THROW EXCEPTION: error::wallet_files_doesnt_correspond"

I would like to add the checks so generate_from_keys can't output malformed wallet files.

The key correspondence checks were taken from the wallet2.cpp generate_from_json function where the key correspondence is checked properly.

please review. I found no corresponding tests to update
