### PR TITLE
tx_memory_pool: speedup get_complement() for large requests

### DIFF
--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -101,6 +101,9 @@ namespace crypto {
 
   constexpr static crypto::hash null_hash = {};
   constexpr static crypto::hash8 null_hash8 = {};
+
+  inline bool operator<(const hash &lhs, const hash &rhs) noexcept { return memcmp(&lhs, &rhs, sizeof(hash)) < 0; }
+  inline bool operator>(const hash &lhs, const hash &rhs) noexcept { return rhs < lhs; }
 }
 
 CRYPTO_MAKE_HASHABLE(hash)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1850,9 +1850,9 @@ namespace cryptonote
     m_blockchain_storage.flush_invalid_blocks();
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_txpool_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes)
+  bool core::get_txpool_complement(std::vector<crypto::hash> hashes, std::vector<cryptonote::blobdata> &txes)
   {
-    return m_mempool.get_complement(hashes, txes);
+    return m_mempool.get_complement(std::move(hashes), txes);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::update_blockchain_pruning()

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -897,7 +897,7 @@ namespace cryptonote
       *
       * @return true iff success, false otherwise
       */
-     bool get_txpool_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes);
+     bool get_txpool_complement(std::vector<crypto::hash> hashes, std::vector<cryptonote::blobdata> &txes);
 
      /**
       * @brief validates some simple properties of a transaction

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -493,7 +493,7 @@ namespace cryptonote
     /**
      * @brief get transactions not in the passed set
      */
-    bool get_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes) const;
+    bool get_complement(std::vector<crypto::hash> hashes, std::vector<cryptonote::blobdata> &txes) const;
 
     /**
      * @brief get info necessary for update of pool-related info in a wallet, preferably incremental

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -863,7 +863,7 @@ namespace cryptonote
     std::vector<cryptonote::blobdata> local_txs;
 
     std::vector<cryptonote::blobdata> txes;
-    if (!m_core.get_txpool_complement(arg.hashes, txes))
+    if (!m_core.get_txpool_complement(std::move(arg.hashes), txes))
     {
       LOG_ERROR_CCONTEXT("failed to get txpool complement");
       return 1;


### PR DESCRIPTION
Changes complexity from $M * N$ to $(2 * N+M) * log2(M)$, where $M$ is the requester's mempool size and $N$ is the responder's mempool size. The FCMP++ stressnet recently hit mempool sizes of ~55k txs. If the requesting node's mempool is populated, this results in an average of $(55000*55000)/2$ (about 1.5 billion) comparisons for the responding node. Under this commit, this would be reduced to $(2 * 55000+55000)*log2(55000)$ comparisons (about 2.6 million), a 99.83% reduction.

This commit is especially noteworthy for FCMP++ stressnet node performance when considering https://github.com/seraphis-migration/monero/pull/177 is merged into the stressnet branch. The cited change makes the pool complement p2p call much more frequently.