### PR TITLE
tests: Add new fuzzer for RPC endpoints

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -26,6 +26,35 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+monero_add_minimal_executable(fuzz_rpc
+  fuzz_rpc/initialisation.cpp
+  fuzz_rpc/rpc_endpoints.cpp
+  fuzz_rpc/fuzz_rpc.cpp)
+target_compile_definitions(fuzz_rpc PRIVATE SAFE)
+target_link_libraries(fuzz_rpc
+  PRIVATE
+    rpc
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXTRA_LIBRARIES}
+    $ENV{LIB_FUZZING_ENGINE})
+set_property(TARGET fuzz_rpc
+  PROPERTY
+    FOLDER "tests")
+
+monero_add_minimal_executable(fuzz_rpc_full
+  fuzz_rpc/initialisation.cpp
+  fuzz_rpc/rpc_endpoints.cpp
+  fuzz_rpc/fuzz_rpc.cpp)
+target_link_libraries(fuzz_rpc_full
+  PRIVATE
+    rpc
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXTRA_LIBRARIES}
+    $ENV{LIB_FUZZING_ENGINE})
+set_property(TARGET fuzz_rpc_full
+  PROPERTY
+    FOLDER "tests")
+
 monero_add_minimal_executable(block_fuzz_tests block.cpp fuzzer.cpp)
 target_link_libraries(block_fuzz_tests
   PRIVATE

--- a/tests/fuzz/fuzz_rpc/fuzz_rpc.cpp
+++ b/tests/fuzz/fuzz_rpc/fuzz_rpc.cpp
@@ -1,0 +1,116 @@
+#include "initialisation.h"
+#include "rpc_endpoints.h"
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <csignal>
+#include <csetjmp>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+// Helper definition for timeout recovery
+static sigjmp_buf jump_env;
+void timeout_handler(int sig) {
+  if (tools::performance_timers) {
+    tools::performance_timers->clear();
+    delete tools::performance_timers;
+    tools::performance_timers = nullptr;
+  }
+
+  siglongjmp(jump_env, 1);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // In general an iteration need a fair amount of data so ensure we have enough
+  // to work with, otherwise return 0 to skip this iteration.
+  if (size < 512) {
+    return 0;
+  }
+
+  // Determine if this iteration should run in safe mode
+#ifdef SAFE
+  constexpr bool is_safe_mode = true;
+#else
+  constexpr bool is_safe_mode = false;
+#endif
+
+  // Retrieve a list of all fuzz targets
+  auto fuzz_targets = get_fuzz_targets(is_safe_mode);
+
+  // Disable fatal exits for logging.
+  el::Loggers::addFlag(el::LoggingFlag::DisableApplicationAbortOnFatalLog);
+
+  // Register a handler for timeout alarm signal
+  signal(SIGALRM, timeout_handler);
+
+  // Prepare base FuzzedDataProvider
+  FuzzedDataProvider provider(data, size);
+
+  // Randomly choose multiple fuzz_targets to fuzz
+  int rpc_messages_to_sent = provider.ConsumeIntegralInRange<int>(1, 16);
+  std::vector<int> selectors;
+  selectors.reserve(rpc_messages_to_sent);
+  for (int i = 0; i < rpc_messages_to_sent && provider.remaining_bytes() >= 2; ++i) {
+    uint16_t raw = provider.ConsumeIntegral<uint16_t>();
+    selectors.push_back(raw % fuzz_targets.size());
+  }
+
+  // Initialise core and core_rpc_server
+  auto dummy_core = initialise_rpc_core();
+  auto rpc_handler = initialise_rpc_server(*dummy_core, provider, !is_safe_mode);
+
+  // Generalise random blocks/miners/transactions and push to the core blockchains
+  if (!generate_random_blocks(*dummy_core, provider)) {
+    // No randomised blocks has been successfully added, skipping this iteration
+    dummy_core->get_blockchain_storage().get_db().batch_stop();
+    return 0;
+  }
+
+  // Disable bootstrap daemon
+  disable_bootstrap_daemon(*rpc_handler->rpc);
+
+  for (int selector : selectors) {
+    // Configure returning point for timeout
+    if (sigsetjmp(jump_env, 1) == 0) {
+      try {
+        // Start a timeout alarm for 120 secs
+        // SIGALARM will be sent once 120 is up
+        // timeout_handler catches the SIGALARM and return to the
+        // last sigsetjmp call with matching value to allow the code
+        // skipping to the next iteration
+        alarm(120);
+
+        // Fuzz the target function
+        fuzz_targets[selector](*rpc_handler->rpc, provider);
+      } catch (const std::runtime_error&) {
+        // Known runtime_error thrown from monero
+      } catch (const cryptonote::DB_ERROR& e) {
+        // Known error thrown from monero on internal blockchain DB check
+        // when fuzzing with random values
+      }
+
+      // Clear the alarm before next iteration
+      alarm(0);
+    }
+  }
+
+  // Try fuzz the prunt_blockchains API at the end to avoid
+  // multiple prune_blockchains call that result in db lock stall.
+  if ((provider.remaining_bytes() > 0) && !is_safe_mode) {
+    if (sigsetjmp(jump_env, 1) == 0) {
+      try {
+        alarm(120);
+        fuzz_prune_blockchain(*rpc_handler->rpc, provider);
+      } catch (const std::runtime_error&) {
+        // Known runtime_error thrown from monero
+      } catch (const cryptonote::DB_ERROR& e) {
+        // Known error thrown from monero on internal blockchain DB check
+        // when fuzzing with random values
+      }
+      alarm(0);
+    }
+  }
+
+  dummy_core->get_blockchain_storage().get_db().batch_stop();
+  return 0;
+}

--- a/tests/fuzz/fuzz_rpc/initialisation.cpp
+++ b/tests/fuzz/fuzz_rpc/initialisation.cpp
@@ -1,0 +1,369 @@
+#include "initialisation.h"
+
+#include "crypto/crypto.h"
+#include "cryptonote_config.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_basic/tx_extra.h"
+#include "cryptonote_core/cryptonote_core.h"
+#include "cryptonote_core/cryptonote_tx_utils.h"
+#include "cryptonote_core/tx_pool.h"
+#include "cryptonote_protocol/cryptonote_protocol_handler.h"
+#include "p2p/net_node.h"
+#include "p2p/net_node.inl"
+#include "ringct/rctTypes.h"
+#include "serialization/binary_utils.h"
+#include "serialization/variant.h"
+
+#include <boost/program_options/variables_map.hpp>
+#include <vector>
+#include <string>
+#include <functional>
+#include <unordered_map>
+
+// Configure a dummy protocol to avoid external requests
+bool DummyProtocol::is_synchronized() const {
+  return true;
+}
+
+bool DummyProtocol::relay_transactions(cryptonote::NOTIFY_NEW_TRANSACTIONS::request&, const boost::uuids::uuid&, epee::net_utils::zone, cryptonote::relay_method) {
+  return true;
+}
+
+bool DummyProtocol::relay_block(cryptonote::NOTIFY_NEW_FLUFFY_BLOCK::request&, cryptonote::cryptonote_connection_context&) {
+  return true;
+}
+
+bool DummyProtocol::get_payload_sync_data(cryptonote::CORE_SYNC_DATA&) {
+  return true;
+}
+
+bool DummyProtocol::get_payload_sync_data(epee::byte_slice&) {
+  return true;
+}
+
+bool DummyProtocol::on_idle() {
+  return true;
+}
+
+void DummyProtocol::on_connection_closing(cryptonote::cryptonote_connection_context&) {}
+
+void DummyProtocol::for_each_connection(std::function<bool(cryptonote::cryptonote_connection_context&, nodetool::peerid_type)>) {}
+
+void DummyProtocol::set_p2p_endpoint(nodetool::i_p2p_endpoint<cryptonote::cryptonote_connection_context>*) {}
+
+void DummyProtocol::set_update_block_timestamps() {}
+
+// Function to create and initialise a dummy rpc core object
+std::unique_ptr<cryptonote::core> initialise_rpc_core() {
+  // Create fresh pointer for dummy protocol and core
+  auto dummy_protocol = std::make_unique<DummyProtocol>();
+  auto dummy_core = std::make_unique<cryptonote::core>(dummy_protocol.get());
+
+  // Configure the rpc core object with default settings
+  boost::program_options::options_description desc;
+  cryptonote::core::init_options(desc);
+  boost::program_options::variables_map vm;
+
+  // Add command line argument to configure the rpc core object to use regression testing mode (FAKECHAIN)
+  // Enabling FAKECHAIN mode allows skipping validation logic of the authors signature and transactions ID
+  // on valid blocks and transactions while keeping other logic
+  std::vector<const char*> argv = {"fuzz", "--regtest"};
+  boost::program_options::store(boost::program_options::parse_command_line(argv.size(), argv.data(), desc), vm);
+  boost::program_options::notify(vm);
+
+  // Initialise the dummy core with all the above settings
+  dummy_core->init(vm);
+
+  // Create DummyProtocol object and set it to the dummy core
+  cryptonote::t_cryptonote_protocol_handler<cryptonote::core> proto_handler(*dummy_core, nullptr);
+  dummy_core->set_cryptonote_protocol(&proto_handler);
+
+  return dummy_core;
+}
+
+// Build the core_rpc_server handler object with the configured dummy core object
+std::unique_ptr<RpcServerBundle> initialise_rpc_server(cryptonote::core& dummy_core, FuzzedDataProvider& provider, bool need_payment) {
+  // Create rpc server bundle object
+  auto bundle = std::make_unique<RpcServerBundle>();
+
+  // Allocate new protocol and node server then create RPC server object
+  bundle->proto_handler = std::make_unique<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>>(dummy_core, nullptr);
+  bundle->dummy_p2p = std::make_unique<nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>>>(*bundle->proto_handler);
+  bundle->rpc = std::make_unique<cryptonote::core_rpc_server>(dummy_core, *bundle->dummy_p2p);
+
+  // Set up dummy variable map for rpc initialisation with payment
+  if (need_payment) {
+    boost::program_options::variables_map vm;
+    boost::program_options::options_description desc{"fuzz"};
+    command_line::add_arg(desc, cryptonote::arg_data_dir);
+    command_line::add_arg(desc, cryptonote::arg_testnet_on);
+    command_line::add_arg(desc, cryptonote::arg_stagenet_on);
+    cryptonote::core_rpc_server::init_options(desc);
+
+    // Generate random address and use it if it is a valid address with valid format
+    std::string address_arg;
+    if (provider.remaining_bytes() > 95) {
+      std::string random_str = provider.ConsumeBytesAsString(95);
+      if (!random_str.empty() && std::all_of(random_str.begin(), random_str.end(), [](char c) {
+            return isalnum(c);
+          })) {
+        address_arg = "--rpc-payment-address=" + random_str;
+      }
+    }
+
+    // Fall back to default hardcoded address if generated address is invalid
+    if (address_arg.empty()) {
+      address_arg = "--rpc-payment-address=44AFFq5kSiGBoZKfRLKFY7bUuS5JxqLkZ3Zf1diYv5ZdfTP7hS5gZtSGdgjNXmYGFzRiV3yTgF8Yf4zrhGcq14D3z8PUnHT";
+    }
+
+    // Provide needed payment related configuration for init of core_rpc_server
+    std::vector<const char*> argv = {
+      "fuzz",
+      address_arg.c_str()
+    };
+    boost::program_options::store(boost::program_options::parse_command_line(argv.size(), argv.data(), desc), vm);
+    boost::program_options::notify(vm);
+    bool success = bundle->rpc->init(vm, true, "18089", true, "");
+    if (!success) {
+      // Revert back to a fresh core_rpc_server if payment module init is failed
+      bundle->rpc = std::make_unique<cryptonote::core_rpc_server>(dummy_core, *bundle->dummy_p2p);
+    }
+  }
+
+  return bundle;
+}
+
+bool generate_random_blocks(cryptonote::core& core, FuzzedDataProvider& provider) {
+  static std::vector<cryptonote::block> cached_blocks;
+  static std::vector<cryptonote::blobdata> cached_txs;
+
+  bool use_cached_blocks = provider.ConsumeBool();
+  bool use_cached_txs = provider.ConsumeBool();
+
+  if (!use_cached_blocks || cached_blocks.empty()) {
+    // Create new cached blocks
+    cached_blocks.clear();
+
+    // Prepare the genesis block (initial base block) in the block chains
+    cryptonote::block genesis_block;
+    cryptonote::generate_genesis_block(genesis_block, config::GENESIS_TX, config::GENESIS_NONCE);
+    cached_blocks.push_back(genesis_block);
+
+    // Setup initial values
+    const size_t median_weight = 300000;
+    const size_t block_weight = 100000;
+    const uint8_t version = core.get_blockchain_storage().get_current_hard_fork_version();
+
+    // Accumulate coins for genesis block
+    uint64_t coins = 0;
+    for (const auto& o : genesis_block.miner_tx.vout) {
+      coins += o.amount;
+    }
+
+    // Create random number of miners
+    size_t miner_count = provider.ConsumeIntegralInRange<size_t>(1, 4);
+    std::vector<cryptonote::account_base> miners(miner_count);
+    for (auto& miner : miners) {
+      miner.generate();
+    }
+
+    // Create random number of blocks
+    size_t total_blocks = provider.ConsumeIntegralInRange<size_t>(2, 15);
+    for (size_t i = 0; i < total_blocks; ++i) {
+      // Stop generate blocks if no more bytes left
+      if (provider.remaining_bytes() <= 0) {
+        break;
+      }
+
+      // Randomly link a miner identity to this block
+      cryptonote::block blk;
+      size_t selected_miner_index = provider.ConsumeIntegralInRange<size_t>(0, miners.size() - 1);
+      cryptonote::account_base& miner = miners[selected_miner_index];
+
+      // Intiailise block property with random value
+      uint64_t height = cached_blocks.size();
+      crypto::hash prev_id = cached_blocks.back().hash;
+      blk.major_version = version;
+      blk.minor_version = version;
+      blk.timestamp = core.get_blockchain_storage().get_adjusted_time(height);
+      blk.prev_id = prev_id;
+      blk.nonce = provider.ConsumeIntegral<uint32_t>();
+
+      // Calculate and accumulate reward
+      uint64_t base_reward = 0, fee = 0;
+      if (!cryptonote::get_block_reward(median_weight, block_weight, coins, base_reward, version)) {
+        break;
+      }
+
+      // Link empty miner transaction to block
+      cryptonote::transaction miner_tx;
+      cryptonote::construct_miner_tx(
+        height, median_weight, coins, block_weight,
+        fee, miner.get_keys().m_account_address,
+        miner_tx, cryptonote::blobdata(),
+        1, blk.major_version
+      );
+      for (const auto& o : miner_tx.vout) {
+        coins += o.amount;
+      }
+      miner_tx.version = 2;
+      blk.miner_tx = miner_tx;
+
+      // Add the block to the cache
+      cached_blocks.push_back(blk);
+    }
+  }
+
+  if (cached_blocks.empty()) {
+    // No random block generated, exit early to next iteration
+    return false;
+  }
+
+  if (!use_cached_txs || cached_txs.empty()) {
+    // Create new cache transactions
+    cached_txs.clear();
+
+    // Random number of transactions to generate
+    const size_t tx_count = provider.ConsumeIntegralInRange<size_t>(1, 4);
+    for (size_t i = 0; i < tx_count; ++i) {
+      // Stop generate transactions if no more bytes left
+      if (provider.remaining_bytes() <= 0) {
+        break;
+      }
+
+      // Initialise variables
+      cryptonote::transaction tx;
+      std::vector<cryptonote::tx_source_entry> sources;
+      std::vector<cryptonote::tx_destination_entry> destinations;
+      std::vector<uint8_t> extra;
+
+      // Generate sender account
+      cryptonote::account_base sender;
+      sender.generate();
+
+      // Generate receiver account
+      cryptonote::account_base receiver;
+      receiver.generate();
+
+      // Generate random transfer amount
+      uint64_t transfer_amount = provider.ConsumeIntegralInRange<uint64_t>(10000, 1000000000);
+      uint64_t input_amount = transfer_amount + 10000;
+
+      // Prepare source entry
+      cryptonote::tx_source_entry src{};
+      src.amount = input_amount;
+      src.rct = false;
+      src.real_output = 0;
+      src.real_output_in_tx_index = 0;
+
+      // Derive valid public key
+      hw::device &hwdev = sender.get_keys().get_device();
+      cryptonote::keypair tx_key = cryptonote::keypair::generate(hwdev);
+      crypto::key_derivation derivation;
+      if (!crypto::generate_key_derivation(sender.get_keys().m_account_address.m_view_public_key, tx_key.sec, derivation)) {
+        continue;
+      }
+      crypto::public_key out_pub_key;
+      if (!crypto::derive_public_key(derivation, 0, sender.get_keys().m_account_address.m_spend_public_key, out_pub_key)) {
+        continue;
+      }
+      src.real_out_tx_key = tx_key.pub;
+
+      // Configure output entry for source_entry
+      for (size_t j = 0; j < 10; ++j) {
+        cryptonote::tx_source_entry::output_entry oe;
+        oe.first = j;
+        crypto::public_key pk;
+
+        if (j == src.real_output) {
+          pk = out_pub_key;
+        } else {
+          cryptonote::keypair fake = cryptonote::keypair::generate(hwdev);
+          pk = fake.pub;
+        }
+
+        crypto::view_tag vtag{};
+        vtag.data = static_cast<uint8_t>(provider.ConsumeIntegral<uint8_t>());
+
+        cryptonote::txout_to_tagged_key tagged{};
+        tagged.key = pk;
+        tagged.view_tag = vtag;
+
+        oe.second.dest = *reinterpret_cast<const rct::key*>(&tagged.key);
+        oe.second.mask = rct::identity();
+        src.outputs.push_back(oe);
+      }
+      sources.push_back(src);
+
+      // Prepare destination entry
+      cryptonote::tx_destination_entry dst;
+      dst.amount = transfer_amount;
+      dst.addr = receiver.get_keys().m_account_address;
+      dst.is_subaddress = false;
+      destinations.push_back(dst);
+
+      // Construct the transaction
+      crypto::secret_key tx_secret_key;
+      std::vector<crypto::secret_key> additional_tx_keys;
+      std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
+      subaddresses[sender.get_keys().m_account_address.m_spend_public_key] = {0, 0};
+      std::vector<cryptonote::tx_destination_entry> destinations_copy = destinations;
+
+      // Construct transaction objects
+      bool success = cryptonote::construct_tx_and_get_tx_key(
+        sender.get_keys(),
+        subaddresses,
+        sources,
+        destinations_copy,
+        boost::none,
+        extra,
+        tx,
+        tx_secret_key,
+        additional_tx_keys,
+        true,
+        {rct::RangeProofPaddedBulletproof, 0},
+        true
+      );
+      if (!success) {
+        continue;
+      }
+
+      // Force version and unlock_time
+      tx.version = 2;
+      tx.unlock_time = 0;
+
+      // Serialise the transaction
+      cryptonote::blobdata tx_blob;
+      if (!cryptonote::t_serializable_object_to_blob(tx, tx_blob)) {
+        continue;
+      }
+
+      // Add the transaction to cache
+      cached_txs.push_back(tx_blob);
+    }
+  }
+
+  core.get_blockchain_storage().get_db().batch_start();
+
+  bool added_block = false;
+  for (const auto& blk : cached_blocks) {
+    cryptonote::block_verification_context bvc{};
+    if (core.get_blockchain_storage().add_new_block(blk, bvc)) {
+      added_block = true;
+    }
+  }
+
+  bool added_txs = false;
+  for (const auto& tx_blob : cached_txs) {
+    cryptonote::tx_verification_context tvc;
+    if (core.handle_incoming_tx(tx_blob, tvc, cryptonote::relay_method::block, true)) {
+      added_txs = true;
+    } else if (tvc.m_added_to_pool) {
+      added_txs = true;
+    }
+  }
+
+  return added_block;
+}

--- a/tests/fuzz/fuzz_rpc/initialisation.h
+++ b/tests/fuzz/fuzz_rpc/initialisation.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "rpc/core_rpc_server.h"
+#include <fuzzer/FuzzedDataProvider.h>
+
+// Define templates for dummy protocol object
+template class nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>>;
+
+class DummyProtocol : public cryptonote::i_cryptonote_protocol {
+public:
+  bool is_synchronized() const;
+  bool relay_transactions(cryptonote::NOTIFY_NEW_TRANSACTIONS::request&, const boost::uuids::uuid&, epee::net_utils::zone, cryptonote::relay_method);
+  bool relay_block(cryptonote::NOTIFY_NEW_FLUFFY_BLOCK::request&, cryptonote::cryptonote_connection_context&);
+  bool get_payload_sync_data(cryptonote::CORE_SYNC_DATA&);
+  bool get_payload_sync_data(epee::byte_slice&);
+  bool on_idle();
+  void on_connection_closing(cryptonote::cryptonote_connection_context&);
+  void for_each_connection(std::function<bool(cryptonote::cryptonote_connection_context&, nodetool::peerid_type)>);
+  void set_p2p_endpoint(nodetool::i_p2p_endpoint<cryptonote::cryptonote_connection_context>*);
+  void set_update_block_timestamps();
+};
+
+struct RpcServerBundle {
+  std::unique_ptr<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>> proto_handler;
+  std::unique_ptr<nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core>>> dummy_p2p;
+  std::unique_ptr<cryptonote::core_rpc_server> rpc;
+};
+
+std::unique_ptr<cryptonote::core> initialise_rpc_core();
+std::unique_ptr<RpcServerBundle> initialise_rpc_server(cryptonote::core&, FuzzedDataProvider&, bool);
+bool generate_random_blocks(cryptonote::core&, FuzzedDataProvider&);

--- a/tests/fuzz/fuzz_rpc/rpc_endpoints.cpp
+++ b/tests/fuzz/fuzz_rpc/rpc_endpoints.cpp
@@ -1,0 +1,902 @@
+#include "rpc_endpoints.h"
+#include <cstring>
+#include <map>
+
+// Initialising common objects for calling RPC endpoint functions
+cryptonote::core_rpc_server::connection_context ctx;
+epee::json_rpc::error error_resp;
+
+// Helper function to disable bootstrap daemon
+void disable_bootstrap_daemon(cryptonote::core_rpc_server& rpc) {
+  cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::request req;
+  cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::response res;
+
+  req.address = "";
+  req.username = "";
+  req.password = "";
+  req.proxy = "";
+
+  rpc.on_set_bootstrap_daemon(req, res, &ctx);
+}
+
+// Retrieve fuzz targets base on SAFE settings
+std::map<int, std::function<void(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&)>> get_fuzz_targets(bool safe) {
+    // Only return safe and stable fuzz targets
+    if (safe) {
+      return safe_fuzz_targets;
+    }
+
+    // Return the full list of fuuzz targets
+    std::map<int, std::function<void(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&)>> combined = safe_fuzz_targets;
+    combined.insert(risky_fuzz_targets.begin(), risky_fuzz_targets.end());
+    return combined;
+}
+
+// Fuzzing functions for different RPC endpoint functions
+void fuzz_get_height(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_HEIGHT::request req;
+  cryptonote::COMMAND_RPC_GET_HEIGHT::response res;
+
+  rpc.on_get_height(req, res, &ctx);
+}
+
+void fuzz_get_blocks(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    std::string hash_data = provider.ConsumeBytesAsString(sizeof(crypto::hash));
+    if (hash_data.size() != sizeof(crypto::hash)) break;
+    crypto::hash h;
+    std::memcpy(&h, hash_data.data(), sizeof(h));
+    req.block_ids.push_back(h);
+  }
+
+  rpc.on_get_blocks(req, res, &ctx);
+}
+
+void fuzz_get_blocks_by_height(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    uint64_t height = provider.ConsumeIntegral<uint64_t>();
+    req.heights.push_back(height);
+  }
+
+  rpc.on_get_blocks_by_height(req, res, &ctx);
+}
+
+void fuzz_get_hashes(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req;
+  cryptonote::COMMAND_RPC_GET_HASHES_FAST::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    std::string hash_data = provider.ConsumeBytesAsString(sizeof(crypto::hash));
+    if (hash_data.size() != sizeof(crypto::hash)) break;
+    crypto::hash h;
+    std::memcpy(&h, hash_data.data(), sizeof(h));
+    req.block_ids.push_back(h);
+  }
+
+  req.start_height = provider.ConsumeIntegral<uint64_t>();
+
+  rpc.on_get_hashes(req, res, &ctx);
+}
+
+void fuzz_get_indexes(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::request req;
+  cryptonote::COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES::response res;
+  req.client = "fuzz";
+
+  std::string txid_data = provider.ConsumeBytesAsString(sizeof(crypto::hash));
+  if (txid_data.size() == sizeof(crypto::hash)) {
+    std::memcpy(&req.txid, txid_data.data(), sizeof(req.txid));
+  }
+
+  rpc.on_get_indexes(req, res, &ctx);
+}
+
+void fuzz_get_outs_bin(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_OUTPUTS_BIN::request req;
+  cryptonote::COMMAND_RPC_GET_OUTPUTS_BIN::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    cryptonote::get_outputs_out out;
+    out.amount = provider.ConsumeIntegral<uint64_t>();
+    out.index = provider.ConsumeIntegral<uint64_t>();
+    req.outputs.push_back(out);
+  }
+
+  req.get_txid = provider.ConsumeBool();
+
+  rpc.on_get_outs_bin(req, res, &ctx);
+}
+
+void fuzz_get_transactions(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTIONS::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    req.txs_hashes.push_back(provider.ConsumeRandomLengthString(64));
+  }
+
+  req.decode_as_json = provider.ConsumeBool();
+  req.prune = provider.ConsumeBool();
+  req.split = provider.ConsumeBool();
+
+  rpc.on_get_transactions(req, res, &ctx);
+}
+
+void fuzz_get_alt_blocks_hashes(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_ALT_BLOCKS_HASHES::request req;
+  cryptonote::COMMAND_RPC_GET_ALT_BLOCKS_HASHES::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_alt_blocks_hashes(req, res, &ctx);
+}
+
+void fuzz_is_key_image_spent(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_IS_KEY_IMAGE_SPENT::request req;
+  cryptonote::COMMAND_RPC_IS_KEY_IMAGE_SPENT::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
+  for (size_t i = 0; i < count; ++i) {
+    req.key_images.push_back(provider.ConsumeRandomLengthString(64));
+  }
+
+  rpc.on_is_key_image_spent(req, res, &ctx);
+}
+
+void fuzz_send_raw_tx(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SEND_RAW_TX::request req;
+  cryptonote::COMMAND_RPC_SEND_RAW_TX::response res;
+  req.client = "fuzz";
+
+  const std::string raw_tx_blob = provider.ConsumeRandomLengthString(512);
+  req.tx_as_hex = epee::string_tools::buff_to_hex_nodelimer(raw_tx_blob);
+  req.do_not_relay = provider.ConsumeBool();
+  req.do_sanity_checks = provider.ConsumeBool();
+
+  rpc.on_send_raw_tx(req, res, &ctx);
+}
+
+void fuzz_start_mining(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_START_MINING::request req;
+  cryptonote::COMMAND_RPC_START_MINING::response res;
+
+  req.miner_address = provider.ConsumeRandomLengthString(128);
+  req.threads_count = provider.ConsumeIntegralInRange<uint64_t>(0, 256);
+  req.do_background_mining = provider.ConsumeBool();
+  req.ignore_battery = provider.ConsumeBool();
+
+  rpc.on_start_mining(req, res, &ctx);
+}
+
+void fuzz_stop_mining(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_STOP_MINING::request req;
+  cryptonote::COMMAND_RPC_STOP_MINING::response res;
+
+  rpc.on_stop_mining(req, res, &ctx);
+}
+
+void fuzz_mining_status(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_MINING_STATUS::request req;
+  cryptonote::COMMAND_RPC_MINING_STATUS::response res;
+
+  rpc.on_mining_status(req, res, &ctx);
+}
+
+void fuzz_save_bc(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SAVE_BC::request req;
+  cryptonote::COMMAND_RPC_SAVE_BC::response res;
+
+  rpc.on_save_bc(req, res, &ctx);
+}
+
+void fuzz_get_peer_list(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_PEER_LIST::request req;
+  cryptonote::COMMAND_RPC_GET_PEER_LIST::response res;
+
+  req.public_only = provider.ConsumeBool();
+  req.include_blocked = provider.ConsumeBool();
+
+  rpc.on_get_peer_list(req, res, &ctx);
+}
+
+void fuzz_get_public_nodes(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_PUBLIC_NODES::request req;
+  cryptonote::COMMAND_RPC_GET_PUBLIC_NODES::response res;
+
+  req.gray = provider.ConsumeBool();
+  req.white = provider.ConsumeBool();
+  req.include_blocked = provider.ConsumeBool();
+
+  rpc.on_get_public_nodes(req, res, &ctx);
+}
+
+void fuzz_set_log_hash_rate(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SET_LOG_HASH_RATE::request req;
+  cryptonote::COMMAND_RPC_SET_LOG_HASH_RATE::response res;
+
+  req.visible = provider.ConsumeBool();
+
+  rpc.on_set_log_hash_rate(req, res, &ctx);
+}
+
+void fuzz_set_log_level(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SET_LOG_LEVEL::request req;
+  cryptonote::COMMAND_RPC_SET_LOG_LEVEL::response res;
+
+  req.level = provider.ConsumeIntegral<int8_t>();
+
+  rpc.on_set_log_level(req, res, &ctx);
+}
+
+void fuzz_set_log_categories(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SET_LOG_CATEGORIES::request req;
+  cryptonote::COMMAND_RPC_SET_LOG_CATEGORIES::response res;
+
+  req.categories = provider.ConsumeRandomLengthString(32);
+
+  rpc.on_set_log_categories(req, res, &ctx);
+}
+
+void fuzz_get_transaction_pool(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_transaction_pool(req, res, &ctx);
+}
+
+void fuzz_get_transaction_pool_hashes_bin(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_transaction_pool_hashes_bin(req, res, &ctx);
+}
+
+void fuzz_get_transaction_pool_hashes(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_transaction_pool_hashes(req, res, &ctx);
+}
+
+void fuzz_get_transaction_pool_stats(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_STATS::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_STATS::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_transaction_pool_stats(req, res, &ctx);
+}
+
+void fuzz_set_bootstrap_daemon(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::request req;
+  cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::response res;
+
+  req.address = provider.ConsumeRandomLengthString(64);
+  req.username = provider.ConsumeRandomLengthString(32);
+  req.password = provider.ConsumeRandomLengthString(32);
+  req.proxy = provider.ConsumeRandomLengthString(32);
+
+  rpc.on_set_bootstrap_daemon(req, res, &ctx);
+
+  // Immediate reset bootstrap daemon to avoid affecting other fuzzing with external calls
+  disable_bootstrap_daemon(rpc);
+}
+
+void fuzz_stop_daemon(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_STOP_DAEMON::request req;
+  cryptonote::COMMAND_RPC_STOP_DAEMON::response res;
+
+  rpc.on_stop_daemon(req, res, &ctx);
+}
+
+void fuzz_get_info(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_INFO::request req;
+  cryptonote::COMMAND_RPC_GET_INFO::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_info(req, res, &ctx);
+}
+
+void fuzz_get_net_stats(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_NET_STATS::request req;
+  cryptonote::COMMAND_RPC_GET_NET_STATS::response res;
+
+  rpc.on_get_net_stats(req, res, &ctx);
+}
+
+void fuzz_get_limit(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_LIMIT::request req;
+  cryptonote::COMMAND_RPC_GET_LIMIT::response res;
+
+  rpc.on_get_limit(req, res, &ctx);
+}
+
+void fuzz_set_limit(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SET_LIMIT::request req;
+  cryptonote::COMMAND_RPC_SET_LIMIT::response res;
+
+  req.limit_down = provider.ConsumeIntegral<int64_t>();
+  req.limit_up = provider.ConsumeIntegral<int64_t>();
+
+  rpc.on_set_limit(req, res, &ctx);
+}
+
+void fuzz_out_peers(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_OUT_PEERS::request req;
+  cryptonote::COMMAND_RPC_OUT_PEERS::response res;
+
+  req.set = provider.ConsumeBool();
+  req.out_peers = provider.ConsumeIntegral<uint32_t>();
+
+  rpc.on_out_peers(req, res, &ctx);
+}
+
+void fuzz_in_peers(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_IN_PEERS::request req;
+  cryptonote::COMMAND_RPC_IN_PEERS::response res;
+
+  req.set = provider.ConsumeBool();
+  req.in_peers = provider.ConsumeIntegral<uint32_t>();
+
+  rpc.on_in_peers(req, res, &ctx);
+}
+
+void fuzz_get_outs(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_OUTPUTS::request req;
+  cryptonote::COMMAND_RPC_GET_OUTPUTS::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 5);
+  for (size_t i = 0; i < count; ++i) {
+    cryptonote::get_outputs_out out;
+    out.amount = provider.ConsumeIntegral<uint64_t>();
+    out.index = provider.ConsumeIntegral<uint64_t>();
+    req.outputs.push_back(out);
+  }
+
+  req.get_txid = provider.ConsumeBool();
+
+  rpc.on_get_outs(req, res, &ctx);
+}
+
+void fuzz_update(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_UPDATE::request req;
+  cryptonote::COMMAND_RPC_UPDATE::response res;
+
+  req.command = provider.ConsumeRandomLengthString(16);
+  req.path = provider.ConsumeRandomLengthString(32);
+
+  rpc.on_update(req, res, &ctx);
+}
+
+void fuzz_get_output_distribution_bin(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req;
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 5);
+  for (size_t i = 0; i < count; ++i) {
+    req.amounts.push_back(provider.ConsumeIntegral<uint64_t>());
+  }
+
+  req.from_height = provider.ConsumeIntegral<uint64_t>();
+  req.to_height = provider.ConsumeIntegral<uint64_t>();
+  req.cumulative = provider.ConsumeBool();
+  req.binary = provider.ConsumeBool();
+  req.compress = provider.ConsumeBool();
+
+  rpc.on_get_output_distribution_bin(req, res, &ctx);
+}
+
+void fuzz_pop_blocks(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_POP_BLOCKS::request req;
+  cryptonote::COMMAND_RPC_POP_BLOCKS::response res;
+
+  req.nblocks = provider.ConsumeIntegral<uint64_t>();
+  rpc.on_pop_blocks(req, res, &ctx);
+}
+
+void fuzz_getblockcount(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&) {
+  cryptonote::COMMAND_RPC_GETBLOCKCOUNT::request req;
+  cryptonote::COMMAND_RPC_GETBLOCKCOUNT::response res;
+
+  rpc.on_getblockcount(req, res, &ctx);
+}
+
+
+// Fuzzing functions for RPC JSONAPI endpoint functions
+void fuzz_getblockhash(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GETBLOCKHASH::request req;
+  cryptonote::COMMAND_RPC_GETBLOCKHASH::response res;
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 10);
+  for (size_t i = 0; i < count; ++i) {
+    req.push_back(provider.ConsumeIntegral<uint64_t>());
+  }
+
+  rpc.on_getblockhash(req, res, error_resp, &ctx);
+}
+
+void fuzz_getblocktemplate(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GETBLOCKTEMPLATE::request req;
+  cryptonote::COMMAND_RPC_GETBLOCKTEMPLATE::response res;
+
+  req.reserve_size = provider.ConsumeIntegral<uint64_t>();
+  req.wallet_address = provider.ConsumeRandomLengthString(128);
+  req.prev_block = provider.ConsumeRandomLengthString(64);
+  req.extra_nonce = provider.ConsumeRandomLengthString(32);
+
+  rpc.on_getblocktemplate(req, res, error_resp, &ctx);
+}
+
+void fuzz_getminerdata(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GETMINERDATA::request req;
+  cryptonote::COMMAND_RPC_GETMINERDATA::response res;
+
+  rpc.on_getminerdata(req, res, error_resp, &ctx);
+}
+
+void fuzz_calcpow(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_CALCPOW::request req;
+  cryptonote::COMMAND_RPC_CALCPOW::response res;
+
+  req.major_version = provider.ConsumeIntegral<uint8_t>();
+  req.height = provider.ConsumeIntegral<uint64_t>();
+  req.block_blob = provider.ConsumeRandomLengthString(128);
+  req.seed_hash = provider.ConsumeRandomLengthString(64);
+
+  rpc.on_calcpow(req, res, error_resp, &ctx);
+}
+
+void fuzz_add_aux_pow(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ADD_AUX_POW::request req;
+  cryptonote::COMMAND_RPC_ADD_AUX_POW::response res;
+
+  req.blocktemplate_blob = provider.ConsumeRandomLengthString(128);
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 4);
+  for (size_t i = 0; i < count; ++i) {
+    cryptonote::COMMAND_RPC_ADD_AUX_POW::aux_pow_t aux;
+    aux.id = provider.ConsumeRandomLengthString(32);
+    aux.hash = provider.ConsumeRandomLengthString(64);
+    req.aux_pow.push_back(aux);
+  }
+
+  rpc.on_add_aux_pow(req, res, error_resp, &ctx);
+}
+
+void fuzz_submitblock(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SUBMITBLOCK::request req;
+  cryptonote::COMMAND_RPC_SUBMITBLOCK::response res;
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 4);
+  for (size_t i = 0; i < count; ++i) {
+    req.push_back(provider.ConsumeRandomLengthString(256));
+  }
+
+  rpc.on_submitblock(req, res, error_resp, &ctx);
+}
+
+void fuzz_generateblocks(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GENERATEBLOCKS::request req;
+  cryptonote::COMMAND_RPC_GENERATEBLOCKS::response res;
+
+  req.amount_of_blocks = provider.ConsumeIntegral<uint64_t>();
+  req.wallet_address = provider.ConsumeRandomLengthString(128);
+  req.prev_block = provider.ConsumeRandomLengthString(128);
+  req.starting_nonce = provider.ConsumeIntegral<uint32_t>();
+
+  rpc.on_generateblocks(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_last_block_header(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_LAST_BLOCK_HEADER::request req;
+  cryptonote::COMMAND_RPC_GET_LAST_BLOCK_HEADER::response res;
+  req.client = "fuzz";
+
+  req.fill_pow_hash = provider.ConsumeBool();
+
+  rpc.on_get_last_block_header(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_block_header_by_hash(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::response res;
+  req.client = "fuzz";
+
+  req.hash = provider.ConsumeRandomLengthString(64);
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 3);
+  for (size_t i = 0; i < count; ++i) {
+    req.hashes.push_back(provider.ConsumeRandomLengthString(64));
+  }
+
+  req.fill_pow_hash = provider.ConsumeBool();
+
+  rpc.on_get_block_header_by_hash(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_block_header_by_height(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response res;
+  req.client = "fuzz";
+
+  req.height = provider.ConsumeIntegral<uint64_t>();
+  req.fill_pow_hash = provider.ConsumeBool();
+
+  rpc.on_get_block_header_by_height(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_block_headers_range(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response res;
+  req.client = "fuzz";
+
+  req.start_height = provider.ConsumeIntegral<uint64_t>();
+  req.end_height = provider.ConsumeIntegral<uint64_t>();
+  req.fill_pow_hash = provider.ConsumeBool();
+
+  rpc.on_get_block_headers_range(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_block(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BLOCK::request req;
+  cryptonote::COMMAND_RPC_GET_BLOCK::response res;
+  req.client = "fuzz";
+
+  req.hash = provider.ConsumeRandomLengthString(64);
+  req.height = provider.ConsumeIntegral<uint64_t>();
+  req.fill_pow_hash = provider.ConsumeBool();
+
+  rpc.on_get_block(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_connections(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_CONNECTIONS::request req;
+  cryptonote::COMMAND_RPC_GET_CONNECTIONS::response res;
+
+  rpc.on_get_connections(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_info_json(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_INFO::request req;
+  cryptonote::COMMAND_RPC_GET_INFO::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_info_json(req, res, error_resp, &ctx);
+}
+
+void fuzz_hard_fork_info(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::request req;
+  cryptonote::COMMAND_RPC_HARD_FORK_INFO::response res;
+
+  req.version = provider.ConsumeIntegral<uint8_t>();
+
+  rpc.on_hard_fork_info(req, res, error_resp, &ctx);
+}
+
+void fuzz_set_bans(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SETBANS::request req;
+  cryptonote::COMMAND_RPC_SETBANS::response res;
+
+  int count = provider.ConsumeIntegralInRange<int>(0, 4);
+  for (int i = 0; i < count; ++i) {
+    cryptonote::COMMAND_RPC_SETBANS::ban entry;
+    entry.host = provider.ConsumeRandomLengthString(32);
+    entry.ip = provider.ConsumeIntegral<uint32_t>();
+    entry.ban = provider.ConsumeBool();
+    entry.seconds = provider.ConsumeIntegral<uint32_t>();
+    req.bans.push_back(entry);
+  }
+
+  rpc.on_set_bans(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_bans(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GETBANS::request req;
+  cryptonote::COMMAND_RPC_GETBANS::response res;
+
+  rpc.on_get_bans(req, res, error_resp, &ctx);
+}
+
+void fuzz_banned(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_BANNED::request req;
+  cryptonote::COMMAND_RPC_BANNED::response res;
+
+  req.address = provider.ConsumeRandomLengthString(32);
+
+  rpc.on_banned(req, res, error_resp, &ctx);
+}
+
+void fuzz_flush_txpool(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_FLUSH_TRANSACTION_POOL::request req;
+  cryptonote::COMMAND_RPC_FLUSH_TRANSACTION_POOL::response res;
+
+  int count = provider.ConsumeIntegralInRange<int>(0, 8);
+  for (int i = 0; i < count; ++i) {
+    req.txids.push_back(provider.ConsumeRandomLengthString(64));
+  }
+
+  rpc.on_flush_txpool(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_output_histogram(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req;
+  cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response res;
+  req.client = "fuzz";
+
+  int amount_count = provider.ConsumeIntegralInRange<int>(0, 5);
+  for (int i = 0; i < amount_count; ++i) {
+    req.amounts.push_back(provider.ConsumeIntegral<uint64_t>());
+  }
+  req.min_count = provider.ConsumeIntegral<uint64_t>();
+  req.max_count = provider.ConsumeIntegral<uint64_t>();
+  req.unlocked = provider.ConsumeBool();
+  req.recent_cutoff = provider.ConsumeIntegral<uint64_t>();
+
+  rpc.on_get_output_histogram(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_version(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_VERSION::request req;
+  cryptonote::COMMAND_RPC_GET_VERSION::response res;
+
+  rpc.on_get_version(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_coinbase_tx_sum(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_COINBASE_TX_SUM::request req;
+  cryptonote::COMMAND_RPC_GET_COINBASE_TX_SUM::response res;
+  req.client = "fuzz";
+
+  req.height = provider.ConsumeIntegral<uint64_t>();
+  req.count = provider.ConsumeIntegral<uint64_t>();
+
+  rpc.on_get_coinbase_tx_sum(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_base_fee_estimate(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request req;
+  cryptonote::COMMAND_RPC_GET_BASE_FEE_ESTIMATE::response res;
+  req.client = "fuzz";
+
+  req.grace_blocks = provider.ConsumeIntegral<uint64_t>();
+
+  rpc.on_get_base_fee_estimate(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_alternate_chains(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_ALTERNATE_CHAINS::request req;
+  cryptonote::COMMAND_RPC_GET_ALTERNATE_CHAINS::response res;
+
+  rpc.on_get_alternate_chains(req, res, error_resp, &ctx);
+}
+
+void fuzz_relay_tx(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_RELAY_TX::request req;
+  cryptonote::COMMAND_RPC_RELAY_TX::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 4);
+  for (size_t i = 0; i < count && provider.remaining_bytes() > 0; ++i) {
+    req.txids.push_back(provider.ConsumeRandomLengthString(64));
+  }
+  epee::json_rpc::error error_resp;
+  rpc.on_relay_tx(req, res, error_resp, &ctx);
+}
+
+void fuzz_sync_info(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_SYNC_INFO::request req;
+  cryptonote::COMMAND_RPC_SYNC_INFO::response res;
+  req.client = "fuzz";
+
+  rpc.on_sync_info(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_txpool_backlog(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request req;
+  cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response res;
+  req.client = "fuzz";
+
+  rpc.on_get_txpool_backlog(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_output_distribution(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request req;
+  cryptonote::COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response res;
+  req.client = "fuzz";
+
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 8);
+  for (size_t i = 0; i < count && provider.remaining_bytes() > 0; ++i) {
+    req.amounts.push_back(provider.ConsumeIntegral<uint64_t>());
+  }
+
+  req.from_height = provider.ConsumeIntegral<uint64_t>();
+  req.to_height = provider.ConsumeIntegral<uint64_t>();
+  req.cumulative = provider.ConsumeBool();
+  req.binary = provider.ConsumeBool();
+  req.compress = provider.ConsumeBool();
+
+  rpc.on_get_output_distribution(req, res, error_resp, &ctx);
+}
+
+void fuzz_prune_blockchain(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_PRUNE_BLOCKCHAIN::request req;
+  cryptonote::COMMAND_RPC_PRUNE_BLOCKCHAIN::response res;
+
+  req.check = provider.ConsumeBool();
+
+  rpc.on_prune_blockchain(req, res, error_resp, &ctx);
+}
+
+void fuzz_flush_cache(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_FLUSH_CACHE::request req;
+  cryptonote::COMMAND_RPC_FLUSH_CACHE::response res;
+
+  req.bad_blocks = provider.ConsumeBool();
+
+  rpc.on_flush_cache(req, res, error_resp, &ctx);
+}
+
+void fuzz_get_txids_loose(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_GET_TXIDS_LOOSE::request req;
+  cryptonote::COMMAND_RPC_GET_TXIDS_LOOSE::response res;
+
+  req.txid_template = provider.ConsumeRandomLengthString(64);
+  req.num_matching_bits = provider.ConsumeIntegral<uint32_t>();
+
+  rpc.on_get_txids_loose(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_info(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_INFO::request req;
+  cryptonote::COMMAND_RPC_ACCESS_INFO::response res;
+  req.client = "fuzz";
+
+  rpc.on_rpc_access_info(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_submit_nonce(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_SUBMIT_NONCE::request req;
+  cryptonote::COMMAND_RPC_ACCESS_SUBMIT_NONCE::response res;
+  req.client = "fuzz";
+
+  req.nonce = provider.ConsumeIntegral<uint32_t>();
+  req.cookie = provider.ConsumeIntegral<uint32_t>();
+
+  rpc.on_rpc_access_submit_nonce(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_pay(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_PAY::request req;
+  cryptonote::COMMAND_RPC_ACCESS_PAY::response res;
+  req.client = "fuzz";
+
+  req.paying_for = provider.ConsumeRandomLengthString(32);
+  req.payment = provider.ConsumeIntegral<uint64_t>();
+
+  rpc.on_rpc_access_pay(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_tracking(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_TRACKING::request req;
+  cryptonote::COMMAND_RPC_ACCESS_TRACKING::response res;
+
+  req.clear = provider.ConsumeBool();
+
+  rpc.on_rpc_access_tracking(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_data(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_DATA::request req;
+  cryptonote::COMMAND_RPC_ACCESS_DATA::response res;
+
+  rpc.on_rpc_access_data(req, res, error_resp, &ctx);
+}
+
+void fuzz_rpc_access_account(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& provider) {
+  cryptonote::COMMAND_RPC_ACCESS_ACCOUNT::request req;
+  cryptonote::COMMAND_RPC_ACCESS_ACCOUNT::response res;
+  req.client = "fuzz";
+
+  req.delta_balance = provider.ConsumeIntegral<int64_t>();
+
+  rpc.on_rpc_access_account(req, res, error_resp, &ctx);
+}
+
+// Maps storing all fuzzing functions
+std::map<int, std::function<void(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&)>> safe_fuzz_targets = {
+  {0, fuzz_get_height},
+  {1, fuzz_get_blocks},
+  {2, fuzz_get_blocks_by_height},
+  {3, fuzz_get_hashes},
+  {4, fuzz_get_indexes},
+  {5, fuzz_get_outs_bin},
+  {6, fuzz_get_transactions},
+  {7, fuzz_get_alt_blocks_hashes},
+  {8, fuzz_get_peer_list},
+  {9, fuzz_get_public_nodes},
+  {10, fuzz_set_log_hash_rate},
+  {11, fuzz_set_log_level},
+  {12, fuzz_set_log_categories},
+  {13, fuzz_get_transaction_pool},
+  {14, fuzz_get_transaction_pool_hashes_bin},
+  {15, fuzz_get_transaction_pool_hashes},
+  {16, fuzz_get_transaction_pool_stats},
+  {17, fuzz_get_info},
+  {18, fuzz_get_net_stats},
+  {19, fuzz_get_limit},
+  {20, fuzz_set_limit},
+  {21, fuzz_out_peers},
+  {22, fuzz_in_peers},
+  {23, fuzz_get_outs},
+  {24, fuzz_get_output_distribution_bin},
+  {25, fuzz_getblockcount},
+  {26, fuzz_getblockhash},
+  {27, fuzz_getblocktemplate},
+  {28, fuzz_getminerdata},
+  {29, fuzz_calcpow},
+  {30, fuzz_get_last_block_header},
+  {31, fuzz_get_block_header_by_hash},
+  {32, fuzz_get_block_header_by_height},
+  {33, fuzz_get_block_headers_range},
+  {34, fuzz_get_block},
+  {35, fuzz_get_connections},
+  {36, fuzz_get_info_json},
+  {37, fuzz_hard_fork_info},
+  {38, fuzz_set_bans},
+  {39, fuzz_get_bans},
+  {40, fuzz_banned},
+  {41, fuzz_get_output_histogram},
+  {42, fuzz_get_version},
+  {43, fuzz_get_coinbase_tx_sum},
+  {44, fuzz_get_base_fee_estimate},
+  {45, fuzz_get_alternate_chains},
+  {46, fuzz_sync_info},
+  {47, fuzz_get_txpool_backlog},
+  {48, fuzz_get_output_distribution},
+};
+
+std::map<int, std::function<void(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&)>> risky_fuzz_targets = {
+  {49, fuzz_is_key_image_spent},
+  {50, fuzz_send_raw_tx},
+  {51, fuzz_start_mining},
+  {52, fuzz_stop_mining},
+  {53, fuzz_mining_status},
+  {54, fuzz_save_bc},
+  {55, fuzz_set_bootstrap_daemon},
+  {56, fuzz_stop_daemon},
+  {57, fuzz_update},
+  {58, fuzz_pop_blocks},
+  {59, fuzz_add_aux_pow},
+  {60, fuzz_submitblock},
+  {61, fuzz_generateblocks},
+  {62, fuzz_flush_txpool},
+  {63, fuzz_relay_tx},
+  {64, fuzz_flush_cache},
+  {65, fuzz_get_txids_loose},
+  {66, fuzz_rpc_access_info},
+  {67, fuzz_rpc_access_submit_nonce},
+  {68, fuzz_rpc_access_pay},
+  {69, fuzz_rpc_access_tracking},
+  {70, fuzz_rpc_access_data},
+  {71, fuzz_rpc_access_account},
+};

--- a/tests/fuzz/fuzz_rpc/rpc_endpoints.h
+++ b/tests/fuzz/fuzz_rpc/rpc_endpoints.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "common/perf_timer.h"
+#include "rpc/core_rpc_server.h"
+#include <fuzzer/FuzzedDataProvider.h>
+
+namespace tools {
+  extern __thread std::vector<LoggingPerformanceTimer*> *performance_timers;
+}
+
+void disable_bootstrap_daemon(cryptonote::core_rpc_server& rpc);
+std::map<int, std::function<void(cryptonote::core_rpc_server& rpc, FuzzedDataProvider&)>> get_fuzz_targets(bool safe);
+
+void fuzz_get_height(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_blocks(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_blocks_by_height(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_hashes(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_indexes(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_outs_bin(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_transactions(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_alt_blocks_hashes(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_is_key_image_spent(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_send_raw_tx(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_start_mining(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_stop_mining(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_mining_status(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_save_bc(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_peer_list(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_public_nodes(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_log_hash_rate(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_log_level(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_log_categories(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_transaction_pool(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_transaction_pool_hashes_bin(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_transaction_pool_hashes(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_transaction_pool_stats(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_bootstrap_daemon(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_stop_daemon(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_info(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_net_stats(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_limit(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_limit(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_out_peers(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_in_peers(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_outs(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_update(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_output_distribution_bin(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_pop_blocks(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_getblockcount(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_getblockhash(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_getblocktemplate(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_getminerdata(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_calcpow(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_add_aux_pow(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_submitblock(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_generateblocks(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_last_block_header(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_block_header_by_hash(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_block_header_by_height(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_block_headers_range(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_block(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_connections(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_info_json(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_hard_fork_info(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_set_bans(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_bans(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_banned(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_flush_txpool(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_output_histogram(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_version(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_coinbase_tx_sum(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_base_fee_estimate(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_alternate_chains(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_relay_tx(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_sync_info(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_txpool_backlog(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_output_distribution(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_prune_blockchain(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_flush_cache(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_txids_loose(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_info(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_submit_nonce(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_pay(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_tracking(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_data(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_rpc_access_account(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+void fuzz_get_height(cryptonote::core_rpc_server&, FuzzedDataProvider& provider);
+
+extern std::map<int, std::function<void(cryptonote::core_rpc_server&, FuzzedDataProvider&)>> safe_fuzz_targets;
+extern std::map<int, std::function<void(cryptonote::core_rpc_server&, FuzzedDataProvider&)>> risky_fuzz_targets;


### PR DESCRIPTION
This PR adds a new fuzzer in the tests/fuzz/fuzz_rpc directory and updates the CMakeLists.txt accordingly. The fuzzer is built in two versions, each targeting a different set of RPC endpoint functions in the src/rpc directory.