### PR TITLE
Remove the undocumented, unused array type from the portable storage specification

### DIFF
--- a/contrib/epee/include/storages/portable_storage_base.h
+++ b/contrib/epee/include/storages/portable_storage_base.h
@@ -61,7 +61,6 @@
 #define SERIALIZE_TYPE_STRING               10
 #define SERIALIZE_TYPE_BOOL                 11
 #define SERIALIZE_TYPE_OBJECT               12
-#define SERIALIZE_TYPE_ARRAY                13
 
 #define SERIALIZE_FLAG_ARRAY              0x80
 
@@ -141,7 +140,7 @@ namespace epee
     };
 
 
-    typedef  boost::make_recursive_variant<
+    typedef  boost::variant<
       array_entry_t<section>, 
       array_entry_t<uint64_t>, 
       array_entry_t<uint32_t>, 
@@ -154,9 +153,8 @@ namespace epee
       array_entry_t<double>, 
       array_entry_t<bool>, 
       array_entry_t<std::string>,
-      array_entry_t<section>, 
-      array_entry_t<boost::recursive_variant_> 
-    >::type array_entry;
+      array_entry_t<section>
+    > array_entry;
 
     typedef boost::variant<uint64_t, uint32_t, uint16_t, uint8_t, int64_t, int32_t, int16_t, int8_t, double, bool, std::string, section, array_entry> storage_entry;
 

--- a/contrib/epee/include/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/storages/portable_storage_from_bin.h
@@ -227,7 +227,6 @@ namespace epee
       case SERIALIZE_TYPE_BOOL:   return read_ae<bool>();
       case SERIALIZE_TYPE_STRING: return read_ae<std::string>();
       case SERIALIZE_TYPE_OBJECT: return read_ae<section>();
-      case SERIALIZE_TYPE_ARRAY:  return read_ae<array_entry>();
       default: 
         CHECK_AND_ASSERT_THROW_MES(false, "unknown entry_type code = " << type);
       }
@@ -319,7 +318,6 @@ namespace epee
       case SERIALIZE_TYPE_BOOL:   return read_se<bool>();
       case SERIALIZE_TYPE_STRING: return read_se<std::string>();
       case SERIALIZE_TYPE_OBJECT: return read_se<section>();
-      case SERIALIZE_TYPE_ARRAY:  return read_se<array_entry>();
       default: 
         CHECK_AND_ASSERT_THROW_MES(false, "unknown entry_type code = " << ent_type);
       }

--- a/contrib/epee/include/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/storages/portable_storage_to_bin.h
@@ -127,15 +127,6 @@ namespace epee
           pack_entry_to_buff(m_strm, s);
         return true;
       }
-      bool operator()(const array_entry_t<array_entry>& arra_ar)    
-      {
-        uint8_t type = SERIALIZE_TYPE_ARRAY|SERIALIZE_FLAG_ARRAY;
-        m_strm.write((const char*)&type, 1);
-        pack_varint(m_strm, arra_ar.m_array.size());
-        for(const array_entry& s: arra_ar.m_array)
-          pack_entry_to_buff(m_strm, s);
-        return true;
-      }
     };
 
     template<class t_stream>
@@ -178,8 +169,6 @@ namespace epee
 
       bool operator()(const array_entry& v)  
       {
-        //uint8_t type = SERIALIZE_TYPE_ARRAY;
-        //m_strm.write((const char*)&type, 1);
         return pack_entry_to_buff(m_strm, v);
       }
     };

--- a/docs/PORTABLE_STORAGE.md
+++ b/docs/PORTABLE_STORAGE.md
@@ -119,7 +119,6 @@ The types defined are:
 #define SERIALIZE_TYPE_STRING               10
 #define SERIALIZE_TYPE_BOOL                 11
 #define SERIALIZE_TYPE_OBJECT               12
-#define SERIALIZE_TYPE_ARRAY                13
 ```
 
 The entry type can be bitwise OR'ed with a flag:
@@ -146,10 +145,6 @@ little endian byte order.
 
 Entry values which are objects (i.e. `SERIALIZE_TYPE_OBJECT`), are stored as
 [sections](#Section).
-
-Note, I have not yet seen the type `SERIALIZE_TYPE_ARRAY` in use. My assumption
-is this would be used for *untyped* arrays and so subsequent entries could be of
-any type.
 
 ### Overall example
 


### PR DESCRIPTION
This is currently unused, so it shouldn't be an issue to remove. It also likely isn't safe to adopt as it has unclear, potentially not actually implemented, behavior. Removing it now reduces the scope of the codec and prevents introducing usage. This not only promotes some ideal of safety (highly debatable if this is actually safer or just a nit) but makes it easier to safely reimplement the format (as seen in several PRs over the years due to the memory consumption of the original implementation).

Pleasantly removes the of `make_recursive_variant`, which is documented to not be portable. While obviously, it's sufficiently portable that hasn't been an issue, it's nice to note.

I removed all references to the constant and updated the code to compile. There may be some functions that are now unreachable and can also be removed. I did not personally run the full test suite and presume the CI will handle that.

cc @jeffro256 as the person I primarily want to poke for review of this.