### PR TITLE
add getter for daemon proxy

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1547,6 +1547,7 @@ private:
     std::string get_keys_file() const;
     std::string get_daemon_address() const;
     const boost::optional<epee::net_utils::http::login>& get_daemon_login() const { return m_daemon_login; }
+    std::string get_daemon_proxy() const { return m_proxy; }
     uint64_t get_daemon_blockchain_height(std::string& err);
     uint64_t get_daemon_blockchain_target_height(std::string& err);
     uint64_t get_daemon_adjusted_time();


### PR DESCRIPTION
wallet2 already provides getters for connection information, like the daemon address and login credentials.

This PR just adds a getter for the daemon proxy URI, so it can be collected by clients too.