### PR TITLE
tx pool: only increment m_txpool_weight for newly added pool txs

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -343,7 +343,8 @@ namespace cryptonote
     }
 
     tvc.m_verifivation_failed = false;
-    m_txpool_weight += tx_weight;
+    if (tvc.m_added_to_pool)
+      m_txpool_weight += tx_weight;
 
     ++m_cookie;
 


### PR DESCRIPTION
Otherwise we can end up double counting txs towards the weight, which can over-state the pool weight. E.g. relay tx to node in stem phase, add its weight to pool weight, then receive tx from another node, then bump the pool weight again. That double counts the tx towards the pool weight.

If the weight exceeds the max, the node will "prune" txs from the pool. Thus, over-counting is probably a cause of, but perhaps not the only cause of: https://github.com/seraphis-migration/monero/issues/148

Tested on stressnet and so far we haven't received any new reports of the issue linked above.