### PR TITLE
ci: bump debian to 11 [0.18]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,10 @@ jobs:
 
   build-debian:
     # Oldest supported Debian version
-    name: 'Debian 10'
+    name: 'Debian 11'
     runs-on: ubuntu-latest
     container:
-      image: debian:10
+      image: debian:11
       env:
         DEBIAN_FRONTEND: noninteractive
     steps:


### PR DESCRIPTION
#9968 

Debian 10 repo is no longer available. Not a transient issue. https://ftp.debian.org/debian/