### PR TITLE
cryptonote_core: `--dns-version-check` is deprecated

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -706,7 +706,7 @@ namespace cryptonote
     else if (check_updates_string == "update")
       check_updates_level = UPDATES_UPDATE;
     else {
-      MERROR("Invalid argument to --dns-versions-check: " << check_updates_string);
+      MERROR("Invalid argument to --check-updates: " << check_updates_string);
       return false;
     }
 


### PR DESCRIPTION
When issuing an incorrect argument for `--check-updates`, the error shows a flag that no longer exists