### PR TITLE
fix inconsistent casing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multistage docker build, requires docker 17.05
 
 # builder stage
-FROM ubuntu:20.04 as builder
+FROM ubuntu:20.04 AS builder
 
 RUN set -ex && \
     apt-get update && \


### PR DESCRIPTION
Switch from lower case "as" to upper case "AS" to be consistent with the other keywords.

fixes #9894