### PR TITLE
wallet: sanity check ring indices only against spendable

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8978,7 +8978,9 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       return;
 
     const auto unique = outs_unique(outs);
-    if (tx_sanity_check(unique.first, unique.second, rct_offsets.empty() ? 0 : rct_offsets.back()))
+    const uint64_t rct_outs_available = rct_offsets.size() >= CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE
+      ? rct_offsets.at(rct_offsets.size() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE) : 0;
+    if (tx_sanity_check(unique.first, unique.second, rct_outs_available))
     {
       return;
     }


### PR DESCRIPTION
In networks with low historical activity (e.g. stressnets), a ginormous spike in activity within the last 10 blocks might cause this sanity check to fail pretty consistently. The change presented in this commit should be moving towards correct behavior since it's not useful to sanity check indices against a set of outputs that aren't currently spendable anyways.