### PR TITLE
set do_not_relay always false in submit_multisig_main

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1639,8 +1639,8 @@ bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, b
       return false;
     }
 
-    // actually commit or save the transactions
-    commit_or_save(txs.m_ptx, m_do_not_relay);
+    // actually commit the transactions
+    commit_or_save(txs.m_ptx, /* do_not_relay */ false);
   }
   catch (const std::exception &e)
   {


### PR DESCRIPTION
This is supposed to be a fix for #9698

There I had the misunderstanding that the `do-not-relay` option means we don't want to broadcast any tx to the daemon, but now I think we actually still want to allow submitting transactions (via CLI commands `submit_transfer` or in this case `submit_multisig`) even if `do-not-relay` is set true.