### PR TITLE
CMake: override option with toolchain variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ include(CheckFunctionExists)
 if (POLICY CMP0148)
     cmake_policy(SET CMP0148 OLD) # https://cmake.org/cmake/help/latest/policy/CMP0148.html
 endif()
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
 include(FindPythonInterp)
 
 if (IOS)


### PR DESCRIPTION
In a Guix build on `master`:

```
CMake Warning (dev) at CMakeLists.txt:406 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'BUILD_TESTS'.

CMake Warning (dev) at CMakeLists.txt:464 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'STATIC'.
```

From `cmake --help-policy CMP0077`:

```
* The ``OLD`` behavior for this policy is to proceed even when a normal
  variable of the same name exists.  If the cache entry does not already
  exist and have a type then it is created and/or given a type and the
  normal variable is removed.

* The ``NEW`` behavior for this policy is to do nothing when a normal
  variable of the same name exists.  The normal variable is not removed.
  The cache entry is not created or updated and is ignored if it exists.
```

The expected behavior is that the variables defined in `toolchain.cmake.in` (such as `STATIC`) override the default options.