### PR TITLE
construct_tx_and_get_tx_key: don't erase exception trace

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -610,7 +610,10 @@ namespace cryptonote
   {
     hw::device &hwdev = sender_account_keys.get_device();
     hwdev.open_tx(tx_key);
-    try {
+    const auto auto_close_tx = epee::misc_utils::create_scope_leave_handler([&hwdev](){
+      hwdev.close_tx();
+    });
+    {
       // figure out if we need to make additional tx pubkeys
       size_t num_stdaddresses = 0;
       size_t num_subaddresses = 0;
@@ -628,11 +631,7 @@ namespace cryptonote
 
       bool shuffle_outs = true;
       bool r = construct_tx_with_tx_key(sender_account_keys, subaddresses, sources, destinations, change_addr, extra, tx, tx_key, additional_tx_keys, rct, rct_config, shuffle_outs, use_view_tags);
-      hwdev.close_tx();
       return r;
-    } catch(...) {
-      hwdev.close_tx();
-      throw;
     }
   }
   //---------------------------------------------------------------


### PR DESCRIPTION
The catch-and-rethrow pattern here erases the stack trace on where exceptions in `construct_tx_with_tx_key` (a quite complicated function) are thrown, which makes debugging issues harder.