### PR TITLE
depends: support building without wallet dependencies

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -11,6 +11,8 @@ FALLBACK_DOWNLOAD_PATH ?= https://downloads.getmonero.org/depends-sources
 C_STANDARD ?= c11
 CXX_STANDARD ?= c++17
 
+NO_WALLET ?=
+
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)
 PATCHES_PATH = $(BASEDIR)/patches
@@ -113,8 +115,11 @@ build_id_string:=$(realpath $(GUIX_ENVIRONMENT))
 $(host_arch)_$(host_os)_id_string:=$(realpath $(GUIX_ENVIRONMENT))
 endif
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages)
-native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
+wallet_packages_$(NO_WALLET) = $(wallet_packages)
+wallet_native_packages_$(NO_WALLET) = $(wallet_native_packages)
+
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(wallet_packages_)
+native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages) $(wallet_native_packages_)
 
 all_packages = $(packages) $(native_packages)
 

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -1,18 +1,21 @@
-native_packages := native_protobuf
-packages := boost openssl zeromq unbound sodium protobuf
+native_packages :=
+packages := boost openssl zeromq unbound sodium
+
+ifneq ($(host_os),mingw32)
+packages += ncurses readline
+endif
+
+wallet_native_packages := native_protobuf
+wallet_packages = protobuf
 
 ifneq ($(host_os),android)
-packages += libusb
+wallet_packages += libusb
 endif
 
 ifneq ($(host_os),freebsd)
 ifneq ($(host_os),android)
-packages += hidapi
+wallet_packages += hidapi
 endif
-endif
-
-ifneq ($(host_os),mingw32)
-packages += ncurses readline
 endif
 
 linux_native_packages :=


### PR DESCRIPTION
Pulled from #10208.

Allows for faster builds when only the daemon is needed.