### PR TITLE
Blockchain: cancel pop_blocks() operation on interrupt

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -562,7 +562,7 @@ void Blockchain::pop_blocks(uint64_t nblocks)
     const uint64_t blockchain_height = m_db->height();
     if (blockchain_height > 0)
       nblocks = std::min(nblocks, blockchain_height - 1);
-    while (i < nblocks)
+    while (i < nblocks && !m_cancel.load())
     {
       pop_block_from_blockchain();
       ++i;


### PR DESCRIPTION
On SIGINT, `Blockchain::cancel()` is called, which sets `m_cancel` to `true`. This commit stops attempting to pop blocks from the chain once that flag is set. This should leave the blockchain in a well-defined state, even if the `pop_blocks()` operation itself did not "complete".