### PR TITLE
Daemon RPC: rm high_height_ok field from getblocks.bin

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -729,12 +729,6 @@ namespace cryptonote
         crypto::hash last_block_hash;
         m_core.get_blockchain_top(last_block_height, last_block_hash);
 
-        if (!req.high_height_ok && req.start_height > last_block_height)
-        {
-          res.status = "Failed";
-          return true;
-        }
-
         if (req.start_height > last_block_height ||
            (!req.block_ids.empty() && last_block_hash == req.block_ids.front()))
         {

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -189,7 +189,6 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint64_t    start_height;
       bool        prune;
       bool        no_miner_tx;
-      bool        high_height_ok;
       uint64_t    pool_info_since;
       uint64_t    max_block_count;
 
@@ -200,7 +199,6 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(prune)
         KV_SERIALIZE_OPT(no_miner_tx, false)
-        KV_SERIALIZE_OPT(high_height_ok, false) // default false maintains backwards compatibility for clients that relied on failure on high height
         KV_SERIALIZE_OPT(pool_info_since, (uint64_t)0)
         KV_SERIALIZE_OPT(max_block_count, (uint64_t)0)
       END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
This removes the `high_height_ok` field added in #9382 

Since current behavior on release is to ban clients with too high a height included in the request, it seems reasonably justified to modify that behavior to instead return a successful response that includes the chain height and top block hash.