### PR TITLE
Address warning when building caused by messages_map.cpp string handling

### DIFF
--- a/src/device_trezor/trezor/messages_map.cpp
+++ b/src/device_trezor/trezor/messages_map.cpp
@@ -45,7 +45,7 @@ namespace trezor
 {
 
   const char * TYPE_PREFIX = "MessageType_";
-  const char * PACKAGES[] = {
+  const std::string PACKAGES[] = {
       "hw.trezor.messages.",
       "hw.trezor.messages.common.",
       "hw.trezor.messages.management.",


### PR DESCRIPTION
when running make debug I noticed the following warning in terminal which goes away with these code changes:

Possibly original person used &text so as to not copy string objects, but that was happening anyways the way it was done and was improperly binding pointer to a temporary object.

/monero/src/device_trezor/trezor/messages_map.cpp: In static member function ‘static google::protobuf::Message* hw::trezor::MessageMapper::get_message(const std::string&)’: /monero/src/device_trezor/trezor/messages_map.cpp:83:23: warning: loop variable ‘text’ of type ‘const std::string&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const char*’ [-Wrange-loop-construct] 83 | for(const string &text : PACKAGES){ | ^~~~ /monero/src/device_trezor/trezor/messages_map.cpp:83:23: note: use non-reference type ‘const std::string’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const char* const&’ to prevent copying 