### PR TITLE
wallet_rpc_server: allow creating more than 64 addresses at once [0.18]

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -734,9 +734,9 @@ namespace tools
     CHECK_IF_BACKGROUND_SYNCING();
     try
     {
-      if (req.count < 1 || req.count > 64) {
+      if (req.count < 1 || req.count > 65536) {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "Count must be between 1 and 64.";
+        er.message = "Count must be between 1 and 65536.";
         return false;
       }
 


### PR DESCRIPTION
it's too low a limit (at least one person mentioned having to call create_address in a loop due to it)

#8730 by @moneromooo-monero 