### PR TITLE
wallet: more accurate blockchain height approximation

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12870,17 +12870,26 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
-  // time of v2 fork
-  const time_t fork_time = m_nettype == TESTNET ? 1448285909 : m_nettype == STAGENET ? 1520937818 : 1458748658;
-  // v2 fork block
-  const uint64_t fork_block = m_nettype == TESTNET ? 624634 : m_nettype == STAGENET ? 32000 : 1009827;
+  const size_t wallet_num_hard_forks = m_nettype == TESTNET  ? num_testnet_hard_forks
+                                     : m_nettype == STAGENET ? num_stagenet_hard_forks
+                                     :                         num_mainnet_hard_forks;
+  const hardfork_t *wallet_hard_forks = m_nettype == TESTNET  ? testnet_hard_forks
+                                      : m_nettype == STAGENET ? stagenet_hard_forks
+                                      :                         mainnet_hard_forks;
+  // time of latest fork
+  const time_t fork_time = wallet_hard_forks[wallet_num_hard_forks-1].time;
+  // latest fork block
+  const uint64_t fork_block = wallet_hard_forks[wallet_num_hard_forks-1].height;
   // avg seconds per block
   const int seconds_per_block = DIFFICULTY_TARGET_V2;
   // Calculated blockchain height
-  uint64_t approx_blockchain_height = fork_block + (time(NULL) - fork_time)/seconds_per_block;
+  uint64_t approx_blockchain_height = fork_block;
+  const time_t now = time(NULL);
+  if (now > fork_time)
+    approx_blockchain_height += (now - fork_time) / seconds_per_block;
   // testnet and stagenet got some huge rollbacks, so the estimation is way off
-  static const uint64_t approximate_rolled_back_blocks = m_nettype == TESTNET ? 342100 : m_nettype == STAGENET ? 60000 : 30000;
-  if ((m_nettype == TESTNET || m_nettype == STAGENET) && approx_blockchain_height > approximate_rolled_back_blocks)
+  const uint64_t approximate_rolled_back_blocks = m_nettype == TESTNET ? 26600 : m_nettype == STAGENET ? 48600 : 33600;
+  if (approx_blockchain_height > approximate_rolled_back_blocks)
     approx_blockchain_height -= approximate_rolled_back_blocks;
   LOG_PRINT_L2("Calculated blockchain height: " << approx_blockchain_height);
   return approx_blockchain_height;


### PR DESCRIPTION
## Issue short description

`restore_height` can be set higher than actual block height on wallet creation, due to inaccurate approximation

### Related issues:
- https://github.com/seraphis-migration/monero/pull/130#issue-3475688746
- https://github.com/monero-project/monero/issues/9362#issuecomment-3015964331

_______________________________________________________________

## Changes made:
- Use latest hard fork block ([src](https://github.com/monero-project/monero/blob/master/src/hardforks/hardforks.cpp)) for `get_approximate_blockchain_height()` ([src](https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/wallet/wallet2.cpp#L12829-L12832)).
- Update `approximate_rolled_back_blocks` ([src](https://github.com/monero-project/monero/blob/d32b5bfe18e2f5b979fa8dc3a8966c76159ca722/src/wallet/wallet2.cpp#L12838)) and also apply it for `MAINNET`.

_______________________________________________________________

## Some more info

Note: negative values for `deviation` mean the estimated height is higher than actual height.

Current estimates (starting from v2 height, offset by `approximate_rolled_back_blocks`, one month safety margin):
| nettype  | estimated | actual  | deviation         |
|-         |-          |-        | -                  |
| mainnet  | 3498067   | 3517127 |  19060 (~ 26 days) |
| stagenet | 1942002   | 1964485 |  22483 (~ 31 days) |
| testnet  | 2857971   | 2850082 |  -7889 (~-10 days) |

Note: I included the following table just to show how bad the estimates would be without applying `approximate_rolled_back_blocks`. I'd argue it makes sense to apply it for `MAINNET` and to keep an eye on it when the hard forks get updated in the future. For the actual difference that this PR makes see [Historical deviations](#Historical-deviations) below.

Updated estimates (starting from latest height in `hardforks.cpp`, _without_ `approximate_rolled_back_blocks`, one month safety margin):
| nettype  | estimated | actual  | deviation         |
|-         |-          |-        | -                  |
| mainnet  | 3532426   | 3520682 | -11744 (~-16 days) |
| stagenet | 1994540   | 1967959 | -26581 (~-36 days) |
| testnet  | 2858138   | 2853760 |  -4378 (~ -6 days) |

_______________________________________________________________


## Historical deviations

With help of a [python script](https://gist.github.com/SNeedlewoods/8117d0606325178498e93353c44cd3b3) (search for `NOTE` to find adjustable parameters) I compared the historical deviations between `actual - expected` block height, starting from `fork_block` [src](https://github.com/monero-project/monero/blob/7c6e84466a90f6701ebe09ff8f61ea8af3883181/src/wallet/wallet2.cpp#L13581) until today in one month increments

With old rules (starting from v2 height, offset by `approximate_rolled_back_blocks`, one month safety margin):
```
nettype      min blocks days  max blocks days  avg blocks days
    mainnet      49152  ~ 68      52224  ~ 72      50530  ~ 70
   stagenet      21504  ~ 29      79456  ~110      47401  ~ 65
    testnet      -7268  ~-11     363520  ~504      89514  ~124
```

With new rules (starting from latest height in `hardforks.cpp`,  with adjusted `approximate_rolled_back_blocks`, one month safety margin):
```
nettype      min blocks days  max blocks days  avg blocks days
   mainnet       22016  ~ 30      23040  ~ 32      22440  ~ 31
  stagenet       22272  ~ 30      44032  ~ 61      33261  ~ 46
   testnet       22528  ~ 31      48128  ~ 66      37644  ~ 52
```
