### PR TITLE
serialization: massage pair casting to remove user-defined-cast warnings

### DIFF
--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -132,7 +132,8 @@ bool do_serialize_container(Archive<true> &ar, C &v)
     if (i != v.begin())
       ar.delimit_array();
     using serializable_value_type = typename ::serialization::detail::serializable_value_type<C>::type;
-    if(!::serialization::detail::serialize_container_element(ar, (serializable_value_type&)*i))
+    auto &i_ref = const_cast<serializable_value_type&>(reinterpret_cast<const serializable_value_type&>(*i));
+    if(!::serialization::detail::serialize_container_element(ar, i_ref))
       return false;
     if (!ar.good())
       return false;


### PR DESCRIPTION
Similar to: https://github.com/sstsimulator/sst-core/pull/1315