### PR TITLE
ci: run brew update [0.18]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,8 @@ jobs:
       - uses: ./.github/actions/set-make-job-count
       - name: install dependencies
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf ccache
+          brew update
+          brew install --quiet cmake boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf ccache
       - name: build
         run: |
           ${{env.CCACHE_SETTINGS}}


### PR DESCRIPTION
- Run `brew update` to ensure CI runs with the latest homebrew packages. This takes ~10 seconds.
- Explicitly install `cmake` (so it is upgraded).
- Add `--quiet` to stop it from moaning about packages that are already installed.
