### PR TITLE
ci: gitian: update runner to 22.04 [0.18]

### DIFF
--- a/.github/workflows/gitian.yml
+++ b/.github/workflows/gitian.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-gitian:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
20.04 runner was deprecated.