### PR TITLE
remove 66.85.74.134 as seed node

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -751,7 +751,6 @@ namespace nodetool
     {
       full_addrs.insert("176.9.0.187:18080");
       full_addrs.insert("88.198.163.90:18080");
-      full_addrs.insert("66.85.74.134:18080");
       full_addrs.insert("51.79.173.165:18080");
       full_addrs.insert("192.99.8.110:18080");
       full_addrs.insert("37.187.74.171:18080");


### PR DESCRIPTION
remove 66.85.74.134 as seed node. bastards doubled the price of the server.