### PR TITLE
wallet2: warn instead of throw when RingDB doesn't include spend

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9300,8 +9300,11 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
               MINFO("Ignoring output " << out << ", too recent");
             }
           }
-          THROW_WALLET_EXCEPTION_IF(!own_found, error::wallet_internal_error,
-              "Known ring does not include the spent output: " + std::to_string(td.m_global_output_index));
+          if (!own_found)
+          {
+            MWARNING("Known ring does not include the spent output: " + std::to_string(td.m_global_output_index)
+                + ", there may have been a reorg that moved the spent output's position in the chain");
+          }
         }
       }
 


### PR DESCRIPTION
A reorg can end up causing an output's position in the chain to move. Since the wallet doesn't update the RingDB on reorg, it may refer to the output's stale position in the chain, and then throw when attempting to spend that output in the future.

Logging a warning instead of throwing seems a reasonable solution rather than introducing complex logic to update the stale ring member's value on rerog, since RingDB can be deprecated with FCMP++, and the downside to warning here is minimal.