### PR TITLE
fix: multisig stale data after failed refresh

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1933,8 +1933,8 @@ private:
     std::vector<tools::wallet2::address_book_row> m_address_book;
     std::pair<std::map<std::string, std::string>, std::vector<std::string>> m_account_tags;
     uint64_t m_upper_transaction_weight_limit; //TODO: auto-calc this value or request from daemon, now use some fixed value
-    const std::vector<std::vector<tools::wallet2::multisig_info>> *m_multisig_rescan_info;
-    const std::vector<std::vector<rct::key>> *m_multisig_rescan_k;
+    std::vector<std::vector<tools::wallet2::multisig_info>> m_multisig_rescan_info;
+    std::vector<std::vector<rct::key>> m_multisig_rescan_k;
     std::unordered_map<crypto::public_key, crypto::key_image> m_cold_key_images;
 
     std::atomic<bool> m_run;


### PR DESCRIPTION
Without this PR you should be able to reproduce the error with the following steps:
1. 2/2 multisig-wallets W1 and W2 both own some enotes with partial key images
2. use `export_multisig_info` for both wallets
3. use `import_multisig_info` for W1
4. turn off daemon (to reproduce the "no connection to daemon" error in next step, in the real world this happens by accident) 
5. attempt `import_multisig_info` for W2 (it fails as expected)
6. turn on daemon
7. use `import_multisig_info` for W2 (it looks like it worked, but it actually dropped enotes with partial key images from `m_transfers`, this becomes a problem e.g. if you try to sign a tx from this wallet)
8. use `transfer` from W1
9. use `sign_multisig` from W2, here we get `Error: Multisig error: This signature was made with stale data: export fresh multisig data, which other participants must then use`