### PR TITLE
epee: include math header for upcoming Boost 1.89

### DIFF
--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "net/abstract_http_client.h"
 #include "net/http_base.h"
 #include "net/net_parse_helpers.h"


### PR DESCRIPTION
When building on Ubuntu 22.04 with GCC 11.4.0 and Boost 1.89.0.beta1, the build failed with:
```
error: ‘floor’ was not declared in this scope
     41 |       num_char = (int)floor((float)num_char / (float)radix);
        |                       ^~~~~
```

https://github.com/monero-project/monero/blob/389e3ba1df4a6df4c8f9d116aa239d4c00f5bc78/contrib/epee/src/abstract_http_client.cpp#L41

Seen while beta testing upcoming Boost 1.89.0 (planned release tomorrow, Aug 13) at Homebrew - https://github.com/Homebrew/homebrew-core/pull/233031

No issues with Boost 1.88.0 so some Boost changes must have resulted in no longer indirectly including `math.h` or `cmath`.