### PR TITLE
build.sh: enhanced shell scripts

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -57,8 +57,8 @@ export SOURCE_DATE_EPOCH=1397818193
 
 # Collect some information about the build environment to help debug potential reproducibility issues
 mkdir -p "${LOGDIR}"
-ls -1 /gnu/store | sort > ${LOGDIR}/guix-hashes.txt
-printenv | sort | grep -v '^\(BASE_CACHE=\|DISTNAME=\|DISTSRC=\|OUTDIR=\|LOGDIR=\|SOURCES_PATH=\|JOBS=\|OPTIONS=\|DEPENDS_ONLY=\)' > ${LOGDIR}/guix-env.txt
+ls -1 /gnu/store | sort > "${LOGDIR}/guix-hashes.txt"
+printenv | sort | grep -v '^\(BASE_CACHE=\|DISTNAME=\|DISTSRC=\|OUTDIR=\|LOGDIR=\|SOURCES_PATH=\|JOBS=\|OPTIONS=\|DEPENDS_ONLY=\)' > "${LOGDIR}/guix-env.txt"
 
 # The depends folder also serves as a base-prefix for depends packages for
 # $HOSTs after successfully building.
@@ -238,7 +238,7 @@ esac
 mkdir -p "${OUTDIR}"
 
 # Log the depends build ids
-make -C contrib/depends --no-print-directory HOST="$HOST" print-final_build_id_long | tr ':' '\n' > ${LOGDIR}/depends-hashes.txt
+make -C contrib/depends --no-print-directory HOST="$HOST" print-final_build_id_long | tr ':' '\n' > "${LOGDIR}/depends-hashes.txt"
 
 # Build the depends tree, overriding variables that assume multilib gcc
 make -C contrib/depends --jobs="$JOBS" HOST="$HOST" \
@@ -293,7 +293,7 @@ if [ ! -e "$GIT_ARCHIVE" ]; then
     git ls-files --recurse-submodules \
     | sort \
     | tar --create --transform "s,^,monero-source-${VERSION}/," --mode='u+rw,go+r-w,a+X' --files-from=- \
-    | gzip -9n > ${GIT_ARCHIVE}
+    | gzip -9n > "${GIT_ARCHIVE}"
     sha256sum "$GIT_ARCHIVE"
 fi
 


### PR DESCRIPTION
### Summary

- Added quotes around log directory paths in the guix build script so filenames containing spaces are handled safely

- Quoted the output path for depends build IDs to prevent word splitting during redirection

- Ensured the gzipped source archive is written using a quoted path to avoid globbing issues

### Testing

✅ shellcheck -x contrib/guix/libexec/build.sh