### PR TITLE
cmake: remove iwyu target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,13 +1190,3 @@ endif()
 
 # when ON - will install libwallet_merged into "lib"
 option(BUILD_GUI_DEPS "Build GUI dependencies." OFF)
-
-find_package(PythonInterp)
-find_program(iwyu_tool_path NAMES iwyu_tool.py iwyu_tool)
-if (iwyu_tool_path AND PYTHONINTERP_FOUND)
-  add_custom_target(iwyu
-    COMMAND "${PYTHON_EXECUTABLE}" "${iwyu_tool_path}" -p "${CMAKE_BINARY_DIR}" -- --no_fwd_decls
-    COMMENT "Running include-what-you-use tool"
-    VERBATIM
-  )
-endif()


### PR DESCRIPTION
This doesn't need to exist in our `CMakeLists.txt`, instead use: https://github.com/monero-project/monero/blob/master/utils/health/clang-include-what-you-use-run.sh