### PR TITLE
guix: link libgcc_s statically for Linux targets

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -296,7 +296,7 @@ esac
 
 # LDFLAGS
 case "$HOST" in
-    *linux-gnu*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+    *linux-gnu*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -static-libgcc" ;;
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 


### PR DESCRIPTION
This matches Gitian behavior on the release branch.

This is also fixed by #10198, but I'd rather have it set explicitly here as well.