### PR TITLE
functional_tests: fix piecemeal export in cold_signing

### DIFF
--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -102,10 +102,8 @@ class ColdSigningTest():
             res = self.hot_wallet.incoming_transfers()
             num_outputs = len(res.transfers)
             done = [False] * num_outputs
-            while len([x for x in done if not done[x]]) > 0:
-                start = int(random.random() * num_outputs)
-                if start == num_outputs:
-                    num_outputs -= 1
+            while len([x for x in done if not x]) > 0:
+                start = random.choice([i for i in range(len(done)) if not done[i]]) # start at a random undone output
                 count = 1 + int(random.random() * 5)
                 res = self.hot_wallet.export_outputs(all = True, start = start, count = count)
 


### PR DESCRIPTION
The `while` loop condition was incorrect, which could lead to incomplete imports. Also, setting `start` to an *undone* output speeds up the test by 16s on my machine.

Fixes failures caught by #10008