### PR TITLE
rpc: remove `COMMAND_RPC_SUBMIT_RAW_TX`

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -337,36 +337,6 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
   //-----------------------------------------------
-  struct COMMAND_RPC_SUBMIT_RAW_TX
-  {
-      struct request_t
-      {
-        std::string address;
-        std::string view_key;
-        std::string tx;
-
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(address)
-          KV_SERIALIZE(view_key)
-          KV_SERIALIZE(tx)  
-        END_KV_SERIALIZE_MAP()
-      };
-      typedef epee::misc_utils::struct_init<request_t> request;
-    
-      
-      struct response_t
-      {
-        std::string status;
-        std::string error;
-        
-        BEGIN_KV_SERIALIZE_MAP()
-          KV_SERIALIZE(status)
-          KV_SERIALIZE(error)
-        END_KV_SERIALIZE_MAP()
-      };
-      typedef epee::misc_utils::struct_init<response_t> response;
-  };
-  //-----------------------------------------------
   struct COMMAND_RPC_GET_TRANSACTIONS
   {
     struct request_t: public rpc_access_request_base


### PR DESCRIPTION
Removes the unused [`COMMAND_RPC_SUBMIT_RAW_TX`](https://github.com/search?q=repo%3Amonero-project%2Fmonero+COMMAND_RPC_SUBMIT_RAW_TX&type=code) type leftover from https://github.com/monero-project/monero/commit/8bfa6c2d9fa13caf363455af46ab0192dbe49897#diff-da6ab0aecdf9547f57bb822783cae11fcfbaf7a2eae0d9cb5dbb69c8fc3b660aR458-R484.

Not to be confused with the used:

https://github.com/monero-project/monero/blob/8a53c96b1229d16f1111cfda1421ba7e18c504b3/src/rpc/core_rpc_server_commands_defs.h#L629