### PR TITLE
ci: macos: reinstall cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: ./.github/actions/set-make-job-count
       - name: install dependencies
         run: |
+          brew uninstall cmake
           brew update
           brew install --quiet cmake boost hidapi openssl zmq miniupnpc expat libunwind-headers protobuf ccache
       - name: build


### PR DESCRIPTION
Fixes CI.

See: https://github.com/monero-project/monero/actions/runs/17346427435/job/49247032842#step:5:75