### PR TITLE
Add new dynamic fees to ZMQ

### DIFF
--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -844,9 +844,8 @@ namespace rpc
   {
     res.hard_fork_version = m_core.get_blockchain_storage().get_current_hard_fork_version();
 
-    std::vector<uint64_t> fees;
-    m_core.get_blockchain_storage().get_dynamic_base_fee_estimate_2021_scaling(req.num_grace_blocks, fees);
-    res.estimated_base_fee = fees[0];
+    m_core.get_blockchain_storage().get_dynamic_base_fee_estimate_2021_scaling(req.num_grace_blocks, res.fees);
+    res.estimated_base_fee = res.fees.at(0);
 
     {
       res.size_scale = 1; // per byte fee

--- a/src/rpc/daemon_messages.cpp
+++ b/src/rpc/daemon_messages.cpp
@@ -753,6 +753,7 @@ void GetFeeEstimate::Request::fromJson(const rapidjson::Value& val)
 
 void GetFeeEstimate::Response::doToJson(rapidjson::Writer<epee::byte_stream>& dest) const
 {
+  INSERT_INTO_JSON_OBJECT(dest, fees, fees);
   INSERT_INTO_JSON_OBJECT(dest, estimated_base_fee, estimated_base_fee);
   INSERT_INTO_JSON_OBJECT(dest, fee_mask, fee_mask);
   INSERT_INTO_JSON_OBJECT(dest, size_scale, size_scale);
@@ -766,6 +767,7 @@ void GetFeeEstimate::Response::fromJson(const rapidjson::Value& val)
     throw json::WRONG_TYPE("json object");
   }
 
+  GET_FROM_JSON_OBJECT(val, fees, fees);
   GET_FROM_JSON_OBJECT(val, estimated_base_fee, estimated_base_fee);
   GET_FROM_JSON_OBJECT(val, fee_mask, fee_mask);
   GET_FROM_JSON_OBJECT(val, size_scale, size_scale);

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -425,6 +425,7 @@ BEGIN_RPC_MESSAGE_CLASS(GetFeeEstimate);
     RPC_MESSAGE_MEMBER(uint64_t, num_grace_blocks);
   END_RPC_MESSAGE_REQUEST;
   BEGIN_RPC_MESSAGE_RESPONSE;
+    RPC_MESSAGE_MEMBER(std::vector<uint64_t>, fees);
     RPC_MESSAGE_MEMBER(uint64_t, estimated_base_fee);
     RPC_MESSAGE_MEMBER(uint64_t, fee_mask);
     RPC_MESSAGE_MEMBER(uint32_t, size_scale);


### PR DESCRIPTION
ZMQ clients (LWS, etc.) do not have access to the new dynamic fee levels. This adds supports for that. There is a corresponding patch to LWS, with a change to the API.