### PR TITLE
crypto: fixes Pointer overflow check

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -763,7 +763,7 @@ POP_WARNINGS
     memcpy(buf.salt, "view_tag", 8); // leave off null terminator
     buf.derivation = derivation;
     tools::write_varint(end, output_index);
-    assert(end <= buf.output_index + sizeof buf.output_index);
+    assert(static_cast<size_t>(end - reinterpret_cast<char *>(&buf.output_index)) <= sizeof buf.output_index);
 
     // view_tag_full = H[salt|derivation|output_index]
     hash view_tag_full;


### PR DESCRIPTION
https://github.com/monero-project/monero/blob/389e3ba1df4a6df4c8f9d116aa239d4c00f5bc78/src/crypto/crypto.cpp#L766-L766

When checking for integer overflow, you may often write tests like p + i < p. This works fine if p and i are unsigned integers, since any overflow in the addition will cause the value to simply "wrap around." However, using this pattern when p is a pointer is problematic because pointer overflow has undefined behavior according to the C and C++ standards. If the addition overflows and has an undefined result, the comparison will likewise be undefined; it may produce an unintended result, or may be deleted entirely by an optimizing compiler.

---


fix this problem, we should avoid pointer arithmetic that could result in undefined behavior. Instead of comparing pointers directly, we should compare the offset (as an integer) between `end` and the start of the buffer to the size of the buffer. Specifically, we can compute the difference as `end - reinterpret_cast<char *>(&buf)` and ensure that this value is less than or equal to the size of the buffer (`sizeof buf`). This approach uses only valid pointer arithmetic (since both pointers are within the same object), and the result is a `ptrdiff_t` or `size_t` value that can be safely compared to the buffer size. The change should be made in the function `crypto_ops::derive_view_tag` in `src/crypto/crypto.cpp`, specifically replacing the assertion on line 766.

### References
Embedded in Academia: [Pointer Overflow Checking](https://blog.regehr.org/archives/1395)
LWN: [GCC and pointer overflows](https://lwn.net/Articles/278137/)