### PR TITLE
CMakeLists: add cache option for MANUAL_SUBMODULES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ else()
   message(STATUS "Building without build tag")
 endif()
 
+option(MANUAL_SUBMODULES "Skip submodule up-to-date checks" OFF)
 if(NOT MANUAL_SUBMODULES)
   find_package(Git)
   if(GIT_FOUND)


### PR DESCRIPTION
Adds a line in the CMakeCache.txt of the build dir to edit `MANUAL_SUBMODULES`. Convenient for debugging a submodule's integration with Monero codebase when you don't want to pass the def on the command line each time. 