### PR TITLE
wallet2: ignore checkpoints in fast_refresh when height < 1000

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3888,7 +3888,7 @@ void wallet2::fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, 
 {
   std::vector<crypto::hash> hashes;
 
-  const uint64_t checkpoint_height = m_checkpoints.get_nearest_checkpoint_height(stop_height);
+  const uint64_t checkpoint_height = (stop_height < 1000) ? 0 : m_checkpoints.get_nearest_checkpoint_height(stop_height);
   if ((stop_height > checkpoint_height && m_blockchain.size()-1 < checkpoint_height) && !force)
   {
     // we will drop all these, so don't bother getting them


### PR DESCRIPTION
This PR fixes an edge case introduced in #9935 where functional tests (which mine from genesis) fail due to the use of mainnet checkpoints.

With this change, we skip checkpoint usage in `fast_refresh` if the restore height is below 1000. This restores the original behavior prior to #9935 by ignoring checkpoints entirely for low heights.

This is a test-only fix and has no impact on real wallets.