### PR TITLE
Send ZMQ miner notifications after txpool additions [RELEASE]

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4532,11 +4532,14 @@ leave:
   }
 
   const crypto::hash seedhash = get_block_id_by_height(crypto::rx_seedheight(new_height));
-  send_miner_notifications(new_height, seedhash, id, already_generated_coins);
 
-  // Make sure that txpool notifications happen BEFORE block notifications
+  // Make sure that txpool notifications happen BEFORE block and miner data notifications
   notify_txpool_event(std::move(txpool_events));
 
+  // send miner notifications to switch as soon as possible
+  send_miner_notifications(new_height, seedhash, id, already_generated_coins);
+
+  // then send block notifications
   for (const auto& notifier: m_block_notifiers)
     notifier(new_height - 1, {std::addressof(bl), 1});
 


### PR DESCRIPTION
See #10103 

Bug was introduced in c069c04ede338929c50297558fee15192aa0f67c #9135, before this txpool additions were not notified on block addition. From @SChernykh this only affects v0.18.4.x releases.

When receiving blocks with previously unknown conditions, miner data was sent first, but txpool add events for already-added transactions in previous block were sent afterward. Miners would then include already-mined transactions in their new templates due to receiving the mistimed txpool add event.

The fix is to send miner notifications AFTER txpool events are sent, and before normal block notifications are sent (for mining switch speed purposes)

Fixes c069c04ede338929c50297558fee15192aa0f67c / #9135
Fixes dfee15eee18a97be5a8fb9822527f98ebd1b33e9 / #7891