### PR TITLE
functional_tests: fix piecemeal export in cold_signing, part 2

### DIFF
--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -122,6 +122,8 @@ class ColdSigningTest():
                     # new outputs first
                     if 'Imported outputs omit more outputs that we know of' not in str(e):
                         raise
+                    else:
+                        continue
                 for i in range(start, start + count):
                     if i < len(done):
                         done[i] = True


### PR DESCRIPTION
Do not mark output import as done if exception is thrown for output being past last imported output.

The reason that the failure is uncommon with #10053 is because the cold wallet already has imported 80 outputs at this point in the test, and we only add ~3 outputs at a time, and import in 1-6 output chunks.