### PR TITLE
simplewallet: batch address creation limit to match rpc

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -136,7 +136,7 @@ using tools::fee_priority;
 
 #define REFRESH_PERIOD 90 // seconds
 
-#define MAX_MNEW_ADDRESSES 1000
+#define MAX_MNEW_ADDRESSES 65536
 
 #define CHECK_MULTISIG_ENABLED() \
   do \


### PR DESCRIPTION
in the past, rpc was 64 then changed to 65536.
simplewallet was 1000. not sure why they were/are different values, but seems sane to have it match rpc

edit: I've tested this on cli and it works. Took ~15min to complete.