### PR TITLE
net_node: add hinto seed nodes [v0.18]

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -738,6 +738,7 @@ namespace nodetool
       full_addrs.insert("192.99.8.110:28080");
       full_addrs.insert("37.187.74.171:28080");
       full_addrs.insert("88.99.195.15:28080");
+      full_addrs.insert("5.104.84.64:28080");
     }
     else if (m_nettype == cryptonote::STAGENET)
     {
@@ -746,6 +747,7 @@ namespace nodetool
       full_addrs.insert("192.99.8.110:38080");
       full_addrs.insert("37.187.74.171:38080");
       full_addrs.insert("88.99.195.15:38080");
+      full_addrs.insert("5.104.84.64:38080");
     }
     else if (m_nettype == cryptonote::FAKECHAIN)
     {
@@ -758,6 +760,7 @@ namespace nodetool
       full_addrs.insert("192.99.8.110:18080");
       full_addrs.insert("37.187.74.171:18080");
       full_addrs.insert("88.99.195.15:18080");
+      full_addrs.insert("5.104.84.64:18080");
     }
     return full_addrs;
   }
@@ -894,6 +897,7 @@ namespace nodetool
           "plowsoffjexmxalw73tkjmf422gq6575fc7vicuu4javzn2ynnte6tyd.onion:18083",
           "plowsofe6cleftfmk2raiw5h2x66atrik3nja4bfd3zrfa2hdlgworad.onion:18083",
           "aclc4e2jhhtr44guufbnwk5bzwhaecinax4yip4wr4tjn27sjsfg6zqd.onion:18083",
+          "lykcas4tus7mkm4bhsgqe4drtd4awi7gja24goscc47xfgzj54yofyqd.onion:18083",
         };
       }
       return {};


### PR DESCRIPTION
https://github.com/monero-project/monero/pull/10114

Testnet/stagenet are reachable but still syncing, should be ready before `v0.18.4.3`.