### PR TITLE
crypto: break out fe_pow22523 into separate function

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -1953,26 +1953,18 @@ void sc_reduce(unsigned char *s) {
   s[31] = s11 >> 17;
 }
 
-/* New code */
+/* From fe_pow22523.c */
 
-static void fe_divpowm1(fe r, const fe u, const fe v) {
-  fe v3, uv7, t0, t1, t2;
+void fe_pow22523(fe out, const fe z) {
+  fe t0;
+  fe t1;
+  fe t2;
   int i;
 
-  fe_sq(v3, v);
-  fe_mul(v3, v3, v); /* v3 = v^3 */
-  fe_sq(uv7, v3);
-  fe_mul(uv7, uv7, v);
-  fe_mul(uv7, uv7, u); /* uv7 = uv^7 */
-
-  /*fe_pow22523(uv7, uv7);*/
-
-  /* From fe_pow22523.c */
-
-  fe_sq(t0, uv7);
+  fe_sq(t0, z);
   fe_sq(t1, t0);
   fe_sq(t1, t1);
-  fe_mul(t1, uv7, t1);
+  fe_mul(t1, z, t1);
   fe_mul(t0, t0, t1);
   fe_sq(t0, t0);
   fe_mul(t0, t1, t0);
@@ -2011,12 +2003,24 @@ static void fe_divpowm1(fe r, const fe u, const fe v) {
   fe_mul(t0, t1, t0);
   fe_sq(t0, t0);
   fe_sq(t0, t0);
-  fe_mul(t0, t0, uv7);
+  fe_mul(out, t0, z);
+}
 
-  /* End fe_pow22523.c */
-  /* t0 = (uv^7)^((q-5)/8) */
-  fe_mul(t0, t0, v3);
-  fe_mul(r, t0, u); /* u^(m+1)v^(-(m+1)) */
+/* New code */
+
+static void fe_divpowm1(fe r, const fe u, const fe v) {
+  fe v3, uv7;
+
+  fe_sq(v3, v);
+  fe_mul(v3, v3, v); /* v3 = v^3 */
+  fe_sq(uv7, v3);
+  fe_mul(uv7, uv7, v);
+  fe_mul(uv7, uv7, u); /* uv7 = uv^7 */
+
+  fe_pow22523(r, uv7); /* (uv^7)^((q-5)/8) */
+
+  fe_mul(r, r, v3);
+  fe_mul(r, r, u); /* u^(m+1)v^(-(m+1)) */
 }
 
 static void ge_cached_0(ge_cached *r) {

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -128,6 +128,10 @@ void ge_tobytes(unsigned char *, const ge_p2 *);
 
 void sc_reduce(unsigned char *);
 
+/* From fe_pow22523.c */
+
+void fe_pow22523(fe, const fe);
+
 /* New code */
 
 void ge_scalarmult(ge_p2 *, const unsigned char *, const ge_p3 *);


### PR DESCRIPTION
Used in [sqrt](https://github.com/seraphis-migration/monero/blob/da7bbef285278a1368052730215cb405b35aadd8/src/fcmp_pp/fcmp_pp_crypto.cpp#L75) implemented in FCMP++, which is used in this [`torsion_check_vartime`](https://github.com/seraphis-migration/monero/blob/da7bbef285278a1368052730215cb405b35aadd8/src/fcmp_pp/fcmp_pp_crypto.cpp#L259-L267).

`torsion_check_vartime` is part of an optimization* that wallets use to check outputs and commitments for torsion, before clearing torsion if they do indeed have torsion (most are expected to not have torsion, hence this optimization). Outputs in the tree cannot have torsion. Wallets build the tree locally, and therefore need to make sure torsioned outputs do not enter the tree.

*`torsion_check_vartime` is currently unproven. That is why the integration presently only uses it wallet-side in order to speed up wallet sync, and not at consensus. Wallet-side worst case is a DoS. Daemon-side worst case is inflation. Theoretically we could hold off on using it wallet-side until after the fork, at which point we ban torsioned outputs at consensus, and can therefore be certain the function works correctly for all pre-fork potentially torsioned outputs.