### PR TITLE
Improve initial refresh: use nearest checkpoint in fast_refresh

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -158,6 +158,19 @@ namespace cryptonote
     return m_points.rbegin()->first;
   }
   //---------------------------------------------------------------------------
+  uint64_t checkpoints::get_nearest_checkpoint_height(uint64_t block_height) const
+  {
+    if (m_points.empty())
+      return 0;
+
+    auto it = m_points.upper_bound(block_height);
+    if (it == m_points.begin())
+      return 0;
+
+    --it;
+    return it->first;
+  }
+  //---------------------------------------------------------------------------
   const std::map<uint64_t, crypto::hash>& checkpoints::get_points() const
   {
     return m_points;

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -130,6 +130,14 @@ namespace cryptonote
     uint64_t get_max_height() const;
 
     /**
+     * @brief gets the highest checkpoint height less than the given block height
+     *
+     * @param block_height the reference block height
+     * @return the nearest checkpoint height below block_height, or 0 if none
+     */
+    uint64_t get_nearest_checkpoint_height(uint64_t block_height) const;
+
+    /**
      * @brief gets the checkpoints container
      *
      * @return a const reference to the checkpoints container

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3790,11 +3790,11 @@ void wallet2::fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, 
 {
   std::vector<crypto::hash> hashes;
 
-  const uint64_t checkpoint_height = m_checkpoints.get_max_height();
+  const uint64_t checkpoint_height = m_checkpoints.get_nearest_checkpoint_height(stop_height);
   if ((stop_height > checkpoint_height && m_blockchain.size()-1 < checkpoint_height) && !force)
   {
     // we will drop all these, so don't bother getting them
-    uint64_t missing_blocks = m_checkpoints.get_max_height() - m_blockchain.size();
+    uint64_t missing_blocks = checkpoint_height - m_blockchain.size();
     while (missing_blocks-- > 0)
       m_blockchain.push_back(crypto::null_hash); // maybe a bit suboptimal, but deque won't do huge reallocs like vector
     m_blockchain.push_back(m_checkpoints.get_points().at(checkpoint_height));


### PR DESCRIPTION
This PR updates `wallet2::fast_refresh` to use the nearest checkpoint at or below the restore height, instead of always using the latest checkpoint.

Previously, if a wallet was restored from a height earlier than the latest checkpoint (now 3375700), wallet2 would fallback to downloading block hashes from height 0 (genesis). This could take several minutes.

With this change, the fast refresh starts from the closest checkpoint below the restore height, avoiding the full hash fetch from genesis and making initial refresh faster for older wallets.