### PR TITLE
daemon: kick invalid txs from pool

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1753,6 +1753,98 @@ namespace cryptonote
     return n_removed;
   }
   //---------------------------------------------------------------------------------
+  size_t tx_memory_pool::kick_invalid_txs(const std::unordered_set<crypto::hash> &keep_txids)
+  {
+    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    CRITICAL_REGION_LOCAL1(m_blockchain);
+
+    LockedTXN lock(m_blockchain.get_db());
+
+    const uint64_t cur_n_blocks = m_blockchain.get_db().height();
+
+    // Get all tx id's that reference inputs that can no longer be valid
+    std::vector<crypto::hash> remove;
+    std::unordered_map<uint64_t/*amount*/, uint64_t/*n_outputs*/> n_outputs;
+    m_blockchain.for_all_txpool_txes([&, this](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd) {
+      if (keep_txids.count(txid))
+        return true;
+      if (meta.max_used_block_height > 0)
+      {
+        if (meta.max_used_block_height >= cur_n_blocks)
+          remove.push_back(txid);
+        return true;
+      }
+      cryptonote::transaction tx;
+      if (!parse_and_validate_tx_base_from_blob(*bd, tx))
+      {
+        MWARNING("Failed to parse tx base from txpool, removing");
+        remove.push_back(txid);
+        return true;
+      }
+      for (const auto &vin : tx.vin)
+      {
+        if (vin.type() != typeid(cryptonote::txin_to_key))
+        {
+          MERROR("Unexpected input type in pool");
+          continue;
+        }
+        const cryptonote::txin_to_key &txin = boost::get<cryptonote::txin_to_key>(vin);
+        if (txin.key_offsets.empty())
+        {
+          MERROR("Unexpected empty key_offsets in pool");
+          continue;
+        }
+        const std::vector<uint64_t> output_ids = cryptonote::relative_output_offsets_to_absolute(txin.key_offsets);
+        if (output_ids.empty())
+        {
+          MERROR("Unexpected empty output_ids in pool");
+          continue;
+        }
+        if (!n_outputs.count(txin.amount))
+        {
+          n_outputs[txin.amount] = m_blockchain.get_db().get_num_outputs(txin.amount);
+        }
+        // If any rings in the tx use an output ID that can no longer be in the chain, then remove the tx from pool
+        if (output_ids.back() >= n_outputs[txin.amount])
+        {
+          remove.push_back(txid);
+          break;
+        }
+      }
+      return true;
+    }, true, relay_category::all);
+
+    // Remove them from pool
+    std::size_t count = 0;
+    for (const crypto::hash &txid : remove)
+    {
+      try
+      {
+        size_t weight;
+        uint64_t fee;
+        cryptonote::transaction tx;
+        cryptonote::blobdata blob;
+        bool relayed, do_not_relay, double_spend_seen, pruned;
+        if (!take_tx(txid, tx, blob, weight, fee, relayed, do_not_relay, double_spend_seen, pruned))
+        {
+          MERROR("Failed to remove invalid tx " << txid << " from txpool");
+        }
+        else
+        {
+          MINFO("Removed invalid tx " << txid << " from pool");
+          ++count;
+        }
+        continue;
+      }
+      catch (const std::exception &e)
+      {
+        MERROR("Failed to remove invalid tx " << txid << " from txpool: " << e.what());
+        continue;
+      }
+    }
+    return count;
+  }
+  //---------------------------------------------------------------------------------
   void tx_memory_pool::add_tx_to_transient_lists(const crypto::hash& txid, double fee, time_t receive_time)
   {
 

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -407,6 +407,15 @@ namespace cryptonote
      */
     size_t validate(uint8_t version);
 
+    /**
+     * @brief kick transactions from the pool that reference inputs that can no longer be valid
+     *
+     * @param keep_txids tx ids we don't want to kick
+     *
+     * @return the number of transactions removed
+     */
+    size_t kick_invalid_txs(const std::unordered_set<crypto::hash> &keep_txids);
+
      /**
       * @brief return the cookie
       *


### PR DESCRIPTION
The daemon pops blocks to handle a reorg. Upon popping a block, the daemon places txs from the block back into the pool. Some txs placed back in the pool may have ring signatures that reference outputs that are no longer in the chain.

Without this change, these invalid txs may linger in the pool ([potentially up to 1 week](https://github.com/monero-project/monero/blob/8d4c625713e3419573dfcc7119c8848f47cabbaa/src/cryptonote_core/tx_pool.cpp#L722)), preventing users from re-submitting new valid txs spending inputs that should be spendable.

This change kicks these invalid txs from the pool, allowing users to re-submit new valid txs.