### PR TITLE
crypto: derive key image generator

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -618,6 +618,12 @@ namespace crypto {
     ge_p1p1_to_p3(&res, &point2);
   }
 
+  void crypto_ops::derive_key_image_generator(const public_key &pub, ec_point &ki_gen) {
+    ge_p3 point;
+    hash_to_ec(pub, point);
+    ge_p3_tobytes(&ki_gen, &point);
+  }
+
   void crypto_ops::generate_key_image(const public_key &pub, const secret_key &sec, key_image &image) {
     ge_p3 point;
     ge_p2 point2;

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -129,6 +129,8 @@ namespace crypto {
     friend void generate_tx_proof_v1(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const secret_key &, signature &);
     static bool check_tx_proof(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const signature &, const int);
     friend bool check_tx_proof(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const signature &, const int);
+    static void derive_key_image_generator(const public_key &, ec_point &);
+    friend void derive_key_image_generator(const public_key &, ec_point &);
     static void generate_key_image(const public_key &, const secret_key &, key_image &);
     friend void generate_key_image(const public_key &, const secret_key &, key_image &);
     static void generate_ring_signature(const hash &, const key_image &,
@@ -252,6 +254,10 @@ namespace crypto {
   }
   inline bool check_tx_proof(const hash &prefix_hash, const public_key &R, const public_key &A, const boost::optional<public_key> &B, const public_key &D, const signature &sig, const int version) {
     return crypto_ops::check_tx_proof(prefix_hash, R, A, B, D, sig, version);
+  }
+
+  inline void derive_key_image_generator(const public_key &pub, ec_point &ki_gen) {
+    crypto_ops::derive_key_image_generator(pub, ki_gen);
   }
 
   /* To send money to a key:


### PR DESCRIPTION
Helper function to derive `I` (the key image generator) used in the FCMP++ composition. The key image generator enters the FCMP++ tree as part of an output tuple {output pubkey, key image generator, commitment}.

Note: key images are x*I, where x is the one-time priv key used to spend an output.

See: https://github.com/kayabaNerve/fcmp-plus-plus-paper/blob/6f01fd3296b17f90b5c97c738cc3320e3369ad49/fcmp%2B%2B.pdf