### PR TITLE
wallet: identify spends in pool when scanning

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1835,7 +1835,7 @@ private:
     bool prepare_file_names(const std::string& file_path);
     void process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height);
     void process_outgoing(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height, uint64_t ts, uint64_t spent, uint64_t received, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
-    void add_unconfirmed_tx(const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
+    void add_unconfirmed_tx(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount_in, const std::vector<cryptonote::tx_destination_entry> &dests, const crypto::hash &payment_id, uint64_t change_amount, uint32_t subaddr_account, const std::set<uint32_t>& subaddr_indices);
     void generate_genesis(cryptonote::block& b) const;
     void check_genesis(const crypto::hash& genesis_hash) const; //throws
     bool generate_chacha_key_from_secret_keys(crypto::chacha_key &key) const;


### PR DESCRIPTION
Fixes #10013 

- Make sure to mark identified spends in the pool as spends. The wallet might not know these have been spent if it wasn't the wallet that relayed the tx to the daemon, or the wallet was cleared via rescan_bc.
- Make sure to add spends to `m_unconfirmed_txs` if not present.
- Make sure to process the entire pool again if refreshing for the first time. The wallet fetches pool and blocks at the same time. The wallet scans blocks first, then pool. If the wallet identifies received outputs in the chain, then it may have spent those received outputs in the pool. So we make sure to re-process the entire pool again after scanning the chain for the first time.
- EDIT: Multisig wallets that know about spent key images can now detect spend txs in the pool. This PR updates tests to account for that new functionality.