### PR TITLE
guix: build freebsd target with clang 18

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -284,7 +284,8 @@ chain for " target " development."))
              xz ; used to unpack freebsd_base
              gcc-toolchain-12
              (list gcc-toolchain-12 "static")
-             clang-toolchain-11 binutils))
+             clang-toolchain-18
+             binutils))
           ((string-contains target "android")
             (list
               unzip ; used to unpack android_ndk


### PR DESCRIPTION
Tested `monerod` and `monero-wallet-cli` on FreeBSD 13.1.