### PR TITLE
cryptonote_basic: add overload for get_block_longhash()

### DIFF
--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -45,7 +45,8 @@ target_link_libraries(blockchain_db
   PUBLIC
     common
     cncrypto
-    ringct
+    cryptonote_basic
+    ringct_basic
     ${LMDB_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(cryptonote_basic
     checkpoints
     cryptonote_format_utils_basic
     device
+    ringct_basic
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -38,7 +38,7 @@
 #include "cryptonote_config.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
-#include "ringct/rctSigs.h"
+#include "ringct/rctOps.h"
 
 using namespace epee;
 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1605,6 +1605,31 @@ namespace cryptonote
     return get_tx_tree_hash(txs_ids);
   }
   //---------------------------------------------------------------
+  crypto::hash get_block_longhash(const blobdata_ref block_hashing_blob,
+    const uint64_t height,
+    const uint8_t major_version,
+    const crypto::hash &seed_hash)
+  {
+    crypto::hash res;
+
+    if (height == 202612) // block 202612 bug workaround
+    {
+      static const std::string longhash_202612 = "84f64766475d51837ac9efbef1926486e58563c95a19fef4aec3254f03000000";
+      epee::string_tools::hex_to_pod(longhash_202612, res);
+    }
+    else if (major_version >= RX_BLOCK_VERSION) // RandomX
+    {
+      crypto::rx_slow_hash(seed_hash.data, block_hashing_blob.data(), block_hashing_blob.size(), res.data);
+    }
+    else // CryptoNight
+    {
+      const int pow_variant = major_version >= 7 ? major_version - 6 : 0;
+      crypto::cn_slow_hash(block_hashing_blob.data(), block_hashing_blob.size(), res, pow_variant, height);
+    }
+
+    return res;
+  }
+  //---------------------------------------------------------------
   bool is_valid_decomposed_amount(uint64_t amount)
   {
     if (0 == amount)

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -261,6 +261,10 @@ namespace cryptonote
   void get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes, crypto::hash& h);
   crypto::hash get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes);
   crypto::hash get_tx_tree_hash(const block& b);
+  crypto::hash get_block_longhash(const blobdata_ref block_hashing_blob,
+    const uint64_t height,
+    const uint8_t major_version,
+    const crypto::hash &seed_hash);
   bool is_valid_decomposed_amount(uint64_t amount);
   void get_hash_stats(uint64_t &tx_hashes_calculated, uint64_t &tx_hashes_cached, uint64_t &block_hashes_calculated, uint64_t & block_hashes_cached);
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -679,29 +679,13 @@ namespace cryptonote
 
   bool get_block_longhash(const Blockchain *pbc, const blobdata& bd, crypto::hash& res, const uint64_t height, const int major_version, const crypto::hash *seed_hash, const int miners)
   {
-    // block 202612 bug workaround
-    if (height == 202612)
+    crypto::hash seed_hash_ = crypto::null_hash;
+    if (pbc != NULL && major_version >= RX_BLOCK_VERSION)
     {
-      static const std::string longhash_202612 = "84f64766475d51837ac9efbef1926486e58563c95a19fef4aec3254f03000000";
-      epee::string_tools::hex_to_pod(longhash_202612, res);
-      return true;
+      const uint64_t seed_height = rx_seedheight(height);
+      seed_hash_ = seed_hash ? *seed_hash : pbc->get_pending_block_id_by_height(seed_height);
     }
-    if (major_version >= RX_BLOCK_VERSION)
-    {
-      crypto::hash hash;
-      if (pbc != NULL)
-      {
-        const uint64_t seed_height = rx_seedheight(height);
-        hash = seed_hash ? *seed_hash : pbc->get_pending_block_id_by_height(seed_height);
-      } else
-      {
-        memset(&hash, 0, sizeof(hash));  // only happens when generating genesis block
-      }
-      rx_slow_hash(hash.data, bd.data(), bd.size(), res.data);
-    } else {
-      const int pow_variant = major_version >= 7 ? major_version - 6 : 0;
-      crypto::cn_slow_hash(bd.data(), bd.size(), res, pow_variant, height);
-    }
+    res = get_block_longhash(bd, height, major_version, seed_hash_);
     return true;
   }
 

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -69,7 +69,6 @@ target_link_libraries(ringct
   PUBLIC
     common
     cncrypto
-    cryptonote_basic
     device
   PRIVATE
     ${OPENSSL_LIBRARIES}

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -28,16 +28,18 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "rctSigs.h"
+
 #include "misc_log_ex.h"
 #include "misc_language.h"
 #include "common/perf_timer.h"
 #include "common/threadpool.h"
 #include "common/util.h"
-#include "rctSigs.h"
 #include "bulletproofs.h"
 #include "bulletproofs_plus.h"
-#include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_config.h"
+#include "device/device.hpp"
+#include "serialization/crypto.h"
 
 using namespace crypto;
 using namespace std;
@@ -612,7 +614,8 @@ namespace rct {
       key prehash;
       CHECK_AND_ASSERT_THROW_MES(const_cast<rctSig&>(rv).serialize_rctsig_base(ba, inputs, outputs),
           "Failed to serialize rctSigBase");
-      cryptonote::get_blob_hash(ss.str(), h);
+      const std::string sig_base_blob = ss.str();
+      cn_fast_hash(sig_base_blob.data(), sig_base_blob.size(), h);
       hashes.push_back(hash2rct(h));
 
       keyV kv;


### PR DESCRIPTION
Moves the core logic for `get_block_longhash()` into `cryptonote_basic` library from `cryptonote_core`. No change in behavior should occur, it's purely a refactoring. 

Depends on #9919