### PR TITLE
epee: syncobj: replace shims with Boost classes

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -495,7 +495,7 @@ public:
           if(is_response)
           {//response to some invoke 
 
-            epee::critical_region_t<decltype(m_invoke_response_handlers_lock)> invoke_response_handlers_guard(m_invoke_response_handlers_lock);
+            boost::unique_lock invoke_response_handlers_guard(m_invoke_response_handlers_lock);
             if(!m_invoke_response_handlers.empty())
             {//async call scenario
               boost::shared_ptr<invoke_response_handler_base> response_handler = m_invoke_response_handlers.front();

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -76,84 +76,11 @@ namespace epee
     bool m_rised;
   };
 
-  class critical_region;
+  using critical_section = boost::recursive_mutex;
 
-  class critical_section
-  {
-    boost::recursive_mutex m_section;
-
-  public:
-    //to make copy fake!
-    critical_section(const critical_section& section)
-    {
-    }
-
-    critical_section()
-    {
-    }
-
-    ~critical_section()
-    {
-    }
-
-    void lock()
-    {
-      m_section.lock();
-      //EnterCriticalSection( &m_section );
-    }
-
-    void unlock()
-    {
-      m_section.unlock();
-    }
-
-    bool tryLock()
-    {
-      return m_section.try_lock();
-    }
-
-    // to make copy fake
-    critical_section& operator=(const critical_section& section)
-    {
-      return *this;
-    }
-  };
-
-
-  template<class t_lock>
-  class critical_region_t
-  {
-    t_lock&	m_locker;
-    bool m_unlocked;
-
-    critical_region_t(const critical_region_t&) {}
-
-  public:
-    critical_region_t(t_lock& cs): m_locker(cs), m_unlocked(false)
-    {
-      m_locker.lock();
-    }
-
-    ~critical_region_t()
-    {
-      unlock();
-    }
-
-    void unlock()
-    {
-      if (!m_unlocked)
-      {
-        m_locker.unlock();
-        m_unlocked = true;
-      }
-    }
-  };
-
-
-#define  CRITICAL_REGION_LOCAL(x) {} epee::critical_region_t<decltype(x)>   critical_region_var(x)
-#define  CRITICAL_REGION_BEGIN(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var(x)
-#define  CRITICAL_REGION_LOCAL1(x) {boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} epee::critical_region_t<decltype(x)>   critical_region_var1(x)
-#define  CRITICAL_REGION_BEGIN1(x) {  boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); epee::critical_region_t<decltype(x)>   critical_region_var1(x)
+#define  CRITICAL_REGION_LOCAL(x) boost::unique_lock critical_region_var(x)
+#define  CRITICAL_REGION_BEGIN(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep())); boost::unique_lock critical_region_var(x)
+#define  CRITICAL_REGION_LOCAL1(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} boost::unique_lock critical_region_var1(x)
 
 #define  CRITICAL_REGION_END() }
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
@@ -135,8 +135,6 @@ void cryptonote_protocol_handler_base::handler_response_blocks_now(size_t packet
 	{
 	  CRITICAL_REGION_LOCAL(	network_throttle_manager::m_lock_get_global_throttle_out );
 		network_throttle_manager::get_global_throttle_out().handle_trafic_tcp( packet_size ); // increase counter - global
-		//epee::critical_region_t<decltype(m_throttle_global_lock)> guard(m_throttle_global_lock); // *** critical *** 
-		//m_throttle_global.m_out.handle_trafic_tcp( packet_size ); // increase counter - global
 	}
 }
 

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -43,10 +43,6 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "WalletAPI"
 
-namespace epee {
-    unsigned int g_test_dbg_lock_sleep = 0;
-}
-
 namespace Monero {
 
 WalletManagerImpl::WalletManagerImpl()

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -51,7 +51,6 @@
 
 
 using namespace std;
-//unsigned int epee::g_test_dbg_lock_sleep = 0;
 
 namespace Consts
 {


### PR DESCRIPTION
a. `critical_section` is functionally identical to a `boost::recursive_mutex`
b. `critical_region_t` is functionally identical to a `boost::unique_lock`
c. remove some vestigial definitions of `g_test_dbg_lock_sleep` as a variable

The "fake" copy constructors provided by the shims aren't used anyways.