### PR TITLE
readme: fix macos depends requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,10 @@ You can also cross-compile static binaries on Linux for Windows and macOS with t
     update-alternatives --set x86_64-w64-mingw32-g++ $(which x86_64-w64-mingw32-g++-posix) && \
     update-alternatives --set x86_64-w64-mingw32-gcc $(which x86_64-w64-mingw32-gcc-posix)
     ```
-* ```make depends target=x86_64-apple-darwin``` for macOS binaries.
-  * Requires: `cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev`
+* ```make depends target=x86_64-apple-darwin``` for Intel macOS binaries.
+  * Requires: `clang`
+* ```make depends target=arm64-apple-darwin``` for Apple Silicon macOS binaries.
+  * Requires: `clang`
 * ```make depends target=i686-linux-gnu``` for 32-bit linux binaries.
   * Requires: `g++-multilib bc`
 * ```make depends target=i686-w64-mingw32``` for 32-bit windows binaries.


### PR DESCRIPTION
#9987

Note: the Apple Silicon target was renamed to `arm64-apple-darwin` on `master`. (#9784)