### PR TITLE
src: add purge_blocks rpc call

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -311,6 +311,12 @@ void BlockchainDB::set_hard_fork(HardFork* hf)
   m_hardfork = hf;
 }
 
+void BlockchainDB::purge_block()
+{
+  get_top_block();
+  remove_block();
+}
+
 void BlockchainDB::pop_block(block& blk, std::vector<transaction>& txs)
 {
   blk = get_top_block();

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1152,6 +1152,18 @@ public:
    */
   virtual void pop_block(block& blk, std::vector<transaction>& txs);
 
+  /**
+   *
+   * @brief purge the top block off the blockchain
+   *
+   * The subclass should remove the most recent block from the blockchain,
+   * along with all transactions, outputs, and other metadata created as
+   * a result of its addition to the blockchain.  Most of this is handled
+   * by the concrete members of the base class provided the subclass correctly
+   * implements remove_* functions.
+   *
+   */
+   virtual void purge_block();
 
   /**
    * @brief check if a transaction with a given hash exists

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1106,8 +1106,9 @@ namespace cryptonote
      * @brief removes blocks from the top of the blockchain
      *
      * @param nblocks number of blocks to be removed
+     * @param purge if fast mode is enabled doesnt add popped txis to pool
      */
-    void pop_blocks(uint64_t nblocks);
+    void pop_blocks(uint64_t nblocks, bool purge = false);
 
     /**
      * @brief checks whether a given block height is included in the precompiled block hash area
@@ -1343,9 +1344,11 @@ namespace cryptonote
     /**
      * @brief removes the most recent block from the blockchain
      *
+     * @param purge if fast mode is enabled doesnt add popped txis to pool
+     *
      * @return the block removed
      */
-    block pop_block_from_blockchain();
+    block pop_block_from_blockchain(bool purge = false);
 
     /**
      * @brief validate and add a new block to the end of the blockchain

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -510,7 +510,7 @@ namespace cryptonote
       *
       * @note see tx_memory_pool::get_pool_transactions_info
       */
-     bool get_pool_transactions_info(const std::vector<crypto::hash>& txids, std::vector<std::pair<crypto::hash, tx_memory_pool::tx_details>>& txs, bool include_sensitive_txes = false) const;
+      bool get_pool_transactions_info(const std::vector<crypto::hash>& txids, std::vector<std::pair<crypto::hash, tx_memory_pool::tx_details>>& txs, bool include_sensitive_txes = false) const;
 
      /**
       * @copydoc tx_memory_pool::get_pool_info

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -929,6 +929,31 @@ bool t_command_parser_executor::sync_info(const std::vector<std::string>& args)
   return m_executor.sync_info();
 }
 
+bool t_command_parser_executor::purge_blocks(const std::vector<std::string>& args)
+{
+  if (args.size() != 1)
+  {
+    std::cout << "Invalid syntax: One parameter expected. For more details, use the help command." << std::endl;
+    return true;
+  }
+
+  try
+  {
+    uint64_t nblocks = boost::lexical_cast<uint64_t>(args[0]);
+    if (nblocks < 1)
+    {
+      std::cout << "Invalid syntax: Number of blocks must be greater than 0. For more details, use the help command." << std::endl;
+      return true;
+    }
+    return m_executor.purge_blocks(nblocks);
+  }
+  catch (const boost::bad_lexical_cast&)
+  {
+    std::cout << "Invalid syntax: Number of blocks must be a number greater than 0. For more details, use the help command." << std::endl;
+  }
+  return true;
+}
+
 bool t_command_parser_executor::pop_blocks(const std::vector<std::string>& args)
 {
   if (args.size() != 1)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -140,6 +140,8 @@ public:
 
   bool sync_info(const std::vector<std::string>& args);
 
+  bool purge_blocks(const std::vector<std::string>& args);
+
   bool pop_blocks(const std::vector<std::string>& args);
 
   bool rpc_payments(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -297,6 +297,12 @@ t_command_server::t_command_server(
     , "Print information about the blockchain sync state."
     );
     m_command_lookup.set_handler(
+      "purge_blocks"
+    , std::bind(&t_command_parser_executor::purge_blocks, &m_parser, p::_1)
+    , "purge_blocks <nblocks>"
+    , "Remove blocks from end of blockchain, it will flush txpool and remove blocks without keeping the transactions"
+    );
+    m_command_lookup.set_handler(
       "pop_blocks"
     , std::bind(&t_command_parser_executor::pop_blocks, &m_parser, p::_1)
     , "pop_blocks <nblocks>"

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -154,6 +154,8 @@ public:
 
   bool sync_info();
 
+  bool purge_blocks(uint64_t num_blocks);
+
   bool pop_blocks(uint64_t num_blocks);
 
   bool prune_blockchain();

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3276,6 +3276,18 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_purge_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res, const connection_context *ctx)
+  {
+    RPC_TRACKER(purge_blocks);
+
+    m_core.get_blockchain_storage().pop_blocks(req.nblocks, true);
+
+    res.height = m_core.get_current_blockchain_height();
+    res.status = CORE_RPC_STATUS_OK;
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_pop_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res, const connection_context *ctx)
   {
     RPC_TRACKER(pop_blocks);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -139,6 +139,7 @@ namespace cryptonote
       MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)      
       MAP_URI_AUTO_JON2_IF("/update", on_update, COMMAND_RPC_UPDATE, !m_restricted)
       MAP_URI_AUTO_BIN2("/get_output_distribution.bin", on_get_output_distribution_bin, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
+      MAP_URI_AUTO_JON2_IF("/purge_blocks", on_purge_blocks, COMMAND_RPC_POP_BLOCKS, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/pop_blocks", on_pop_blocks, COMMAND_RPC_POP_BLOCKS, !m_restricted)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("get_block_count",           on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
@@ -225,6 +226,7 @@ namespace cryptonote
     bool on_in_peers(const COMMAND_RPC_IN_PEERS::request& req, COMMAND_RPC_IN_PEERS::response& res, const connection_context *ctx = NULL);
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res, const connection_context *ctx = NULL);
     bool on_get_output_distribution_bin(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, const connection_context *ctx = NULL);
+    bool on_purge_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res, const connection_context *ctx = NULL);
     bool on_pop_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res, const connection_context *ctx = NULL);
     
     //json_rpc

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -241,6 +241,12 @@ class Daemon(object):
         }
         return self.rpc.send_request("/pop_blocks", pop_blocks)
 
+    def purge_blocks(self, nblocks = 1):
+        purge_blocks = {
+            'nblocks' : nblocks,
+        }
+        return self.rpc.send_request("/purge_blocks", purge_blocks)
+
     def start_mining(self, miner_address, threads_count = 0, do_background_mining = False, ignore_battery = False):
         start_mining = {
             'miner_address' : miner_address,


### PR DESCRIPTION
# Add `purge_blocks` RPC Call

## Overview
This PR introduces a new `purge_blocks` RPC command to efficiently remove blocks from the end of the blockchain. Unlike the existing `pop_blocks`, this command skips re-adding transactions from purged blocks to the transaction pool, resulting in faster execution.

## Why It's Needed
When rolling back the blockchain (e.g., during node recovery or testing), reprocessing transactions from rolled-back blocks is often unnecessary and time-consuming. The `purge_blocks` command optimizes this by bypassing transaction pool updates, significantly speeding up block removal in such scenarios. In addition to that, a faster `pop_blocks` is much needed when doing development on Monero.

## Key Changes
- Adds `purge_block` logic to `BlockchainDB` for direct block removal.
- Extends internal block-popping functions with a `purge` flag to toggle transaction handling.
- Exposes the functionality via a new RPC endpoint and CLI command.

This change maintains backward compatibility while providing a more efficient alternative to `pop_blocks` for use cases where transaction preservation is not required.

## Performance Comparison: 

| Blocks | pop_blocks (ms) | purge_blocks (ms) | Improvement (%) |
|--------|-----------------|-------------------|-----------------|
| 1      | 269             | 255               | 5.20%           |
| 2      | 264             | 251               | 4.92%           |
| 5      | 288             | 249               | 13.54%          |
| 10     | 341             | 254               | 25.52%          |
| 20     | 488             | 252               | 48.36%          |
| 30     | 481             | 251               | 47.81%          |
| 40     | 677             | 263               | 61.09%          |
| 50     | 1138            | 262               | 76.91%          |
| 100    | 2214            | 262               | 88.13%          |
| 200    | 4227            | 263               | 93.90%          |
| 400    | 8218            | 282               | 96.57%          |
| 500    | 16783           | 299               | 98.22%          |
| 1000   | 28463           | 371               | 98.70%          |
| 1500   | 44127           | 391               | 99.11%          |
| 2500   | 46732           | 515               | 98.90%          |



### Benchmark Raw Output: 
```

Starting comparison between pop_blocks and purge_blocks...
----------------------------------------------------------
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:52:57.321 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 1 block(s)
------------------------------
Running pop_blocks for 1 block(s)...
pop_blocks output:
2025-03-26 08:52:58.498 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880418, popped 1 blocks, in 269 (ms).
Execution time: 1.190185211 seconds
------------------------------
Running purge_blocks for 1 block(s)...
purge_blocks output:
2025-03-26 08:52:59.690 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880417, purged 1 blocks, in 255 (ms).
Execution time: .992989747 seconds
------------------------------
Comparing outputs for 1 block(s):
Differences found for 1 block(s):
1,2c1,2
< 2025-03-26 08:52:58.498       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880418, popped 1 blocks, in 269 (ms).
---
> 2025-03-26 08:52:59.690       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880417, purged 1 blocks, in 255 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:00.686 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 2 block(s)
------------------------------
Running pop_blocks for 2 block(s)...
pop_blocks output:
2025-03-26 08:53:01.925 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880415, popped 2 blocks, in 264 (ms).
Execution time: 1.197757362 seconds
------------------------------
Running purge_blocks for 2 block(s)...
purge_blocks output:
2025-03-26 08:53:03.125 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880413, purged 2 blocks, in 251 (ms).
Execution time: 1.377256333 seconds
------------------------------
Comparing outputs for 2 block(s):
Differences found for 2 block(s):
1,2c1,2
< 2025-03-26 08:53:01.925       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880415, popped 2 blocks, in 264 (ms).
---
> 2025-03-26 08:53:03.125       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880413, purged 2 blocks, in 251 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:04.504 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 5 block(s)
------------------------------
Running pop_blocks for 5 block(s)...
pop_blocks output:
2025-03-26 08:53:05.289 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880408, popped 5 blocks, in 288 (ms).
Execution time: 1.509523612 seconds
------------------------------
Running purge_blocks for 5 block(s)...
purge_blocks output:
2025-03-26 08:53:06.800 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880403, purged 5 blocks, in 249 (ms).
Execution time: 1.115785130 seconds
------------------------------
Comparing outputs for 5 block(s):
Differences found for 5 block(s):
1,2c1,2
< 2025-03-26 08:53:05.289       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880408, popped 5 blocks, in 288 (ms).
---
> 2025-03-26 08:53:06.800       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880403, purged 5 blocks, in 249 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:07.918 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 10 block(s)
------------------------------
Running pop_blocks for 10 block(s)...
pop_blocks output:
2025-03-26 08:53:09.006 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880393, popped 10 blocks, in 341 (ms).
Execution time: .649906053 seconds
------------------------------
Running purge_blocks for 10 block(s)...
purge_blocks output:
2025-03-26 08:53:09.657 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880383, purged 10 blocks, in 254 (ms).
Execution time: 1.949071926 seconds
------------------------------
Comparing outputs for 10 block(s):
Differences found for 10 block(s):
1,2c1,2
< 2025-03-26 08:53:09.006       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880393, popped 10 blocks, in 341 (ms).
---
> 2025-03-26 08:53:09.657       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880383, purged 10 blocks, in 254 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:11.609 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 20 block(s)
------------------------------
Running pop_blocks for 20 block(s)...
pop_blocks output:
2025-03-26 08:53:13.623 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880363, popped 20 blocks, in 488 (ms).
Execution time: 1.014969200 seconds
------------------------------
Running purge_blocks for 20 block(s)...
purge_blocks output:
2025-03-26 08:53:14.639 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880343, purged 20 blocks, in 252 (ms).
Execution time: 1.149649288 seconds
------------------------------
Comparing outputs for 20 block(s):
Differences found for 20 block(s):
1,2c1,2
< 2025-03-26 08:53:13.623       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880363, popped 20 blocks, in 488 (ms).
---
> 2025-03-26 08:53:14.639       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880343, purged 20 blocks, in 252 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:15.791 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 30 block(s)
------------------------------
Running pop_blocks for 30 block(s)...
pop_blocks output:
2025-03-26 08:53:17.613 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880313, popped 30 blocks, in 481 (ms).
Execution time: 1.719372142 seconds
------------------------------
Running purge_blocks for 30 block(s)...
purge_blocks output:
2025-03-26 08:53:19.334 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880283, purged 30 blocks, in 251 (ms).
Execution time: 1.155499610 seconds
------------------------------
Comparing outputs for 30 block(s):
Differences found for 30 block(s):
1,2c1,2
< 2025-03-26 08:53:17.613       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880313, popped 30 blocks, in 481 (ms).
---
> 2025-03-26 08:53:19.334       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880283, purged 30 blocks, in 251 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:20.492 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 40 block(s)
------------------------------
Running pop_blocks for 40 block(s)...
pop_blocks output:
2025-03-26 08:53:21.630 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880243, popped 40 blocks, in 677 (ms).
Execution time: 1.554736178 seconds
------------------------------
Running purge_blocks for 40 block(s)...
purge_blocks output:
2025-03-26 08:53:23.187 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880203, purged 40 blocks, in 263 (ms).
Execution time: .818716400 seconds
------------------------------
Comparing outputs for 40 block(s):
Differences found for 40 block(s):
1,2c1,2
< 2025-03-26 08:53:21.630       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880243, popped 40 blocks, in 677 (ms).
---
> 2025-03-26 08:53:23.187       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880203, purged 40 blocks, in 263 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:24.007 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 50 block(s)
------------------------------
Running pop_blocks for 50 block(s)...
pop_blocks output:
2025-03-26 08:53:26.051 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880153, popped 50 blocks, in 1138 (ms).
Execution time: 1.520032400 seconds
------------------------------
Running purge_blocks for 50 block(s)...
purge_blocks output:
2025-03-26 08:53:27.572 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880103, purged 50 blocks, in 262 (ms).
Execution time: .995971078 seconds
------------------------------
Comparing outputs for 50 block(s):
Differences found for 50 block(s):
1,2c1,2
< 2025-03-26 08:53:26.051       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880153, popped 50 blocks, in 1138 (ms).
---
> 2025-03-26 08:53:27.572       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2880103, purged 50 blocks, in 262 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:28.571 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 100 block(s)
------------------------------
Running pop_blocks for 100 block(s)...
pop_blocks output:
2025-03-26 08:53:30.466 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2880003, popped 100 blocks, in 2214 (ms).
Execution time: 2.996588039 seconds
------------------------------
Running purge_blocks for 100 block(s)...
purge_blocks output:
2025-03-26 08:53:33.463 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2879903, purged 100 blocks, in 262 (ms).
Execution time: 1.878910771 seconds
------------------------------
Comparing outputs for 100 block(s):
Differences found for 100 block(s):
1,2c1,2
< 2025-03-26 08:53:30.466       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2880003, popped 100 blocks, in 2214 (ms).
---
> 2025-03-26 08:53:33.463       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2879903, purged 100 blocks, in 262 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:35.345 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 200 block(s)
------------------------------
Running pop_blocks for 200 block(s)...
pop_blocks output:
2025-03-26 08:53:39.222 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2879703, popped 200 blocks, in 4227 (ms).
Execution time: 5.583349172 seconds
------------------------------
Running purge_blocks for 200 block(s)...
purge_blocks output:
2025-03-26 08:53:44.807 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2879503, purged 200 blocks, in 263 (ms).
Execution time: 1.404070745 seconds
------------------------------
Comparing outputs for 200 block(s):
Differences found for 200 block(s):
1,2c1,2
< 2025-03-26 08:53:39.222       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2879703, popped 200 blocks, in 4227 (ms).
---
> 2025-03-26 08:53:44.807       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2879503, purged 200 blocks, in 263 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:53:46.213 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 400 block(s)
------------------------------
Running pop_blocks for 400 block(s)...
pop_blocks output:
2025-03-26 08:53:52.694 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2879103, popped 400 blocks, in 8218 (ms).
Execution time: 9.299852833 seconds
------------------------------
Running purge_blocks for 400 block(s)...
purge_blocks output:
2025-03-26 08:54:01.999 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2878703, purged 400 blocks, in 282 (ms).
Execution time: 1.353334041 seconds
------------------------------
Comparing outputs for 400 block(s):
Differences found for 400 block(s):
1,2c1,2
< 2025-03-26 08:53:52.694       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2879103, popped 400 blocks, in 8218 (ms).
---
> 2025-03-26 08:54:01.999       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2878703, purged 400 blocks, in 282 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:54:03.352 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 500 block(s)
------------------------------
Running pop_blocks for 500 block(s)...
pop_blocks output:
2025-03-26 08:54:12.595 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2878203, popped 500 blocks, in 16783 (ms).
Execution time: 17.391902525 seconds
------------------------------
Running purge_blocks for 500 block(s)...
purge_blocks output:
2025-03-26 08:54:29.989 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2877703, purged 500 blocks, in 299 (ms).
Execution time: 1.064550634 seconds
------------------------------
Comparing outputs for 500 block(s):
Differences found for 500 block(s):
1,2c1,2
< 2025-03-26 08:54:12.595       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2878203, popped 500 blocks, in 16783 (ms).
---
> 2025-03-26 08:54:29.989       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2877703, purged 500 blocks, in 299 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:54:31.055 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 1000 block(s)
------------------------------
Running pop_blocks for 1000 block(s)...
pop_blocks output:
2025-03-26 08:54:41.302 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2876703, popped 1000 blocks, in 28463 (ms).
Execution time: 29.298021616 seconds
------------------------------
Running purge_blocks for 1000 block(s)...
purge_blocks output:
2025-03-26 08:55:10.603 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2875703, purged 1000 blocks, in 371 (ms).
Execution time: 1.007511189 seconds
------------------------------
Comparing outputs for 1000 block(s):
Differences found for 1000 block(s):
1,2c1,2
< 2025-03-26 08:54:41.302       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2876703, popped 1000 blocks, in 28463 (ms).
---
> 2025-03-26 08:55:10.603       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2875703, purged 1000 blocks, in 371 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:55:11.613 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 1500 block(s)
------------------------------
Running pop_blocks for 1500 block(s)...
pop_blocks output:
2025-03-26 08:55:30.849 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2874203, popped 1500 blocks, in 44127 (ms).
Execution time: 45.356454620 seconds
------------------------------
Running purge_blocks for 1500 block(s)...
purge_blocks output:
2025-03-26 08:56:16.209 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2872703, purged 1500 blocks, in 391 (ms).
Execution time: 1.180050476 seconds
------------------------------
Comparing outputs for 1500 block(s):
Differences found for 1500 block(s):
1,2c1,2
< 2025-03-26 08:55:30.849       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2874203, popped 1500 blocks, in 44127 (ms).
---
> 2025-03-26 08:56:16.209       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2872703, purged 1500 blocks, in 391 (ms).
==============================
Flush txpool before starting...
----------------------------------------------------------
2025-03-26 08:56:17.390 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
Pool successfully flushed
----------------------------------------------------------

==============================
Test for 2500 block(s)
------------------------------
Running pop_blocks for 2500 block(s)...
pop_blocks output:
2025-03-26 08:56:44.966 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2870203, popped 2500 blocks, in 46732 (ms).
Execution time: 47.268573809 seconds
------------------------------
Running purge_blocks for 2500 block(s)...
purge_blocks output:
2025-03-26 08:57:32.236 I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
new height: 2867703, purged 2500 blocks, in 515 (ms).
Execution time: 2.136869878 seconds
------------------------------
Comparing outputs for 2500 block(s):
Differences found for 2500 block(s):
1,2c1,2
< 2025-03-26 08:56:44.966       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
< new height: 2870203, popped 2500 blocks, in 46732 (ms).
---
> 2025-03-26 08:57:32.236       I Monero 'Fluorine Fermi' (v0.18.1.0-6542a9bb5)
> new height: 2867703, purged 2500 blocks, in 515 (ms).
==============================

```
