### PR TITLE
msys2 build: include int headers

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <set>
 #include <list>
 #include <vector>

--- a/src/common/perf_timer.h
+++ b/src/common/perf_timer.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <stdio.h>
 #include <memory>


### PR DESCRIPTION
For `uint*_t`, otherwise some downstream MSYS2 builds break. 