### PR TITLE
depends: boost: update to 1.89.0

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1.84.0
-$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
-$(package)_file_name=$(package)_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454
+$(package)_version=1.89.0
+$(package)_download_path=https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
+$(package)_file_name=boost-$($(package)_version)-b2-nodocs.tar.gz
+$(package)_sha256_hash=aa25e7b9c227c21abb8a681efd4fe6e54823815ffc12394c9339de998eb503fb
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release


### PR DESCRIPTION
- File size: 123.1 MB →‬ 73.0 MB (-41%)
- Switching to the `.tar.gz` archive, while not size-optimal, would allow me to drop the `bzip2` dependency from #10208.
  - The only other package that uses a `.tar.bz2` archive is `libusb`, which we don't need to build for the daemon.