### PR TITLE
wallet2: don't expand subaddress table when importing cold outputs

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14323,8 +14323,6 @@ process:
       create_one_off_subaddress(td.m_subaddr_index);
     bool r = cryptonote::generate_key_image_helper(m_account.get_keys(), m_subaddresses, out_key, tx_pub_key, additional_tx_pub_keys, td.m_internal_output_index, in_ephemeral, td.m_key_image, m_account.get_device());
     THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "Failed to generate key image");
-    if (should_expand(td.m_subaddr_index))
-      expand_subaddresses(td.m_subaddr_index);
     td.m_key_image_known = true;
     td.m_key_image_request = true;
     td.m_key_image_partial = false;
@@ -14427,8 +14425,6 @@ size_t wallet2::import_outputs(const std::tuple<uint64_t, uint64_t, std::vector<
       create_one_off_subaddress(td.m_subaddr_index);
     bool r = cryptonote::generate_key_image_helper(m_account.get_keys(), m_subaddresses, out_key, tx_pub_key, additional_tx_pub_keys, td.m_internal_output_index, in_ephemeral, td.m_key_image, m_account.get_device());
     THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "Failed to generate key image");
-    if (should_expand(td.m_subaddr_index))
-      expand_subaddresses(td.m_subaddr_index);
     td.m_key_image_known = true;
     td.m_key_image_request = true;
     td.m_key_image_partial = false;


### PR DESCRIPTION
The hot wallet can pass as the subaddresss index (0xFFFFFFFF, 0xFFFFFFFF), and the cold wallet will generate the key image as long as that subaddress is valid for the passed onetime address (which doesn't actually need to be present on-chain). Then, immediately after, it will sit there and try to expand its subaddress table to <code>m_subaddress_lookahead_minor * 2<sup>32</sup></code> items for basically no reason. An optimistically expanded subaddress table is really only useful for on-chain scanning, which a cold wallet wouldn't be doing. It only needs the subaddresses for the outputs it knows it owns.