### PR TITLE
epee: only parse valid port

### DIFF
--- a/contrib/epee/src/net_parse_helpers.cpp
+++ b/contrib/epee/src/net_parse_helpers.cpp
@@ -92,7 +92,13 @@ namespace net_utils
     }
     return true;
   }
-  
+
+  static bool parse_port(const std::string& port_str, uint64_t& out_port)
+  {
+    out_port = 0;
+    return boost::conversion::try_lexical_convert(port_str, out_port) && out_port <= 65535;
+  }
+
   bool parse_uri(const std::string uri, http::uri_content& content)
   {
 
@@ -153,7 +159,8 @@ namespace net_utils
     }
     if(result[6].matched)
     {
-      content.port = boost::lexical_cast<uint64_t>(result[6]);
+      if (!parse_port(result[6].str(), content.port))
+        return false;
     }
     if(result[7].matched)
     {
@@ -189,7 +196,8 @@ namespace net_utils
     }
     if(result[6].matched)
     {
-      content.port = boost::lexical_cast<uint64_t>(result[6]);
+      if (!parse_port(result[6].str(), content.port))
+        return false;
     }
     if(result[7].matched)
     {


### PR DESCRIPTION
Reported by hacksandhops and Ada Logic.