### PR TITLE
Dockerfile: remove unused deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,12 @@ FROM ubuntu:20.04 AS builder
 RUN set -ex && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install \
-        automake \
-        autotools-dev \
-        bsdmainutils \
         build-essential \
         ca-certificates \
-        ccache \
         cmake \
         curl \
         git \
-        libtool \
-        pkg-config \
-        gperf
+        pkg-config
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
- `bsdmainutils`: "This is a transitional package, it can be safely removed."
- `ccache`: Doesn't make sense to include here. We're not rebuilding anything.
- others: see comments on #9990