### PR TITLE
guix: drop support for i686-linux-gnu

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -44,7 +44,6 @@ jobs:
           - target: "aarch64-linux-gnu"
           - target: "arm-linux-gnueabihf"
           - target: "riscv64-linux-gnu"
-          - target: "i686-linux-gnu"
           - target: "x86_64-w64-mingw32"
           - target: "x86_64-unknown-freebsd"
           - target: "x86_64-apple-darwin"

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -172,7 +172,7 @@ details.
   bootstrappable build.
 
   _(defaults to "x86\_64-linux-gnu aarch64-linux-gnu arm-linux-gnueabihf
-  riscv64-linux-gnu i686-linux-gnu x86\_64-w64-mingw32 x86\_64-unknown-freebsd
+  riscv64-linux-gnu x86\_64-w64-mingw32 x86\_64-unknown-freebsd
   x86\_64-apple-darwin arm64-apple-darwin aarch64-linux-android")_
 
 * _**SOURCES_PATH**_

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -83,7 +83,6 @@ export HOSTS="${HOSTS:-x86_64-linux-gnu
                        aarch64-linux-gnu
                        arm-linux-gnueabihf
                        riscv64-linux-gnu
-                       i686-linux-gnu
                        x86_64-w64-mingw32
                        x86_64-unknown-freebsd
                        x86_64-apple-darwin


### PR DESCRIPTION
This PR drops support for x86 (32-bit) Linux release builds. Submitting this to test the waters.

The last commercially available x86 processors were released [over 18 years ago](https://en.wikipedia.org/wiki/List_of_Intel_processors#Intel_Core).

https://libera.monerologs.net/monero-dev/20250406#c516924