### PR TITLE
docker: StageX bootstrappable static monerod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,16 @@ jobs:
           ${{env.BUILD_DEFAULT}}
           cmake --build build --target test
 
+  build-docker:
+    name: 'Docker'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: build image
+        run: docker build .
+
   source-archive:
     name: "source archive"
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,33 @@
-# Multistage docker build, requires docker 17.05
+FROM stagex/pallet-gcc-gnu-gnu:sx2026.05.0@sha256:c06b4e5e490d7fdc77951510b5256f889a8bd51c6fa9d6c41c7f6c4cea88f35c AS builder
+COPY --from=stagex/core-curl:sx2026.05.0@sha256:7a95abfe88eea0a7afd614d219e0b0f11fd77ce257046489baa0fbbf2fc6c088 . /
+COPY --from=stagex/core-openssl:sx2026.05.0@sha256:9a8cac9cacc5fdcbd09f0cf36b1895f71c02fb92fc9806fae824de1d18f60bb0 . /
+COPY --from=stagex/core-ca-certificates:sx2026.05.0@sha256:7773dae6630aa3bdcc82cfec6c9265c0c501aaf0af67cc73631b09e1cff1b094 . /
+COPY --from=stagex/user-patch:sx2026.05.0@sha256:1d4428893f0ea9abfabc1fb5e365c5593fe10c6ed8ffc592d6528157a4299942 . /
+COPY --from=stagex/core-cmake:sx2026.05.0@sha256:ac023f4f1dfb1f7fb649c63de4f54f072ca206f43311807b1e1fd21edecaf8fe . /
+COPY --from=stagex/core-ncurses:sx2026.05.0@sha256:90cc5d029c5073405f9db39c88b9509b8959bbd8f19d8cd02c20e9350cc40254 . /
 
-# builder stage
-FROM ubuntu:26.04 AS builder
-
-RUN set -ex && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install \
-        build-essential \
-        ca-certificates \
-        cmake \
-        curl \
-        git \
-        pkg-config
-
-WORKDIR /src
+ENV TARGET="x86_64-pc-linux-musl"
+WORKDIR /monero
 COPY . .
 
-ARG NPROC
-RUN set -ex && \
-    git submodule init && git submodule update && \
-    rm -rf build && \
-    if [ -z "$NPROC" ] ; \
-    then make -j$(nproc) depends target=x86_64-linux-gnu ; \
-    else make -j$NPROC depends target=x86_64-linux-gnu ; \
-    fi
+RUN make -C contrib/depends -j$(nproc) download-linux NO_WALLET=1 NO_READLINE=1
 
-# runtime stage
-FROM ubuntu:26.04
+RUN make -C contrib/depends -j$(nproc) HOST="${TARGET}" NO_WALLET=1 NO_READLINE=1
 
-ENV UID=999
+RUN cmake --toolchain "contrib/depends/${TARGET}/share/toolchain.cmake" -S . -B build \
+        -DSTACK_TRACE=OFF \
+        -DBUILD_WALLET=OFF \
+        -DUSE_READLINE=OFF \
+        -DUSE_DEVICE_TREZOR=OFF \
+        -DSTATIC_FLAGS="-static-pie" && \
+    cmake --build build --target daemon --parallel $(nproc)
 
-RUN set -ex && \
-    apt-get update && \
-    apt-get --no-install-recommends --yes install ca-certificates && \
-    apt-get clean && \
-    rm -rf /var/lib/apt
-COPY --from=builder /src/build/x86_64-linux-gnu/release/bin /usr/local/bin/
+FROM scratch
 
-# Create monero user
-RUN useradd --system --user-group --uid $UID monero && \
-	mkdir -p /wallet /home/monero/.bitmonero && \
-	chown -R monero:monero /home/monero/.bitmonero && \
-	chown -R monero:monero /wallet
-
-# Contains the blockchain
-VOLUME /home/monero/.bitmonero
-
-# Generate your wallet via accessing the container and run:
-# cd /wallet
-# monero-wallet-cli
-VOLUME /wallet
+COPY --from=builder /monero/build/bin/monerod /
 
 EXPOSE 18080
 EXPOSE 18081
 
-# switch to user monero
-USER monero
-
-ENTRYPOINT ["monerod"]
+ENTRYPOINT ["/monerod"]
 CMD ["--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"]

--- a/README.md
+++ b/README.md
@@ -566,21 +566,15 @@ Packages are available for
 * Docker
 
     ```bash
-    # Build using all available cores
-    docker build -t monero .
+    # Build image
+    docker build -t monerod .
 
-    # or build using a specific number of cores (reduce RAM requirement)
-    docker build --build-arg NPROC=1 -t monero .
+    # Create a directory on the host for the blockchain
+    mkdir -p /path/to/bitmonero
 
-    # either run in foreground
-    docker run -it -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
-
-    # or in background
-    docker run -it -d -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
+    # Run it
+    docker run -d --user $(id -u):$(id -g) -v /path/to/bitmonero:/.bitmonero -p 18080:18080 -p 18081:18081 monerod
     ```
-
-  * The build needs 3 GB space.
-  * Wait one hour or more
 
 Packaging for your favorite distribution would be a welcome contribution!
 


### PR DESCRIPTION
Produces an image containing only a bootstrappable static `x86_64-pc-linux-musl` `monerod` binary using [StageX](https://codeberg.org/stagex/stagex) and `depends`.