### PR TITLE
cryptonote_core: rm confusing/redundant BP consensus rule

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3606,22 +3606,6 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       MERROR_VER("Unsupported rct type: " << rv.type);
       return false;
     }
-
-    // for bulletproofs, check they're only multi-output after v8
-    if (rct::is_rct_bulletproof(rv.type))
-    {
-      if (hf_version < 8)
-      {
-        for (const rct::Bulletproof &proof: rv.p.bulletproofs)
-        {
-          if (proof.V.size() > 1)
-          {
-            MERROR_VER("Multi output bulletproofs are invalid before v8");
-            return false;
-          }
-        }
-      }
-    }
   }
   return true;
 }


### PR DESCRIPTION
This rule is confusing/redundant because before v8, no bulletproofs whatsoever were allowed, multi-output or not. And during and after v8, ONLY multi-output bulletproofs were allowed, i.e. exactly 1 bulletproof is allowed which proves the range of all amount commitments in the transaction.

Sources:
  * No BP before v8:
    - https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/cryptonote_core/blockchain.cpp#L3021-L3032
  * Only 1 BP allowed:
    - https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/cryptonote_basic/cryptonote_format_utils.cpp#L174
    - https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/cryptonote_basic/cryptonote_format_utils.cpp#L150
  * BP must cover all outputs:
    - https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/cryptonote_basic/cryptonote_format_utils.cpp#L190-L194
    - https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/cryptonote_basic/cryptonote_format_utils.cpp#L166-L170