### PR TITLE
Boost: vendor serialization impls for C++17 types

### DIFF
--- a/external/boost/serialization/README.md
+++ b/external/boost/serialization/README.md
@@ -1,0 +1,4 @@
+# Boost Serialization Vendoring
+
+* optional_shim.hpp - Compare to file include/boost/serialization/optional.hpp in the Boost serialization repository, checked out at commit ff0a5f9f4a4040c6f992581245fed48d9634acfe. This is the newest version of the file at time of writing. Once minimum required Boost version is >= 1.84, then we can drop this header.
+* std_variant_shim.hpp - Compare to file include/boost/serialization/std_variant.hpp in the Boost serialization repository, checked out at commit 2805bc3faa8f8fb7ce80ec518158563c5fcf26f6. This is the newest version of the file at time of writing. Once minimum required Boost version includes commit 042c590a7ac84933413243d8e9c3b06a791803a7 in the multiprecision repository, then we can drop this header. Commit 042c590a7ac84933413243d8e9c3b06a791803a7 removes a namespace clash in Boost's multiprecision library with the std_variant.hpp header.

--- a/external/boost/serialization/optional_shim.hpp
+++ b/external/boost/serialization/optional_shim.hpp
@@ -1,0 +1,177 @@
+#include <boost/version.hpp>
+
+#ifndef BOOST_VERSION
+#error "Missing Boost version"
+#endif
+
+#if BOOST_VERSION >= 108400
+#include <boost/serialization/optional.hpp>
+#else
+
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
+// (C) Copyright 2002-4 Pavel Vozenilek .
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// Provides non-intrusive serialization for boost::optional.
+
+#ifndef BOOST_SERIALIZATION_OPTIONAL_HPP
+#define BOOST_SERIALIZATION_OPTIONAL_HPP
+
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/config.hpp>
+#include <boost/optional.hpp>
+#ifndef BOOST_NO_CXX17_HDR_OPTIONAL
+#include <optional>
+#endif
+
+#include <boost/serialization/item_version_type.hpp>
+#include <boost/serialization/version.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/serialization/detail/is_default_constructible.hpp>
+
+// function specializations must be defined in the appropriate
+// namespace - boost::serialization
+namespace boost {
+namespace serialization {
+namespace detail {
+
+// OT is of the form optional<T>
+template<class Archive, class OT>
+void save_impl(
+    Archive & ar,
+    const OT & ot
+){
+    // It is an inherent limitation to the serialization of optional.hpp
+    // that the underlying type must be either a pointer or must have a
+    // default constructor.  It's possible that this could change sometime
+    // in the future, but for now, one will have to work around it.  This can
+    // be done by serialization the optional<T> as optional<T *>
+    #ifndef BOOST_NO_CXX11_HDR_TYPE_TRAITS
+        BOOST_STATIC_ASSERT(
+            boost::serialization::detail::is_default_constructible<typename OT::value_type>::value
+            || boost::is_pointer<typename OT::value_type>::value
+        );
+    #endif
+    const bool tflag(ot);
+    ar << boost::serialization::make_nvp("initialized", tflag);
+    if (tflag){
+        ar << boost::serialization::make_nvp("value", *ot);
+    }
+}
+
+// OT is of the form optional<T>
+template<class Archive, class OT>
+void load_impl(
+    Archive & ar,
+    OT & ot,
+    const unsigned int version
+){
+    bool tflag;
+    ar >> boost::serialization::make_nvp("initialized", tflag);
+    if(! tflag){
+        ot.reset();
+        return;
+    }
+
+    if(0 == version){
+        boost::serialization::item_version_type item_version(0);
+        auto library_version(
+            ar.get_library_version()
+        );
+        if(decltype(library_version)(3) < library_version){
+            ar >> BOOST_SERIALIZATION_NVP(item_version);
+        }
+    }
+    typename OT::value_type t;
+    ar >> boost::serialization::make_nvp("value",t);
+    ot = t;
+}
+
+} // detail
+
+template<class Archive, class T>
+void save(
+    Archive & ar,
+    const boost::optional< T > & ot,
+    const unsigned int /*version*/
+){
+    detail::save_impl(ar, ot);
+}
+
+#ifndef BOOST_NO_CXX17_HDR_OPTIONAL
+template<class Archive, class T>
+void save(
+    Archive & ar,
+    const std::optional< T > & ot,
+    const unsigned int /*version*/
+){
+    detail::save_impl(ar, ot);
+}
+#endif
+
+template<class Archive, class T>
+void load(
+    Archive & ar,
+    boost::optional< T > & ot,
+    const unsigned int version
+){
+    detail::load_impl(ar, ot, version);
+}
+
+#ifndef BOOST_NO_CXX17_HDR_OPTIONAL
+template<class Archive, class T>
+void load(
+    Archive & ar,
+    std::optional< T >  & ot,
+    const unsigned int version
+){
+    detail::load_impl(ar, ot, version);
+}
+#endif
+
+template<class Archive, class T>
+void serialize(
+    Archive & ar,
+    boost::optional< T > & ot,
+    const unsigned int version
+){
+    boost::serialization::split_free(ar, ot, version);
+}
+
+#ifndef BOOST_NO_CXX17_HDR_OPTIONAL
+template<class Archive, class T>
+void serialize(
+    Archive & ar,
+    std::optional< T > & ot,
+    const unsigned int version
+){
+    boost::serialization::split_free(ar, ot, version);
+}
+#endif
+
+template<class T>
+struct version<boost::optional<T> >{
+    BOOST_STATIC_CONSTANT(int, value = 1);
+};
+
+#ifndef BOOST_NO_CXX17_HDR_OPTIONAL
+template<class T>
+struct version<std::optional<T> >{
+    BOOST_STATIC_CONSTANT(int, value = 1);
+};
+#endif
+
+} // serialization
+} // boost
+
+#endif // BOOST_SERIALIZATION_OPTIONAL_HPP
+#endif //BOOST_VERSION < 108400

--- a/external/boost/serialization/std_variant_shim.hpp
+++ b/external/boost/serialization/std_variant_shim.hpp
@@ -1,0 +1,204 @@
+#ifndef BOOST_SERIALIZATION_STD_VARIANT_HPP
+#define BOOST_SERIALIZATION_STD_VARIANT_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// variant.hpp - non-intrusive serialization of variant types
+//
+// copyright (c) 2019 Samuel Debionne, ESRF
+//
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org for updates, documentation, and revision history.
+//
+// Widely inspired form boost::variant serialization
+//
+
+#include <boost/serialization/throw_exception.hpp>
+
+#include <variant>
+
+#include <boost/archive/archive_exception.hpp>
+
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/nvp.hpp>
+
+namespace boost {
+namespace serialization {
+
+template<class Archive>
+struct std_variant_save_visitor
+{
+    std_variant_save_visitor(Archive& ar) :
+        m_ar(ar)
+    {}
+    template<class T>
+    void operator()(T const & value) const
+    {
+        m_ar << BOOST_SERIALIZATION_NVP(value);
+    }
+private:
+    Archive & m_ar;
+};
+
+
+template<class Archive>
+struct std_variant_load_visitor
+{
+    std_variant_load_visitor(Archive& ar) :
+        m_ar(ar)
+    {}
+    template<class T>
+    void operator()(T & value) const
+    {
+        m_ar >> BOOST_SERIALIZATION_NVP(value);
+    }
+private:
+    Archive & m_ar;
+};
+
+template<class Archive, class ...Types>
+void save(
+    Archive & ar,
+    std::variant<Types...> const & v,
+    unsigned int /*version*/
+){
+    const std::size_t which = v.index();
+    ar << BOOST_SERIALIZATION_NVP(which);
+    std_variant_save_visitor<Archive> visitor(ar);
+    std::visit(visitor, v);
+}
+
+// Minimalist metaprogramming for handling parameter pack
+namespace mp_shim {
+    namespace detail {
+    template <typename Seq>
+    struct front_impl;
+
+    template <template <typename...> class Seq, typename T, typename... Ts>
+    struct front_impl<Seq<T, Ts...>> {
+        using type = T;
+    };
+
+    template <typename Seq>
+    struct pop_front_impl;
+
+    template <template <typename...> class Seq, typename T, typename... Ts>
+    struct pop_front_impl<Seq<T, Ts...>> {
+        using type = Seq<Ts...>;
+    };
+    } //namespace detail
+
+    template <typename... Ts>
+    struct typelist {};
+
+    template <typename Seq>
+    using front = typename detail::front_impl<Seq>::type;
+
+    template <typename Seq>
+    using pop_front = typename detail::pop_front_impl<Seq>::type;
+}  // namespace mp_shim
+
+template<std::size_t N, class Seq>
+struct variant_impl_shim
+{
+    template<class Archive, class V>
+    static void load (
+        Archive & ar,
+        std::size_t which,
+        V & v,
+        const unsigned int version
+    ){
+        if(which == 0){
+            // note: A non-intrusive implementation (such as this one)
+            // necessary has to copy the value.  This wouldn't be necessary
+            // with an implementation that de-serialized to the address of the
+            // aligned storage included in the variant.
+            using type = mp_shim::front<Seq>;
+            type value;
+            ar >> BOOST_SERIALIZATION_NVP(value);
+            v = std::move(value);
+            type * new_address = & std::get<type>(v);
+            ar.reset_object_address(new_address, & value);
+            return;
+        }
+        //typedef typename mpl::pop_front<S>::type type;
+        using types = mp_shim::pop_front<Seq>;
+        variant_impl_shim<N - 1, types>::load(ar, which - 1, v, version);
+    }
+};
+
+template<class Seq>
+struct variant_impl_shim<0, Seq>
+{
+    template<class Archive, class V>
+    static void load (
+        Archive & /*ar*/,
+        std::size_t /*which*/,
+        V & /*v*/,
+        const unsigned int /*version*/
+    ){}
+};
+
+template<class Archive, class... Types>
+void load(
+    Archive & ar, 
+    std::variant<Types...>& v,
+    const unsigned int version
+){
+    std::size_t which;
+    ar >> BOOST_SERIALIZATION_NVP(which);
+    if(which >=  sizeof...(Types))
+        // this might happen if a type was removed from the list of variant types
+        boost::serialization::throw_exception(
+            boost::archive::archive_exception(
+                boost::archive::archive_exception::unsupported_version
+            )
+        );
+    variant_impl_shim<sizeof...(Types), mp_shim::typelist<Types...>>::load(ar, which, v, version);
+}
+
+template<class Archive,class... Types>
+inline void serialize(
+    Archive & ar,
+    std::variant<Types...> & v,
+    const unsigned int file_version
+){
+    split_free(ar,v,file_version);
+}
+
+// Specialization for std::monostate
+template<class Archive>
+void serialize(Archive &, std::monostate &, const unsigned int /*version*/)
+{}
+
+} // namespace serialization
+} // namespace boost
+
+//template<typename T0_, BOOST_VARIANT_ENUM_SHIFTED_PARAMS(typename T)>
+
+#include <boost/serialization/tracking.hpp>
+
+namespace boost {
+    namespace serialization {
+        
+template<class... Types>
+struct tracking_level<
+    std::variant<Types...>
+>{
+    typedef mpl::integral_c_tag tag;
+    typedef mpl::int_< ::boost::serialization::track_always> type;
+    BOOST_STATIC_CONSTANT(int, value = type::value);
+};
+
+} // namespace serialization
+} // namespace boost
+
+#endif //BOOST_SERIALIZATION_VARIANT_HPP

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -39,7 +39,7 @@
 #include <boost/optional.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/variant.hpp>
-#include <boost/serialization/optional.hpp>
+#include <boost/serialization/optional_shim.hpp>
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/functional/hash.hpp>
 


### PR DESCRIPTION
Includes Boost serialization implementations for `std::optional` and `std::variant`. Neither are available until Boost 1.84. Additionally, there was a [namespace clash](https://github.com/boostorg/serialization/issues/328) between Boost `serialization` and `multiprecision` libraries that caused Monero to fail compilation. A [fix](https://github.com/boostorg/multiprecision/pull/680) was upstreamed to Boost `multiprecision`, but it probably won't be available until 1.89. So in the meantime, these two shim files will allow us to serialize `std::optional` and `std::variant` without bumping the minimum required Boost version.

Part of upstreaming Carrot/FCMP++.