### PR TITLE
build: use `$(MAKE)` instead of `cmake --build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ cmake-debug:
 	cd $(builddir)/debug && cmake -D CMAKE_BUILD_TYPE=Debug $(topdir)
 
 debug: cmake-debug
-	cd $(builddir)/debug && cmake --build .
+	cd $(builddir)/debug && $(MAKE)
 
 # Temporarily disable some tests:
 #  * libwallet_api_tests fail (Issue #895)
@@ -80,7 +80,7 @@ cmake-release:
 	cd $(builddir)/release && cmake -D CMAKE_BUILD_TYPE=Release $(topdir)
 
 release: cmake-release
-	cd $(builddir)/release && cmake --build .
+	cd $(builddir)/release && $(MAKE)
 
 release-test:
 	mkdir -p $(builddir)/release
@@ -92,7 +92,7 @@ release-all:
 
 release-static:
 	mkdir -p $(builddir)/release
-	cd $(builddir)/release && cmake -D STATIC=ON -D ARCH="default" -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
+	cd $(builddir)/release && cmake -D STATIC=ON -D ARCH="default" -D CMAKE_BUILD_TYPE=Release $(topdir) && $(MAKE)
 
 coverage:
 	mkdir -p $(builddir)/debug


### PR DESCRIPTION
- `make -j$(nproc)` = all cores
- `make release -j$(nproc)` = 1 core

`$(MAKE)` was used before [this pr](https://github.com/monero-project/monero/pull/9538) changed it to `cmake --build .`
This reverts back to using `$(MAKE)`

Update: closed because this breaks windows compilation

replaced by: #10323