### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/CMakeLists_IOS.txt
+++ b/CMakeLists_IOS.txt
@@ -1,4 +1,4 @@
-# Portions Copyright (c) 2017-2024, The Monero Project
+# Portions Copyright (c) 2017-2025, The Monero Project
 # This file is based off of the https://code.google.com/archive/p/ios-cmake/
 # It has been altered for Monero iOS development
 #

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 All rights reserved.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero
 
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Table of Contents

--- a/cmake/FindCcache.cmake
+++ b/cmake/FindCcache.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/cmake/SetClangTidy.cmake
+++ b/cmake/SetClangTidy.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/cmake/test-libusb-version.c
+++ b/cmake/test-libusb-version.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/cmake/test-protobuf.cpp
+++ b/cmake/test-protobuf.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/cmake/test-static-assert.c
+++ b/cmake/test-static-assert.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/cmake/test-static-assert.cpp
+++ b/cmake/test-static-assert.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/contrib/epee/CMakeLists.txt
+++ b/contrib/epee/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/contrib/epee/include/byte_slice.h
+++ b/contrib/epee/include/byte_slice.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/contrib/epee/include/fnv1.h
+++ b/contrib/epee/include/fnv1.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/include/hex.h
+++ b/contrib/epee/include/hex.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/include/int-util.h
+++ b/contrib/epee/include/int-util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/memwipe.h
+++ b/contrib/epee/include/memwipe.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/mlocker.h
+++ b/contrib/epee/include/mlocker.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/include/net/buffer.h
+++ b/contrib/epee/include/net/buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -8,7 +8,7 @@
 // ! (how ever if in some wonderful juristdictions that is not the case, then why not make another sub-class withat that members and licence it as epee part)
 // ! Working on above premise, IF this is valid in your juristdictions, then consider this code as released as:
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/net/enums.h
+++ b/contrib/epee/include/net/enums.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/contrib/epee/include/net/http_auth.h
+++ b/contrib/epee/include/net/http_auth.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/include/net/network_throttle-detail.hpp
+++ b/contrib/epee/include/net/network_throttle-detail.hpp
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief implementaion for throttling of connection (count and rate-limit speed etc)
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief interface for throttling of connection (count and rate-limit speed etc)
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/rolling_median.h
+++ b/contrib/epee/include/rolling_median.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/serialization/wire.h
+++ b/contrib/epee/include/serialization/wire.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/adapted/list.h
+++ b/contrib/epee/include/serialization/wire/adapted/list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/adapted/vector.h
+++ b/contrib/epee/include/serialization/wire/adapted/vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/error.h
+++ b/contrib/epee/include/serialization/wire/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/field.h
+++ b/contrib/epee/include/serialization/wire/field.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/fwd.h
+++ b/contrib/epee/include/serialization/wire/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/traits.h
+++ b/contrib/epee/include/serialization/wire/traits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/wrapper/defaulted.h
+++ b/contrib/epee/include/serialization/wire/wrapper/defaulted.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/serialization/wire/write.h
+++ b/contrib/epee/include/serialization/wire/write.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/include/storages/portable_storage_bin_utils.h
+++ b/contrib/epee/include/storages/portable_storage_bin_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/include/wipeable_string.h
+++ b/contrib/epee/include/wipeable_string.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/contrib/epee/src/buffer.cpp
+++ b/contrib/epee/src/buffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/src/byte_slice.cpp
+++ b/contrib/epee/src/byte_slice.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/src/byte_stream.cpp
+++ b/contrib/epee/src/byte_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief base for connection, contains e.g. the ratelimit hooks
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/hex.cpp
+++ b/contrib/epee/src/hex.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/src/int-util.cpp
+++ b/contrib/epee/src/int-util.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/levin_base.cpp
+++ b/contrib/epee/src/levin_base.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/contrib/epee/src/memwipe.c
+++ b/contrib/epee/src/memwipe.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/contrib/epee/src/network_throttle-detail.cpp
+++ b/contrib/epee/src/network_throttle-detail.cpp
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief implementaion for throttling of connection (count and rate-limit speed etc)
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/network_throttle.cpp
+++ b/contrib/epee/src/network_throttle.cpp
@@ -26,7 +26,7 @@ Throttling work by:
 
 */
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/contrib/epee/src/wipeable_string.cpp
+++ b/contrib/epee/src/wipeable_string.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,7 +65,7 @@ the previous paragraph is here.
 ## License
 
 Copyright (c) 2009-2015 Pieter Hintjens.
-Copyright (c) 2017-2024, The Monero Project
+Copyright (c) 2017-2025, The Monero Project
 
 This Specification is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/external/db_drivers/CMakeLists.txt
+++ b/external/db_drivers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/external/db_drivers/liblmdb/CMakeLists.txt
+++ b/external/db_drivers/liblmdb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/external/easylogging++/CMakeLists.txt
+++ b/external/easylogging++/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/blockchain_db/locked_txn.h
+++ b/src/blockchain_db/locked_txn.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/blockchain_utilities/README.md
+++ b/src/blockchain_utilities/README.md
@@ -1,6 +1,6 @@
 # Monero Blockchain Utilities
 
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 ## Introduction
 

--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blockchain_utilities.h
+++ b/src/blockchain_utilities/blockchain_utilities.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blocksdat_file.cpp
+++ b/src/blockchain_utilities/blocksdat_file.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/blocksdat_file.h
+++ b/src/blockchain_utilities/blocksdat_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/bootstrap_file.cpp
+++ b/src/blockchain_utilities/bootstrap_file.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/bootstrap_file.h
+++ b/src/blockchain_utilities/bootstrap_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blockchain_utilities/bootstrap_serialization.h
+++ b/src/blockchain_utilities/bootstrap_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/blocks/CMakeLists.txt
+++ b/src/blocks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/src/checkpoints/CMakeLists.txt
+++ b/src/checkpoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/common/aligned.c
+++ b/src/common/aligned.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/aligned.h
+++ b/src/common/aligned.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/apply_permutation.h
+++ b/src/common/apply_permutation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/base58.cpp
+++ b/src/common/base58.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/base58.h
+++ b/src/common/base58.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/combinator.cpp
+++ b/src/common/combinator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/common/combinator.h
+++ b/src/common/combinator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/common_fwd.h
+++ b/src/common/common_fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/container_helpers.h
+++ b/src/common/container_helpers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/data_cache.h
+++ b/src/common/data_cache.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/download.h
+++ b/src/common/download.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/error.cpp
+++ b/src/common/error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/common/error.h
+++ b/src/common/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/common/expect.h
+++ b/src/common/expect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/common/http_connection.h
+++ b/src/common/http_connection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/i18n.cpp
+++ b/src/common/i18n.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/i18n.h
+++ b/src/common/i18n.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/json_util.h
+++ b/src/common/json_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/notify.cpp
+++ b/src/common/notify.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/notify.h
+++ b/src/common/notify.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/password.cpp
+++ b/src/common/password.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/password.h
+++ b/src/common/password.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/perf_timer.h
+++ b/src/common/perf_timer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/pod-class.h
+++ b/src/common/pod-class.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/pruning.cpp
+++ b/src/common/pruning.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/pruning.h
+++ b/src/common/pruning.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/scoped_message_writer.h
+++ b/src/common/scoped_message_writer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/sfinae_helpers.h
+++ b/src/common/sfinae_helpers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/spawn.cpp
+++ b/src/common/spawn.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/spawn.h
+++ b/src/common/spawn.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/stack_trace.h
+++ b/src/common/stack_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/unordered_containers_boost_serialization.h
+++ b/src/common/unordered_containers_boost_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/updates.h
+++ b/src/common/updates.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/utf8.h
+++ b/src/common/utf8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/common/va_args.h
+++ b/src/common/va_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, The Monero Project
+// Copyright (c) 2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/common/varint.h
+++ b/src/common/varint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/crypto/blake256.c
+++ b/src/crypto/blake256.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/blake256.h
+++ b/src/crypto/blake256.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/c_threads.h
+++ b/src/crypto/c_threads.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/crypto/chacha.h
+++ b/src/crypto/chacha.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto-ops-data.c
+++ b/src/crypto/crypto-ops-data.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto-ops.h
+++ b/src/crypto/crypto-ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto_ops_builder/README.md
+++ b/src/crypto/crypto_ops_builder/README.md
@@ -1,6 +1,6 @@
 # Monero
 
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 ## Crypto Ops Builder
 

--- a/src/crypto/crypto_ops_builder/crypto-ops-data.c
+++ b/src/crypto/crypto_ops_builder/crypto-ops-data.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto_ops_builder/crypto-ops-old.c
+++ b/src/crypto/crypto_ops_builder/crypto-ops-old.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto_ops_builder/crypto-ops.h
+++ b/src/crypto/crypto_ops_builder/crypto-ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/crypto_ops_builder/ref10CommentedCombined/MakeCryptoOps.py
+++ b/src/crypto/crypto_ops_builder/ref10CommentedCombined/MakeCryptoOps.py
@@ -15,7 +15,7 @@ print("maybe someone smart can replace the sed with perl..")
 a = ""
 
 license = textwrap.dedent("""\
-    // Copyright (c) 2014-2024, The Monero Project
+    // Copyright (c) 2014-2025, The Monero Project
     // 
     // All rights reserved.
     // 

--- a/src/crypto/crypto_ops_builder/ref10CommentedCombined/crypto-ops.h
+++ b/src/crypto/crypto_ops_builder/ref10CommentedCombined/crypto-ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/duration.h
+++ b/src/crypto/duration.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/crypto/generators.cpp
+++ b/src/crypto/generators.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/generators.h
+++ b/src/crypto/generators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/generic-ops.h
+++ b/src/crypto/generic-ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/groestl.h
+++ b/src/crypto/groestl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/groestl_tables.h
+++ b/src/crypto/groestl_tables.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash-extra-blake.c
+++ b/src/crypto/hash-extra-blake.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash-extra-groestl.c
+++ b/src/crypto/hash-extra-groestl.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash-extra-jh.c
+++ b/src/crypto/hash-extra-jh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash-extra-skein.c
+++ b/src/crypto/hash-extra-skein.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash.c
+++ b/src/crypto/hash.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/hmac-keccak.c
+++ b/src/crypto/hmac-keccak.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/crypto/hmac-keccak.h
+++ b/src/crypto/hmac-keccak.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/crypto/initializer.h
+++ b/src/crypto/initializer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/random.h
+++ b/src/crypto/random.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/crypto/skein_port.h
+++ b/src/crypto/skein_port.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/crypto/tree-hash.c
+++ b/src/crypto/tree-hash.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/crypto/wallet/CMakeLists.txt
+++ b/src/crypto/wallet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, The Monero Project
+# Copyright (c) 2020-2025, The Monero Project
 
 #
 # All rights reserved.

--- a/src/crypto/wallet/crypto.h
+++ b/src/crypto/wallet/crypto.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/crypto/wallet/empty.h.in
+++ b/src/crypto/wallet/empty.h.in
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/account_boost_serialization.h
+++ b/src/cryptonote_basic/account_boost_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/account_generators.h
+++ b/src/cryptonote_basic/account_generators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/blobdatatype.h
+++ b/src/cryptonote_basic/blobdatatype.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/connection_context.cpp
+++ b/src/cryptonote_basic/connection_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/cryptonote_format_utils_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils_basic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_basic/difficulty.h
+++ b/src/cryptonote_basic/difficulty.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/events.h
+++ b/src/cryptonote_basic/events.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/cryptonote_basic/fwd.h
+++ b/src/cryptonote_basic/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/merge_mining.cpp
+++ b/src/cryptonote_basic/merge_mining.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/cryptonote_basic/merge_mining.h
+++ b/src/cryptonote_basic/merge_mining.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/subaddress_index.h
+++ b/src/cryptonote_basic/subaddress_index.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/blockchain_and_pool.h
+++ b/src/cryptonote_core/blockchain_and_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_core/i_core_events.h
+++ b/src/cryptonote_core/i_core_events.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/tx_sanity_check.cpp
+++ b/src/cryptonote_core/tx_sanity_check.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_core/tx_sanity_check.h
+++ b/src/cryptonote_core/tx_sanity_check.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_core/tx_verification_utils.h
+++ b/src/cryptonote_core/tx_verification_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_protocol/CMakeLists.txt
+++ b/src/cryptonote_protocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief This is the place to implement our handlers for protocol network actions, e.g. for ratelimit for download-requests
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer/user in monero.cc project - most of code is from CryptoNote)
 /// @brief This is the original cryptonote protocol network-events handler, modified by us
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2,7 +2,7 @@
 /// @author rfree (current maintainer/user in monero.cc project - most of code is from CryptoNote)
 /// @brief This is the original cryptonote protocol network-events handler, modified by us
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/cryptonote_protocol/enums.h
+++ b/src/cryptonote_protocol/enums.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_protocol/fwd.h
+++ b/src/cryptonote_protocol/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -6,7 +6,7 @@
 
 */
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/command_server.h
+++ b/src/daemon/command_server.h
@@ -9,7 +9,7 @@ Passing RPC commands:
 
 */
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/core.h
+++ b/src/daemon/core.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 //

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/executor.cpp
+++ b/src/daemon/executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/executor.h
+++ b/src/daemon/executor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/daemon/p2p.h
+++ b/src/daemon/p2p.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -6,7 +6,7 @@
 
 */
 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/CMakeLists.txt
+++ b/src/daemonizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/daemonizer/daemonizer.h
+++ b/src/daemonizer/daemonizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/posix_fork.h
+++ b/src/daemonizer/posix_fork.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/daemonizer/windows_daemonizer.inl
+++ b/src/daemonizer/windows_daemonizer.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/windows_service.cpp
+++ b/src/daemonizer/windows_service.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/windows_service.h
+++ b/src/daemonizer/windows_service.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/daemonizer/windows_service_runner.h
+++ b/src/daemonizer/windows_service_runner.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/debug_utilities/CMakeLists.txt
+++ b/src/debug_utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/debug_utilities/dns_checks.cpp
+++ b/src/debug_utilities/dns_checks.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/debug_utilities/object_sizes.cpp
+++ b/src/debug_utilities/object_sizes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_cold.hpp
+++ b/src/device/device_cold.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_io.hpp
+++ b/src/device/device_io.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_io_hid.cpp
+++ b/src/device/device_io_hid.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_io_hid.hpp
+++ b/src/device/device_io_hid.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/log.cpp
+++ b/src/device/log.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device/log.hpp
+++ b/src/device/log.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/device_trezor.hpp
+++ b/src/device_trezor/device_trezor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor.hpp
+++ b/src/device_trezor/trezor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/debug_link.cpp
+++ b/src/device_trezor/trezor/debug_link.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/debug_link.hpp
+++ b/src/device_trezor/trezor/debug_link.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/exceptions.hpp
+++ b/src/device_trezor/trezor/exceptions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/messages_map.cpp
+++ b/src/device_trezor/trezor/messages_map.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/messages_map.hpp
+++ b/src/device_trezor/trezor/messages_map.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/device_trezor/trezor/trezor_defs.hpp
+++ b/src/device_trezor/trezor/trezor_defs.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/gen_multisig/CMakeLists.txt
+++ b/src/gen_multisig/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024, The Monero Project
+# Copyright (c) 2017-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/gen_ssl_cert/CMakeLists.txt
+++ b/src/gen_ssl_cert/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024, The Monero Project
+# Copyright (c) 2017-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/gen_ssl_cert/gen_ssl_cert.cpp
+++ b/src/gen_ssl_cert/gen_ssl_cert.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/hardforks/CMakeLists.txt
+++ b/src/hardforks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/hardforks/hardforks.h
+++ b/src/hardforks/hardforks.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/lmdb/CMakeLists.txt
+++ b/src/lmdb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/src/lmdb/database.cpp
+++ b/src/lmdb/database.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/lmdb/database.h
+++ b/src/lmdb/database.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/error.cpp
+++ b/src/lmdb/error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/lmdb/error.h
+++ b/src/lmdb/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/lmdb/key_stream.h
+++ b/src/lmdb/key_stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/table.cpp
+++ b/src/lmdb/table.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/transaction.h
+++ b/src/lmdb/transaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/util.h
+++ b/src/lmdb/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/value_stream.cpp
+++ b/src/lmdb/value_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/lmdb/value_stream.h
+++ b/src/lmdb/value_stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // All rights reserved.
 //

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/mnemonics/chinese_simplified.h
+++ b/src/mnemonics/chinese_simplified.h
@@ -21,7 +21,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// Code surrounding the word list is Copyright (c) 2014-2024, The Monero Project
+// Code surrounding the word list is Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/mnemonics/dutch.h
+++ b/src/mnemonics/dutch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/english.h
+++ b/src/mnemonics/english.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/english_old.h
+++ b/src/mnemonics/english_old.h
@@ -1,6 +1,6 @@
 // Word list originally created as part of the Electrum project, Copyright (C) 2014 Thomas Voegtlin
 // 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/esperanto.h
+++ b/src/mnemonics/esperanto.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/french.h
+++ b/src/mnemonics/french.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/mnemonics/german.h
+++ b/src/mnemonics/german.h
@@ -1,6 +1,6 @@
 // Word list created by Monero contributor Shrikez
 // 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/italian.h
+++ b/src/mnemonics/italian.h
@@ -1,6 +1,6 @@
 // Word list created by Monero contributor Shrikez
 // 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/japanese.h
+++ b/src/mnemonics/japanese.h
@@ -21,7 +21,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// Code surrounding the word list is Copyright (c) 2014-2024, The Monero Project
+// Code surrounding the word list is Copyright (c) 2014-2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/lojban.h
+++ b/src/mnemonics/lojban.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/mnemonics/portuguese.h
+++ b/src/mnemonics/portuguese.h
@@ -21,7 +21,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// Code surrounding the word list is Copyright (c) 2014-2024, The Monero Project
+// Code surrounding the word list is Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/mnemonics/russian.h
+++ b/src/mnemonics/russian.h
@@ -1,6 +1,6 @@
 // Word list created by Monero contributor sammy007
 // 
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/singleton.h
+++ b/src/mnemonics/singleton.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/mnemonics/spanish.h
+++ b/src/mnemonics/spanish.h
@@ -21,7 +21,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// Code surrounding the word list is Copyright (c) 2014-2024, The Monero Project
+// Code surrounding the word list is Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/CMakeLists.txt
+++ b/src/multisig/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024, The Monero Project
+# Copyright (c) 2017-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/multisig/multisig.cpp
+++ b/src/multisig/multisig.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig.h
+++ b/src/multisig/multisig.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_account.cpp
+++ b/src/multisig/multisig_account.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_account.h
+++ b/src/multisig/multisig_account.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_account_kex_impl.cpp
+++ b/src/multisig/multisig_account_kex_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_clsag_context.cpp
+++ b/src/multisig/multisig_clsag_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_clsag_context.h
+++ b/src/multisig/multisig_clsag_context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_kex_msg.cpp
+++ b/src/multisig/multisig_kex_msg.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/multisig/multisig_kex_msg.h
+++ b/src/multisig/multisig_kex_msg.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_kex_msg_serialization.h
+++ b/src/multisig/multisig_kex_msg_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_tx_builder_ringct.cpp
+++ b/src/multisig/multisig_tx_builder_ringct.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/multisig/multisig_tx_builder_ringct.h
+++ b/src/multisig/multisig_tx_builder_ringct.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 #
 # All rights reserved.

--- a/src/net/dandelionpp.cpp
+++ b/src/net/dandelionpp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/dandelionpp.h
+++ b/src/net/dandelionpp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/error.cpp
+++ b/src/net/error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/error.h
+++ b/src/net/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/fwd.h
+++ b/src/net/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/http.cpp
+++ b/src/net/http.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/i2p_address.cpp
+++ b/src/net/i2p_address.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/i2p_address.h
+++ b/src/net/i2p_address.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/parse.h
+++ b/src/net/parse.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/resolve.cpp
+++ b/src/net/resolve.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/resolve.h
+++ b/src/net/resolve.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/socks.h
+++ b/src/net/socks.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/socks_connect.cpp
+++ b/src/net/socks_connect.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/socks_connect.h
+++ b/src/net/socks_connect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/tor_address.cpp
+++ b/src/net/tor_address.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/tor_address.h
+++ b/src/net/tor_address.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/net/zmq.cpp
+++ b/src/net/zmq.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/net/zmq.h
+++ b/src/net/zmq.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2p/CMakeLists.txt
+++ b/src/p2p/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/CMakeLists.txt
+++ b/src/ringct/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2024, The Monero Project
+# Copyright (c) 2016-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/ringct/bulletproofs.cc
+++ b/src/ringct/bulletproofs.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/bulletproofs.h
+++ b/src/ringct/bulletproofs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/bulletproofs_plus.cc
+++ b/src/ringct/bulletproofs_plus.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/bulletproofs_plus.h
+++ b/src/ringct/bulletproofs_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/multiexp.cc
+++ b/src/ringct/multiexp.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/ringct/multiexp.h
+++ b/src/ringct/multiexp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/ringct/rctCryptoOps.c
+++ b/src/ringct/rctCryptoOps.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/ringct/rctCryptoOps.h
+++ b/src/ringct/rctCryptoOps.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/rpc/bootstrap_node_selector.cpp
+++ b/src/rpc/bootstrap_node_selector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/rpc/bootstrap_node_selector.h
+++ b/src/rpc/bootstrap_node_selector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/core_rpc_server_error_codes.h
+++ b/src/rpc/core_rpc_server_error_codes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/daemon_handler.h
+++ b/src/rpc/daemon_handler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/daemon_messages.cpp
+++ b/src/rpc/daemon_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/daemon_rpc_version.h
+++ b/src/rpc/daemon_rpc_version.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/fwd.h
+++ b/src/rpc/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/rpc/instanciations.cpp
+++ b/src/rpc/instanciations.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/rpc/message.cpp
+++ b/src/rpc/message.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/message.h
+++ b/src/rpc/message.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/rpc/rpc_handler.h
+++ b/src/rpc/rpc_handler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_payment.cpp
+++ b/src/rpc/rpc_payment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_payment.h
+++ b/src/rpc/rpc_payment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_payment_costs.h
+++ b/src/rpc/rpc_payment_costs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_payment_signature.cpp
+++ b/src/rpc/rpc_payment_signature.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_payment_signature.h
+++ b/src/rpc/rpc_payment_signature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_version_str.cpp
+++ b/src/rpc/rpc_version_str.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/rpc_version_str.h
+++ b/src/rpc/rpc_version_str.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/rpc/zmq_pub.h
+++ b/src/rpc/zmq_pub.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/rpc/zmq_server.h
+++ b/src/rpc/zmq_server.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/seraphis_crypto/CMakeLists.txt
+++ b/src/seraphis_crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, The Monero Project
+# Copyright (c) 2021-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/seraphis_crypto/sp_transcript.h
+++ b/src/seraphis_crypto/sp_transcript.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024, The Monero Project
+// Copyright (c) 2022-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/CMakeLists.txt
+++ b/src/serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2024, The Monero Project
+# Copyright (c) 2016-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/binary_utils.h
+++ b/src/serialization/binary_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/containers.h
+++ b/src/serialization/containers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/debug_archive.h
+++ b/src/serialization/debug_archive.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/difficulty_type.h
+++ b/src/serialization/difficulty_type.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/json_archive.h
+++ b/src/serialization/json_archive.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/string.h
+++ b/src/serialization/string.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/tuple.h
+++ b/src/serialization/tuple.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/subaddress.cpp
+++ b/src/wallet/api/subaddress.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/subaddress.h
+++ b/src/wallet/api/subaddress.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/subaddress_account.h
+++ b/src/wallet/api/subaddress_account.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/wallet/message_transporter.cpp
+++ b/src/wallet/message_transporter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/ringdb.cpp
+++ b/src/wallet/ringdb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/wallet/ringdb.h
+++ b/src/wallet/ringdb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/wallet/wallet_rpc_server_error_codes.h
+++ b/src/wallet/wallet_rpc_server_error_codes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/tests/block_weight/CMakeLists.txt
+++ b/tests/block_weight/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/block_weight/block_weight.cpp
+++ b/tests/block_weight/block_weight.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/block_weight/block_weight.py
+++ b/tests/block_weight/block_weight.py
@@ -2,7 +2,7 @@
 # Simulate a maximal block attack on the Monero network
 # This uses the scheme proposed by ArticMine
 # Written by Sarang Nother
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 import sys
 import math
 

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/core_tests/block_reward.cpp
+++ b/tests/core_tests/block_reward.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/block_reward.h
+++ b/tests/core_tests/block_reward.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/block_validation.h
+++ b/tests/core_tests/block_validation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproof_plus.cpp
+++ b/tests/core_tests/bulletproof_plus.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproof_plus.h
+++ b/tests/core_tests/bulletproof_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproofs.cpp
+++ b/tests/core_tests/bulletproofs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/bulletproofs.h
+++ b/tests/core_tests/bulletproofs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chain_split_1.cpp
+++ b/tests/core_tests/chain_split_1.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chain_split_1.h
+++ b/tests/core_tests/chain_split_1.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chain_switch_1.cpp
+++ b/tests/core_tests/chain_switch_1.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chain_switch_1.h
+++ b/tests/core_tests/chain_switch_1.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen001.cpp
+++ b/tests/core_tests/chaingen001.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen_serialization.h
+++ b/tests/core_tests/chaingen_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/chaingen_tests_list.h
+++ b/tests/core_tests/chaingen_tests_list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/double_spend.cpp
+++ b/tests/core_tests/double_spend.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/double_spend.h
+++ b/tests/core_tests/double_spend.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/double_spend.inl
+++ b/tests/core_tests/double_spend.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/integer_overflow.cpp
+++ b/tests/core_tests/integer_overflow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/integer_overflow.h
+++ b/tests/core_tests/integer_overflow.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/multisig.h
+++ b/tests/core_tests/multisig.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/rct.cpp
+++ b/tests/core_tests/rct.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/rct.h
+++ b/tests/core_tests/rct.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/rct2.cpp
+++ b/tests/core_tests/rct2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/rct2.h
+++ b/tests/core_tests/rct2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/ring_signature_1.cpp
+++ b/tests/core_tests/ring_signature_1.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/ring_signature_1.h
+++ b/tests/core_tests/ring_signature_1.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/transaction_tests.cpp
+++ b/tests/core_tests/transaction_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/transaction_tests.h
+++ b/tests/core_tests/transaction_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/core_tests/tx_pool.h
+++ b/tests/core_tests/tx_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/tx_validation.h
+++ b/tests/core_tests/tx_validation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/v2_tests.cpp
+++ b/tests/core_tests/v2_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/v2_tests.h
+++ b/tests/core_tests/v2_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/core_tests/wallet_tools.h
+++ b/tests/core_tests/wallet_tools.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/crypto/cnv4-jit.c
+++ b/tests/crypto/cnv4-jit.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/crypto-ops-data.c
+++ b/tests/crypto/crypto-ops-data.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/crypto-ops.c
+++ b/tests/crypto/crypto-ops.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/crypto-tests.h
+++ b/tests/crypto/crypto-tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/crypto.cpp
+++ b/tests/crypto/crypto.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/hash.c
+++ b/tests/crypto/hash.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/main.cpp
+++ b/tests/crypto/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/crypto/random.c
+++ b/tests/crypto/random.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/difficulty/CMakeLists.txt
+++ b/tests/difficulty/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/difficulty/difficulty.cpp
+++ b/tests/difficulty/difficulty.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/difficulty/generate-data
+++ b/tests/difficulty/generate-data
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/functional_tests/address_book.py
+++ b/tests/functional_tests/address_book.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #encoding=utf-8
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/bans.py
+++ b/tests/functional_tests/bans.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/blockchain.py
+++ b/tests/functional_tests/blockchain.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/cpu_power_test.cpp
+++ b/tests/functional_tests/cpu_power_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/daemon_info.py
+++ b/tests/functional_tests/daemon_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/tests/functional_tests/get_output_distribution.py
+++ b/tests/functional_tests/get_output_distribution.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/http_digest_auth.py
+++ b/tests/functional_tests/http_digest_auth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2024-2024, The Monero Project
+# Copyright (c) 2024-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/integrated_address.py
+++ b/tests/functional_tests/integrated_address.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/k_anonymity.py
+++ b/tests/functional_tests/k_anonymity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2023-2024, The Monero Project
+# Copyright (c) 2023-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/functional_tests/main.cpp
+++ b/tests/functional_tests/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/make_test_signature.cc
+++ b/tests/functional_tests/make_test_signature.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/mining.py
+++ b/tests/functional_tests/mining.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/tests/functional_tests/multisig.py
+++ b/tests/functional_tests/multisig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/p2p.py
+++ b/tests/functional_tests/p2p.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/tests/functional_tests/proofs.py
+++ b/tests/functional_tests/proofs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/rpc_payment.py
+++ b/tests/functional_tests/rpc_payment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/sign_message.py
+++ b/tests/functional_tests/sign_message.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/speed.py
+++ b/tests/functional_tests/speed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/transactions_flow_test.h
+++ b/tests/functional_tests/transactions_flow_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/transactions_generation_from_blockchain.cpp
+++ b/tests/functional_tests/transactions_generation_from_blockchain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/transactions_generation_from_blockchain.h
+++ b/tests/functional_tests/transactions_generation_from_blockchain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/txpool.py
+++ b/tests/functional_tests/txpool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/uri.py
+++ b/tests/functional_tests/uri.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #encoding=utf-8
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/util_resources.py
+++ b/tests/functional_tests/util_resources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2021-2024, The Monero Project
+# Copyright (c) 2021-2025, The Monero Project
 
 #
 # All rights reserved.

--- a/tests/functional_tests/validate_address.py
+++ b/tests/functional_tests/validate_address.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/functional_tests/wallet.py
+++ b/tests/functional_tests/wallet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #encoding=utf-8
 
-# Copyright (c) 2019-2024, The Monero Project
+# Copyright (c) 2019-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/fuzz/base58.cpp
+++ b/tests/fuzz/base58.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/block.cpp
+++ b/tests/fuzz/block.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/bulletproof.cpp
+++ b/tests/fuzz/bulletproof.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/cold-outputs.cpp
+++ b/tests/fuzz/cold-outputs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/fuzzer.cpp
+++ b/tests/fuzz/fuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/fuzzer.h
+++ b/tests/fuzz/fuzzer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/http-client.cpp
+++ b/tests/fuzz/http-client.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/levin.cpp
+++ b/tests/fuzz/levin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/load_from_binary.cpp
+++ b/tests/fuzz/load_from_binary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/load_from_json.cpp
+++ b/tests/fuzz/load_from_json.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/parse_url.cpp
+++ b/tests/fuzz/parse_url.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/signature.cpp
+++ b/tests/fuzz/signature.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/transaction.cpp
+++ b/tests/fuzz/transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/fuzz/tx-extra.cpp
+++ b/tests/fuzz/tx-extra.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/fuzz/utf8.cpp
+++ b/tests/fuzz/utf8.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/hash-target.cpp
+++ b/tests/hash-target.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/hash/CMakeLists.txt
+++ b/tests/hash/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/hash/main.cpp
+++ b/tests/hash/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/io.h
+++ b/tests/io.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/libwallet_api_tests/CMakeLists.txt
+++ b/tests/libwallet_api_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/net_load_tests/CMakeLists.txt
+++ b/tests/net_load_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/net_load_tests/clt.cpp
+++ b/tests/net_load_tests/clt.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/net_load_tests/net_load_tests.h
+++ b/tests/net_load_tests/net_load_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/net_load_tests/srv.cpp
+++ b/tests/net_load_tests/srv.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/performance_tests/bulletproof.h
+++ b/tests/performance_tests/bulletproof.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/bulletproof_plus.h
+++ b/tests/performance_tests/bulletproof_plus.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/check_hash.h
+++ b/tests/performance_tests/check_hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/check_tx_signature.h
+++ b/tests/performance_tests/check_tx_signature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/cn_fast_hash.h
+++ b/tests/performance_tests/cn_fast_hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/cn_slow_hash.h
+++ b/tests/performance_tests/cn_slow_hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/construct_tx.h
+++ b/tests/performance_tests/construct_tx.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/crypto_ops.h
+++ b/tests/performance_tests/crypto_ops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/derive_public_key.h
+++ b/tests/performance_tests/derive_public_key.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/derive_secret_key.h
+++ b/tests/performance_tests/derive_secret_key.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/derive_view_tag.h
+++ b/tests/performance_tests/derive_view_tag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/performance_tests/equality.h
+++ b/tests/performance_tests/equality.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/ge_frombytes_vartime.h
+++ b/tests/performance_tests/ge_frombytes_vartime.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/ge_tobytes.h
+++ b/tests/performance_tests/ge_tobytes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/generate_key_derivation.h
+++ b/tests/performance_tests/generate_key_derivation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/generate_key_image.h
+++ b/tests/performance_tests/generate_key_image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/generate_key_image_helper.h
+++ b/tests/performance_tests/generate_key_image_helper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/generate_keypair.h
+++ b/tests/performance_tests/generate_keypair.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/is_out_to_acc.h
+++ b/tests/performance_tests/is_out_to_acc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/is_valid_decomposed_amount.h
+++ b/tests/performance_tests/is_valid_decomposed_amount.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, The Monero Project
+// Copyright (c) 2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/multi_tx_test_base.h
+++ b/tests/performance_tests/multi_tx_test_base.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/multiexp.h
+++ b/tests/performance_tests/multiexp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/performance_tests/out_can_be_to_acc.h
+++ b/tests/performance_tests/out_can_be_to_acc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/performance_tests/performance_tests.h
+++ b/tests/performance_tests/performance_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/performance_utils.h
+++ b/tests/performance_tests/performance_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/range_proof.h
+++ b/tests/performance_tests/range_proof.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/rct_mlsag.h
+++ b/tests/performance_tests/rct_mlsag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/sc_check.h
+++ b/tests/performance_tests/sc_check.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/performance_tests/sc_reduce32.h
+++ b/tests/performance_tests/sc_reduce32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/sig_clsag.h
+++ b/tests/performance_tests/sig_clsag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/sig_mlsag.h
+++ b/tests/performance_tests/sig_mlsag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/signature.h
+++ b/tests/performance_tests/signature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/single_tx_test_base.h
+++ b/tests/performance_tests/single_tx_test_base.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/performance_tests/subaddress_expand.h
+++ b/tests/performance_tests/subaddress_expand.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/trezor/CMakeLists.txt
+++ b/tests/trezor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/trezor/daemon.h
+++ b/tests/trezor/daemon.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/trezor/tools.cpp
+++ b/tests/trezor/tools.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/trezor/tools.h
+++ b/tests/trezor/tools.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/trezor/trezor_tests.cpp
+++ b/tests/trezor/trezor_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/trezor/trezor_tests.h
+++ b/tests/trezor/trezor_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/tests/unit_tests/account.cpp
+++ b/tests/unit_tests/account.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/aligned.cpp
+++ b/tests/unit_tests/aligned.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/apply_permutation.cpp
+++ b/tests/unit_tests/apply_permutation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/base58.cpp
+++ b/tests/unit_tests/base58.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/block_queue.cpp
+++ b/tests/unit_tests/block_queue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/blockchain_db.cpp
+++ b/tests/unit_tests/blockchain_db.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/bootstrap_node_selector.cpp
+++ b/tests/unit_tests/bootstrap_node_selector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/bulletproofs.cpp
+++ b/tests/unit_tests/bulletproofs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/bulletproofs_plus.cpp
+++ b/tests/unit_tests/bulletproofs_plus.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/canonical_amounts.cpp
+++ b/tests/unit_tests/canonical_amounts.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/chacha.cpp
+++ b/tests/unit_tests/chacha.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/command_line.cpp
+++ b/tests/unit_tests/command_line.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/decompose_amount_into_digits.cpp
+++ b/tests/unit_tests/decompose_amount_into_digits.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/device.cpp
+++ b/tests/unit_tests/device.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/difficulty.cpp
+++ b/tests/unit_tests/difficulty.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/dns_resolver.cpp
+++ b/tests/unit_tests/dns_resolver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/epee_http_server.cpp
+++ b/tests/unit_tests/epee_http_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/expect.cpp
+++ b/tests/unit_tests/expect.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/tests/unit_tests/get_xtype_from_string.cpp
+++ b/tests/unit_tests/get_xtype_from_string.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/hashchain.cpp
+++ b/tests/unit_tests/hashchain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/hmac_keccak.cpp
+++ b/tests/unit_tests/hmac_keccak.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/http.cpp
+++ b/tests/unit_tests/http.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 // 

--- a/tests/unit_tests/json_serialization.h
+++ b/tests/unit_tests/json_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/tests/unit_tests/keccak.cpp
+++ b/tests/unit_tests/keccak.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/lmdb.cpp
+++ b/tests/unit_tests/lmdb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/long_term_block_weight.cpp
+++ b/tests/unit_tests/long_term_block_weight.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/memwipe.cpp
+++ b/tests/unit_tests/memwipe.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/mlocker.cpp
+++ b/tests/unit_tests/mlocker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/mul_div.cpp
+++ b/tests/unit_tests/mul_div.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/multiexp.cpp
+++ b/tests/unit_tests/multiexp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 //
 // All rights reserved.

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/notify.cpp
+++ b/tests/unit_tests/notify.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/output_distribution.cpp
+++ b/tests/unit_tests/output_distribution.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/parse_amount.cpp
+++ b/tests/unit_tests/parse_amount.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/pruning.cpp
+++ b/tests/unit_tests/pruning.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/random.cpp
+++ b/tests/unit_tests/random.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/ringct.cpp
+++ b/tests/unit_tests/ringct.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/ringdb.cpp
+++ b/tests/unit_tests/ringdb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/rolling_median.cpp
+++ b/tests/unit_tests/rolling_median.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/rpc_version_str.cpp
+++ b/tests/unit_tests/rpc_version_str.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/scaling_2021.cpp
+++ b/tests/unit_tests/scaling_2021.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, The Monero Project
+// Copyright (c) 2019-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/sha256.cpp
+++ b/tests/unit_tests/sha256.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/slow_memmem.cpp
+++ b/tests/unit_tests/slow_memmem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/subaddress.cpp
+++ b/tests/unit_tests/subaddress.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/test_notifier.cpp
+++ b/tests/unit_tests/test_notifier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/test_peerlist.cpp
+++ b/tests/unit_tests/test_peerlist.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/test_protocol_pack.cpp
+++ b/tests/unit_tests/test_protocol_pack.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/threadpool.cpp
+++ b/tests/unit_tests/threadpool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/tx_proof.cpp
+++ b/tests/unit_tests/tx_proof.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/unbound.cpp
+++ b/tests/unit_tests/unbound.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/unit_tests_utils.h
+++ b/tests/unit_tests/unit_tests_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/uri.cpp
+++ b/tests/unit_tests/uri.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, The Monero Project
+// Copyright (c) 2016-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/util.cpp
+++ b/tests/unit_tests/util.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/varint.cpp
+++ b/tests/unit_tests/varint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/ver_rct_non_semantics_simple_cached.cpp
+++ b/tests/unit_tests/ver_rct_non_semantics_simple_cached.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/vercmp.cpp
+++ b/tests/unit_tests/vercmp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/tests/unit_tests/wallet_storage.cpp
+++ b/tests/unit_tests/wallet_storage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, The Monero Project
+// Copyright (c) 2023-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/tests/unit_tests/wipeable_string.cpp
+++ b/tests/unit_tests/wipeable_string.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/tests/unit_tests/zmq_rpc.cpp
+++ b/tests/unit_tests/zmq_rpc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 
 // 
 // All rights reserved.

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024, The Monero Project
+# Copyright (c) 2017-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/translations/generate_translations_header.c
+++ b/translations/generate_translations_header.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2013, Sergey Lyubka
-// Copyright (c) 2017-2024, The Monero Project
+// Copyright (c) 2017-2025, The Monero Project
 // All rights reserved.
 // Released under the MIT license.
 

--- a/utils/health/build-scripts/clang-build-time-analyzer-clone-build.sh
+++ b/utils/health/build-scripts/clang-build-time-analyzer-clone-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/clang-build-time-analyzer-run.sh
+++ b/utils/health/clang-build-time-analyzer-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/clang-include-what-you-use-run.sh
+++ b/utils/health/clang-include-what-you-use-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/clang-tidy-run-cc.sh
+++ b/utils/health/clang-tidy-run-cc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/clang-tidy-run-common.sh
+++ b/utils/health/clang-tidy-run-common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/clang-tidy-run-cpp.sh
+++ b/utils/health/clang-tidy-run-cpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/health/valgrind-tests.sh
+++ b/utils/health/valgrind-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 #
 # All rights reserved.
 #

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/utils/python-rpc/framework/rpc.py
+++ b/utils/python-rpc/framework/rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.

--- a/utils/python-rpc/framework/zmq.py
+++ b/utils/python-rpc/framework/zmq.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, The Monero Project
+# Copyright (c) 2018-2025, The Monero Project
 
 # 
 # All rights reserved.


### PR DESCRIPTION
This PR updates the copyright year to 2025 in the entire codebase. I used the following command to programmatically update the year in the entire codebase:

```bash
git grep -l '2024, The Monero Project' | xargs sed -i 's/2024, The Monero Project/2025, The Monero Project/g'
```

I will do the same in the `monero-gui` codebase (I realised the outdated copyright year when I looked into the files for some review): https://github.com/monero-project/monero-gui/pull/4509.