### PR TITLE
Cleaner validation (faster and saner)

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3018,21 +3018,6 @@ bool Blockchain::check_tx_outputs(const transaction& tx, tx_verification_context
     }
   }
 
-  // from v4, forbid invalid pubkeys
-  if (hf_version >= 4) {
-    for (const auto &o: tx.vout) {
-      crypto::public_key output_public_key;
-      if (!get_output_public_key(o, output_public_key)) {
-        tvc.m_invalid_output = true;
-        return false;
-      }
-      if (!crypto::check_key(output_public_key)) {
-        tvc.m_invalid_output = true;
-        return false;
-      }
-    }
-  }
-
   // from v8, allow bulletproofs
   if (hf_version < 8) {
     if (tx.version >= 2) {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1050,6 +1050,8 @@ namespace cryptonote
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, tokey_in, false);
+      if (rct::ki2rct(tokey_in.k_image) == rct::identity())
+        return false;
       if (!(rct::scalarmultKey(rct::ki2rct(tokey_in.k_image), rct::curveOrder()) == rct::identity()))
         return false;
     }


### PR DESCRIPTION
`check_tx_outputs` is called in one place, `ver_non_input_consensus_templated`:

```cpp
// Rule 5
if (!core::check_tx_semantic(tx, tvc, hf_version))
    return false;

// Rule 6
if (!Blockchain::check_tx_outputs(tx, tvc, hf_version) || tvc.m_verifivation_failed)
    return false;
```

Note in the snippet above that `core::check_tx_semantic` is called right before `check_tx_outputs`, and calls `check_outs_valid`:

```cpp
  bool core::check_tx_semantic(const transaction& tx, tx_verification_context& tvc,
      uint8_t hf_version)
  {
...
    if(!check_outs_valid(tx))
    {
      MERROR_VER("tx with invalid outputs, rejected for tx id= " << get_transaction_hash(tx));
      tvc.m_verifivation_failed = true;
      tvc.m_invalid_output = true;
      return false;
    }
```

`check_outs_valid` also makes sure output pubkeys are canonical:

```cpp
  bool check_outs_valid(const transaction& tx)
  {
    for(const tx_out& out: tx.vout)
    {
      crypto::public_key output_public_key;
      CHECK_AND_ASSERT_MES(get_output_public_key(out, output_public_key), false, "Failed to get output public key (output type: "
        << out.target.type().name() << "), in transaction id=" << get_transaction_hash(tx));

      if (tx.version == 1)
      {
        CHECK_AND_NO_ASSERT_MES(0 < out.amount, false, "zero amount output in transaction id=" << get_transaction_hash(tx));
      }

      if(!check_key(output_public_key))
        return false;
    }
    return true;
  }
```

Thus, we don't have to call `check_key` for every output pub key in `check_tx_outputs` again. We can safely remove this redundant call to `check_key` inside `check_tx_outputs`. This change saves 1 unnecessary point de-compression for every output pubkey since hf v4, which is a nice perf gain, in addition to the key image sanity check done for clarity + preventing future mistakes.