### PR TITLE
build: set cmake_minimum_required(VERSION 3.5) consistently [release-v0.18]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ function(forbid_undefined_symbols)
     file(MAKE_DIRECTORY "${TEST_PROJECT}")
     file(WRITE "${TEST_PROJECT}/CMakeLists.txt"
       [=[
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(test)
 option(EXPECT_SUCCESS "" ON)
 file(WRITE "${CMAKE_SOURCE_DIR}/incorrect_source.cpp" "void undefined_symbol(); void symbol() { undefined_symbol(); }")


### PR DESCRIPTION
This sets cmake required version to 3.5 (as per readme and other CMakeLists.txt) to fix build issues caused by compatibility with cmake 4.0.0. Other parts of the build system were using 3.5 already - but this one caused build to fail.