### PR TITLE
wallet_rpc_server: add HTTP body size limit

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -398,6 +398,7 @@ namespace tools
     }
 
     m_net_server.set_threads_prefix("RPC");
+    m_net_server.get_config_object().m_max_content_length = MAX_RPC_CONTENT_LENGTH;
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::init(
       rng, std::move(bind_port), std::move(rpc_config->bind_ip),


### PR DESCRIPTION
Sets `m_max_content_length` to `MAX_RPC_CONTENT_LENGTH` (1MB) to match the protection already implemented in `core_rpc_server.cpp` (line 427).

Without this limit, wallet RPC accepts unlimited HTTP body sizes which could lead to resource exhaustion issues.

**Testing:**
- Verified requests under 1MB work normally
- Verified requests over 1MB are rejected
- Behavior now consistent with core RPC server


Addresses private HackerOne security report