### PR TITLE
functional_tests: check transfers list consistency in cold_signing

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2202,6 +2202,11 @@ namespace tools
       {
         if (req.account_index != td.m_subaddr_index.major || (!req.subaddr_indices.empty() && req.subaddr_indices.count(td.m_subaddr_index.minor) == 0))
           continue;
+
+        // wallet2::is_transfer_unlocked() needs a daemon connection to work. if it fails, assume locked
+        bool unlocked = false;
+        try { unlocked = m_wallet->is_transfer_unlocked(td); } catch (...) {}
+
         wallet_rpc::transfer_details rpc_transfers;
         rpc_transfers.amount       = td.amount();
         rpc_transfers.spent        = td.m_spent;
@@ -2212,7 +2217,7 @@ namespace tools
         rpc_transfers.pubkey       = epee::string_tools::pod_to_hex(td.get_public_key());
         rpc_transfers.block_height = td.m_block_height;
         rpc_transfers.frozen       = td.m_frozen;
-        rpc_transfers.unlocked     = m_wallet->is_transfer_unlocked(td);
+        rpc_transfers.unlocked     = unlocked;
         res.transfers.push_back(rpc_transfers);
       }
     }

--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -131,8 +131,31 @@ class ColdSigningTest():
             res = self.hot_wallet.export_outputs()
             self.cold_wallet.import_outputs(res.outputs_data_hex)
 
+        # Check consistency between hot & cold transfers list, especially that one-time addresses and amounts line up
+        def check_transfers_list_consistency(do_check_key_images):
+            hot_transfers_list = self.hot_wallet.incoming_transfers()
+            cold_transfers_list = self.cold_wallet.incoming_transfers()
+            if 'transfers' not in hot_transfers_list:
+                assert 'transfers' not in cold_transfers_list
+                return
+            hot_transfers_list = hot_transfers_list['transfers']
+            cold_transfers_list = cold_transfers_list['transfers']
+            assert len(hot_transfers_list) == len(cold_transfers_list)
+            attributes_to_cmp = ['amount', 'subaddr_index', 'pubkey']
+            if do_check_key_images:
+                attributes_to_cmp.append("key_image")
+            for i in range(len(hot_transfers_list)):
+                for attr in attributes_to_cmp:
+                    hot_val = hot_transfers_list[i][attr]
+                    cold_val = cold_transfers_list[i][attr]
+                    assert hot_val == cold_val, "outputs mismatch ({}, \"{}\"): {} vs {}".format(i, attr, hot_val, cold_val)
+
+        check_transfers_list_consistency(False)
+
         res = self.cold_wallet.export_key_images(True)
         self.hot_wallet.import_key_images(res.signed_key_images, offset = res.offset)
+
+        check_transfers_list_consistency(True)
 
     def create_tx(self, destination_addr, piecemeal_output_export):
         daemon = Daemon()


### PR DESCRIPTION
Helped me catch some bad behavior while developing for Carrot/FCMP++ hot/cold wallets.

This PR is part of upstreaming Carrot/FCMP++.

Depends on #10007.