### PR TITLE
Daemon RPC: fix on_getblockhash error return on too high height

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1852,6 +1852,7 @@ namespace cryptonote
     {
       error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
       error_resp.message = std::string("Requested block height: ") + std::to_string(h) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
+      return false;
     }
     res = string_tools::pod_to_hex(m_core.get_block_id_by_height(h));
     return true;


### PR DESCRIPTION
Notice how the RPC handler needs to return false for the macro handling the function to properly handle the error return:

https://github.com/monero-project/monero/blob/b591866fcfed400bc89631686655aa769ec5f2dd/contrib/epee/include/net/http_server_handlers_map2.h#L216-L223