### PR TITLE
Skip ping connections in outgoing count

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -288,13 +288,15 @@ namespace net_utils
     explicit connection( io_context_t& io_context,
                         std::shared_ptr<shared_state> state,
 			t_connection_type connection_type,
-			epee::net_utils::ssl_support_t ssl_support);
+			epee::net_utils::ssl_support_t ssl_support,
+      t_connection_context&& initial = t_connection_context{});
 
     explicit connection( io_context_t& io_context,
       boost::asio::ip::tcp::socket&& sock,
 			 std::shared_ptr<shared_state> state,
 			t_connection_type connection_type,
-			epee::net_utils::ssl_support_t ssl_support);
+			epee::net_utils::ssl_support_t ssl_support,
+      t_connection_context&& initial = t_connection_context{});
 
 
 
@@ -399,7 +401,7 @@ namespace net_utils
     try_connect_result_t try_connect(connection_ptr new_connection_l, const std::string& adr, const std::string& port, boost::asio::ip::tcp::socket &sock_, const boost::asio::ip::tcp::endpoint &remote_endpoint, const std::string &bind_ip, uint32_t conn_timeout, epee::net_utils::ssl_support_t ssl_support);
     bool connect(const std::string& adr, const std::string& port, uint32_t conn_timeot, t_connection_context& cn, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
     template<class t_callback>
-    bool connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeot, const t_callback &cb, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
+    bool connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeot, const t_callback &cb, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect, t_connection_context&& initial = t_connection_context{});
 
     boost::asio::ssl::context& get_ssl_context() noexcept
     {

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -975,14 +975,16 @@ namespace net_utils
     io_context_t &io_context,
     std::shared_ptr<shared_state> shared_state,
     t_connection_type connection_type,
-    ssl_support_t ssl_support
+    ssl_support_t ssl_support,
+    t_connection_context&& initial
   ):
     connection(
       io_context,
       socket_t{io_context},
       std::move(shared_state),
       connection_type,
-      ssl_support
+      ssl_support,
+      std::move(initial)
     )
   {
   }
@@ -993,12 +995,14 @@ namespace net_utils
     socket_t &&socket,
     std::shared_ptr<shared_state> shared_state,
     t_connection_type connection_type,
-    ssl_support_t ssl_support
+    ssl_support_t ssl_support,
+    t_connection_context&& initial
   ):
     connection_basic(io_context, std::move(socket), shared_state, ssl_support),
     m_handler(this, *shared_state, m_conn_context),
     m_connection_type(connection_type),
     m_io_context{io_context},
+    m_conn_context(std::move(initial)),
     m_strand{m_io_context},
     m_timers{m_io_context}
   {
@@ -1850,10 +1854,10 @@ namespace net_utils
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler> template<class t_callback>
-  bool boosted_tcp_server<t_protocol_handler>::connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeout, const t_callback &cb, const std::string& bind_ip, epee::net_utils::ssl_support_t ssl_support)
+  bool boosted_tcp_server<t_protocol_handler>::connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeout, const t_callback &cb, const std::string& bind_ip, epee::net_utils::ssl_support_t ssl_support, t_connection_context&& initial)
   {
     TRY_ENTRY();    
-    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_context_, m_state, m_connection_type, ssl_support) );
+    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_context_, m_state, m_connection_type, ssl_support, std::move(initial)) );
     connections_mutex.lock();
     connections_.insert(new_connection_l);
     MDEBUG("connections_ size now " << connections_.size());

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -109,15 +109,17 @@ namespace nodetool
   template<class base_type>
   struct p2p_connection_context_t: base_type //t_payload_net_handler::connection_context //public net_utils::connection_context_base
   {
-    p2p_connection_context_t()
+    explicit p2p_connection_context_t(bool is_ping = false)
       : peer_id(0),
         support_flags(0),
+        is_ping(is_ping),
         m_in_timedsync(false)
     {}
 
     peerid_type peer_id;
     uint32_t support_flags;
     bool m_in_timedsync;
+    bool is_ping;
     std::set<epee::net_utils::network_address> sent_addresses;
   };
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1059,7 +1059,7 @@ namespace nodetool
             {
               ++number_of_in_peers;
             }
-            else
+            else if (!cntxt.is_ping)
             {
               ++number_of_out_peers;
             }
@@ -1970,7 +1970,7 @@ namespace nodetool
     size_t count = 0;
     zone.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
     {
-      if(!cntxt.m_is_income)
+      if(!cntxt.m_is_income && !cntxt.is_ping)
         ++count;
       return true;
     });
@@ -2451,7 +2451,7 @@ namespace nodetool
         return false;
       }
       return true;
-    }, "0.0.0.0", m_ssl_support);
+    }, "0.0.0.0", m_ssl_support, p2p_connection_context{true /* is_ping */});
     if(!r)
     {
       LOG_WARNING_CC(context, "Failed to call connect_async, network error.");


### PR DESCRIPTION
Just as the title says. This gets more accurate reporting internally and externally.