### PR TITLE
Move wallet2_api definitions into separate cpp

### DIFF
--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -30,7 +30,11 @@
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
+# A new library with just `wallet2_api.cpp` could be added to reduce link time
+# depdencies. Just compile the cpp twice in each library, its small
+
 set(wallet_api_sources
+  wallet2_api.cpp
   wallet.cpp
   wallet_manager.cpp
   transaction_info.cpp

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -38,9 +38,7 @@
 #include <vector>
 
 namespace Monero {
-  
-AddressBook::~AddressBook() {}
-  
+
 AddressBookImpl::AddressBookImpl(WalletImpl *wallet)
     : m_wallet(wallet), m_errorCode(Status_Ok) {}
 

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -46,9 +46,6 @@ using namespace std;
 
 namespace Monero {
 
-PendingTransaction::~PendingTransaction() {}
-
-
 PendingTransactionImpl::PendingTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet)
 {

--- a/src/wallet/api/subaddress.cpp
+++ b/src/wallet/api/subaddress.cpp
@@ -35,9 +35,7 @@
 #include <vector>
 
 namespace Monero {
-  
-Subaddress::~Subaddress() {}
-  
+
 SubaddressImpl::SubaddressImpl(WalletImpl *wallet)
     : m_wallet(wallet) {}
 

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -44,8 +44,6 @@ using namespace epee;
 
 namespace Monero {
 
-TransactionHistory::~TransactionHistory() {}
-
 
 TransactionHistoryImpl::TransactionHistoryImpl(WalletImpl *wallet)
     : m_wallet(wallet)

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -35,12 +35,6 @@ using namespace std;
 
 namespace Monero {
 
-TransactionInfo::~TransactionInfo() {}
-
-TransactionInfo::Transfer::Transfer(uint64_t _amount, const string &_address)
-    : amount(_amount), address(_address) {}
-
-
 TransactionInfoImpl::TransactionInfoImpl()
     : m_direction(Direction_Out)
       , m_pending(false)

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -44,8 +44,6 @@ using namespace std;
 
 namespace Monero {
 
-UnsignedTransaction::~UnsignedTransaction() {}
-
 
 UnsignedTransactionImpl::UnsignedTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet)

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -298,9 +298,6 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
     WalletImpl     * m_wallet;
 };
 
-Wallet::~Wallet() {}
-
-WalletListener::~WalletListener() {}
 
 
 string Wallet::displayAmount(uint64_t amount)

--- a/src/wallet/api/wallet2_api.cpp
+++ b/src/wallet/api/wallet2_api.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2025, The Monero Project
 //
 // All rights reserved.
 //
@@ -25,64 +25,23 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#include "subaddress_account.h"
-#include "wallet.h"
-#include "crypto/hash.h"
-#include "wallet/wallet2.h"
-#include "common_defines.h"
-
-#include <vector>
+#include "wallet2_api.h"
 
 namespace Monero {
+  TransactionInfo::Transfer::Transfer(uint64_t _amount, const std::string &_address)
+    : amount(_amount), address(_address) {}
 
-SubaddressAccountImpl::SubaddressAccountImpl(WalletImpl *wallet)
-    : m_wallet(wallet) {}
-
-void SubaddressAccountImpl::addRow(const std::string &label)
-{
-  m_wallet->m_wallet->add_subaddress_account(label);
-  refresh();
+  PendingTransaction::~PendingTransaction() {}
+  UnsignedTransaction::~UnsignedTransaction() {}
+  TransactionInfo::~TransactionInfo() {}
+  TransactionHistory::~TransactionHistory() {}
+  AddressBook::~AddressBook() {}
+  Subaddress::~Subaddress() {}
+  SubaddressAccount::~SubaddressAccount() {}
+  Wallet::~Wallet() {}
+  WalletListener::~WalletListener() {}
+  WalletManager::~WalletManager() {}
 }
-
-void SubaddressAccountImpl::setLabel(uint32_t accountIndex, const std::string &label)
-{
-  m_wallet->m_wallet->set_subaddress_label({accountIndex, 0}, label);
-  refresh();
-}
-
-void SubaddressAccountImpl::refresh() 
-{
-  LOG_PRINT_L2("Refreshing subaddress account");
-  
-  clearRows();
-  for (uint32_t i = 0; i < m_wallet->m_wallet->get_num_subaddress_accounts(); ++i)
-  {
-    m_rows.push_back(new SubaddressAccountRow(
-      i,
-      m_wallet->m_wallet->get_subaddress_as_str({i,0}),
-      m_wallet->m_wallet->get_subaddress_label({i,0}),
-      cryptonote::print_money(m_wallet->m_wallet->balance(i, false)),
-      cryptonote::print_money(m_wallet->m_wallet->unlocked_balance(i, false))
-    ));
-  }
-}
-
-void SubaddressAccountImpl::clearRows() {
-   for (auto r : m_rows) {
-     delete r;
-   }
-   m_rows.clear();
-}
-
-std::vector<SubaddressAccountRow*> SubaddressAccountImpl::getAll() const
-{
-  return m_rows;
-}
-
-SubaddressAccountImpl::~SubaddressAccountImpl()
-{
-  clearRows();
-}
-
-} // namespace

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -1143,6 +1143,7 @@ struct Wallet
  */
 struct WalletManager
 {
+    virtual ~WalletManager() = 0;
 
     /*!
      * \brief  Creates new wallet


### PR DESCRIPTION
This moves constructors+destructors definitions that are declared in `wallet2_api.h` into a separate cpp file instead of scattering them into other implementation files. The advantage is that the static linker can identify dead object files more easily, and strip out tons of code that isn't used downstream.

The primary example is the executable [`lwsf_ledger`](https://github.com/vtnerd/lwsf) which goes from ~17M to ~5.7M on Ubuntu 22.04 and from ~12M to ~3.7M on macOS. Basically, without this change the linker includes the entire `wallet2` implementation into `lwsf_ledger` even though that executable is deliberately only using the `lwsf` implementation of the API.

Since this is just moving definitions into a different cpp, I don't expect and disruptions to other projects. Note that _link time_ dependencies are still large; reducing that requires a separate library target which I didn't include because lwsf currently still (basically) has all the link-time dependencies.

I also made a `virtual` `~WalletManager` because it really ought to have one, even though I think all GUIs just "leak" this memory since its used for the lifetime of the app.