### PR TITLE
wallet: Reset rpc-server refresh interval post-full sync

### DIFF
--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -288,7 +288,7 @@ namespace tools
       std::atomic<bool> m_stop;
       bool m_restricted;
       const boost::program_options::variables_map *m_vm;
-      uint32_t m_auto_refresh_period;
+      std::atomic<uint32_t> m_auto_refresh_period;
       std::chrono::time_point<std::chrono::steady_clock> m_last_auto_refresh_time;
   };
 }


### PR DESCRIPTION
This commit fd08594caae37a592a6e9257e6ad577d9f8f9c32 introduced in this MR https://github.com/monero-project/monero/pull/9875 changed the refresh interval to 200ms during wallet sync, fixing other bugs in the process. 

Here I've done two things:

1. Recognize that m_auto_refresh_period can change, and protect it from multithreaded access via an atomic (it can change when a user sends a request to stop auto refresh, and its polled for in a separate thread that runs every 200ms during sync and 1000ms when we reach tip of chain).
2. Remove the if-condition that prevented us from executing tip-of chain logic that would transition us to the less-frequent polling once we arrive at the tip of the chain.