### PR TITLE
guix: use canonical repository

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -308,7 +308,7 @@ Source: https://logs.guix.gnu.org/guix/2020-11-12.log#232527
 Start by cloning Guix:
 
 ```
-git clone https://git.savannah.gnu.org/git/guix.git
+git clone https://codeberg.org/guix/guix.git
 cd guix
 ```
 
@@ -595,7 +595,7 @@ checklist.
    ```
    Generation 38   Feb 22 2021 16:39:31    (current)
      guix f350df4
-       repository URL: https://git.savannah.gnu.org/git/guix.git
+       repository URL: https://codeberg.org/guix/guix.git
        branch: version-1.2.0
        commit: f350df405fbcd5b9e27e6b6aa500da7f101f41e7
    ```

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,23 +51,13 @@ fi
 #
 # Before updating the pinned hash:
 #
-# - Push new commits to monero-project/guix from upstream. Do not forget to update
-#   the keyring branch as well. Guix uses this branch to authenticate commits.
-#
-#   The repository is set to monero-project/guix because fetching from the official
-#   repo at https://git.savannah.gnu.org/git/guix.git is unreliable in CI jobs.
-#
-#   Do not attempt to push custom changes to monero-project/guix, it will not work!
-#   If a change is necessary to Guix, submit a patch to https://issues.guix.gnu.org/
-#   New packages can be defined in manifest.scm until they are available upstream.
-#
 # - Make sure a bootstrapped build works with the new commit using a fresh Guix install:
 #   $ export ADDITIONAL_GUIX_COMMON_FLAGS='--no-substitutes'
 #
 # - Check how the update affects our build graph and which packages have been updated.
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://github.com/monero-project/guix.git \
+    guix time-machine --url=https://codeberg.org/guix/guix.git \
                       --commit=9d09b0cf841fb657a1aec12e9bab68e00c2b493c \
                       --cores="$JOBS" \
                       --keep-failed \


### PR DESCRIPTION
https://guix.gnu.org/blog/2025/migrating-to-codeberg/

The new repository should be more reliable. We can archive https://github.com/monero-project/guix as a result.