### PR TITLE
crypto: check+throw for Cryptonight v1 invalid input

### DIFF
--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -30,8 +30,9 @@
 
 #pragma once
 
-#include <stddef.h>
 #include <iostream>
+#include <stddef.h>
+#include <stdexcept>
 
 #include "common/pod-class.h"
 #include "generic-ops.h"
@@ -70,11 +71,20 @@ namespace crypto {
     return h;
   }
 
+  static constexpr void cn_variant1_check(const std::size_t length, const int variant)
+  {
+    // see VARIANT1_CHECK in slow-hash.c
+    if (variant == 1 && length < 43)
+      throw std::logic_error("Cryptonight variant 1 is undefined for inputs of less than 43 bytes");
+  }
+
   inline void cn_slow_hash(const void *data, std::size_t length, hash &hash, int variant = 0, uint64_t height = 0) {
+    cn_variant1_check(length, variant);
     cn_slow_hash(data, length, reinterpret_cast<char *>(&hash), variant, 0/*prehashed*/, height);
   }
 
   inline void cn_slow_hash_prehashed(const void *data, std::size_t length, hash &hash, int variant = 0, uint64_t height = 0) {
+    cn_variant1_check(length, variant);
     cn_slow_hash(data, length, reinterpret_cast<char *>(&hash), variant, 1/*prehashed*/, height);
   }
 


### PR DESCRIPTION
If `crypto::cn_slow_hash()` is called with `variant=1` and an input length of less thab 43 bytes, it triggers a program exit. This checks first and throws an exception instead.

Thank you to ADA Logics and the MAGIC Monero Fund for reporting this!