### PR TITLE
guix: remove --user option

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -444,7 +444,6 @@ EOF
                                  --keep-failed \
                                  --fallback \
                                  --link-profile \
-                                 --user="user" \
                                  --root="$(profiledir_for_host "${HOST}")" \
                                  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                                  ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \


### PR DESCRIPTION
```
  -u, --user=USER        instead of copying the name and home of the current
                         user into an isolated container, use the name USER
                         with home directory /home/USER
```

This can cause a silent failure to bind-mount directories into the container if user "user" is not present on the system.

Removing the option does not introduce non-determinism in build results.

Fixes #9885.