### PR TITLE
cryptonote_basic: is_coinbase() take prefix

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -172,7 +172,7 @@ namespace cryptonote {
     return tools::base58::encode_addr(integrated_address_prefix, t_serializable_object_to_blob(iadr));
   }
   //-----------------------------------------------------------------------
-  bool is_coinbase(const transaction& tx)
+  bool is_coinbase(const transaction_prefix& tx)
   {
     if(tx.vin.size() != 1)
       return false;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -108,7 +108,7 @@ namespace cryptonote {
     , std::function<std::string(const std::string&, const std::vector<std::string>&, bool)> dns_confirm = return_first_address
     );
 
-  bool is_coinbase(const transaction& tx);
+  bool is_coinbase(const transaction_prefix& tx);
 
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b);


### PR DESCRIPTION
Useful for wallet business logic, which stores the *prefixes* in `m_transfers`, not the whole transaction.

Part of upstreaming Carrot