### PR TITLE
Fix cmake usage in FetchContent and ExternalProject

### DIFF
--- a/cmake/CheckLinkerFlag.cmake
+++ b/cmake/CheckLinkerFlag.cmake
@@ -6,7 +6,7 @@ macro(CHECK_LINKER_FLAG flag VARIABLE)
       message(STATUS "Looking for ${flag} linker flag")
     endif()
 
-    set(_cle_source ${CMAKE_SOURCE_DIR}/cmake/CheckLinkerFlag.c)
+    set(_cle_source ${monero_SOURCE_DIR}/cmake/CheckLinkerFlag.c)
 
     set(saved_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
     set(CMAKE_C_FLAGS "${flag}")


### PR DESCRIPTION
The CMake configure stage fails if another projects uses the Monero project in `FetchContent` or `ExternalProject` due to an incorrect path. This fixes the path so that it is relative to the top-level `project(monero)` declaration, instead of the top-level CMake directory.

Slightly longer explanation: I am working on the [`lwsf`](https://github.com/vtnerd/lwsf) library which implements the `wallet2_api.h`, but targets a LWS-rpc server instead of `monerod`-rpc server. Ideally this project gets optionally built into the [`monero_c`](https://github.com/MrCyjaneK/monero_c) project for use in dart, typescript, and C#. Both projects need to use the libraries within the `monero` project, and instead of building twice, `FetchContent` allows the projects to coordinate configuring+building the `monero` project once.