### PR TITLE
serialization: revert `VA_ARGS_COMMAPREFIX` usage

### DIFF
--- a/src/common/va_args.h
+++ b/src/common/va_args.h
@@ -33,13 +33,3 @@
 #define PP_THIRD_ARG(a,b,c,...) c
 #define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),true,false,)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
-
-// VA_ARGS_COMMAPREFIX(): VA_ARGS_COMMAPREFIX(__VA_ARGS__) expands to __VA_ARGS__ with a comma in
-// front if more than one argument, else nothing.
-// If __VA_OPT__ supported, use that. Else, use GCC's ,## hack
-#if VA_OPT_SUPPORTED
-#    define VA_ARGS_COMMAPREFIX(...) __VA_OPT__(,) __VA_ARGS__
-#else
-#    define VA_ARGS_COMMAPREFIX(...) , ## __VA_ARGS__
-#endif
-

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -191,9 +191,9 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  * VARINT_FIELD_F(). Otherwise, this macro is similar to
  * BEGIN_SERIALIZE_OBJECT(), as you should list only field serializations.
  */
-#define BEGIN_SERIALIZE_OBJECT_FN(stype, ...)                                           \
-  template <bool W, template <bool> class Archive>                                      \
-  bool do_serialize_object(Archive<W> &ar, stype &v VA_ARGS_COMMAPREFIX(__VA_ARGS__)) {
+#define BEGIN_SERIALIZE_OBJECT_FN(stype)           \
+  template <bool W, template <bool> class Archive> \
+  bool do_serialize_object(Archive<W> &ar, stype &v) {
 
 /*! \macro PREPARE_CUSTOM_VECTOR_SERIALIZATION
  */
@@ -211,10 +211,10 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  *
  * \brief serializes a field \a f tagged \a t  
  */
-#define FIELD_N(t, f, ...)                                    \
+#define FIELD_N(t, f)                    \
   do {							\
     ar.tag(t);						\
-    bool r = do_serialize(ar, f VA_ARGS_COMMAPREFIX(__VA_ARGS__)); \
+    bool r = do_serialize(ar, f); \
     if (!r || !ar.good()) return false;			\
   } while(0);
 
@@ -233,7 +233,7 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  *
  * \brief tags the field with the variable name and then serializes it (for use in a free function)
  */
-#define FIELD_F(f, ...) FIELD_N(#f, v.f VA_ARGS_COMMAPREFIX(__VA_ARGS__))
+#define FIELD_F(f) FIELD_N(#f, v.f)
 
 /*! \macro FIELDS(f)
  *


### PR DESCRIPTION
Partially revert #9287. The fallback for the `VA_ARGS_COMMAPREFIX` macro doesn't work, but the fallback is needed for GCC 7, since `__VA_OPT__` isn't supported until GCC 8.1. We still support GCC 7, so #9287 breaks the build on those platforms.

Issue spotted by @j-berman when trying to build the Monero GUI against the [`fcmp++-alpha-stressnet`](https://github.com/seraphis-migration/monero/tree/fcmp%2B%2B-alpha-stressnet) branch in the Ubuntu 18 docker. The issue wasn't caught by CI since there's no analogue to #9287 merged to the release branch.