### PR TITLE
wallet: deprecate `wallet2::find_and_save_rings()`

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2148,15 +2148,7 @@ bool simple_wallet::blackballed(const std::vector<std::string> &args)
 
 bool simple_wallet::save_known_rings(const std::vector<std::string> &args)
 {
-  try
-  {
-    LOCK_IDLE_SCOPE();
-    m_wallet->find_and_save_rings();
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Failed to save known rings: ") << e.what();
-  }
+  fail_msg_writer() << tr("save_known_rings is deprecated");
   return true;
 }
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2434,7 +2434,6 @@ void WalletImpl::doRefresh()
             if (m_history->count() == 0) {
                 m_history->refresh();
             }
-            m_wallet->find_and_save_rings(false);
         } else {
            LOG_PRINT_L3(__FUNCTION__ << ": skipping refresh - daemon is not synced");
         }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1735,7 +1735,7 @@ private:
     bool set_rings(const std::vector<std::pair<crypto::key_image, std::vector<uint64_t>>> &rings, bool relative);
     bool unset_ring(const std::vector<crypto::key_image> &key_images);
     bool unset_ring(const crypto::hash &txid);
-    bool find_and_save_rings(bool force = true);
+    [[deprecated]] bool find_and_save_rings(bool force = true);
 
     bool blackball_output(const std::pair<uint64_t, uint64_t> &output);
     bool set_blackballed_outputs(const std::vector<std::pair<uint64_t, uint64_t>> &outputs, bool add = false);


### PR DESCRIPTION
Rings for outgoing transactions are stored within the scanning code since the last hardfork, so this code is largely unneccessary now.