### PR TITLE
easylogging: replace NULL with empty string literal

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -1093,7 +1093,7 @@ class File : base::StaticClass {
   static std::string extractPathFromFilename(const std::string& fullPath,
       const char* seperator = base::consts::kFilePathSeperator);
   /// @brief builds stripped filename and puts it in buff
-  static void buildStrippedFilename(const char* filename, char buff[], const std::string &commonPrefix = NULL,
+  static void buildStrippedFilename(const char* filename, char buff[], const std::string &commonPrefix = "",
                                     std::size_t limit = base::consts::kSourceFilenameMaxLength);
   /// @brief builds base filename and puts it in buff
   static void buildBaseFilename(const std::string& fullPath, char buff[],


### PR DESCRIPTION
Undefined behavior. Contructor explicitely deleted in libstdc++ for c++23: https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/basic_string.h#L756

```
/distsrc/monero/external/easylogging++/easylogging++.h:1096:106: error: use of deleted function 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::nullptr_t = std::nullptr_t]'
 1096 |   static void buildStrippedFilename(const char* filename, char buff[], const std::string &commonPrefix = NULL,
      |                                                                                                          ^~~~
```