### PR TITLE
guix: bump time-machine to 4d8c55de60cf9a5cafc4b881035131921d07314d

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -452,6 +452,7 @@ EOF
                                  --keep-failed \
                                  --fallback \
                                  --link-profile \
+                                 --writable-root \
                                  --root="$(profiledir_for_host "${HOST}")" \
                                  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                                  ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -68,7 +68,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/monero-project/guix.git \
-                      --commit=9d09b0cf841fb657a1aec12e9bab68e00c2b493c \
+                      --commit=4d8c55de60cf9a5cafc4b881035131921d07314d \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/patches/winpthreads-remap-guix-store.patch
+++ b/contrib/guix/patches/winpthreads-remap-guix-store.patch
@@ -6,12 +6,12 @@ the package, map all guix store prefixes to something fixed, e.g. /usr.
 
 --- a/mingw-w64-libraries/winpthreads/Makefile.in
 +++ b/mingw-w64-libraries/winpthreads/Makefile.in
-@@ -478,7 +478,7 @@ top_build_prefix = @top_build_prefix@
+@@ -465,7 +465,7 @@ top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@
  SUBDIRS = . tests
--AM_CFLAGS = -Wall -DWIN32_LEAN_AND_MEAN $(am__append_1)
-+AM_CFLAGS = -Wall -DWIN32_LEAN_AND_MEAN $(am__append_1) $(shell find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
+-AM_CFLAGS = $(am__append_1) $(am__append_3)
++AM_CFLAGS = $(am__append_1) $(am__append_3) $(shell find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
  ACLOCAL_AMFLAGS = -I m4
  lib_LTLIBRARIES = libwinpthread.la
- include_HEADERS = include/pthread.h include/sched.h include/semaphore.h include/pthread_unistd.h include/pthread_time.h include/pthread_compat.h include/pthread_signal.h
+ include_HEADERS = \


### PR DESCRIPTION
Requires #9455 and #10001 to pass CI (unless the `clang-toolchain-11` build gets fixed upstream)

Previous bump: #9467

This bump spans a `core-packages-team` merge, resulting in a large number of updated packages.

It does not include the upcoming `rust-team` merge, which we'll need for https://github.com/monero-project/monero/pull/9801#issuecomment-3066881685. I expect this will take another month or so.

To ensure reproducibility, reviewers are requested to [perform a build](https://github.com/monero-project/monero/tree/master/contrib/guix) and share their hashes (once CI is green).

### Notable changes

- binutils `2.41` -> `2.44`
- gcc 14 becomes available
- 10 packages eliminated from the build graph
- only one (annoying) non-deterministic build failure in a full-source bootstrap, see: #9900

### Stats

| | old | new |
|--|-----:|-----:|
|Total graph edges|7870|7487|
|Total store items |990|956|
|Total packages|209|199|
|Excluding bootstrap|154| 144|
|Environment only| 66|66|

### Changes to the build environment

Includes packages that are available in the build container.

| package | old | new |
|---|---|---|
| bash | 5.1.16 | 5.2.37 |
| bash-minimal | 5.1.16 | 5.2.37 |
| bash-static | 5.1.16 | 5.2.37 |
| binutils | 2.41 | 2.44 |
| binutils-cross-x86_64-linux-gnu | 2.41 | 2.44 |
| diffutils | 3.10 | 3.12 |
| ed | 1.20.1 | 1.21 |
| expat | 2.5.0 | 2.7.1 |
| findutils | 4.9.0 | 4.10.0 |
| gcc | 12.4.0 | 14.3.0 |
| git-minimal | 2.46.0 | 2.50.1 |
| glibc\* | 2.39 | 2.41 |
| gzip | 1.13 | 1.14 |
| libffi | 3.4.4 | 3.4.6 |
| libgc | 8.2.4 | 8.2.8 |
| libidn2 | 2.3.4 | 2.3.7 |
| libpsl | 0.21.1 | 0.21.5 |
| libstdc++ | 11.4.0 | 14.3.0 |
| libtasn1 | 4.19.0 | 4.20.0 |
| libunistring | 1.1 | 1.3 |
| libxcrypt | 4.4.36 | 4.4.38 |
| linux-libre-headers | 5.15.49 | 6.12.17 |
| linux-libre-headers-cross-x86_64-linux-gnu | 6.1.119 | 6.1.143 |
| mpfr | 4.2.1 | 4.2.2 |
| nettle | 3.9.1 | 3.10.1 |
| patch | 2.7.6-0.f144b35 | 2.8 |
| readline | 8.1.2 | 8.2.13 |
| sed | 4.8 | 4.9 |
| tar | 1.34 | 1.35 |
| zlib | 1.3 | 1.3.1 |
| zstd | 1.5.2 | 1.5.6 |

\* this does not affect run-time requirements of release binaries.

### Changes to transitive build dependencies

Includes (transitive) build dependencies that are not included in the build environment.

| package | old | new | notes|
|---|---|---|---|
| c-ares | 1.18.1 | 1.34.4 | |
| check | **n/a** | 0.15.2 | https://codeberg.org/guix/guix/commit/0897cd3a25de93cad580e266493295058cab442b |
| cl-asdf | 3.3.7 | **removed** | |
| clisp | 2.49-92 | **removed** | |
| cppi | 1.18 | **removed** | |
| elfutils | 0.187 | 0.192 | |
| file | 5.45 | 5.46 | |
| freetype | 2.13.0 | 2.13.3 | |
| gdbm | 1.23 | 1.25 | |
| gettext-minimal | 0.21 | 0.23.1 | |
| git-minimal | 2.41.0 | **removed** | |
| glibc-intermediate | 2.39 | 2.41 | |
| glibc-utf8-locales | 2.39 | 2.41 | |
| gnulib | 2024-05-30-1.ac4b301 | **removed** | |
| indent | 2.2.13 | **removed** | |
| iptables | 1.8.8 | 1.8.11 | |
| libarchive | 3.6.1 | **removed** | |
| libffcall | 2.2 | **removed** | |
| libfontenc | 1.1.4 | 1.1.8 | |
| libgcrypt | 1.10.1 | **removed** | |
| libgpg-error | 1.47 | **removed** | |
| libnftnl | 1.2.3 | 1.2.8 | |
| libpthread-stubs | 0.4 | **removed** | |
| libstdc++ | **n/a** | 12.4.0 | https://codeberg.org/guix/guix/commit/f4a18c7956e8546072603f050c1bf39e6425545c |
| libstdc++-headers | 11.4.0 | 12.4.0 | |
| libx11 | 1.8.7 | 1.8.10 | |
| libxau | 1.0.10 | 1.0.12 | |
| libxcb | 1.15 | 1.17.0 | |
| libxdmcp | 1.1.3 | 1.1.5 | |
| libxext | 1.3.4 | 1.3.6 | |
| libxrender | 0.9.10 | 0.9.12 | |
| libxslt | 1.1.37 | **removed** | |
| lzip | 1.23 | 1.25 | |
| mkfontscale | 1.2.2 | 1.2.3 | |
| python | 3.10.7 | 3.11.11 | |
| python-minimal | 3.10.7 | 3.11.11 | |
| python-minimal-wrapper | 3.10.7 | 3.11.11 | |
| python-wrapper | 3.10.7 | 3.11.11 | |
| tzdata | 2023d | 2025a | |
| ucd | 15.1.0 | **removed** | |
| util-linux | 2.37.4 | 2.40.4 | |
| util-macros | 1.19.3 | 1.20.2 | |
| xcb-proto | 1.15.2 | 1.17.0 | |
| xorgproto | 2023.2 | 2024.1 | |
| xtrans | 1.4.0 | 1.5.2 | |

### Changes to commencement

Only includes changes to bootstrap packages.

| package | old | new |
|---|---|---|
| bash-mesboot | 5.1.16 | 5.2.37 |
| binutils-cross-boot0 | 2.41 | 2.44 |
| diffutils-boot0 | 3.10 | 3.12 |
| file-boot0 | 5.45 | 5.46 |
| findutils-boot0 | 4.9.0 | 4.10.0 |
| gash-boot | 0.3.0 | 0.3.1 |
| gcc-cross-boot0 | 11.4.0 | 14.3.0 |
| gcc-cross-boot0-wrapped | 11.4.0 | 14.3.0 |
| sed-boot0 | 4.8 | 4.9 |
| tar-boot0 | 1.34 | 1.35 |
| tar-mesboot | 1.34 | 1.35 |

