### PR TITLE
replace wallet2 with Wallet API in simplewallet

### DIFF
--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -41,7 +41,7 @@ monero_add_executable(simplewallet
   ${simplewallet_private_headers})
 target_link_libraries(simplewallet
   PRIVATE
-    wallet
+    wallet_api
     rpc_base
     cryptonote_core
     cncrypto

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -35,6 +35,7 @@
  */
 
 // use boost bind placeholders for now
+#include <memory>
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
 #include <boost/bind.hpp>
 
@@ -71,12 +72,17 @@
 #include "common/json_util.h"
 #include "ringct/rctSigs.h"
 #include "multisig/multisig.h"
+#include "wallet/api/enote_details.h"
 #include "wallet/wallet_args.h"
+#include "wallet/fee_algorithm.h"
 #include "wallet/fee_priority.h"
 #include "version.h"
 #include <stdexcept>
 #include "wallet/message_store.h"
+#include "wallet/wallet_errors.h"
+#include "net/parse.h"
 #include "QrCode.hpp"
+#include "string_tools.h"
 
 #ifdef WIN32
 #include <boost/locale.hpp>
@@ -91,6 +97,7 @@
 using namespace std;
 using namespace epee;
 using namespace cryptonote;
+using namespace Monero;
 using boost::lexical_cast;
 namespace po = boost::program_options;
 typedef cryptonote::simple_wallet sw;
@@ -107,7 +114,7 @@ using tools::fee_priority;
   bool auto_refresh_enabled = m_auto_refresh_enabled.load(std::memory_order_relaxed); \
   m_auto_refresh_enabled.store(false, std::memory_order_relaxed); \
   /* stop any background refresh and other processes, and take over */ \
-  m_wallet->stop(); \
+  m_wallet_impl->stop(); \
   boost::unique_lock<boost::mutex> lock(m_idle_mutex); \
   m_idle_cond.notify_all(); \
   const epee::scope_guard scope_exit_handler([&](){ \
@@ -119,8 +126,9 @@ using tools::fee_priority;
 #define SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(code) \
   LOCK_IDLE_SCOPE(); \
   boost::optional<tools::password_container> pwd_container = boost::none; \
-  if (m_wallet->ask_password() && !(pwd_container = get_and_verify_password())) { code; } \
-  tools::wallet_keys_unlocker unlocker(*m_wallet, pwd_container ? &pwd_container->password() : nullptr);
+  if (m_wallet_impl->getAskPasswordType() != Wallet::AskPasswordType::AskPassword_Never && !(pwd_container = get_and_verify_password())) { code; } \
+  std::unique_ptr<Monero::WalletKeysDecryptGuard> unlocker = \
+          m_wallet_impl->createKeysDecryptGuard(std::string_view(pwd_container ? pwd_container->password().data() : "", pwd_container ? pwd_container->password().size() : 0))
 
 #define SCOPED_WALLET_UNLOCK() SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return true;)
 
@@ -134,6 +142,13 @@ using tools::fee_priority;
     return true; \
   } while(0)
 
+#define SHORT_PAYMENT_ID_WITHOUT_INTEGRATED_ADDRESS_SUPPORT_CHECK() \
+  do { \
+    fail_msg_writer() << tr("Short payment IDs are supposed to be used with integrated addresses."); \
+    fail_msg_writer() << tr("If you want to make a payment with a certain payment_id, the receiver has to generate an address with `integrated_address <payment_id>`"); \
+    return true; \
+  } while(0)
+
 #define REFRESH_PERIOD 90 // seconds
 
 #define MAX_MNEW_ADDRESSES 65536
@@ -141,7 +156,7 @@ using tools::fee_priority;
 #define CHECK_MULTISIG_ENABLED() \
   do \
   { \
-    if (!m_wallet->is_multisig_enabled()) \
+    if (!m_wallet_impl->getEnableMultisig()) \
     { \
       fail_msg_writer() << tr("Multisig is disabled."); \
       fail_msg_writer() << tr("Multisig is an experimental feature and may have bugs. Things that could go wrong include: funds sent to a multisig wallet can't be spent at all, can only be spent with the participation of a malicious group member, or can be stolen by a malicious group member."); \
@@ -151,16 +166,40 @@ using tools::fee_priority;
     } \
   } while(0)
 
+#define CHECK_MULTISIG_READY() \
+  const MultisigState ms_status{m_wallet_impl->multisig()}; \
+  do \
+  { \
+    if (m_wallet_impl->getDeviceState().key_on_device) \
+    { \
+      fail_msg_writer() << tr("command not supported by HW wallet"); \
+      return false; \
+    } \
+    if (!ms_status.isMultisig) \
+    { \
+      fail_msg_writer() << tr("This wallet is not multisig"); \
+      return false; \
+    } \
+    if (!ms_status.isReady) \
+    { \
+      fail_msg_writer() << tr("This multisig wallet is not yet finalized"); \
+      return false; \
+    } \
+  } while(0)
+
 #define CHECK_IF_BACKGROUND_SYNCING(msg) \
   do \
   { \
-    if (m_wallet->is_background_wallet() || m_wallet->is_background_syncing()) \
+    if (m_wallet_impl->isBackgroundWallet() || m_wallet_impl->isBackgroundSyncing()) \
     { \
-      std::string type = m_wallet->is_background_wallet() ? "background wallet" : "background syncing wallet"; \
+      std::string type = m_wallet_impl->isBackgroundWallet() ? "background wallet" : "background syncing wallet"; \
       fail_msg_writer() << boost::format(tr("%s %s")) % type % msg; \
       return false; \
     } \
   } while (0)
+
+// Copied from wallet2, used by save_to_file() and load_from_file()
+static const std::string ASCII_OUTPUT_MAGIC = "MoneroAsciiDataV1";
 
 namespace
 {
@@ -184,22 +223,47 @@ namespace
   const command_line::arg_descriptor<std::string> arg_restore_date = {"restore-date", sw::tr("Restore from estimated blockchain height on specified date"), ""};
   const command_line::arg_descriptor<bool> arg_do_not_relay = {"do-not-relay", sw::tr("The newly created transaction will not be relayed to the monero network"), false};
   const command_line::arg_descriptor<bool> arg_create_address_file = {"create-address-file", sw::tr("Create an address file for new wallets"), false};
-  const command_line::arg_descriptor<std::string> arg_subaddress_lookahead = {"subaddress-lookahead", tools::wallet2::tr("Set subaddress lookahead sizes to <major>:<minor>"), ""};
+  const command_line::arg_descriptor<std::string> arg_subaddress_lookahead = {"subaddress-lookahead", sw::tr("Set subaddress lookahead sizes to <major>:<minor>"), ""};
   const command_line::arg_descriptor<bool> arg_use_english_language_names = {"use-english-language-names", sw::tr("Display English language names"), false};
+  const command_line::arg_descriptor<std::string> arg_daemon_address = {"daemon-address", sw::tr("Use daemon instance at <host>:<port>"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_host = {"daemon-host", sw::tr("Use daemon instance at host <arg> instead of localhost"), ""};
+  const command_line::arg_descriptor<std::string> arg_proxy = {"proxy", sw::tr("[<ip>:]<port> socks proxy to use for daemon connections"), {}, true};
+  const command_line::arg_descriptor<bool> arg_trusted_daemon = {"trusted-daemon", sw::tr("Enable commands which rely on a trusted daemon"), false};
+  const command_line::arg_descriptor<bool> arg_untrusted_daemon = {"untrusted-daemon", sw::tr("Disable commands which rely on a trusted daemon"), false};
+  const command_line::arg_descriptor<std::string> arg_password = {"password", sw::tr("Wallet password (escape/quote as needed)"), "", true};
+  const command_line::arg_descriptor<std::string> arg_password_file = wallet_args::arg_password_file();
+  const command_line::arg_descriptor<int> arg_daemon_port = {"daemon-port", sw::tr("Use daemon instance at port <arg> instead of 18081"), 0};
+  const command_line::arg_descriptor<std::string> arg_daemon_login = {"daemon-login", sw::tr("Specify username[:password] for daemon RPC client"), "", true};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl = {"daemon-ssl", sw::tr("Enable SSL on daemon RPC connections: enabled|disabled|autodetect"), "autodetect"};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_private_key = {"daemon-ssl-private-key", sw::tr("Path to a PEM format private key"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_certificate = {"daemon-ssl-certificate", sw::tr("Path to a PEM format certificate"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_ca_certificates = {"daemon-ssl-ca-certificates", sw::tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s).")};
+  const command_line::arg_descriptor<std::vector<std::string>> arg_daemon_ssl_allowed_fingerprints = {"daemon-ssl-allowed-fingerprints", sw::tr("List of valid fingerprints of allowed RPC servers")};
+  const command_line::arg_descriptor<bool> arg_daemon_ssl_allow_any_cert = {"daemon-ssl-allow-any-cert", sw::tr("Allow any SSL certificate from the daemon"), false};
+  const command_line::arg_descriptor<bool> arg_daemon_ssl_allow_chained = {"daemon-ssl-allow-chained", sw::tr("Allow user (via --daemon-ssl-ca-certificates) chain certificates"), false};
+  const command_line::arg_descriptor<bool> arg_allow_mismatched_daemon_version = {"allow-mismatched-daemon-version", sw::tr("Allow communicating with a daemon that uses a different version"), false};
+  const command_line::arg_descriptor<bool> arg_testnet = {"testnet", sw::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
+  const command_line::arg_descriptor<bool> arg_stagenet = {"stagenet", sw::tr("For stagenet. Daemon must also be launched with --stagenet flag"), false};
+  const command_line::arg_descriptor<uint64_t> arg_kdf_rounds = {"kdf-rounds", sw::tr("Number of rounds for the key derivation function"), 1};
+  const command_line::arg_descriptor<std::string> arg_hw_device = {"hw-device", sw::tr("HW device to use"), ""};
+  const command_line::arg_descriptor<std::string> arg_hw_device_derivation_path = {"hw-device-deriv-path", sw::tr("HW device wallet derivation path (e.g., SLIP-10)"), ""};
+  const command_line::arg_descriptor<std::string> arg_tx_notify = { "tx-notify" , sw::tr("Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash") , "" };
+  const command_line::arg_descriptor<bool> arg_offline = {"offline", sw::tr("Do not connect to a daemon, nor use DNS"), false};
+  const command_line::arg_descriptor<std::string> arg_extra_entropy = {"extra-entropy", sw::tr("File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, which typically means more than 256 bits of data)")};
 
   const command_line::arg_descriptor< std::vector<std::string> > arg_command = {"command", ""};
 
   const char* USAGE_START_MINING("start_mining [<number_of_threads>] [bg_mining] [ignore_battery]");
-  const char* USAGE_SET_DAEMON("set_daemon <host>[:<port>] [trusted|untrusted|this-is-probably-a-spy-node]");
+  const char* USAGE_SET_DAEMON("set_daemon <host>[:<port>] [trusted|untrusted|this-is-probably-a-spy-node] [login=<user>[:<password>]] [proxy=[<ip>:]<port>]");
   const char* USAGE_SHOW_BALANCE("balance [detail]");
   const char* USAGE_INCOMING_TRANSFERS("incoming_transfers [available|unavailable] [verbose] [uses] [index=<N1>[,<N2>[,...]]]");
   const char* USAGE_PAYMENTS("payments <PID_1> [<PID_2> ... <PID_N>]");
   const char* USAGE_PAYMENT_ID("payment_id");
-  const char* USAGE_TRANSFER("transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <amount>) [subtractfeefrom=<D0>[,<D1>,all,...]] [<payment_id>]");
-  const char* USAGE_SWEEP_ALL("sweep_all [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address> [<payment_id (obsolete)>]");
-  const char* USAGE_SWEEP_ACCOUNT("sweep_account <account> [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address> [<payment_id (obsolete)>]");
-  const char* USAGE_SWEEP_BELOW("sweep_below <amount_threshold> [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> [<payment_id (obsolete)>]");
-  const char* USAGE_SWEEP_SINGLE("sweep_single [<priority>] [<ring_size>] [outputs=<N>] <key_image> <address> [<payment_id (obsolete)>]");
+  const char* USAGE_TRANSFER("transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <amount>) [subtractfeefrom=<D0>[,<D1>,all,...]]");
+  const char* USAGE_SWEEP_ALL("sweep_all [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address>");
+  const char* USAGE_SWEEP_ACCOUNT("sweep_account <account> [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] [outputs=<N>] <address>");
+  const char* USAGE_SWEEP_BELOW("sweep_below <amount_threshold> [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] [outputs=<N>] <address>");
+  const char* USAGE_SWEEP_SINGLE("sweep_single [<priority>] [<ring_size>] [outputs=<N>] <key_image> <address>");
   const char* USAGE_DONATE("donate [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <amount>");
   const char* USAGE_SIGN_TRANSFER("sign_transfer [export_raw] [<filename>]");
   const char* USAGE_SET_LOG("set_log <level>|{+,-,}<categories>");
@@ -218,7 +282,7 @@ namespace
   const char* USAGE_SET_TX_KEY("set_tx_key <txid> <tx_key> [<subaddress>]");
   const char* USAGE_CHECK_TX_KEY("check_tx_key <txid> <txkey> <address>");
   const char* USAGE_GET_TX_PROOF("get_tx_proof <txid> <address> [<message>]");
-  const char* USAGE_CHECK_TX_PROOF("check_tx_proof <txid> <address> <signature_file> [<message>]");
+  const char* USAGE_CHECK_TX_PROOF("check_tx_proof <txid> <address> ( <signature_file> | <signature> ) [<message>]");
   const char* USAGE_GET_SPEND_PROOF("get_spend_proof <txid> [<message>]");
   const char* USAGE_CHECK_SPEND_PROOF("check_spend_proof <txid> <signature_file> [<message>]");
   const char* USAGE_GET_RESERVE_PROOF("get_reserve_proof (all|<amount>) [<message>]");
@@ -246,33 +310,11 @@ namespace
   const char* USAGE_SIGN_MULTISIG("sign_multisig <filename>");
   const char* USAGE_SUBMIT_MULTISIG("submit_multisig <filename>");
   const char* USAGE_EXPORT_RAW_MULTISIG_TX("export_raw_multisig_tx <filename>");
-  const char* USAGE_MMS("mms [<subcommand> [<subcommand_parameters>]]");
-  const char* USAGE_MMS_INIT("mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>");
-  const char* USAGE_MMS_INFO("mms info");
-  const char* USAGE_MMS_SIGNER("mms signer [<number> <label> [<transport_address> [<monero_address>]]]");
-  const char* USAGE_MMS_LIST("mms list");
-  const char* USAGE_MMS_NEXT("mms next [sync]");
-  const char* USAGE_MMS_SYNC("mms sync");
-  const char* USAGE_MMS_TRANSFER("mms transfer <transfer_command_arguments>");
-  const char* USAGE_MMS_DELETE("mms delete (<message_id> | all)");
-  const char* USAGE_MMS_SEND("mms send [<message_id>]");
-  const char* USAGE_MMS_RECEIVE("mms receive");
-  const char* USAGE_MMS_EXPORT("mms export <message_id>");
-  const char* USAGE_MMS_NOTE("mms note [<label> <text>]");
-  const char* USAGE_MMS_SHOW("mms show <message_id>");
-  const char* USAGE_MMS_SET("mms set <option_name> [<option_value>]");
-  const char* USAGE_MMS_SEND_SIGNER_CONFIG("mms send_signer_config");
-  const char* USAGE_MMS_START_AUTO_CONFIG("mms start_auto_config [<label> <label> ...]");
-  const char* USAGE_MMS_CONFIG_CHECKSUM("mms config_checksum");
-  const char* USAGE_MMS_STOP_AUTO_CONFIG("mms stop_auto_config");
-  const char* USAGE_MMS_AUTO_CONFIG("mms auto_config <auto_config_token>");
   const char* USAGE_PRINT_RING("print_ring <key_image> | <txid>");
   const char* USAGE_SET_RING("set_ring <filename> | ( <key_image> absolute|relative <index> [<index>...] )");
-  const char* USAGE_UNSET_RING("unset_ring <txid> | ( <key_image> [<key_image>...] )");
-  const char* USAGE_SAVE_KNOWN_RINGS("save_known_rings");
-  const char* USAGE_FREEZE("freeze <key_image>");
-  const char* USAGE_THAW("thaw <key_image>");
-  const char* USAGE_FROZEN("frozen <key_image>");
+  const char* USAGE_FREEZE("freeze <key_image> | <enote_pubkey>");
+  const char* USAGE_THAW("thaw <key_image> | <enote_pubkey>");
+  const char* USAGE_FROZEN("frozen [<key_image> | <enote_pubkey>]");
   const char* USAGE_LOCK("lock");
   const char* USAGE_NET_STATS("net_stats");
   const char* USAGE_PUBLIC_NODES("public_nodes");
@@ -338,27 +380,6 @@ namespace
     return password_prompter(verify ? sw::tr("Enter a custom password for the background sync cache") : sw::tr("Background sync cache password"), verify);
   }
 
-  inline std::string interpret_rpc_response(bool ok, const std::string& status)
-  {
-    std::string err;
-    if (ok)
-    {
-      if (status == CORE_RPC_STATUS_BUSY)
-      {
-        err = sw::tr("daemon is busy. Please try again later.");
-      }
-      else if (status != CORE_RPC_STATUS_OK)
-      {
-        err = status;
-      }
-    }
-    else
-    {
-      err = sw::tr("possibly lost connection to daemon");
-    }
-    return err;
-  }
-
   tools::scoped_message_writer success_msg_writer(bool color = false)
   {
     return tools::scoped_message_writer(color ? console_color_green : console_color_default, false, std::string(), el::Level::Info);
@@ -421,17 +442,17 @@ namespace
   const struct
   {
     const char *name;
-    tools::wallet2::RefreshType refresh_type;
+    Wallet::RefreshType refresh_type;
   } refresh_type_names[] =
   {
-    { "full", tools::wallet2::RefreshFull },
-    { "optimize-coinbase", tools::wallet2::RefreshOptimizeCoinbase },
-    { "optimized-coinbase", tools::wallet2::RefreshOptimizeCoinbase },
-    { "no-coinbase", tools::wallet2::RefreshNoCoinbase },
-    { "default", tools::wallet2::RefreshDefault },
+    { "full", Wallet::RefreshType::Refresh_Full },
+    { "optimize-coinbase", Wallet::RefreshType::Refresh_OptimizeCoinbase },
+    { "optimized-coinbase", Wallet::RefreshType::Refresh_OptimizeCoinbase },
+    { "no-coinbase", Wallet::RefreshType::Refresh_NoCoinbase },
+    { "default", Wallet::RefreshType::Refresh_Default },
   };
 
-  bool parse_refresh_type(const std::string &s, tools::wallet2::RefreshType &refresh_type)
+  bool parse_refresh_type(const std::string &s, Wallet::RefreshType &refresh_type)
   {
     for (size_t n = 0; n < sizeof(refresh_type_names) / sizeof(refresh_type_names[0]); ++n)
     {
@@ -445,7 +466,7 @@ namespace
     return false;
   }
 
-  std::string get_refresh_type_name(tools::wallet2::RefreshType type)
+  std::string get_refresh_type_name(Wallet::RefreshType type)
   {
     for (size_t n = 0; n < sizeof(refresh_type_names) / sizeof(refresh_type_names[0]); ++n)
     {
@@ -458,15 +479,15 @@ namespace
   const struct
   {
     const char *name;
-    tools::wallet2::BackgroundSyncType background_sync_type;
+    Wallet::BackgroundSyncType background_sync_type;
   } background_sync_type_names[] =
   {
-    { "off", tools::wallet2::BackgroundSyncOff },
-    { "reuse-wallet-password", tools::wallet2::BackgroundSyncReusePassword },
-    { "custom-background-password", tools::wallet2::BackgroundSyncCustomPassword },
+    { "off", Wallet::BackgroundSync_Off },
+    { "reuse-wallet-password", Wallet::BackgroundSync_ReusePassword },
+    { "custom-background-password", Wallet::BackgroundSync_CustomPassword },
   };
 
-  bool parse_background_sync_type(const std::string &s, tools::wallet2::BackgroundSyncType &background_sync_type)
+  bool parse_background_sync_type(const std::string &s, Wallet::BackgroundSyncType &background_sync_type)
   {
     for (size_t n = 0; n < sizeof(background_sync_type_names) / sizeof(background_sync_type_names[0]); ++n)
     {
@@ -480,7 +501,7 @@ namespace
     return false;
   }
 
-  std::string get_background_sync_type_name(tools::wallet2::BackgroundSyncType type)
+  std::string get_background_sync_type_name(Wallet::BackgroundSyncType type)
   {
     for (size_t n = 0; n < sizeof(background_sync_type_names) / sizeof(background_sync_type_names[0]); ++n)
     {
@@ -568,7 +589,7 @@ namespace
   bool parse_subtract_fee_from_outputs
   (
     const std::string& arg,
-    tools::wallet2::unique_index_container& subtract_fee_from_outputs,
+    std::set<uint32_t>& subtract_fee_from_outputs,
     bool& subtract_fee_from_all,
     bool& matches
   )
@@ -618,129 +639,236 @@ namespace
     }
     return (boost::filesystem::path(wallet_dir) / path).string();
   }
-} // anonymous namespace
 
-void simple_wallet::handle_transfer_exception(const std::exception_ptr &e, bool trusted_daemon)
-{
-    bool warn_of_possible_attack = !trusted_daemon;
-    try
+  bool get_nettype(const boost::program_options::variables_map &vm, NetworkType &nettype_out)
+  {
+    bool is_testnet = command_line::has_arg(vm, arg_testnet);
+    bool is_stagenet = command_line::has_arg(vm, arg_stagenet);
+    if (is_testnet && is_stagenet)
     {
-      std::rethrow_exception(e);
+      fail_msg_writer() << tr("Can't specify more than one of --testnet and --stagenet");
+      return false;
     }
-    catch (const tools::error::deprecated_rpc_access&)
+    nettype_out = is_testnet ? NetworkType::TESTNET :
+                  is_stagenet ? NetworkType::STAGENET :
+                  NetworkType::MAINNET;
+    return true;
+  }
+
+  bool get_daemon_address(const boost::program_options::variables_map &vm, std::string &daemon_address, std::string &daemon_username, std::string &daemon_password)
+  {
+    daemon_address = command_line::get_arg(vm, arg_daemon_address);
+    auto daemon_host = command_line::get_arg(vm, arg_daemon_host);
+    auto daemon_port = command_line::get_arg(vm, arg_daemon_port);
+
+    THROW_WALLET_EXCEPTION_IF(!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port,
+        tools::error::wallet_internal_error, sw::tr("can't specify daemon host or port more than once"));
+
+    if (daemon_host.empty())
+      daemon_host = "localhost";
+
+    if (!daemon_port)
     {
-      fail_msg_writer() << tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722");
+      NetworkType nettype;
+      if (!get_nettype(vm, nettype))
+        return false;
+      daemon_port = get_config(static_cast<network_type>(nettype)).RPC_DEFAULT_PORT;
     }
-    catch (const tools::error::no_connection_to_daemon&)
+
+    if (daemon_address.empty())
+      daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
+
+    if (command_line::has_arg(vm, arg_daemon_login))
     {
-      fail_msg_writer() << sw::tr("no connection to daemon. Please make sure daemon is running.");
+      std::function<boost::optional<tools::password_container>(const char *, bool)> pw_prompter = password_prompter;
+      auto parsed = tools::login::parse(
+        command_line::get_arg(vm, arg_daemon_login), false, [pw_prompter](bool verify) {
+          if (!pw_prompter)
+          {
+            MERROR("Password needed without prompt function");
+            return boost::optional<tools::password_container>();
+          }
+          return pw_prompter("Daemon client password", verify);
+        }
+      );
+      if (!parsed)
+        return false;
+
+      daemon_username = std::move(parsed->username);
+      epee::wipeable_string daemon_pw = std::move(parsed->password).password();
+      daemon_password = std::string(daemon_pw.data(), daemon_pw.size());
     }
-    catch (const tools::error::daemon_busy&)
+
+    return true;
+  }
+
+  bool get_daemon_init_settings(const boost::program_options::variables_map &vm,
+                                std::string &daemon_address,
+                                std::string &daemon_username,
+                                std::string &daemon_password,
+                                boost::optional<bool> &trusted_daemon,
+                                Monero::Wallet::SSLSupport &ssl_support,
+                                std::string &ssl_private_key_path,
+                                std::string &ssl_certificate_path,
+                                std::string &ssl_ca_file_path,
+                                std::vector<std::string> &ssl_allowed_fingerprints_str,
+                                bool &ssl_allow_any_cert,
+                                std::string &proxy)
+  {
+    if (!get_daemon_address(vm, daemon_address, daemon_username, daemon_password))
+      return false;
+
+    std::string ssl_support_str = command_line::get_arg(vm, arg_daemon_ssl);
+    ssl_private_key_path = command_line::get_arg(vm, arg_daemon_ssl_private_key);
+    ssl_certificate_path = command_line::get_arg(vm, arg_daemon_ssl_certificate);
+    ssl_ca_file_path     = command_line::get_arg(vm, arg_daemon_ssl_ca_certificates);
+    ssl_allowed_fingerprints_str = command_line::get_arg(vm, arg_daemon_ssl_allowed_fingerprints);
+    ssl_allow_any_cert   = command_line::get_arg(vm, arg_daemon_ssl_allow_any_cert);
+
+    const bool use_proxy = command_line::has_arg(vm, arg_proxy);
+
+    // user specified CA file or fingeprints implies enabled SSL by default
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    if (ssl_allow_any_cert)
+      ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+    else if (!ssl_ca_file_path.empty() || !ssl_allowed_fingerprints_str.empty())
     {
-      fail_msg_writer() << tr("daemon is busy. Please try again later.");
-    }
-    catch (const tools::error::wallet_rpc_error& e)
-    {
-      LOG_ERROR("RPC error: " << e.to_string());
-      fail_msg_writer() << sw::tr("RPC error: ") << e.what();
-    }
-    catch (const tools::error::get_outs_error &e)
-    {
-      fail_msg_writer() << sw::tr("failed to get random outputs to mix: ") << e.what();
-    }
-    catch (const tools::error::not_enough_unlocked_money& e)
-    {
-      LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
-        print_money(e.available()) %
-        print_money(e.tx_amount()));
-      fail_msg_writer() << sw::tr("Not enough money in unlocked balance");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::not_enough_money& e)
-    {
-      LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
-        print_money(e.available()) %
-        print_money(e.tx_amount()));
-      fail_msg_writer() << sw::tr("Not enough money in unlocked balance");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::tx_not_possible& e)
-    {
-      LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)") %
-        print_money(e.available()) %
-        print_money(e.tx_amount() + e.fee())  %
-        print_money(e.tx_amount()) %
-        print_money(e.fee()));
-      fail_msg_writer() << sw::tr("Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::not_enough_outs_to_mix& e)
-    {
-      auto writer = fail_msg_writer();
-      writer << sw::tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
-      for (std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs())
+      std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ ssl_allowed_fingerprints_str.size() };
+      std::transform(ssl_allowed_fingerprints_str.begin(), ssl_allowed_fingerprints_str.end(), ssl_allowed_fingerprints.begin(), epee::from_hex_locale::to_vector);
+      for (const auto &fpr: ssl_allowed_fingerprints)
       {
-        writer << "\n" << sw::tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << sw::tr("found outputs to use") << " = " << outs_for_amount.second;
+        THROW_WALLET_EXCEPTION_IF(fpr.size() != SSL_FINGERPRINT_SIZE, tools::error::wallet_internal_error,
+            "SHA-256 fingerprint should be " BOOST_PP_STRINGIZE(SSL_FINGERPRINT_SIZE) " bytes long.");
       }
-      writer << sw::tr("Please use sweep_unmixable.");
-    }
-    catch (const tools::error::tx_not_constructed&)
-    {
-      fail_msg_writer() << sw::tr("transaction was not constructed");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::tx_rejected& e)
-    {
-      fail_msg_writer() << (boost::format(sw::tr("transaction %s was rejected by daemon")) % get_transaction_hash(e.tx()));
-      std::string reason = e.reason();
-      if (!reason.empty())
-        fail_msg_writer() << sw::tr("Reason: ") << reason;
-    }
-    catch (const tools::error::tx_sum_overflow& e)
-    {
-      fail_msg_writer() << e.what();
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::zero_amount&)
-    {
-      fail_msg_writer() << sw::tr("destination amount is zero");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::zero_destination&)
-    {
-      fail_msg_writer() << sw::tr("transaction has no destination");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::tx_too_big& e)
-    {
-      fail_msg_writer() << sw::tr("failed to find a suitable way to split transactions");
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::transfer_error& e)
-    {
-      LOG_ERROR("unknown transfer error: " << e.to_string());
-      fail_msg_writer() << sw::tr("unknown transfer error: ") << e.what();
-    }
-    catch (const tools::error::multisig_export_needed& e)
-    {
-      LOG_ERROR("Multisig error: " << e.to_string());
-      fail_msg_writer() << sw::tr("Multisig error: ") << e.what();
-      warn_of_possible_attack = false;
-    }
-    catch (const tools::error::wallet_internal_error& e)
-    {
-      LOG_ERROR("internal error: " << e.to_string());
-      fail_msg_writer() << sw::tr("internal error: ") << e.what();
-    }
-    catch (const std::exception& e)
-    {
-      LOG_ERROR("unexpected error: " << e.what());
-      fail_msg_writer() << sw::tr("unexpected error: ") << e.what();
+
+      ssl_options = epee::net_utils::ssl_options_t{
+        std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)
+      };
+
+      if (command_line::get_arg(vm, arg_daemon_ssl_allow_chained))
+        ssl_options.verification = epee::net_utils::ssl_verification_t::user_ca;
     }
 
-    if (warn_of_possible_attack)
-      fail_msg_writer() << sw::tr("There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.");
-}
+    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_daemon_ssl))
+    {
+      THROW_WALLET_EXCEPTION_IF(!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support_str), tools::error::wallet_internal_error,
+         sw::tr("Invalid argument for ") + std::string(arg_daemon_ssl.name));
+      ssl_support = static_cast<Wallet::SSLSupport>(ssl_options.support);
+    }
+
+    ssl_options.auth = epee::net_utils::ssl_authentication_t{
+      std::move(ssl_private_key_path), std::move(ssl_certificate_path)
+    };
+
+    {
+      const boost::string_ref real_daemon = boost::string_ref{daemon_address}.substr(0, daemon_address.rfind(':'));
+
+      // If SSL or proxy is enabled, then a specific cert, CA or fingerprint must
+      // be specified. This is specific to the wallet.
+      const bool verification_required =
+        ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+        (ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || use_proxy);
+
+      THROW_WALLET_EXCEPTION_IF(
+        verification_required && !ssl_options.has_strong_verification(real_daemon),
+        tools::error::wallet_internal_error,
+        sw::tr("Enabling --") + std::string{use_proxy ? arg_proxy.name : arg_daemon_ssl.name} + sw::tr(" requires --") +
+          arg_daemon_ssl_allow_any_cert.name + sw::tr(" or --") +
+          arg_daemon_ssl_ca_certificates.name + sw::tr(" or --") + arg_daemon_ssl_allowed_fingerprints.name + sw::tr(" or use of a .onion/.i2p domain")
+      );
+    }
+
+    if (use_proxy)
+    {
+      proxy = command_line::get_arg(vm, arg_proxy);
+      THROW_WALLET_EXCEPTION_IF(
+        !net::get_tcp_endpoint(proxy),
+        tools::error::wallet_internal_error,
+        std::string{"Invalid address specified for --"} + arg_proxy.name);
+    }
+
+    if (!command_line::is_arg_defaulted(vm, arg_trusted_daemon) || !command_line::is_arg_defaulted(vm, arg_untrusted_daemon))
+      trusted_daemon = command_line::get_arg(vm, arg_trusted_daemon) && !command_line::get_arg(vm, arg_untrusted_daemon);
+    THROW_WALLET_EXCEPTION_IF(!command_line::is_arg_defaulted(vm, arg_trusted_daemon) && !command_line::is_arg_defaulted(vm, arg_untrusted_daemon),
+      tools::error::wallet_internal_error, sw::tr("--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted"));
+
+    // set --trusted-daemon if local and not overridden
+    if (!trusted_daemon)
+    {
+      try
+      {
+        trusted_daemon = false;
+        if (tools::is_local_address(daemon_address))
+        {
+          MINFO(sw::tr("Daemon is local, assuming trusted"));
+          trusted_daemon = true;
+        }
+      }
+      catch (const std::exception &e) { }
+    }
+
+    return true;
+  }
+
+  bool get_fake_outs_count(const std::unique_ptr<Wallet> &w, std::vector<std::string> &local_args, size_t &fake_outs_count)
+  {
+    const size_t min_ring_size = w->getMinRingSize();
+    fake_outs_count = std::max<size_t>(min_ring_size, 1) - 1;
+    if(local_args.size() > 0) {
+      size_t ring_size;
+      if(!epee::string_tools::get_xtype_from_string(ring_size, local_args[0]))
+      {
+      }
+      else if (ring_size == 0 && min_ring_size > 0)
+      {
+        fail_msg_writer() << tr("Ring size must not be 0");
+        return false;
+      }
+      else if (min_ring_size == 0 && w->getMaxRingSize() == 0)
+      {
+        if (ring_size != 0)
+        {
+          fail_msg_writer() << tr("Ring size must be 0");
+          return false;
+        }
+        fake_outs_count = 0;
+        local_args.erase(local_args.begin());
+        return true;
+      }
+      else
+      {
+        fake_outs_count = ring_size - 1;
+        local_args.erase(local_args.begin());
+      }
+    }
+    uint64_t adjusted_fake_outs_count = w->adjustMixin(fake_outs_count);
+    if (adjusted_fake_outs_count > fake_outs_count)
+    {
+      fail_msg_writer() << (boost::format(tr("ring size %u is too small, minimum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
+      return false;
+    }
+    if (adjusted_fake_outs_count < fake_outs_count)
+    {
+      fail_msg_writer() << (boost::format(tr("ring size %u is too large, maximum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
+      return false;
+    }
+    return true;
+  }
+
+  bool is_short_payment_id(const std::string &payment_id)
+  {
+    // 8 bytes = 16 hex chars
+    return payment_id.size() == 16 && Wallet::paymentIdValid(payment_id);
+  }
+  bool is_long_payment_id(const std::string &payment_id)
+  {
+    // 32 bytes = 64 hex chars
+    return payment_id.size() == 64 && Wallet::paymentIdValid(payment_id);
+  }
+
+//----------------------------------------------------------------------------------------------------
+
+} // anonymous namespace
 
 namespace
 {
@@ -772,12 +900,12 @@ namespace
   }
 }
 
-bool parse_priority(const std::string& arg, fee_priority& priority)
+bool parse_priority(const std::string& arg, std::uint32_t& priority)
 {
   const auto priority_optional = tools::fee_priority_utilities::from_string(arg);
   if (!priority_optional.has_value())
     return false;
-  priority = priority_optional.value();
+  priority = tools::fee_priority_utilities::as_integral(priority_optional.value());
   return true;
 }
 
@@ -829,22 +957,25 @@ bool simple_wallet::viewkey(const std::vector<std::string> &args/* = std::vector
 {
   // don't log
   PAUSE_READLINE();
-  if (m_wallet->key_on_device()) {
+  if (m_wallet_impl->getDeviceState().key_on_device) {
     std::cout << "secret: On device. Not available" << std::endl;
   } else {
     SCOPED_WALLET_UNLOCK();
     printf("secret: ");
-    print_secret_key(m_wallet->get_account().get_keys().m_view_secret_key);
+    crypto::secret_key view_key;
+    if (!epee::string_tools::hex_to_pod(m_wallet_impl->secretViewKey(), view_key))
+        return false;
+    print_secret_key(view_key);
     putchar('\n');
   }
-  std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_view_public_key) << std::endl;
+  std::cout << "public: " << m_wallet_impl->publicViewKey() << std::endl;
 
   return true;
 }
 
 bool simple_wallet::spendkey(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and has no spend key");
     return true;
@@ -852,15 +983,18 @@ bool simple_wallet::spendkey(const std::vector<std::string> &args/* = std::vecto
   CHECK_IF_BACKGROUND_SYNCING("has no spend key");
   // don't log
   PAUSE_READLINE();
-  if (m_wallet->key_on_device()) {
+  if (m_wallet_impl->getDeviceState().key_on_device) {
     std::cout << "secret: On device. Not available" << std::endl;
   } else {
     SCOPED_WALLET_UNLOCK();
     printf("secret: ");
-    print_secret_key(m_wallet->get_account().get_keys().m_spend_secret_key);
+    crypto::secret_key spend_key;
+    if (!epee::string_tools::hex_to_pod(m_wallet_impl->secretSpendKey(), spend_key))
+        return false;
+    print_secret_key(spend_key);
     putchar('\n');
   }
-  std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_spend_public_key) << std::endl;
+  std::cout << "public: " << m_wallet_impl->publicSpendKey() << std::endl;
 
   return true;
 }
@@ -870,22 +1004,22 @@ bool simple_wallet::print_seed(bool encrypted)
   bool success =  false;
   epee::wipeable_string seed;
 
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and has no seed");
     return true;
   }
   CHECK_IF_BACKGROUND_SYNCING("has no seed");
 
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-  if (ms_status.multisig_is_active)
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (ms_status.isMultisig)
   {
-    if (!ms_status.is_ready)
+    if (!ms_status.isReady)
     {
       fail_msg_writer() << tr("wallet is multisig but not yet finalized");
       return true;
@@ -894,7 +1028,7 @@ bool simple_wallet::print_seed(bool encrypted)
 
   SCOPED_WALLET_UNLOCK();
 
-  if (!ms_status.multisig_is_active && !m_wallet->is_deterministic())
+  if (!ms_status.isMultisig && !m_wallet_impl->isDeterministic())
   {
     fail_msg_writer() << tr("wallet is non-deterministic and has no seed");
     return true;
@@ -909,10 +1043,16 @@ bool simple_wallet::print_seed(bool encrypted)
     seed_pass = pwd_container->password();
   }
 
-  if (ms_status.multisig_is_active)
-    success = m_wallet->get_multisig_seed(seed, seed_pass);
-  else if (m_wallet->is_deterministic())
-    success = m_wallet->get_seed(seed, seed_pass);
+  if (ms_status.isMultisig)
+  {
+    seed = m_wallet_impl->getMultisigSeed(std::string(seed_pass.data(), seed_pass.size()));
+    success = seed != "";
+  }
+  else if (m_wallet_impl->isDeterministic())
+  {
+    seed = m_wallet_impl->seed(std::string(seed_pass.data(), seed_pass.size()));
+    success = seed != "";
+  }
 
   if (success) 
   {
@@ -937,23 +1077,23 @@ bool simple_wallet::encrypted_seed(const std::vector<std::string> &args/* = std:
 
 bool simple_wallet::restore_height(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  success_msg_writer() << m_wallet->get_refresh_from_block_height();
+  success_msg_writer() << m_wallet_impl->getRefreshFromBlockHeight();
   return true;
 }
 
 bool simple_wallet::seed_set_language(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("wallet is multisig and has no seed");
     return true;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and has no seed");
     return true;
@@ -964,7 +1104,7 @@ bool simple_wallet::seed_set_language(const std::vector<std::string> &args/* = s
   {
     SCOPED_WALLET_UNLOCK();
 
-    if (!m_wallet->is_deterministic())
+    if (!m_wallet_impl->isDeterministic())
     {
       fail_msg_writer() << tr("wallet is non-deterministic and has no seed");
       return true;
@@ -987,8 +1127,8 @@ bool simple_wallet::seed_set_language(const std::vector<std::string> &args/* = s
   if (mnemonic_language.empty())
     return true;
 
-  m_wallet->set_seed_language(std::move(mnemonic_language));
-  m_wallet->rewrite(m_wallet_file, password);
+  m_wallet_impl->setSeedLanguage(std::move(mnemonic_language));
+  m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(password.data(), password.size()));
   return true;
 }
 
@@ -1007,14 +1147,15 @@ bool simple_wallet::change_password(const std::vector<std::string> &args)
   if(!pwd_container)
     return true;
 
-  try
+  if (!m_wallet_impl->setPassword(std::string_view(orig_pwd_container->password().data(),
+                                                   orig_pwd_container->password().size()),
+                                  std::string_view(pwd_container->password().data(),
+                                                   pwd_container->password().size())))
   {
-    m_wallet->change_password(m_wallet->get_wallet_file(), orig_pwd_container->password(), pwd_container->password());
-  }
-  catch (const tools::error::wallet_logic_error& e)
-  {
-    fail_msg_writer() << tr("Error with wallet rewrite: ") << e.what();
-    return true;
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("Error with wallet rewrite: ") << error_msg;
   }
 
   return true;
@@ -1029,8 +1170,17 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
 {
   if (!try_connect_to_daemon())
     return true;
-  const bool per_byte = m_wallet->use_fork_rules(HF_VERSION_PER_BYTE_FEE);
-  const uint64_t base_fee = m_wallet->get_base_fee();
+  int error_code;
+  std::string error_msg;
+  const bool per_byte = m_wallet_impl->useForkRules(HF_VERSION_PER_BYTE_FEE, 0);
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("Error trying to determine hard-fork rules: ") << error_msg;
+    return true;
+  }
+
+  const uint64_t base_fee = m_wallet_impl->getBaseFee();
   const char *base = per_byte ? "byte" : "kB";
   const uint64_t typical_size = per_byte ? 2500 : 13;
   const uint64_t size_granularity = per_byte ? 1 : 1024;
@@ -1041,18 +1191,22 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
   {
     if (priority == fee_priority::Default)
       continue;
-    uint64_t mult = m_wallet->get_fee_multiplier(priority);
+    uint64_t mult = m_wallet_impl->getFeeMultiplier(tools::fee_priority_utilities::as_integral(priority), static_cast<int>(tools::fee_algorithm::Unset));
     fees.push_back(base_fee * typical_size * mult);
   }
   std::vector<std::pair<uint64_t, uint64_t>> blocks;
-  try
+  uint64_t base_size = typical_size * size_granularity;
+  std::vector<std::pair<double, double>> fee_levels;
+  for (uint64_t fee: fees)
   {
-    uint64_t base_size = typical_size * size_granularity;
-    blocks = m_wallet->estimate_backlog(base_size, base_size + size_granularity - 1, fees);
+    double our_fee_byte_min = fee / (double)base_size, our_fee_byte_max = fee / (double)(base_size + size_granularity);
+    fee_levels.emplace_back(our_fee_byte_min, our_fee_byte_max);
   }
-  catch (const std::exception &e)
+  blocks = m_wallet_impl->estimateBacklog(fee_levels);
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    fail_msg_writer() << tr("Error: failed to estimate backlog array size: ") << e.what();
+    fail_msg_writer() << tr("Error trying to estimate backlog: ") << error_msg;
     return true;
   }
   if (blocks.size() != 4)
@@ -1074,7 +1228,8 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
     if (nblocks_low > 0)
     {
       std::string msg;
-      if (priority == m_wallet->get_default_priority() || (m_wallet->get_default_priority() == fee_priority::Default && priority == fee_priority::Normal))
+      auto default_priority = tools::fee_priority_utilities::from_integral(m_wallet_impl->getDefaultPriority());
+      if (priority == default_priority || (default_priority == fee_priority::Default && priority == fee_priority::Normal))
         msg = tr(" (current)");
       uint64_t minutes_low = nblocks_low * DIFFICULTY_TARGET_V2 / 60, minutes_high = nblocks_high * DIFFICULTY_TARGET_V2 / 60;
       if (nblocks_high == nblocks_low)
@@ -1091,31 +1246,24 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
 bool simple_wallet::prepare_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  prepare_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return false;
   }
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("This wallet is already multisig");
     return false;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot be made multisig");
     return false;
   }
   CHECK_IF_BACKGROUND_SYNCING("cannot be made multisig");
 
-  if(m_wallet->get_num_transfer_details())
+  if(m_wallet_impl->getWalletState().n_enotes)
   {
     fail_msg_writer() << tr("This wallet has been used before, please use a new wallet to create a multisig wallet");
     return false;
@@ -1123,15 +1271,18 @@ bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, 
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
-  std::string multisig_info = m_wallet->get_multisig_first_kex_msg();
+  int error_code;
+  std::string error_msg;
+  std::string multisig_info = m_wallet_impl->getMultisigInfo();
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("Error trying to get multisig info") << error_msg;
+    return false;
+  }
   success_msg_writer() << multisig_info;
   success_msg_writer() << tr("Send this multisig info to all other participants, then use make_multisig <threshold> <info1> [<info2>...] with others' multisig info");
   success_msg_writer() << tr("This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet's participants ");
-
-  if (called_by_mms)
-  {
-    get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::key_set, multisig_info);
-  }
 
   return true;
 }
@@ -1139,30 +1290,23 @@ bool simple_wallet::prepare_multisig_main(const std::vector<std::string> &args, 
 bool simple_wallet::make_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  make_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return false;
   }
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("This wallet is already multisig");
     return false;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot be made multisig");
     return false;
   }
 
-  if(m_wallet->get_num_transfer_details())
+  if(m_wallet_impl->getWalletState().n_enotes)
   {
     fail_msg_writer() << tr("This wallet has been used before, please use a new wallet to create a multisig wallet");
     return false;
@@ -1191,37 +1335,34 @@ bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, boo
 
   LOCK_IDLE_SCOPE();
 
-  try
+  auto local_args = args;
+  local_args.erase(local_args.begin());
+  std::string multisig_extra_info = m_wallet_impl->makeMultisig(local_args, threshold, std::string_view(orig_pwd_container->password().data(), orig_pwd_container->password().size()));
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    auto local_args = args;
-    local_args.erase(local_args.begin());
-    std::string multisig_extra_info = m_wallet->make_multisig(orig_pwd_container->password(), local_args, threshold);
-    if (!m_wallet->get_multisig_status().is_ready)
-    {
-      success_msg_writer() << tr("Another step is needed");
-      success_msg_writer() << multisig_extra_info;
-      success_msg_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
-      if (called_by_mms)
-      {
-        get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::additional_key_set, multisig_extra_info);
-      }
-      return true;
-    }
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Error creating multisig: ") << e.what();
+    fail_msg_writer() << tr("Error creating multisig: ") << error_msg;
     return false;
   }
 
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-  if (!ms_status.multisig_is_active)
+  if (!m_wallet_impl->multisig().isReady)
+  {
+    success_msg_writer() << tr("Another step is needed");
+    success_msg_writer() << multisig_extra_info;
+    success_msg_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
+    return true;
+  }
+
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (!ms_status.isMultisig)
   {
     fail_msg_writer() << tr("Error creating multisig: new wallet is not multisig");
     return false;
   }
   success_msg_writer() << std::to_string(ms_status.threshold) << "/" << ms_status.total << tr(" multisig address: ")
-      << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
+      << m_wallet_impl->address();
 
   return true;
 }
@@ -1229,6 +1370,23 @@ bool simple_wallet::make_multisig_main(const std::vector<std::string> &args, boo
 bool simple_wallet::exchange_multisig_keys(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (m_wallet_impl->getDeviceState().key_on_device)
+  {
+    fail_msg_writer() << tr("command not supported by HW wallet");
+    return false;
+  }
+  if (!ms_status.isMultisig)
+  {
+    fail_msg_writer() << tr("This wallet is not multisig");
+    return false;
+  }
+  if (ms_status.isReady)
+  {
+    fail_msg_writer() << tr("This wallet is already finalized");
+    return false;
+  }
+
   bool force_update_use_with_caution = false;
 
   auto local_args = args;
@@ -1238,92 +1396,45 @@ bool simple_wallet::exchange_multisig_keys(const std::vector<std::string> &args)
     local_args.erase(local_args.begin());
   }
 
-  exchange_multisig_keys_main(local_args, force_update_use_with_caution, false);
-  return true;
-}
+  const auto orig_pwd_container = get_and_verify_password();
+  if(orig_pwd_container == boost::none)
+  {
+    fail_msg_writer() << tr("Your original password was incorrect.");
+    return false;
+  }
 
-bool simple_wallet::exchange_multisig_keys_main(const std::vector<std::string> &args,
-  const bool force_update_use_with_caution,
-  const bool called_by_mms) {
-    CHECK_MULTISIG_ENABLED();
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-    if (m_wallet->key_on_device())
-    {
-      fail_msg_writer() << tr("command not supported by HW wallet");
-      return false;
-    }
-    if (!ms_status.multisig_is_active)
-    {
-      fail_msg_writer() << tr("This wallet is not multisig");
-      return false;
-    }
-    if (ms_status.is_ready)
-    {
-      fail_msg_writer() << tr("This wallet is already finalized");
-      return false;
-    }
+  std::string multisig_extra_info = m_wallet_impl->exchangeMultisigKeys(args,
+                                                                        std::string_view(orig_pwd_container->password().data(),
+                                                                                         orig_pwd_container->password().size()),
+                                                                        force_update_use_with_caution);
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("Failed to perform multisig keys exchange: ") << error_msg;
+    return false;
+  }
 
-    const auto orig_pwd_container = get_and_verify_password();
-    if(orig_pwd_container == boost::none)
-    {
-      fail_msg_writer() << tr("Your original password was incorrect.");
-      return false;
-    }
-
-    try
-    {
-      std::string multisig_extra_info = m_wallet->exchange_multisig_keys(orig_pwd_container->password(), args, force_update_use_with_caution);
-      if (!m_wallet->get_multisig_status().is_ready)
-      {
-        message_writer() << tr("Another step is needed");
-        message_writer() << multisig_extra_info;
-        message_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
-        if (called_by_mms)
-        {
-          get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::additional_key_set, multisig_extra_info);
-        }
-        return true;
-      } else {
-        const multisig::multisig_account_status ms_status_new{m_wallet->get_multisig_status()};
-        success_msg_writer() << tr("Multisig wallet has been successfully created. Current wallet type: ") << ms_status_new.threshold << "/" << ms_status_new.total;
-        success_msg_writer() << tr("Multisig address: ") << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-      }
-    }
-    catch (const std::exception &e)
-    {
-      fail_msg_writer() << tr("Failed to perform multisig keys exchange: ") << e.what();
-      return false;
-    }
-
+  if (!m_wallet_impl->multisig().isReady)
+  {
+    message_writer() << tr("Another step is needed");
+    message_writer() << multisig_extra_info;
+    message_writer() << tr("Send this multisig info to all other participants, then use exchange_multisig_keys <info1> [<info2>...] with others' multisig info");
     return true;
+  } else {
+    const MultisigState ms_status_new{m_wallet_impl->multisig()};
+    success_msg_writer() << tr("Multisig wallet has been successfully created. Current wallet type: ") << ms_status_new.threshold << "/" << ms_status_new.total;
+    success_msg_writer() << tr("Multisig address: ") << m_wallet_impl->address();
+  }
+
+  return true;
 }
 
 bool simple_wallet::export_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  export_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-  if (m_wallet->key_on_device())
-  {
-    fail_msg_writer() << tr("command not supported by HW wallet");
-    return false;
-  }
-  if (!ms_status.multisig_is_active)
-  {
-    fail_msg_writer() << tr("This wallet is not multisig");
-    return false;
-  }
-  if (!ms_status.is_ready)
-  {
-    fail_msg_writer() << tr("This multisig wallet is not yet finalized");
-    return false;
-  }
+  CHECK_MULTISIG_READY();
   if (args.size() != 1)
   {
     PRINT_USAGE(USAGE_EXPORT_MULTISIG_INFO);
@@ -1331,33 +1442,24 @@ bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, b
   }
 
   const std::string filename = args[0];
-  if (!called_by_mms && m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
+  if (m_wallet_impl->getConfirmExportOverwrite() && !check_file_overwrite(filename))
     return true;
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
-  try
+  std::string ciphertext;
+  if (!m_wallet_impl->exportMultisigImages(ciphertext))
   {
-    cryptonote::blobdata ciphertext = m_wallet->export_multisig();
-
-    if (called_by_mms)
-    {
-      get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::multisig_sync_data, ciphertext);
-    }
-    else
-    {
-      bool r = m_wallet->save_to_file(filename, ciphertext);
-      if (!r)
-      {
-        fail_msg_writer() << tr("failed to save file ") << filename;
-        return false;
-      }
-    }
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("Error exporting multisig info: ") << error_msg;
+    return false;
   }
-  catch (const std::exception &e)
+  bool r = save_to_file(filename, ciphertext);
+  if (!r)
   {
-    LOG_ERROR("Error exporting multisig info: " << e.what());
-    fail_msg_writer() << tr("Error exporting multisig info: ") << e.what();
+    fail_msg_writer() << tr("failed to save file ") << filename;
     return false;
   }
 
@@ -1368,83 +1470,54 @@ bool simple_wallet::export_multisig_main(const std::vector<std::string> &args, b
 bool simple_wallet::import_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  import_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-
-  if (m_wallet->key_on_device())
-  {
-    fail_msg_writer() << tr("command not supported by HW wallet");
-    return false;
-  }
-  if (!ms_status.multisig_is_active)
-  {
-    fail_msg_writer() << tr("This wallet is not multisig");
-    return false;
-  }
-  if (!ms_status.is_ready)
-  {
-    fail_msg_writer() << tr("This multisig wallet is not yet finalized");
-    return false;
-  }
+  CHECK_MULTISIG_READY();
   if (args.size() + 1 < ms_status.threshold)
   {
     PRINT_USAGE(USAGE_IMPORT_MULTISIG_INFO);
     return false;
   }
+  int error_code;
+  std::string error_msg;
 
   std::vector<cryptonote::blobdata> info;
   for (size_t n = 0; n < args.size(); ++n)
   {
-    if (called_by_mms)
+    const std::string &filename = args[n];
+    std::string data;
+    bool r = load_from_file(filename, data);
+    if (!r)
     {
-      info.push_back(args[n]);
+      fail_msg_writer() << tr("failed to read file ") << filename;
+      return false;
     }
-    else
-    {
-      const std::string &filename = args[n];
-      std::string data;
-      bool r = m_wallet->load_from_file(filename, data);
-      if (!r)
-      {
-        fail_msg_writer() << tr("failed to read file ") << filename;
-        return false;
-      }
-      info.push_back(std::move(data));
-    }
+    info.push_back(std::move(data));
   }
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
   // all read and parsed, actually import
-  try
   {
     m_in_manual_refresh.store(true, std::memory_order_relaxed);
     const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
-    size_t n_outputs = m_wallet->import_multisig(info);
+    size_t n_outputs = m_wallet_impl->importMultisigImages(info);
+
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+    {
+      fail_msg_writer() << tr("Failed to import multisig info: ") << error_msg;
+      return false;
+    }
+
     // Clear line "Height xxx of xxx"
     std::cout << "\r                                                                \r";
     success_msg_writer() << tr("Multisig info imported. Number of outputs updated: ") << n_outputs;
   }
-  catch (const std::exception &e)
+  if (m_wallet_impl->trustedDaemon())
   {
-    fail_msg_writer() << tr("Failed to import multisig info: ") << e.what();
-    return false;
-  }
-  if (m_wallet->is_trusted_daemon())
-  {
-    try
+    if (!m_wallet_impl->rescanSpent())
     {
-      m_wallet->rescan_spent();
-    }
-    catch (const std::exception &e)
-    {
-      message_writer() << tr("Failed to update spent status after importing multisig info: ") << e.what();
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+      message_writer() << tr("Failed to update spent status after importing multisig info: ") << error_msg;
       return false;
     }
   }
@@ -1456,39 +1529,10 @@ bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, b
   return true;
 }
 
-bool simple_wallet::accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs)
-{
-  std::string extra_message;
-  return accept_loaded_tx([&txs](){return txs.m_ptx.size();}, [&txs](size_t n)->const tools::wallet2::tx_construction_data&{return txs.m_ptx[n].construction_data;}, extra_message);
-}
-
 bool simple_wallet::sign_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  sign_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};\
-
-  if (m_wallet->key_on_device())
-  {
-    fail_msg_writer() << tr("command not supported by HW wallet");
-    return false;
-  }
-  if (!ms_status.multisig_is_active)
-  {
-    fail_msg_writer() << tr("This wallet is not multisig");
-    return false;
-  }
-  if (!ms_status.is_ready)
-  {
-    fail_msg_writer() << tr("This multisig wallet is not yet finalized");
-    return false;
-  }
+  CHECK_MULTISIG_READY();
   if (args.size() != 1)
   {
     PRINT_USAGE(USAGE_SIGN_MULTISIG);
@@ -1498,63 +1542,46 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
   std::string filename = args[0];
-  std::vector<crypto::hash> txids;
+  std::vector<std::string> txids;
   uint32_t signers = 0;
-  try
+  int error_code;
+  std::string error_msg;
+  std::string multisig_tx_data;
+  std::string ciphertext;
+
+  if (!load_from_file(filename, multisig_tx_data))
   {
-    if (called_by_mms)
-    {
-      tools::wallet2::multisig_tx_set exported_txs;
-      std::string ciphertext;
-      bool r = m_wallet->load_multisig_tx(args[0], exported_txs, [&](const tools::wallet2::multisig_tx_set &tx){ signers = tx.m_signers.size(); return accept_loaded_tx(tx); });
-      if (r)
-      {
-        r = m_wallet->sign_multisig_tx(exported_txs, txids);
-      }
-      if (r)
-      {
-        ciphertext = m_wallet->save_multisig_tx(exported_txs);
-        if (ciphertext.empty())
-        {
-          r = false;
-        }
-      }
-      if (r)
-      {
-        mms::message_type message_type = mms::message_type::fully_signed_tx;
-        if (txids.empty())
-        {
-          message_type = mms::message_type::partially_signed_tx;
-        }
-        get_message_store().process_wallet_created_data(get_multisig_wallet_state(), message_type, ciphertext);
-        filename = "MMS";   // for the messages below
-      }
-      else
-      {
-        fail_msg_writer() << tr("Failed to sign multisig transaction");
-        return false;
-      }
-    }
-    else
-    {
-      bool r = m_wallet->sign_multisig_tx_from_file(filename, txids, [&](const tools::wallet2::multisig_tx_set &tx){ signers = tx.m_signers.size(); return accept_loaded_tx(tx); });
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to sign multisig transaction");
-        return false;
-      }
-    }
-  }
-  catch (const tools::error::multisig_export_needed& e)
-  {
-    fail_msg_writer() << tr("Multisig error: ") << e.what();
+    fail_msg_writer() << tr("Failed to load multisig tx data from file");
     return false;
   }
-  catch (const std::exception &e)
+  PendingTransaction *ptx = m_wallet_impl->restoreMultisigTransaction(multisig_tx_data, /* ask_for_confirmation */ true);
+  if (!ptx)
   {
-    fail_msg_writer() << tr("Failed to sign multisig transaction: ") << e.what();
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
     return false;
   }
+  // Confirm loaded tx
+  if (!ptx->confirmationMessage().empty() && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
+  ptx->finishRestoringMultisigTransaction();
+
+  ptx->signMultisigTx(&txids);
+  if (!ptx->status())
+  {
+    fail_msg_writer() << ptx->errorString();
+    return false;
+  }
+  ciphertext = ptx->multisigSignData();
+  if (ciphertext.empty())
+  {
+    fail_msg_writer() << tr("Failed to get multisig sign data") << ptx->errorString();
+    return false;
+  }
+  signers = ptx->signersKeys().size();
 
   if (txids.empty())
   {
@@ -1570,7 +1597,7 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
     {
       if (!txids_as_text.empty())
         txids_as_text += (", ");
-      txids_as_text += epee::string_tools::pod_to_hex(txid);
+      txids_as_text += txid;
     }
     success_msg_writer(true) << tr("Transaction successfully signed to file ") << filename << ", txid " << txids_as_text;
     success_msg_writer(true) << tr("It may be relayed to the network with submit_multisig");
@@ -1581,30 +1608,7 @@ bool simple_wallet::sign_multisig_main(const std::vector<std::string> &args, boo
 bool simple_wallet::submit_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  submit_multisig_main(args, false);
-  return true;
-}
-
-bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, bool called_by_mms)
-{
-  CHECK_MULTISIG_ENABLED();
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-
-  if (m_wallet->key_on_device())
-  {
-    fail_msg_writer() << tr("command not supported by HW wallet");
-    return false;
-  }
-  if (!ms_status.multisig_is_active)
-  {
-    fail_msg_writer() << tr("This wallet is not multisig");
-    return false;
-  }
-  if (!ms_status.is_ready)
-  {
-    fail_msg_writer() << tr("This multisig wallet is not yet finalized");
-    return false;
-  }
+  CHECK_MULTISIG_READY();
   if (args.size() != 1)
   {
     PRINT_USAGE(USAGE_SUBMIT_MULTISIG);
@@ -1617,45 +1621,41 @@ bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, b
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
   std::string filename = args[0];
-  try
+  int error_code;
+  std::string error_msg;
+  std::string multisig_tx_data;
+  if (load_from_file(filename, multisig_tx_data))
   {
-    tools::wallet2::multisig_tx_set txs;
-    if (called_by_mms)
-    {
-      bool r = m_wallet->load_multisig_tx(args[0], txs, [&](const tools::wallet2::multisig_tx_set &tx){ return accept_loaded_tx(tx); });
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to load multisig transaction from MMS");
-        return false;
-      }
-    }
-    else
-    {
-      bool r = m_wallet->load_multisig_tx_from_file(filename, txs, [&](const tools::wallet2::multisig_tx_set &tx){ return accept_loaded_tx(tx); });
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to load multisig transaction from file");
-        return false;
-      }
-    }
-    if (txs.m_signers.size() < ms_status.threshold)
-    {
-      fail_msg_writer() << (boost::format(tr("Multisig transaction signed by only %u signers, needs %u more signatures"))
-          % txs.m_signers.size() % (ms_status.threshold - txs.m_signers.size())).str();
-      return false;
-    }
+    fail_msg_writer() << tr("Failed to load multisig transaction from file");
+    return false;
+  }
+  PendingTransaction *ptx = m_wallet_impl->restoreMultisigTransaction(multisig_tx_data, /* ask_for_confirmation */ true);
+  if (!ptx)
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
+    return false;
+  }
+  // Confirm loaded tx
+  if (!ptx->confirmationMessage().empty() && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
+  ptx->finishRestoringMultisigTransaction();
 
-    // actually commit the transactions
-    commit_or_save(txs.m_ptx, /* do_not_relay */ false);
-  }
-  catch (const std::exception &e)
+  std::size_t n_signers = ptx->signersKeys().size();
+  if (n_signers < ms_status.threshold)
   {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
+    fail_msg_writer() << (boost::format(tr("Multisig transaction signed by only %u signers, needs %u more signatures"))
+        % n_signers % (ms_status.threshold - n_signers)).str();
+    return false;
   }
-  catch (...)
+
+  // actually commit or save the transactions
+  commit_or_save(*ptx, /* do_not_relay */ false);
+  if (ptx->status())
   {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
     return false;
   }
 
@@ -1665,23 +1665,7 @@ bool simple_wallet::submit_multisig_main(const std::vector<std::string> &args, b
 bool simple_wallet::export_raw_multisig(const std::vector<std::string> &args)
 {
   CHECK_MULTISIG_ENABLED();
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-
-  if (m_wallet->key_on_device())
-  {
-    fail_msg_writer() << tr("command not supported by HW wallet");
-    return true;
-  }
-  if (!ms_status.multisig_is_active)
-  {
-    fail_msg_writer() << tr("This wallet is not multisig");
-    return true;
-  }
-  if (!ms_status.is_ready)
-  {
-    fail_msg_writer() << tr("This multisig wallet is not yet finalized");
-    return true;
-  }
+  CHECK_MULTISIG_READY();
   if (args.size() != 1)
   {
     PRINT_USAGE(USAGE_EXPORT_RAW_MULTISIG_TX);
@@ -1689,104 +1673,97 @@ bool simple_wallet::export_raw_multisig(const std::vector<std::string> &args)
   }
 
   std::string filename = args[0];
-  if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
+  if (m_wallet_impl->getConfirmExportOverwrite() && !check_file_overwrite(filename))
     return true;
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  int error_code;
+  std::string error_msg;
+  std::string multisig_tx_data;
+  if (load_from_file(filename, multisig_tx_data))
   {
-    tools::wallet2::multisig_tx_set txs;
-    bool r = m_wallet->load_multisig_tx_from_file(filename, txs, [&](const tools::wallet2::multisig_tx_set &tx){ return accept_loaded_tx(tx); });
-    if (!r)
-    {
-      fail_msg_writer() << tr("Failed to load multisig transaction from file");
-      return true;
-    }
-    if (txs.m_signers.size() < ms_status.threshold)
-    {
-      fail_msg_writer() << (boost::format(tr("Multisig transaction signed by only %u signers, needs %u more signatures"))
-          % txs.m_signers.size() % (ms_status.threshold - txs.m_signers.size())).str();
-      return true;
-    }
+    fail_msg_writer() << tr("Failed to load multisig transaction from file");
+    return true;
+  }
+  PendingTransaction *ptx = m_wallet_impl->restoreMultisigTransaction(multisig_tx_data, /* ask_for_confirmation */ true);
+  if (!ptx)
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
+    return true;
+  }
+  // Confirm loaded tx
+  if (!ptx->confirmationMessage().empty() && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
+  ptx->finishRestoringMultisigTransaction();
 
-    // save the transactions
-    std::string filenames;
-    for (auto &ptx: txs.m_ptx)
-    {
-      const crypto::hash txid = cryptonote::get_transaction_hash(ptx.tx);
-      const std::string filename = std::string("raw_multisig_monero_tx_") + epee::string_tools::pod_to_hex(txid);
-      if (!filenames.empty())
-        filenames += ", ";
-      filenames += filename;
-      if (!m_wallet->save_to_file(filename, cryptonote::tx_to_blob(ptx.tx)))
-      {
-        fail_msg_writer() << tr("Failed to export multisig transaction to file ") << filename;
-        return true;
-      }
-    }
-    success_msg_writer() << tr("Saved exported multisig transaction file(s): ") << filenames;
-  }
-  catch (const std::exception& e)
+  std::size_t n_signers = ptx->signersKeys().size();
+  if (n_signers < ms_status.threshold)
   {
-    LOG_ERROR("unexpected error: " << e.what());
-    fail_msg_writer() << tr("unexpected error: ") << e.what();
-  }
-  catch (...)
-  {
-    LOG_ERROR("Unknown error");
-    fail_msg_writer() << tr("unknown error");
+    fail_msg_writer() << (boost::format(tr("Multisig transaction signed by only %u signers, needs %u more signatures"))
+        % n_signers % (ms_status.threshold - n_signers)).str();
+    return true;
   }
 
+  // save the transactions
+  std::string filenames;
+  const std::vector<std::string> tx_ids = ptx->txid();
+  const std::vector<std::string> tx_blobs = ptx->convertTxToRawBlobStr();
+  CHECK_AND_ASSERT_MES(tx_ids.size() == tx_blobs.size(), true, tr("unequal amount of txids and blobs"));
+  for (std::size_t i = 0; i < ptx->txid().size(); ++i)
+  {
+    const std::string filename = std::string("raw_multisig_monero_tx_") + tx_ids[i];
+    if (!filenames.empty())
+      filenames += ", ";
+    filenames += filename;
+    if (!save_to_file(filename, tx_blobs[i]))
+    {
+      fail_msg_writer() << tr("Failed to export multisig transaction to file ") << filename;
+      return true;
+    }
+  }
+  success_msg_writer() << tr("Saved exported multisig transaction file(s): ") << filenames;
   return true;
 }
 
 bool simple_wallet::print_ring(const std::vector<std::string> &args)
 {
   crypto::key_image key_image;
-  crypto::hash txid;
   if (args.size() != 1)
   {
     PRINT_USAGE(USAGE_PRINT_RING);
     return true;
   }
+  std::string key_image_or_tx_id = args[0];
 
-  if (!epee::string_tools::hex_to_pod(args[0], key_image))
+  // sanity check if provided arg is a 32 byte hex string
+  if (!epee::string_tools::hex_to_pod(key_image_or_tx_id, key_image))
   {
-    fail_msg_writer() << tr("Invalid key image");
-    return true;
-  }
-  // this one will always work, they're all 32 byte hex
-  if (!epee::string_tools::hex_to_pod(args[0], txid))
-  {
-    fail_msg_writer() << tr("Invalid txid");
+    fail_msg_writer() << tr("Invalid key image or txid");
     return true;
   }
 
   std::vector<uint64_t> ring;
-  std::vector<std::pair<crypto::key_image, std::vector<uint64_t>>> rings;
-  try
+  std::vector<std::pair<std::string, std::vector<uint64_t>>> rings;
+  if (m_wallet_impl->getRing(key_image_or_tx_id, ring))
+    rings.push_back({key_image_or_tx_id, ring});
+  else if (!m_wallet_impl->getRings(key_image_or_tx_id, rings))
   {
-    if (m_wallet->get_ring(key_image, ring))
-      rings.push_back({key_image, ring});
-    else if (!m_wallet->get_rings(txid, rings))
-    {
-      fail_msg_writer() << tr("Key image either not spent, or spent with ring size 1");
-      return true;
-    }
-
-    for (const auto &ring: rings)
-    {
-      std::stringstream str;
-      for (const auto &x: ring.second)
-        str << x<< " ";
-      // do NOT translate this "absolute" below, the lin can be used as input to set_ring
-      success_msg_writer() << epee::string_tools::pod_to_hex(ring.first) <<  " absolute " << str.str();
-    }
+    fail_msg_writer() << tr("Key image either not spent, or spent with ring size 1");
+    return true;
   }
-  catch (const std::exception &e)
+
+  for (const auto &ring: rings)
   {
-    fail_msg_writer() << tr("Failed to get key image ring: ") << e.what();
+    std::stringstream str;
+    for (const auto &x: ring.second)
+      str << x<< " ";
+    // do NOT translate this "absolute" below, the lin can be used as input to set_ring
+    success_msg_writer() << ring.first <<  " absolute " << str.str();
   }
 
   return true;
@@ -1828,7 +1805,6 @@ bool simple_wallet::set_ring(const std::vector<std::string> &args)
         }
         key_image_str[64] = 0;
         type_str[8] = 0;
-        crypto::key_image key_image;
         if (read_after_key_image == 0 || !epee::string_tools::hex_to_pod(key_image_str, key_image))
         {
           fail_msg_writer() << tr("Invalid key image: ") << str;
@@ -1894,8 +1870,8 @@ bool simple_wallet::set_ring(const std::vector<std::string> &args)
         }
         if (!valid)
           continue;
-        if (!m_wallet->set_ring(key_image, ring, relative))
-          fail_msg_writer() << tr("Failed to set ring for key image: ") << key_image << ". " << tr("Continuing.");
+        if (!m_wallet_impl->setRing(key_image_str, ring, relative))
+          fail_msg_writer() << tr("Failed to set ring for key image: ") << key_image_str << ". " << tr("Continuing.");
       }
       f.reset();
     }
@@ -1908,7 +1884,8 @@ bool simple_wallet::set_ring(const std::vector<std::string> &args)
     return true;
   }
 
-  if (!epee::string_tools::hex_to_pod(args[0], key_image))
+  std::string key_image_str = args[0];
+  if (!epee::string_tools::hex_to_pod(key_image_str, key_image))
   {
     fail_msg_writer() << tr("Invalid key image");
     return true;
@@ -1965,50 +1942,12 @@ bool simple_wallet::set_ring(const std::vector<std::string> &args)
       }
     }
   }
-  if (!m_wallet->set_ring(key_image, ring, relative))
+  if (!m_wallet_impl->setRing(key_image_str, ring, relative))
   {
     fail_msg_writer() << tr("failed to set ring");
     return true;
   }
 
-  return true;
-}
-
-bool simple_wallet::unset_ring(const std::vector<std::string> &args)
-{
-  crypto::hash txid;
-  std::vector<crypto::key_image> key_images;
-
-  if (args.size() < 1)
-  {
-    PRINT_USAGE(USAGE_UNSET_RING);
-    return true;
-  }
-
-  key_images.resize(args.size());
-  for (size_t i = 0; i < args.size(); ++i)
-  {
-    if (!epee::string_tools::hex_to_pod(args[i], key_images[i]))
-    {
-      fail_msg_writer() << tr("Invalid key image or txid");
-      return true;
-    }
-  }
-  static_assert(sizeof(crypto::hash) == sizeof(crypto::key_image), "hash and key_image must have the same size");
-  memcpy(&txid, &key_images[0], sizeof(txid));
-
-  if (!m_wallet->unset_ring(key_images) && !m_wallet->unset_ring(txid))
-  {
-    fail_msg_writer() << tr("failed to unset ring");
-    return true;
-  }
-
-  return true;
-}
-
-bool simple_wallet::save_known_rings(const std::vector<std::string> &args)
-{
-  fail_msg_writer() << tr("save_known_rings is deprecated");
   return true;
 }
 
@@ -2020,23 +1959,31 @@ bool simple_wallet::freeze_thaw(const std::vector<std::string> &args, bool freez
     fail_msg_writer() << boost::format(tr("usage: %s <key_image>|<pubkey>")) % (freeze ? "freeze" : "thaw");
     return true;
   }
-  crypto::key_image ki;
-  if (!epee::string_tools::hex_to_pod(args[0], ki))
+  int error_code;
+  std::string error_msg;
+  if (freeze)
   {
-    fail_msg_writer() << tr("failed to parse key image");
-    return true;
+    m_wallet_impl->freeze(args[0]);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+    {
+      m_wallet_impl->freezeByPubKey(args[0]);
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    }
+    if (error_code)
+      fail_msg_writer() << tr("failed to freeze. Make sure argument is either a valid key image or output public key.");
   }
-  try
+  else
   {
-    if (freeze)
-      m_wallet->freeze(ki);
-    else
-      m_wallet->thaw(ki);
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << e.what();
-    return true;
+    m_wallet_impl->thaw(args[0]);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+    {
+      m_wallet_impl->thawByPubKey(args[0]);
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    }
+    if (error_code)
+      fail_msg_writer() << tr("failed to thaw. Make sure argument is either a valid key image or output public key.");
   }
 
   return true;
@@ -2057,27 +2004,43 @@ bool simple_wallet::frozen(const std::vector<std::string> &args)
   CHECK_IF_BACKGROUND_SYNCING("cannot see frozen key images");
   if (args.empty())
   {
-    size_t ntd = m_wallet->get_num_transfer_details();
+    size_t ntd = m_wallet_impl->getWalletState().n_enotes;
+    std::vector<std::unique_ptr<EnoteDetails>> ed = m_wallet_impl->getEnoteDetails();
     for (size_t i = 0; i < ntd; ++i)
     {
-      if (!m_wallet->frozen(i))
+      if (!m_wallet_impl->isFrozen(ed[i]->keyImage()))
         continue;
-      const tools::wallet2::transfer_details &td = m_wallet->get_transfer_details(i);
-      message_writer() << tr("Frozen: ") << td.m_key_image << " " << cryptonote::print_money(td.amount());
+      message_writer() << tr("Frozen: ") << ed[i]->keyImage() << " " << cryptonote::print_money(ed[i]->amount());
     }
   }
   else
   {
-    crypto::key_image ki;
-    if (!epee::string_tools::hex_to_pod(args[0], ki))
+    crypto::key_image ki_or_pubkey;
+    if (!epee::string_tools::hex_to_pod(args[0], ki_or_pubkey))
     {
       fail_msg_writer() << tr("failed to parse key image");
       return true;
     }
-    if (m_wallet->frozen(ki))
-      message_writer() << tr("Frozen: ") << ki;
+    std::unique_ptr<EnoteDetails> ed = m_wallet_impl->getEnoteDetails(args[0]);
+    if (ed)
+    {
+      if (ed->isFrozen())
+        message_writer() << tr("Frozen: ") << "<"+ed->keyImage()+"> / " << ki_or_pubkey;
+      else
+        message_writer() << tr("Not frozen: ") << "<"+ed->keyImage()+"> / " << ki_or_pubkey;
+    }
+    else if (m_wallet_impl->isFrozen(args[0]))
+      message_writer() << tr("Frozen: ") << ki_or_pubkey;
     else
-      message_writer() << tr("Not frozen: ") << ki;
+    {
+      int error_code;
+      std::string error_msg;
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+      if (!error_code)
+        message_writer() << tr("Not frozen: ") << ki_or_pubkey;
+      else
+        fail_msg_writer() << tr("failed to parse key image");
+    }
   }
   return true;
 }
@@ -2091,34 +2054,36 @@ bool simple_wallet::lock(const std::vector<std::string> &args)
 
 bool simple_wallet::net_stats(const std::vector<std::string> &args)
 {
-  message_writer() << std::to_string(m_wallet->get_bytes_sent()) + tr(" bytes sent");
-  message_writer() << std::to_string(m_wallet->get_bytes_received()) + tr(" bytes received");
+  message_writer() << std::to_string(m_wallet_impl->getBytesSent()) + tr(" bytes sent");
+  message_writer() << std::to_string(m_wallet_impl->getBytesReceived()) + tr(" bytes received");
   return true;
 }
 
 bool simple_wallet::public_nodes(const std::vector<std::string> &args)
 {
-  try
+  // [host_ip, host_rpc_port, last_seen]
+  std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> nodes = m_wallet_impl->getPublicNodes(false);
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    auto nodes = m_wallet->get_public_nodes(false);
-    if (nodes.empty())
-    {
-      fail_msg_writer() << tr("No known public nodes");
-      return true;
-    }
-
-    const uint64_t now = time(NULL);
-    message_writer() << boost::format("%32s %16s") % tr("address") % tr("last_seen");
-    for (const auto &node: nodes)
-    {
-      const std::string last_seen = node.last_seen == 0 ? tr("never") : tools::get_human_readable_timespan(std::chrono::seconds(now - node.last_seen));
-      std::string host = node.host + ":" + std::to_string(node.rpc_port);
-      message_writer() << boost::format("%32s %16s") % host % last_seen;
-    }
+    fail_msg_writer() << error_msg;
+    return true;
   }
-  catch (const std::exception &e)
+  if (nodes.empty())
   {
-    fail_msg_writer() << tr("Error retrieving public node list: ") << e.what();
+    fail_msg_writer() << tr("No known public nodes");
+    return true;
+  }
+
+  const uint64_t now = time(NULL);
+  message_writer() << boost::format("%32s %16s") % tr("address") % tr("last_seen");
+  for (const auto &node: nodes)
+  {
+    const std::string last_seen = std::get<2>(node) == 0 ? tr("never") : tools::get_human_readable_timespan(std::chrono::seconds(now - std::get<2>(node)));
+    std::string host = std::get<0>(node) + ":" + std::to_string(std::get<1>(node));
+    message_writer() << boost::format("%32s %16s") % host % last_seen;
   }
   message_writer(console_color_red, true) << tr("Most of these nodes are probably spies. You should not use them unless connecting via Tor or I2P");
   return true;
@@ -2167,27 +2132,6 @@ bool simple_wallet::on_cancelled_command()
   return true;
 }
 
-bool simple_wallet::cold_sign_tx(const std::vector<tools::wallet2::pending_tx>& ptx_vector, tools::wallet2::signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::function<bool(const tools::wallet2::signed_tx_set &)> accept_func)
-{
-  std::vector<std::string> tx_aux;
-
-  message_writer(console_color_white, false) << tr("Please confirm the transaction on the device");
-
-  m_wallet->cold_sign_tx(ptx_vector, exported_txs, dsts_info, tx_aux);
-
-  if (accept_func && !accept_func(exported_txs))
-  {
-    MERROR("Transactions rejected by callback");
-    return false;
-  }
-
-  // aux info
-  m_wallet->cold_tx_aux_import(exported_txs.ptx, tx_aux);
-
-  // import key images
-  return m_wallet->import_key_images(exported_txs, 0, true);
-}
-
 bool simple_wallet::show_qr_code(const std::vector<std::string> &args)
 {
   uint32_t subaddress_index = 0;
@@ -2198,7 +2142,7 @@ bool simple_wallet::show_qr_code(const std::vector<std::string> &args)
       fail_msg_writer() << tr("invalid index: must be an unsigned integer");
       return true;
     }
-    if (subaddress_index >= m_wallet->get_num_subaddresses(m_current_subaddress_account))
+    if (subaddress_index >= m_wallet_impl->numSubaddresses(m_current_subaddress_account))
     {
       fail_msg_writer() << tr("<subaddress_index> is out of bounds");
       return true;
@@ -2218,7 +2162,7 @@ bool simple_wallet::show_qr_code(const std::vector<std::string> &args)
   WTEXTON();
   try
   {
-    const std::string address = "monero:" + m_wallet->get_subaddress_as_str({m_current_subaddress_account, subaddress_index});
+    const std::string address = "monero:" + m_wallet_impl->address(m_current_subaddress_account, subaddress_index);
     const qrcodegen::QrCode qr = qrcodegen::QrCode::encodeText(address.c_str(), qrcodegen::QrCode::Ecc::LOW);
     for (int y = -2; y < qr.getSize() + 2; y+=2)
     {
@@ -2250,8 +2194,8 @@ bool simple_wallet::set_always_confirm_transfers(const std::vector<std::string> 
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->always_confirm_transfers(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setAlwaysConfirmTransfers(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2263,8 +2207,8 @@ bool simple_wallet::set_print_ring_members(const std::vector<std::string> &args/
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->print_ring_members(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setPrintRingMembers(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2272,7 +2216,7 @@ bool simple_wallet::set_print_ring_members(const std::vector<std::string> &args/
 
 bool simple_wallet::set_store_tx_info(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot transfer");
     return true;
@@ -2282,8 +2226,8 @@ bool simple_wallet::set_store_tx_info(const std::vector<std::string> &args/* = s
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->store_tx_info(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setStoreTxInfo(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2328,8 +2272,8 @@ bool simple_wallet::set_default_priority(const std::vector<std::string> &args/* 
     const auto pwd_container = get_and_verify_password();
     if (pwd_container)
     {
-      m_wallet->set_default_priority(tools::fee_priority_utilities::from_integral(priority));
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setDefaultPriority(priority);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     }
     return true;
   }
@@ -2352,13 +2296,13 @@ bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = st
   {
     parse_bool_and_use(args[1], [&](bool auto_refresh) {
       m_auto_refresh_enabled.store(false, std::memory_order_relaxed);
-      m_wallet->auto_refresh(auto_refresh);
+      m_wallet_impl->setAutoRefresh(auto_refresh);
       m_idle_mutex.lock();
       m_auto_refresh_enabled.store(auto_refresh, std::memory_order_relaxed);
       m_idle_cond.notify_one();
       m_idle_mutex.unlock();
 
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2366,7 +2310,7 @@ bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = st
 
 bool simple_wallet::set_refresh_type(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  tools::wallet2::RefreshType refresh_type;
+  Wallet::RefreshType refresh_type;
   if (!parse_refresh_type(args[1], refresh_type))
   {
     return true;
@@ -2375,8 +2319,8 @@ bool simple_wallet::set_refresh_type(const std::vector<std::string> &args/* = st
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->set_refresh_type(refresh_type);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setRefreshType(refresh_type);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2386,29 +2330,29 @@ bool simple_wallet::set_ask_password(const std::vector<std::string> &args/* = st
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    tools::wallet2::AskPasswordType ask = tools::wallet2::AskPasswordToDecrypt;
+    Wallet::AskPasswordType ask = Wallet::AskPasswordType::AskPassword_ToDecrypt;
     if (args[1] == "never" || args[1] == "0")
-      ask = tools::wallet2::AskPasswordNever;
+      ask = Wallet::AskPasswordType::AskPassword_Never;
     else if (args[1] == "action" || args[1] == "1")
-      ask = tools::wallet2::AskPasswordOnAction;
+      ask = Wallet::AskPasswordType::AskPassword_OnAction;
     else if (args[1] == "encrypt" || args[1] == "decrypt" || args[1] == "2")
-      ask = tools::wallet2::AskPasswordToDecrypt;
+      ask = Wallet::AskPasswordType::AskPassword_ToDecrypt;
     else
     {
       fail_msg_writer() << tr("invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt");
       return true;
     }
 
-    const tools::wallet2::AskPasswordType cur_ask = m_wallet->ask_password();
-    if (!m_wallet->watch_only())
+    const Wallet::AskPasswordType cur_ask = m_wallet_impl->getAskPasswordType();
+    if (!m_wallet_impl->watchOnly())
     {
-      if (cur_ask == tools::wallet2::AskPasswordToDecrypt && ask != tools::wallet2::AskPasswordToDecrypt)
-        m_wallet->decrypt_keys(pwd_container->password());
-      else if (cur_ask != tools::wallet2::AskPasswordToDecrypt && ask == tools::wallet2::AskPasswordToDecrypt)
-        m_wallet->encrypt_keys(pwd_container->password());
+      if (cur_ask == Wallet::AskPasswordType::AskPassword_ToDecrypt && ask != Wallet::AskPasswordType::AskPassword_ToDecrypt)
+        m_wallet_impl->decryptKeys(std::string_view(pwd_container->password().data(), pwd_container->password().size()));
+      else if (cur_ask != Wallet::AskPasswordType::AskPassword_ToDecrypt && ask == Wallet::AskPasswordType::AskPassword_ToDecrypt)
+        m_wallet_impl->encryptKeys(std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     }
-    m_wallet->ask_password(ask);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setAskPasswordType(ask);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2438,7 +2382,7 @@ bool simple_wallet::set_unit(const std::vector<std::string> &args/* = std::vecto
   if (pwd_container)
   {
     cryptonote::set_default_decimal_point(decimal_point);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2455,8 +2399,8 @@ bool simple_wallet::set_max_reorg_depth(const std::vector<std::string> &args/* =
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->max_reorg_depth(depth);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setMaxReorgDepth(depth);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2473,8 +2417,8 @@ bool simple_wallet::set_min_output_count(const std::vector<std::string> &args/* 
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->set_min_output_count(count);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setMinOutputCount(count);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2491,8 +2435,8 @@ bool simple_wallet::set_min_output_value(const std::vector<std::string> &args/* 
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->set_min_output_value(value);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setMinOutputValue(value);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2503,8 +2447,8 @@ bool simple_wallet::set_merge_destinations(const std::vector<std::string> &args/
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->merge_destinations(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setMergeDestinations(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2516,8 +2460,8 @@ bool simple_wallet::set_confirm_backlog(const std::vector<std::string> &args/* =
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->confirm_backlog(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setConfirmBacklog(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2535,8 +2479,8 @@ bool simple_wallet::set_confirm_backlog_threshold(const std::vector<std::string>
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->set_confirm_backlog_threshold(threshold);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setConfirmBacklogThreshold(threshold);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2547,8 +2491,8 @@ bool simple_wallet::set_confirm_export_overwrite(const std::vector<std::string> 
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->confirm_export_overwrite(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setConfirmExportOverwrite(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2565,8 +2509,8 @@ bool simple_wallet::set_refresh_from_block_height(const std::vector<std::string>
       fail_msg_writer() << tr("Invalid height");
       return true;
     }
-    m_wallet->set_refresh_from_block_height(height);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setRefreshFromBlockHeight(height);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2577,8 +2521,8 @@ bool simple_wallet::set_auto_low_priority(const std::vector<std::string> &args/*
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->auto_low_priority(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setAutoLowPriority(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2590,8 +2534,8 @@ bool simple_wallet::set_segregate_pre_fork_outputs(const std::vector<std::string
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->segregate_pre_fork_outputs(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setSegregatePreForkOutputs(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2603,8 +2547,8 @@ bool simple_wallet::set_key_reuse_mitigation2(const std::vector<std::string> &ar
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->key_reuse_mitigation2(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setKeyReuseMitigation2(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2618,8 +2562,8 @@ bool simple_wallet::set_subaddress_lookahead(const std::vector<std::string> &arg
     auto lookahead = parse_subaddress_lookahead(args[1]);
     if (lookahead)
     {
-      m_wallet->set_subaddress_lookahead(lookahead->first, lookahead->second);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setSubaddressLookahead(lookahead->first, lookahead->second);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     }
   }
   return true;
@@ -2636,8 +2580,8 @@ bool simple_wallet::set_segregation_height(const std::vector<std::string> &args/
       fail_msg_writer() << tr("Invalid height");
       return true;
     }
-    m_wallet->segregation_height(height);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setSegregationHeight(height);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2648,8 +2592,8 @@ bool simple_wallet::set_ignore_fractional_outputs(const std::vector<std::string>
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->ignore_fractional_outputs(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setIgnoreFractionalOutputs(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2669,8 +2613,8 @@ bool simple_wallet::set_ignore_outputs_above(const std::vector<std::string> &arg
     }
     if (amount == 0)
       amount = MONEY_SUPPLY;
-    m_wallet->ignore_outputs_above(amount);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setIgnoreOutputsAbove(amount);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2686,8 +2630,8 @@ bool simple_wallet::set_ignore_outputs_below(const std::vector<std::string> &arg
       fail_msg_writer() << tr("Invalid amount");
       return true;
     }
-    m_wallet->ignore_outputs_below(amount);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->setIgnoreOutputsBelow(amount);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2698,8 +2642,8 @@ bool simple_wallet::set_track_uses(const std::vector<std::string> &args/* = std:
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->track_uses(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setTrackUses(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2707,23 +2651,23 @@ bool simple_wallet::set_track_uses(const std::vector<std::string> &args/* = std:
 
 bool simple_wallet::setup_background_sync(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("background sync not implemented for multisig wallet");
     return true;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("background sync not implemented for watch only wallet");
     return true;
   }
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
 
-  tools::wallet2::BackgroundSyncType background_sync_type;
+  Wallet::BackgroundSyncType background_sync_type;
   if (!parse_background_sync_type(args[1], background_sync_type))
   {
     fail_msg_writer() << tr("invalid option");
@@ -2734,23 +2678,31 @@ bool simple_wallet::setup_background_sync(const std::vector<std::string> &args/*
   if (!pwd_container)
     return true;
 
-  try
+  std::string wallet_password = std::string(pwd_container->password().data(), pwd_container->password().size());
+  Monero::optional<std::string> background_cache_password = Monero::optional<std::string>();
+  const epee::scope_guard bgc_scope_exit_handler([&](){
+    memwipe(&wallet_password[0], wallet_password.size());
+    if (background_cache_password)
+      memwipe(&(*background_cache_password)[0], (*background_cache_password).size());
+  });
+  if (background_sync_type == Wallet::BackgroundSync_CustomPassword)
   {
-    boost::optional<epee::wipeable_string> background_cache_password = boost::none;
-    if (background_sync_type == tools::wallet2::BackgroundSyncCustomPassword)
-    {
-      const auto background_pwd_container = background_sync_cache_password_prompter(true);
-      if (!background_pwd_container)
-        return true;
-      background_cache_password = background_pwd_container->password();
-    }
-
-    LOCK_IDLE_SCOPE();
-    m_wallet->setup_background_sync(background_sync_type, pwd_container->password(), background_cache_password);
+    const auto background_pwd_container = background_sync_cache_password_prompter(true);
+    if (!background_pwd_container)
+      return true;
+    background_cache_password = std::string(background_pwd_container->password().data(), background_pwd_container->password().size());
   }
-  catch (const std::exception &e)
+
+  LOCK_IDLE_SCOPE();
+  m_wallet_impl->setupBackgroundSync(background_sync_type, wallet_password, background_cache_password);
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    fail_msg_writer() << tr("Error setting background sync type: ") << e.what();
+    fail_msg_writer() << tr("Error setting background sync type: ") << error_code;
+    return true;
   }
 
   return true;
@@ -2762,8 +2714,8 @@ bool simple_wallet::set_show_wallet_name_when_locked(const std::vector<std::stri
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->show_wallet_name_when_locked(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setShowWalletNameWhenLocked(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2781,8 +2733,8 @@ bool simple_wallet::set_inactivity_lock_timeout(const std::vector<std::string> &
     uint32_t r;
     if (epee::string_tools::get_xtype_from_string(r, args[1]))
     {
-      m_wallet->inactivity_lock_timeout(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setInactivityLockTimeout(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     }
     else
     {
@@ -2797,19 +2749,19 @@ bool simple_wallet::set_setup_background_mining(const std::vector<std::string> &
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    tools::wallet2::BackgroundMiningSetupType setup = tools::wallet2::BackgroundMiningMaybe;
+    Wallet::BackgroundMiningSetupType setup = Wallet::BackgroundMiningSetupType::BackgroundMining_No;
     if (args[1] == "yes" || args[1] == "1")
-      setup = tools::wallet2::BackgroundMiningYes;
+      setup = Wallet::BackgroundMiningSetupType::BackgroundMining_Yes;
     else if (args[1] == "no" || args[1] == "0")
-      setup = tools::wallet2::BackgroundMiningNo;
+      setup = Wallet::BackgroundMiningSetupType::BackgroundMining_No;
     else
     {
       fail_msg_writer() << tr("invalid argument: must be either 1/yes or 0/no");
       return true;
     }
-    m_wallet->setup_background_mining(setup);
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
-    if (setup == tools::wallet2::BackgroundMiningYes)
+    m_wallet_impl->setSetupBackgroundMining(setup);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
+    if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_Yes)
       start_background_mining();
     else
       stop_background_mining();
@@ -2822,19 +2774,18 @@ bool simple_wallet::set_device_name(const std::vector<std::string> &args/* = std
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->device_name(args[1]);
-    bool r = false;
-    try {
-      r = m_wallet->reconnect_device();
-      if (!r){
-        fail_msg_writer() << tr("Device reconnect failed");
-      }
-
-    } catch(const std::exception & e){
-      MWARNING("Device reconnect failed: " << e.what());
-      fail_msg_writer() << tr("Device reconnect failed: ") << e.what();
+    m_wallet_impl->setDeviceName(args[1]);
+    if (!m_wallet_impl->reconnectDevice()){
+      fail_msg_writer() << tr("Device reconnect failed");
+      int error_code;
+      std::string error_msg;
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+      if (error_code)
+          fail_msg_writer() << ": " << error_msg;
     }
-
+    else {
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
+    }
   }
   return true;
 }
@@ -2849,11 +2800,11 @@ bool simple_wallet::set_export_format(const std::vector<std::string> &args/* = s
 
   if (boost::algorithm::iequals(args[1], "ascii"))
   {
-    m_wallet->set_export_format(tools::wallet2::ExportFormat::Ascii);
+    m_wallet_impl->setExportFormat(Wallet::ExportFormat::ExportFormat_Ascii);
   }
   else if (boost::algorithm::iequals(args[1], "binary"))
   {
-    m_wallet->set_export_format(tools::wallet2::ExportFormat::Binary);
+    m_wallet_impl->setExportFormat(Wallet::ExportFormat::ExportFormat_Binary);
   }
   else
   {
@@ -2863,7 +2814,7 @@ bool simple_wallet::set_export_format(const std::vector<std::string> &args/* = s
   const auto pwd_container = get_and_verify_password();
   if (pwd_container)
   {
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
   }
   return true;
 }
@@ -2899,8 +2850,8 @@ bool simple_wallet::set_enable_multisig(const std::vector<std::string> &args/* =
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
-      m_wallet->enable_multisig(r);
-      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+      m_wallet_impl->setEnableMultisig(r);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd_container->password().data(), pwd_container->password().size()));
     });
   }
   return true;
@@ -2937,12 +2888,6 @@ bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<st
   else if ((args.size() == 1) && (args.front() == "all"))
   {
     success_msg_writer() << get_commands_str();
-  }
-  else if ((args.size() == 2) && (args.front() == "mms"))
-  {
-    // Little hack to be able to do "help mms <subcommand>"
-    std::vector<std::string> mms_args(1, args.front() + " " + args.back());
-    success_msg_writer() << get_command_usage(mms_args);
   }
   else
   {
@@ -2987,18 +2932,7 @@ bool simple_wallet::scan_tx(const std::vector<std::string> &args)
     return true;
   }
 
-  // Parse and dedup args
-  std::unordered_set<crypto::hash> txids;
-  for (const auto &s : args) {
-    crypto::hash txid;
-    if (!epee::string_tools::hex_to_pod(s, txid)) {
-      fail_msg_writer() << tr("Invalid txid specified: ") << s;
-      return true;
-    }
-    txids.insert(txid);
-  }
-
-  if (!m_wallet->is_trusted_daemon()) {
+  if (!m_wallet_impl->trustedDaemon()) {
     message_writer(console_color_red, true) << tr("WARNING: this operation may reveal the txids to the remote node and affect your privacy");
     if (!command_line::is_yes(input_line("Do you want to continue?", true))) {
       message_writer() << tr("You have canceled the operation");
@@ -3008,12 +2942,16 @@ bool simple_wallet::scan_tx(const std::vector<std::string> &args)
 
   LOCK_IDLE_SCOPE();
   m_in_manual_refresh.store(true);
-  try {
-    m_wallet->scan_tx(txids);
-  } catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e) {
-    fail_msg_writer() << e.what() << ". Either connect to a trusted daemon by passing --trusted-daemon when starting the wallet, or use rescan_bc to rescan the chain.";
-  } catch (const std::exception &e) {
-    fail_msg_writer() << e.what();
+  bool wont_reprocess_recent_txs_via_untrusted_daemon = false;
+  m_wallet_impl->scanTransactions(args, &wont_reprocess_recent_txs_via_untrusted_daemon);
+  int error;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error, error_msg);
+  if (error)
+  {
+    fail_msg_writer() << error_msg << (wont_reprocess_recent_txs_via_untrusted_daemon
+                                       ? ". Either connect to a trusted daemon by passing --trusted-daemon when starting the wallet, or use rescan_bc to rescan the chain."
+                                       : "");
   }
   m_in_manual_refresh.store(false);
   return true;
@@ -3066,10 +3004,7 @@ simple_wallet::simple_wallet()
                            tr("Show the blockchain height."));
   m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::on_command, this, &simple_wallet::transfer, _1),
                            tr(USAGE_TRANSFER),
-                           tr("Transfer <address> <amount>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included). The \"subtractfeefrom=\" list allows you to choose which destinations to fund the tx fee from instead of the change output. The fee will be split across the chosen destinations proportionally equally. For example, to make 3 transfers where the fee is taken from the first and third destinations, one could do: \"transfer <addr1> 3 <addr2> 0.5 <addr3> 1 subtractfeefrom=0,2\". Let's say the tx fee is 0.1. The balance would drop by exactly 4.5 XMR including fees, and addr1 & addr3 would receive 2.925 & 0.975 XMR, respectively. Use \"subtractfeefrom=all\" to spread the fee across all destinations."));
-  m_cmd_binder.set_handler("sweep_unmixable",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_unmixable, _1),
-                           tr("Send all unmixable outputs to yourself with ring_size 1"));
+                           tr("Transfer <address> <amount>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera. The \"subtractfeefrom=\" list allows you to choose which destinations to fund the tx fee from instead of the change output. The fee will be split across the chosen destinations proportionally equally. For example, to make 3 transfers where the fee is taken from the first and third destinations, one could do: \"transfer <addr1> 3 <addr2> 0.5 <addr3> 1 subtractfeefrom=0,2\". Let's say the tx fee is 0.1. The balance would drop by exactly 4.5 XMR including fees, and addr1 & addr3 would receive 2.925 & 0.975 XMR, respectively. Use \"subtractfeefrom=all\" to spread the fee across all destinations."));
   m_cmd_binder.set_handler("sweep_all", boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_all, _1),
                            tr(USAGE_SWEEP_ALL),
                            tr("Send all unlocked balance to an address. If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs."));
@@ -3158,7 +3093,6 @@ simple_wallet::simple_wallet()
                                   "  Set the wallet's refresh behaviour.\n "
                                   "priority [0|1|2|3|4]\n "
                                   "  Set the fee to default/unimportant/normal/elevated/priority.\n "
-                                  "confirm-missing-payment-id <1|0> (obsolete)\n "
                                   "ask-password <0|1|2   (or never|action|decrypt)>\n "
                                   "  action: ask the password before many actions such as transfer, etc\n "
                                   "  decrypt: same as action, but keeps the spend key encrypted in memory when not needed\n "
@@ -3239,7 +3173,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("check_tx_proof",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::check_tx_proof, _1),
                            tr(USAGE_CHECK_TX_PROOF),
-                           tr("Check the proof for funds going to <address> in <txid> with the challenge string <message> if any."));
+                           tr("Check the proof for funds going to <address> in <txid> with the challenge string <message> if any. (When using <signature_file> make sure the file name does NOT start with `InProof` or `OutProof`.)"));
   m_cmd_binder.set_handler("get_spend_proof",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_spend_proof, _1),
                            tr(USAGE_GET_SPEND_PROOF),
@@ -3379,93 +3313,6 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_raw_multisig, _1),
                            tr(USAGE_EXPORT_RAW_MULTISIG_TX),
                            tr("Export a signed multisig transaction to a file"));
-  m_cmd_binder.set_handler("mms",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS),
-                           tr("Interface with the MMS (Multisig Messaging System)\n"
-                              "<subcommand> is one of:\n"
-                              "  init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help\n"
-                              "  send_signer_config, start_auto_config, stop_auto_config, auto_config, config_checksum\n"
-                              "Get help about a subcommand with: help mms <subcommand>, or help mms <subcommand>"));
-  m_cmd_binder.set_handler("mms init",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_INIT),
-                           tr("Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig"));
-  m_cmd_binder.set_handler("mms info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_INFO),
-                           tr("Display current MMS configuration"));
-  m_cmd_binder.set_handler("mms signer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SIGNER),
-                           tr("Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers"));
-  m_cmd_binder.set_handler("mms list",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_LIST),
-                           tr("List all messages"));
-  m_cmd_binder.set_handler("mms next",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_NEXT),
-                           tr("Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice\n"
-                              "By using 'sync' processing of waiting messages with multisig sync info can be forced regardless of wallet state"));
-  m_cmd_binder.set_handler("mms sync",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SYNC),
-                           tr("Force generation of multisig sync info regardless of wallet state, to recover from special situations like \"stale data\" errors"));
-  m_cmd_binder.set_handler("mms transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_TRANSFER),
-                           tr("Initiate transfer with MMS support; arguments identical to normal 'transfer' command arguments, for info see there"));
-  m_cmd_binder.set_handler("mms delete",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_DELETE),
-                           tr("Delete a single message by giving its id, or delete all messages by using 'all'"));
-  m_cmd_binder.set_handler("mms send",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SEND),
-                           tr("Send a single message by giving its id, or send all waiting messages"));
-  m_cmd_binder.set_handler("mms receive",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_RECEIVE),
-                           tr("Check right away for new messages to receive"));
-  m_cmd_binder.set_handler("mms export",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_EXPORT),
-                           tr("Write the content of a message to a file \"mms_message_content\""));
-  m_cmd_binder.set_handler("mms note",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_NOTE),
-                           tr("Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes"));
-  m_cmd_binder.set_handler("mms show",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SHOW),
-                           tr("Show detailed info about a single message"));
-  m_cmd_binder.set_handler("mms set",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SET),
-                           tr("Available options:\n "
-                                  "auto-send <1|0>\n "
-                                  "  Whether to automatically send newly generated messages right away.\n "));
-  m_cmd_binder.set_handler("mms send_signer_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_SEND_SIGNER_CONFIG),
-                           tr("Send completed signer config to all other authorized signers"));
-  m_cmd_binder.set_handler("mms start_auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_START_AUTO_CONFIG),
-                           tr("Start auto-config at the auto-config manager's wallet by issuing auto-config tokens and optionally set others' labels"));
-  m_cmd_binder.set_handler("mms config_checksum",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_CONFIG_CHECKSUM),
-                           tr("Get a checksum that allows signers to easily check for identical MMS configuration"));
-  m_cmd_binder.set_handler("mms stop_auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_STOP_AUTO_CONFIG),
-                           tr("Delete any auto-config tokens and abort a auto-config process"));
-  m_cmd_binder.set_handler("mms auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, _1),
-                           tr(USAGE_MMS_AUTO_CONFIG),
-                           tr("Start auto-config by using the token received from the auto-config manager"));
   m_cmd_binder.set_handler("print_ring",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::print_ring, _1),
                            tr(USAGE_PRINT_RING),
@@ -3476,26 +3323,18 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_ring, _1),
                            tr(USAGE_SET_RING),
                            tr("Set the ring used for a given key image, so it can be reused in a fork"));
-  m_cmd_binder.set_handler("unset_ring",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::unset_ring, _1),
-                           tr(USAGE_UNSET_RING),
-                           tr("Unsets the ring used for a given key image or transaction"));
-  m_cmd_binder.set_handler("save_known_rings",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::save_known_rings, _1),
-                           tr(USAGE_SAVE_KNOWN_RINGS),
-                           tr("Save known rings to the shared rings database"));
   m_cmd_binder.set_handler("freeze",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::freeze, _1),
                            tr(USAGE_FREEZE),
-                           tr("Freeze a single output by key image so it will not be used"));
+                           tr("Freeze a single enote by key image or enote public key so it will not be used"));
   m_cmd_binder.set_handler("thaw",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::thaw, _1),
                            tr(USAGE_THAW),
-                           tr("Thaw a single output by key image so it may be used again"));
+                           tr("Thaw a single enote by key image or enote public key so it may be used again"));
   m_cmd_binder.set_handler("frozen",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::frozen, _1),
                            tr(USAGE_FROZEN),
-                           tr("Checks whether a given output is currently frozen by key image"));
+                           tr("Checks whether a given enote is currently frozen by key image or enote public key, or print all frozen enotes"));
   m_cmd_binder.set_handler("lock",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::lock, _1),
                            tr(USAGE_LOCK),
@@ -3541,66 +3380,65 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
 {
   if (args.empty())
   {
-    std::string seed_language = m_wallet->get_seed_language();
+    std::string seed_language = m_wallet_impl->getSeedLanguage();
     if (m_use_english_language_names)
       seed_language = crypto::ElectrumWords::get_english_name_for(seed_language);
     std::string priority_string = "invalid";
-    const fee_priority priority = m_wallet->get_default_priority();
+    const auto priority_index = m_wallet_impl->getDefaultPriority();
+    const fee_priority priority = tools::fee_priority_utilities::from_integral(priority_index);
     priority_string = tools::fee_priority_utilities::to_string(priority);
-    const auto priority_index = tools::fee_priority_utilities::as_integral(priority);
     std::string ask_password_string = "invalid";
-    switch (m_wallet->ask_password())
+    switch (m_wallet_impl->getAskPasswordType())
     {
-      case tools::wallet2::AskPasswordNever: ask_password_string = "never"; break;
-      case tools::wallet2::AskPasswordOnAction: ask_password_string = "action"; break;
-      case tools::wallet2::AskPasswordToDecrypt: ask_password_string = "decrypt"; break;
+      case Wallet::AskPasswordType::AskPassword_Never: ask_password_string = "never"; break;
+      case Wallet::AskPasswordType::AskPassword_OnAction: ask_password_string = "action"; break;
+      case Wallet::AskPasswordType::AskPassword_ToDecrypt: ask_password_string = "decrypt"; break;
     }
     std::string setup_background_mining_string = "invalid";
-    switch (m_wallet->setup_background_mining())
+    switch (m_wallet_impl->getSetupBackgroundMining())
     {
-      case tools::wallet2::BackgroundMiningMaybe: setup_background_mining_string = "maybe"; break;
-      case tools::wallet2::BackgroundMiningYes: setup_background_mining_string = "yes"; break;
-      case tools::wallet2::BackgroundMiningNo: setup_background_mining_string = "no"; break;
+      case Wallet::BackgroundMiningSetupType::BackgroundMining_Maybe: setup_background_mining_string = "maybe"; break;
+      case Wallet::BackgroundMiningSetupType::BackgroundMining_Yes: setup_background_mining_string = "yes"; break;
+      case Wallet::BackgroundMiningSetupType::BackgroundMining_No: setup_background_mining_string = "no"; break;
     }
     success_msg_writer() << "seed = " << seed_language;
-    success_msg_writer() << "always-confirm-transfers = " << m_wallet->always_confirm_transfers();
-    success_msg_writer() << "print-ring-members = " << m_wallet->print_ring_members();
-    success_msg_writer() << "store-tx-info = " << m_wallet->store_tx_info();
-    success_msg_writer() << "default-ring-size = " << (m_wallet->default_mixin() ? m_wallet->default_mixin() + 1 : 0);
-    success_msg_writer() << "auto-refresh = " << m_wallet->auto_refresh();
-    success_msg_writer() << "refresh-type = " << get_refresh_type_name(m_wallet->get_refresh_type());
+    success_msg_writer() << "always-confirm-transfers = " << m_wallet_impl->getAlwaysConfirmTransfers();
+    success_msg_writer() << "print-ring-members = " << m_wallet_impl->getPrintRingMembers();
+    success_msg_writer() << "store-tx-info = " << m_wallet_impl->getStoreTxInfo();
+    success_msg_writer() << "auto-refresh = " << m_wallet_impl->getAutoRefresh();
+    success_msg_writer() << "refresh-type = " << get_refresh_type_name(m_wallet_impl->getRefreshType());
     success_msg_writer() << "priority = " << priority_index << " (" << priority_string << ")";
-    success_msg_writer() << "ask-password = " << m_wallet->ask_password() << " (" << ask_password_string << ")";
+    success_msg_writer() << "ask-password = " << static_cast<int>(m_wallet_impl->getAskPasswordType()) << " (" << ask_password_string << ")";
     success_msg_writer() << "unit = " << cryptonote::get_unit(cryptonote::get_default_decimal_point());
-    success_msg_writer() << "max-reorg-depth = " << m_wallet->max_reorg_depth();
-    success_msg_writer() << "min-outputs-count = " << m_wallet->get_min_output_count();
-    success_msg_writer() << "min-outputs-value = " << cryptonote::print_money(m_wallet->get_min_output_value());
-    success_msg_writer() << "merge-destinations = " << m_wallet->merge_destinations();
-    success_msg_writer() << "confirm-backlog = " << m_wallet->confirm_backlog();
-    success_msg_writer() << "confirm-backlog-threshold = " << m_wallet->get_confirm_backlog_threshold();
-    success_msg_writer() << "confirm-export-overwrite = " << m_wallet->confirm_export_overwrite();
-    success_msg_writer() << "refresh-from-block-height = " << m_wallet->get_refresh_from_block_height();
-    success_msg_writer() << "auto-low-priority = " << m_wallet->auto_low_priority();
-    success_msg_writer() << "segregate-pre-fork-outputs = " << m_wallet->segregate_pre_fork_outputs();
-    success_msg_writer() << "key-reuse-mitigation2 = " << m_wallet->key_reuse_mitigation2();
-    const std::pair<size_t, size_t> lookahead = m_wallet->get_subaddress_lookahead();
+    success_msg_writer() << "max-reorg-depth = " << m_wallet_impl->getMaxReorgDepth();
+    success_msg_writer() << "min-outputs-count = " << m_wallet_impl->getMinOutputCount();
+    success_msg_writer() << "min-outputs-value = " << cryptonote::print_money(m_wallet_impl->getMinOutputValue());
+    success_msg_writer() << "merge-destinations = " << m_wallet_impl->getMergeDestinations();
+    success_msg_writer() << "confirm-backlog = " << m_wallet_impl->getConfirmBacklog();
+    success_msg_writer() << "confirm-backlog-threshold = " << m_wallet_impl->getConfirmBacklogThreshold();
+    success_msg_writer() << "confirm-export-overwrite = " << m_wallet_impl->getConfirmExportOverwrite();
+    success_msg_writer() << "refresh-from-block-height = " << m_wallet_impl->getRefreshFromBlockHeight();
+    success_msg_writer() << "auto-low-priority = " << m_wallet_impl->getAutoLowPriority();
+    success_msg_writer() << "segregate-pre-fork-outputs = " << m_wallet_impl->getSegregatePreForkOutputs();
+    success_msg_writer() << "key-reuse-mitigation2 = " << m_wallet_impl->getKeyReuseMitigation2();
+    const std::pair<size_t, size_t> lookahead = m_wallet_impl->getSubaddressLookahead();
     success_msg_writer() << "subaddress-lookahead = " << lookahead.first << ":" << lookahead.second;
-    success_msg_writer() << "segregation-height = " << m_wallet->segregation_height();
-    success_msg_writer() << "ignore-fractional-outputs = " << m_wallet->ignore_fractional_outputs();
-    success_msg_writer() << "ignore-outputs-above = " << cryptonote::print_money(m_wallet->ignore_outputs_above());
-    success_msg_writer() << "ignore-outputs-below = " << cryptonote::print_money(m_wallet->ignore_outputs_below());
-    success_msg_writer() << "track-uses = " << m_wallet->track_uses();
-    success_msg_writer() << "background-sync = " << get_background_sync_type_name(m_wallet->background_sync_type());
+    success_msg_writer() << "segregation-height = " << m_wallet_impl->getSegregationHeight();
+    success_msg_writer() << "ignore-fractional-outputs = " << m_wallet_impl->getIgnoreFractionalOutputs();
+    success_msg_writer() << "ignore-outputs-above = " << cryptonote::print_money(m_wallet_impl->getIgnoreOutputsAbove());
+    success_msg_writer() << "ignore-outputs-below = " << cryptonote::print_money(m_wallet_impl->getIgnoreOutputsBelow());
+    success_msg_writer() << "track-uses = " << m_wallet_impl->getTrackUses();
+    success_msg_writer() << "background-sync = " << get_background_sync_type_name(m_wallet_impl->getBackgroundSyncType());
     success_msg_writer() << "setup-background-mining = " << setup_background_mining_string;
-    success_msg_writer() << "device-name = " << m_wallet->device_name();
-    success_msg_writer() << "export-format = " << (m_wallet->export_format() == tools::wallet2::ExportFormat::Ascii ? "ascii" : "binary");
-    success_msg_writer() << "show-wallet-name-when-locked = " << m_wallet->show_wallet_name_when_locked();
-    success_msg_writer() << "inactivity-lock-timeout = " << m_wallet->inactivity_lock_timeout()
+    success_msg_writer() << "device-name = " << m_wallet_impl->getDeviceState().device_name;
+    success_msg_writer() << "export-format = " << (m_wallet_impl->getExportFormat() == Wallet::ExportFormat::ExportFormat_Ascii ? "ascii" : "binary");
+    success_msg_writer() << "show-wallet-name-when-locked = " << m_wallet_impl->getShowWalletNameWhenLocked();
+    success_msg_writer() << "inactivity-lock-timeout = " << m_wallet_impl->getInactivityLockTimeout()
 #ifdef _WIN32
         << " (disabled on Windows)"
 #endif
         ;
-    success_msg_writer() << "enable-multisig-experimental = " << m_wallet->is_multisig_enabled();
+    success_msg_writer() << "enable-multisig-experimental = " << m_wallet_impl->getEnableMultisig();
     return true;
   }
   else
@@ -3727,14 +3565,14 @@ bool simple_wallet::ask_wallet_create_if_needed(const std::string &wallet_dir)
 
       wallet_path = resolve_wallet_path(wallet_path, wallet_dir);
 
-      if(!tools::wallet2::wallet_valid_path_format(wallet_path))
+      if(!wallet_path.empty())
       {
         fail_msg_writer() << tr("Wallet name not valid. Please try again or use Ctrl-C to quit.");
         wallet_name_valid = false;
       }
       else
       {
-        tools::wallet2::wallet_exists(wallet_path, keys_file_exists, wallet_file_exists);
+        Wallet::walletExists(wallet_path, keys_file_exists, wallet_file_exists);
         LOG_PRINT_L3("wallet_path: " << wallet_path << "");
         LOG_PRINT_L3("keys_file_exists: " << std::boolalpha << keys_file_exists << std::noboolalpha
         << "  wallet_file_exists: " << std::boolalpha << wallet_file_exists << std::noboolalpha);
@@ -3798,7 +3636,7 @@ void simple_wallet::print_seed(const epee::wipeable_string &seed)
 {
   success_msg_writer(true) << "\n" << boost::format(tr("NOTE: the following %s can be used to recover access to your wallet. "
     "Write them down and store them somewhere safe and secure. Please do not store them in "
-    "your email or on file storage services outside of your immediate control.\n")) % (m_wallet->get_multisig_status().multisig_is_active ? tr("string") : tr("25 words"));
+    "your email or on file storage services outside of your immediate control.\n")) % (m_wallet_impl->multisig().isMultisig ? tr("string") : tr("25 words"));
   // don't log
   int space_index = 0;
   size_t len  = seed.size();
@@ -3856,14 +3694,8 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
   });
 
   const std::string wallet_dir = command_line::get_arg(vm, arg_wallet_dir);
-  const bool testnet = tools::wallet2::has_testnet_option(vm);
-  const bool stagenet = tools::wallet2::has_stagenet_option(vm);
-  if (testnet && stagenet)
-  {
-    fail_msg_writer() << tr("Can't specify more than one of --testnet and --stagenet");
-    return false;
-  }
-  const network_type nettype = testnet ? TESTNET : stagenet ? STAGENET : MAINNET;
+
+  m_wallet_manager.reset(WalletManagerFactory::getWalletManager());
 
   epee::wipeable_string multisig_keys;
   epee::wipeable_string password;
@@ -3871,6 +3703,14 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
 
   if (!handle_command_line(vm))
     return false;
+
+  network_type nettype;
+  {
+      NetworkType nettype_tmp;
+      if (!get_nettype(vm, nettype_tmp))
+        return false;
+      nettype = static_cast<network_type>(nettype_tmp);
+  }
 
   bool welcome = false;
 
@@ -4027,6 +3867,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         return false;
       }
 
+      // --generate-from-view-key
       auto r = new_wallet(vm, info.address, boost::none, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4048,6 +3889,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         fail_msg_writer() << tr("failed to parse spend key secret key");
         return false;
       }
+      // --generate-from-spend-key
       auto r = new_wallet(vm, m_recovery_key, true, false, "");
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4124,6 +3966,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         fail_msg_writer() << tr("view key does not match standard address");
         return false;
       }
+      // --generate-from-keys
       auto r = new_wallet(vm, info.address, spendkey, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4257,7 +4100,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         return false;
       }
       
-      // create wallet
+      // create wallet --generate-from-multisig-keys
       auto r = new_wallet(vm, info.address, spendkey, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4266,24 +4109,16 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     
     else if (!m_generate_from_json.empty())
     {
-      try
-      {
-        auto rc = tools::wallet2::make_from_json(vm, false, m_generate_from_json, password_prompter);
-        m_wallet = std::move(rc.first);
-        password = rc.second.password();
-        if (!m_wallet) return false;
-        m_wallet_file = m_wallet->path();
-      }
-      catch (const std::exception &e)
-      {
-        fail_msg_writer() << e.what();
-        return false;
-      }
+      // --generate-from-json
+      auto r = new_wallet(vm, m_generate_from_json);
+      CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
+      m_wallet_file = m_wallet_impl->path();
     }
     else if (!m_generate_from_device.empty())
     {
       m_wallet_file = resolve_wallet_path(m_generate_from_device, wallet_dir);
-      // create wallet
+      // create wallet --generate-from-device
       auto r = new_wallet(vm);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4300,9 +4135,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         if (std::cin.eof() || !command_line::is_yes(confirm))
           CHECK_AND_ASSERT_MES(false, false, tr("account creation aborted"));
 
-        m_wallet->set_refresh_from_block_height(m_wallet->estimate_blockchain_height() > 0 ? m_wallet->estimate_blockchain_height() - 1 : 0);
-        m_wallet->explicit_refresh_from_block_height(true);
-        m_restore_height = m_wallet->get_refresh_from_block_height();
+        m_wallet_impl->setRefreshFromBlockHeight(m_wallet_impl->estimateBlockChainHeight() > 0 ? m_wallet_impl->estimateBlockChainHeight() - 1 : 0);
+        m_wallet_impl->setExplicitRefreshFromBlockHeight(true);
+        m_restore_height = m_wallet_impl->getRefreshFromBlockHeight();
       }
     }
     else
@@ -4313,9 +4148,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
       m_wallet_file = resolve_wallet_path(m_generate_new, wallet_dir);
       boost::optional<epee::wipeable_string> r;
-      if (m_restore_multisig_wallet)
+      if (m_restore_multisig_wallet) // --restore-multisig-wallet
         r = new_wallet(vm, multisig_keys, seed_pass, old_language);
-      else
+      else                           // { --generate-new-wallet | --non-deterministic | --restore-deterministic-wallet / --restore-from-seed }
         r = new_wallet(vm, m_recovery_key, m_restore_deterministic_wallet, m_non_deterministic, old_language);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
       password = *r;
@@ -4324,7 +4159,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
 
     if (m_restoring && m_generate_from_json.empty() && m_generate_from_device.empty())
     {
-      m_wallet->explicit_refresh_from_block_height(!(command_line::is_arg_defaulted(vm, arg_restore_height) &&
+      m_wallet_impl->setExplicitRefreshFromBlockHeight(!(command_line::is_arg_defaulted(vm, arg_restore_height) &&
         command_line::is_arg_defaulted(vm, arg_restore_date)));
       if (command_line::is_arg_defaulted(vm, arg_restore_height) && !command_line::is_arg_defaulted(vm, arg_restore_date))
       {
@@ -4333,19 +4168,20 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         uint8_t day;
         if (!datestr_to_int(m_restore_date, year, month, day))
           return false;
-        try
-        {
-          m_restore_height = m_wallet->get_blockchain_height_by_date(year, month, day);
+        m_restore_height = m_wallet_impl->getBlockchainHeightByDate(year, month, day);
+        int error_code;
+        std::string error_msg;
+        m_wallet_impl->statusWithErrorString(error_code, error_msg);
+        if (!error_code)
           success_msg_writer() << tr("Restore height is: ") << m_restore_height;
-        }
-        catch (const std::runtime_error& e)
+        else
         {
-          fail_msg_writer() << e.what();
+          fail_msg_writer() << error_msg;
           return false;
         }
       }
     }
-    if (!m_wallet->explicit_refresh_from_block_height() && m_restoring)
+    if (!m_wallet_impl->getExplicitRefreshFromBlockHeight() && m_restoring)
     {
       uint32_t version;
       bool connected = try_connect_to_daemon(false, &version);
@@ -4382,7 +4218,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
           {
             if (!datestr_to_int(heightstr, year, month, day))
               return false;
-            m_restore_height = m_wallet->get_blockchain_height_by_date(year, month, day);
+            m_restore_height = m_wallet_impl->getBlockchainHeightByDate(year, month, day);
             success_msg_writer() << tr("Restore height is: ") << m_restore_height;
             std::string confirm = input_line(tr("Is this okay?"), true);
             if (std::cin.eof())
@@ -4403,7 +4239,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     }
     if (m_restoring)
     {
-      uint64_t estimate_height = m_wallet->estimate_blockchain_height();
+      uint64_t estimate_height = m_wallet_impl->estimateBlockChainHeight();
       if (m_restore_height >= estimate_height)
       {
         success_msg_writer() << tr("Restore height ") << m_restore_height << (" is not yet reached. The current estimated height is ") << estimate_height;
@@ -4411,11 +4247,11 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         if (std::cin.eof() || command_line::is_no(confirm))
           m_restore_height = 0;
       }
-      m_wallet->set_refresh_from_block_height(m_restore_height);
+      m_wallet_impl->setRefreshFromBlockHeight(m_restore_height);
     }
     if (enable_multisig)
-      m_wallet->enable_multisig(true);
-    m_wallet->rewrite(m_wallet_file, password);
+      m_wallet_impl->setEnableMultisig(true);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(password.data(), password.size()));
   }
   else
   {
@@ -4430,34 +4266,40 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     CHECK_AND_ASSERT_MES(r, false, tr("failed to open account"));
     password = *r;
   }
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return false;
   }
-
-  if (!m_wallet->is_trusted_daemon())
+  if (command_line::has_arg(vm, arg_allow_mismatched_daemon_version))
+    m_wallet_impl->setAllowMismatchedDaemonVersion(true);
+  if (!m_wallet_impl->trustedDaemon())
   {
-    message_writer(console_color_red, true) << (boost::format(tr("Warning: using an untrusted daemon at %s")) % m_wallet->get_daemon_address()).str();
+    message_writer(console_color_red, true) << (boost::format(tr("Warning: using an untrusted daemon at %s")) % m_wallet_impl->getWalletState().daemon_address).str();
     message_writer(console_color_red, true) << boost::format(tr("Using a third party daemon can be detrimental to your security and privacy"));
     bool ssl = false;
-    if (m_wallet->check_connection(NULL, &ssl) && !ssl)
+    if (m_wallet_impl->connectToDaemon(NULL, &ssl) && !ssl)
       message_writer(console_color_red, true) << boost::format(tr("Using your own without SSL exposes your RPC traffic to monitoring"));
     message_writer(console_color_red, true) << boost::format(tr("You are strongly encouraged to connect to the Monero network using your own daemon"));
     message_writer(console_color_red, true) << boost::format(tr("If you or someone you trust are operating this daemon, you can use --trusted-daemon"));
   }
 
-  if (m_wallet->get_ring_database().empty())
+  if (m_wallet_impl->getWalletState().ring_database.empty())
     fail_msg_writer() << tr("Failed to initialize ring database: privacy enhancing features will be inactive");
 
-  m_wallet->callback(this);
+  m_wallet_impl->setListener(this);
 
-  bool skip_check_backround_mining = !command_line::get_arg(vm, arg_command).empty();
-  if (!skip_check_backround_mining)
+  bool skip_check_background_mining = !command_line::get_arg(vm, arg_command).empty();
+  if (!skip_check_background_mining)
     check_background_mining(password);
 
   if (welcome)
     message_writer(console_color_yellow, true) << tr("If you are new to Monero, type \"welcome\" for a brief overview.");
+
+  // the Wallet API does a refresh of the tx history in WalletImpl::doRefresh()
+  // which does not happpen if a) there is no connection to a daemon, or b) the local daemon is not synced
+  // and that leads to an empty history, therefore we do a manual refresh here
+  m_wallet_impl->history()->refresh();
 
   m_last_activity_time = time(NULL);
   return true;
@@ -4465,7 +4307,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::deinit()
 {
-  if (!m_wallet.get())
+  if (!m_wallet_impl.get())
     return true;
 
   return close_wallet();
@@ -4499,7 +4341,6 @@ bool simple_wallet::handle_command_line(const boost::program_options::variables_
                                     !m_generate_from_device.empty() ||
                                     m_restore_deterministic_wallet ||
                                     m_restore_multisig_wallet;
-
   if (!command_line::is_arg_defaulted(vm, arg_restore_date))
   {
     uint16_t year;
@@ -4517,30 +4358,31 @@ bool simple_wallet::try_connect_to_daemon(bool silent, uint32_t* version)
   if (!version)
     version = &version_;
   bool wallet_is_outdated = false, daemon_is_outdated = false;
-  if (!m_wallet->check_connection(version, NULL, 200000, &wallet_is_outdated, &daemon_is_outdated))
+  std::string daemon_address = m_wallet_impl->getWalletState().daemon_address;
+  if (!m_wallet_impl->connectToDaemon(version, NULL, 200000, &wallet_is_outdated, &daemon_is_outdated))
   {
     if (!silent)
     {
-      if (m_wallet->is_offline())
+      if (m_wallet_impl->isOffline())
         fail_msg_writer() << tr("wallet failed to connect to daemon, because it is set to offline mode");
       else if (wallet_is_outdated)
         fail_msg_writer() << tr("wallet failed to connect to daemon, because it is not up to date. ") <<
           tr("Please make sure you are running the latest wallet.");
       else if (daemon_is_outdated)
-        fail_msg_writer() << tr("wallet failed to connect to daemon: ") << m_wallet->get_daemon_address() << ". " <<
+        fail_msg_writer() << tr("wallet failed to connect to daemon: ") << daemon_address << ". " <<
           tr("Daemon is not up to date. "
           "Please make sure the daemon is running the latest version or change the daemon address using the 'set_daemon' command.");
       else
-        fail_msg_writer() << tr("wallet failed to connect to daemon: ") << m_wallet->get_daemon_address() << ". " <<
+        fail_msg_writer() << tr("wallet failed to connect to daemon: ") << daemon_address << ". " <<
           tr("Daemon either is not started or wrong port was passed. "
           "Please make sure daemon is running or change the daemon address using the 'set_daemon' command.");
     }
     return false;
   }
-  if (!m_wallet->is_mismatched_daemon_version_allowed() && ((*version >> 16) != CORE_RPC_VERSION_MAJOR))
+  if (!m_wallet_impl->getAllowMismatchedDaemonVersion() && ((*version >> 16) != CORE_RPC_VERSION_MAJOR))
   {
     if (!silent)
-      fail_msg_writer() << boost::format(tr("Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.")) % (*version>>16) % CORE_RPC_VERSION_MAJOR % m_wallet->get_daemon_address();
+      fail_msg_writer() << boost::format(tr("Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.")) % (*version>>16) % CORE_RPC_VERSION_MAJOR % daemon_address;
     return false;
   }
   return true;
@@ -4594,13 +4436,13 @@ std::string simple_wallet::get_mnemonic_language()
 boost::optional<tools::password_container> simple_wallet::get_and_verify_password() const
 {
   const bool verify = m_wallet_file.empty();
-  auto pwd_container = (m_wallet->is_background_wallet() && m_wallet->background_sync_type() == tools::wallet2::BackgroundSyncCustomPassword)
+  auto pwd_container = (m_wallet_impl->isBackgroundWallet() && m_wallet_impl->getBackgroundSyncType() == Wallet::BackgroundSync_CustomPassword)
     ? background_sync_cache_password_prompter(verify)
     : default_password_prompter(verify);
   if (!pwd_container)
     return boost::none;
 
-  if (!m_wallet->verify_password(pwd_container->password()))
+  if (!m_wallet_impl->verifyPassword(std::string_view(pwd_container->password().data(), pwd_container->password().size())))
   {
     fail_msg_writer() << tr("invalid password");
     return boost::none;
@@ -4611,22 +4453,8 @@ boost::optional<tools::password_container> simple_wallet::get_and_verify_passwor
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   const crypto::secret_key& recovery_key, bool recover, bool two_random, const std::string &old_language)
 {
-  std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> rc;
-  try { rc = tools::wallet2::make_new(vm, false, password_prompter); }
-  catch(const std::exception &e) { fail_msg_writer() << tr("Error creating wallet: ") << e.what(); return {}; }
-  m_wallet = std::move(rc.first);
-  if (!m_wallet)
-  {
-    return {};
-  }
-  epee::wipeable_string password = rc.second.password();
-
-  if (!m_subaddress_lookahead.empty())
-  {
-    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
-    assert(lookahead);
-    m_wallet->set_subaddress_lookahead(lookahead->first, lookahead->second);
-  }
+  const auto pwd = default_password_prompter(true);
+  epee::wipeable_string password = pwd->password();
 
   bool was_deprecated_wallet = m_restore_deterministic_wallet && ((old_language == crypto::ElectrumWords::old_language_name) ||
     crypto::ElectrumWords::get_is_old_style_seed(m_electrum_seed));
@@ -4639,6 +4467,13 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   {
     mnemonic_language = m_mnemonic_language;
   }
+
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
+    return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
 
   // Ask for seed language if:
   // it's a deterministic wallet AND
@@ -4658,31 +4493,78 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
       return {};
   }
 
-  m_wallet->set_seed_language(mnemonic_language);
-
-  bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
-
-  crypto::secret_key recovery_val;
-  try
-  {
-    recovery_val = m_wallet->generate(m_wallet_file, std::move(rc.second).password(), recovery_key, recover, two_random, create_address_file);
-    message_writer(console_color_white, true) << tr("Generated new wallet: ")
-      << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    PAUSE_READLINE();
-    std::cout << tr("View key: ");
-    print_secret_key(m_wallet->get_account().get_keys().m_view_secret_key);
-    putchar('\n');
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return {};
-  }
+  const bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
 
   // convert rng value to electrum-style word list
   epee::wipeable_string electrum_words;
+  if (recover) // { --generate-from-spend-key | --restore-deterministic-wallet / --restore-from-seed }
+  {
+    crypto::ElectrumWords::bytes_to_words(m_recovery_key, electrum_words, mnemonic_language);
+    // note: if a seed_offset passphrase was set we already decrypted m_recovery_key with it at this time, so we ignore the arg here
+    m_wallet_impl.reset(m_wallet_manager->recoveryWallet(m_wallet_file,
+                                                         std::string(password.data(), password.size()),
+                                                         std::string(electrum_words.data(), electrum_words.size()),
+                                                         nettype,
+                                                         /*restore_height*/ 0,
+                                                         kdf_rounds,
+                                                         /*seed_offset*/ {},
+                                                         create_address_file,
+                                                         /*unattended*/ false));
+  }
+  else // --generate-new-wallet [ --non-deterministic ]
+  {
+    m_wallet_impl.reset(m_wallet_manager->createWallet(m_wallet_file,
+                                                       std::string(password.data(), password.size()),
+                                                       mnemonic_language,
+                                                       nettype,
+                                                       kdf_rounds,
+                                                       create_address_file,
+                                                       two_random,
+                                                       /*unattended*/ false,
+                                                       command_line::get_arg(vm, arg_extra_entropy)));
+    if (!two_random)
+    {
+      // decrypt keys, else the seed willl not match
+      std::unique_ptr<Monero::WalletKeysDecryptGuard> unlocker = std::unique_ptr<Monero::WalletKeysDecryptGuard>(
+              m_wallet_impl->createKeysDecryptGuard(std::string_view(password.data(), password.size())));
+      crypto::secret_key spend_key;
+      epee::string_tools::hex_to_pod(m_wallet_impl->secretSpendKey(), spend_key);
+      crypto::ElectrumWords::bytes_to_words(spend_key, electrum_words, mnemonic_language);
+    }
+  }
 
-  crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, mnemonic_language);
+  if (!m_wallet_impl)
+    return {};
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("failed to generate new wallet: ") << error_msg;
+    return {};
+  }
+
+  if (!init_wallet(vm))
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
+    return {};
+  }
+
+  if (!m_subaddress_lookahead.empty())
+  {
+    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
+    assert(lookahead);
+    m_wallet_impl->setSubaddressLookahead(lookahead->first, lookahead->second);
+  }
+
+  message_writer(console_color_white, true) << tr("Generated new wallet: ")
+    << m_wallet_impl->address();
+  PAUSE_READLINE();
+  std::cout << tr("View key: ") << m_wallet_impl->secretViewKey();
+  putchar('\n');
 
   success_msg_writer() <<
     "**********************************************************************\n" <<
@@ -4695,7 +4577,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     "your current session's state. Otherwise, you might need to synchronize \n"
     "your wallet again (your wallet keys are NOT at risk in any case).\n")
   ;
-  success_msg_writer() << tr("Filename: ") << boost::filesystem::absolute(m_wallet->get_keys_file());
+  success_msg_writer() << tr("Filename: ") << boost::filesystem::absolute(m_wallet_impl->keysFilename());
 
   if (!two_random)
   {
@@ -4710,113 +4592,143 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   const cryptonote::account_public_address& address, const boost::optional<crypto::secret_key>& spendkey,
   const crypto::secret_key& viewkey)
 {
-  std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> rc;
-  try { rc = tools::wallet2::make_new(vm, false, password_prompter); }
-  catch(const std::exception &e) { fail_msg_writer() << tr("Error creating wallet: ") << e.what(); return {}; }
-  m_wallet = std::move(rc.first);
-  if (!m_wallet)
+  const auto pwd = default_password_prompter(true);
+  epee::wipeable_string password = pwd->password();
+
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
+    return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
+
+  // skip mnemonic language for view-only wallet
+  std::string mnemonic_language = crypto::ElectrumWords::old_language_name;
+  if (spendkey)
   {
+    mnemonic_language = get_mnemonic_language();;
+    if (mnemonic_language.empty())
+      return {};
+  }
+
+  const bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
+  // { --generate-from-view-key | --generate-from-keys | --generate-from-multisig-keys }
+  m_wallet_impl.reset(m_wallet_manager->createWalletFromKeys(m_wallet_file,
+                                                             std::string(password.data(), password.size()),
+                                                             mnemonic_language,
+                                                             nettype,
+                                                             m_restore_height,
+                                                             cryptonote::get_account_address_as_str(static_cast<network_type>(nettype), /* subaddress */ false, address),
+                                                             epee::string_tools::pod_to_hex(unwrap(unwrap(viewkey))),
+                                                             spendkey ? epee::string_tools::pod_to_hex(unwrap(unwrap(*spendkey))) : "",
+                                                             kdf_rounds,
+                                                             create_address_file,
+                                                             /* unattended */ false));
+
+  if (!m_wallet_impl)
+    return {};
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("failed to generate new wallet: ") << error_msg;
     return {};
   }
-  epee::wipeable_string password = rc.second.password();
+
+  if (!init_wallet(vm))
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
+    return {};
+  }
 
   if (!m_subaddress_lookahead.empty())
   {
     auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
     assert(lookahead);
-    m_wallet->set_subaddress_lookahead(lookahead->first, lookahead->second);
+    m_wallet_impl->setSubaddressLookahead(lookahead->first, lookahead->second);
   }
 
   if (m_restore_height)
-    m_wallet->set_refresh_from_block_height(m_restore_height);
+    m_wallet_impl->setRefreshFromBlockHeight(m_restore_height);
 
-  bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
-
-  try
-  {
-    if (spendkey)
-    {
-      m_wallet->generate(m_wallet_file, std::move(rc.second).password(), address, *spendkey, viewkey, create_address_file);
-    }
-    else
-    {
-      m_wallet->generate(m_wallet_file, std::move(rc.second).password(), address, viewkey, create_address_file);
-    }
-    message_writer(console_color_white, true) << tr("Generated new wallet: ")
-      << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return {};
-  }
-
+  message_writer(console_color_white, true) << tr("Generated new wallet: ")
+      << m_wallet_impl->address();
 
   return password;
 }
-
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm)
 {
-  std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> rc;
-  try { rc = tools::wallet2::make_new(vm, false, password_prompter); }
-  catch(const std::exception &e) { fail_msg_writer() << tr("Error creating wallet: ") << e.what(); return {}; }
-  m_wallet = std::move(rc.first);
-  if (!m_wallet)
+  const auto pwd = default_password_prompter(true);
+  epee::wipeable_string password = pwd->password();
+
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
+    return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
+
+  // --generate-from-device
+  const std::string hw_device_name = command_line::get_arg(vm, arg_hw_device);
+  const bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
+  const std::string device_derivation_path = command_line::get_arg(vm, arg_hw_device_derivation_path);
+  m_wallet_impl.reset(m_wallet_manager->createWalletFromDevice(m_wallet_file,
+                                                             std::string(password.data(), password.size()),
+                                                             nettype,
+                                                             hw_device_name.empty() ? "Ledger" : hw_device_name,
+                                                             m_restore_height,
+                                                             m_subaddress_lookahead,
+                                                             kdf_rounds,
+                                                             /* listener */ nullptr,
+                                                             device_derivation_path,
+                                                             create_address_file,
+                                                             /* unattended */ false));
+
+  if (!m_wallet_impl)
+    return {};
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
+    fail_msg_writer() << tr("failed to generate new wallet: ") << error_msg;
     return {};
   }
-  m_wallet->callback(this);
-  epee::wipeable_string password = rc.second.password();
 
-  if (!m_subaddress_lookahead.empty())
+  if (!init_wallet(vm))
   {
-    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
-    assert(lookahead);
-    m_wallet->set_subaddress_lookahead(lookahead->first, lookahead->second);
-  }
-
-  if (m_restore_height)
-    m_wallet->set_refresh_from_block_height(m_restore_height);
-
-  auto device_desc = tools::wallet2::device_name_option(vm);
-  auto device_derivation_path = tools::wallet2::device_derivation_path_option(vm);
-  try
-  {
-    bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
-    m_wallet->device_derivation_path(device_derivation_path);
-    m_wallet->restore(m_wallet_file, std::move(rc.second).password(), device_desc.empty() ? "Ledger" : device_desc, create_address_file);
-    message_writer(console_color_white, true) << tr("Generated new wallet on hw device: ")
-      << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
     return {};
   }
+
+  message_writer(console_color_white, true) << tr("Generated new wallet on hw device: ")
+      << m_wallet_impl->address();
 
   return password;
+
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     const epee::wipeable_string &multisig_keys, const epee::wipeable_string &seed_pass, const std::string &old_language)
 {
-  std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> rc;
-  try { rc = tools::wallet2::make_new(vm, false, password_prompter); }
-  catch(const std::exception &e) { fail_msg_writer() << tr("Error creating wallet: ") << e.what(); return {}; }
-  m_wallet = std::move(rc.first);
-  if (!m_wallet)
-  {
-    return {};
-  }
-  epee::wipeable_string password = rc.second.password();
+  // --restore-multisig-wallet
+  const auto pwd = default_password_prompter(true);
+  epee::wipeable_string password = pwd->password();
 
-  if (!m_subaddress_lookahead.empty())
-  {
-    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
-    assert(lookahead);
-    m_wallet->set_subaddress_lookahead(lookahead->first, lookahead->second);
-  }
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
+      return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
 
   std::string mnemonic_language = old_language;
 
@@ -4827,136 +4739,219 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     mnemonic_language = m_mnemonic_language;
   }
 
-  m_wallet->set_seed_language(mnemonic_language);
+  const bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
+  m_wallet_impl.reset(m_wallet_manager->createWalletFromMultisigSeed(
+                            m_wallet_file,
+                            std::string(password.data(), password.size()),
+                            mnemonic_language,
+                            nettype,
+                            m_restore_height,
+                            std::string(multisig_keys.data(), multisig_keys.size()),
+                            std::string(seed_pass.data(), seed_pass.size()),
+                            kdf_rounds,
+                            create_address_file,
+                            /* unattended */ false));
 
-  bool create_address_file = command_line::get_arg(vm, arg_create_address_file);
+  if (!m_wallet_impl)
+    return {};
 
-  try
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    if (seed_pass.empty())
-      m_wallet->generate(m_wallet_file, std::move(rc.second).password(), multisig_keys, create_address_file);
-    else
-    {
-      crypto::secret_key key;
-      crypto::cn_slow_hash(seed_pass.data(), seed_pass.size(), (crypto::hash&)key);
-      sc_reduce32((unsigned char*)key.data);
-      const epee::wipeable_string &msig_keys = m_wallet->decrypt<epee::wipeable_string>(std::string(multisig_keys.data(), multisig_keys.size()), key, true);
-      m_wallet->generate(m_wallet_file, std::move(rc.second).password(), msig_keys, create_address_file);
-    }
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-
-    if (!ms_status.multisig_is_active || !ms_status.is_ready)
-    {
-      fail_msg_writer() << tr("failed to generate new multisig wallet");
-      return {};
-    }
-    message_writer(console_color_white, true) << boost::format(tr("Generated new %u/%u multisig wallet: ")) % ms_status.threshold % ms_status.total
-      << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
+    fail_msg_writer() << tr("failed to generate new wallet: ") << error_msg;
     return {};
   }
+
+  if (!init_wallet(vm))
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
+    return {};
+  }
+
+  if (!m_subaddress_lookahead.empty())
+  {
+    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
+    assert(lookahead);
+    m_wallet_impl->setSubaddressLookahead(lookahead->first, lookahead->second);
+  }
+
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+
+  if (!ms_status.isMultisig || !ms_status.isReady)
+  {
+    fail_msg_writer() << tr("failed to generate new multisig wallet");
+    return {};
+  }
+  message_writer(console_color_white, true) << boost::format(tr("Generated new %u/%u multisig wallet: ")) % ms_status.threshold % ms_status.total
+    << m_wallet_impl->address();
 
   return password;
 }
 //----------------------------------------------------------------------------------------------------
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
+                                                                 const std::string &json_file)
+{
+  // --generate-from-json
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
+      return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
+
+  std::string pw = "";
+  const epee::scope_guard pw_scope_exit_handler([&](){
+    memwipe(&pw[0], pw.size());
+  });
+  m_wallet_impl.reset(m_wallet_manager->createWalletFromJson(
+                            json_file,
+                            nettype,
+                            pw,
+                            kdf_rounds,
+                            /* unattended */ false));
+
+  if (!m_wallet_impl)
+    return {};
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << error_msg;
+    return {};
+  }
+
+  if (!init_wallet(vm))
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
+    return {};
+  }
+
+  if (!m_subaddress_lookahead.empty())
+  {
+    auto lookahead = parse_subaddress_lookahead(m_subaddress_lookahead);
+    assert(lookahead);
+    m_wallet_impl->setSubaddressLookahead(lookahead->first, lookahead->second);
+  }
+
+  message_writer(console_color_white, true) << tr("Generated new wallet: ")
+    << m_wallet_impl->address();
+
+  return epee::wipeable_string(pw.data(), pw.size());
+;
+}
+//----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
 {
-  if (!tools::wallet2::wallet_valid_path_format(m_wallet_file))
+  if (m_wallet_file.empty())
   {
-    fail_msg_writer() << tr("wallet file path not valid: ") << m_wallet_file;
+    fail_msg_writer() << tr("wallet file path empty");
     return {};
   }
 
   bool keys_file_exists;
   bool wallet_file_exists;
 
-  tools::wallet2::wallet_exists(m_wallet_file, keys_file_exists, wallet_file_exists);
+  Wallet::walletExists(m_wallet_file, keys_file_exists, wallet_file_exists);
   if(!keys_file_exists)
   {
     fail_msg_writer() << tr("Key file not found. Failed to open wallet");
     return {};
   }
   
-  epee::wipeable_string password;
-  try
-  {
-    auto rc = tools::wallet2::make_from_file(vm, false, "", password_prompter);
-    m_wallet = std::move(rc.first);
-    password = std::move(std::move(rc.second).password());
-    if (!m_wallet)
-    {
-      return {};
-    }
+  const auto pwd = default_password_prompter(false);
 
-    m_wallet->callback(this);
-    m_wallet->load(m_wallet_file, password);
-    std::string prefix;
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-    if (m_wallet->watch_only())
-      prefix = tr("Opened watch-only wallet");
-    else if (ms_status.multisig_is_active)
-      prefix = (boost::format(tr("Opened %u/%u multisig wallet%s")) % ms_status.threshold % ms_status.total % (ms_status.is_ready ? "" : " (not yet finalized)")).str();
-    else if (m_wallet->is_background_wallet())
-      prefix = tr("Opened background wallet");
-    else
-      prefix = tr("Opened wallet");
-    message_writer(console_color_white, true) <<
-      prefix << ": " << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    if (m_wallet->get_account().get_device()) {
-       message_writer(console_color_white, true) << "Wallet is on device: " << m_wallet->get_account().get_device().get_name();
-    }
-    // If the wallet file is deprecated, we should ask for mnemonic language again and store
-    // everything in the new format.
-    // NOTE: this is_deprecated() refers to the wallet file format before becoming JSON. It does not refer to the "old english" seed words form of "deprecated" used elsewhere.
-    if (m_wallet->is_deprecated())
-    {
-      bool is_deterministic;
-      {
-        SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return {};);
-        is_deterministic = m_wallet->is_deterministic();
-      }
-      if (is_deterministic)
-      {
-        message_writer(console_color_green, false) << "\n" << tr("You had been using "
-          "a deprecated version of the wallet. Please proceed to upgrade your wallet.\n");
-        std::string mnemonic_language = get_mnemonic_language();
-        if (mnemonic_language.empty())
-          return {};
-        m_wallet->set_seed_language(mnemonic_language);
-        m_wallet->rewrite(m_wallet_file, password);
-
-        // Display the seed
-        epee::wipeable_string seed;
-        m_wallet->get_seed(seed);
-        print_seed(seed);
-      }
-      else
-      {
-        message_writer(console_color_green, false) << "\n" << tr("You had been using "
-          "a deprecated version of the wallet. Your wallet file format is being upgraded now.\n");
-        m_wallet->rewrite(m_wallet_file, password);
-      }
-    }
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << tr("failed to load wallet: ") << e.what();
-    if (m_wallet)
-    {
-      // only suggest removing cache if the password was actually correct
-      bool password_is_correct = false;
-      try
-      {
-        password_is_correct = m_wallet->verify_password(password);
-      }
-      catch (...) { } // guard against I/O errors
-      if (password_is_correct)
-        fail_msg_writer() << boost::format(tr("You may want to remove the file \"%s\" and try again")) % m_wallet_file;
-    }
+  NetworkType nettype;
+  if (!get_nettype(vm, nettype))
     return {};
+
+  const uint64_t kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
+  THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
+
+  {
+    std::string tmp_pw = std::string(pwd->password().data(), pwd->password().size());
+    const epee::scope_guard tmp_pw_scope_exit_handler([&](){
+      memwipe(&tmp_pw[0], tmp_pw.size());
+    });
+    m_wallet_impl.reset(m_wallet_manager->openWallet(m_wallet_file,
+                                                     tmp_pw,
+                                                     nettype,
+                                                     kdf_rounds,
+                                                     /* listener */ nullptr,
+                                                     /* unattended */ false));
+  }
+  if (!m_wallet_impl)
+    return {};
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+  {
+    fail_msg_writer() << tr("failed to load wallet: ") << error_msg;
+    return {};
+  }
+
+  if (!init_wallet(vm))
+  {
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+      fail_msg_writer() << tr("failed to initialize wallet: ") << error_msg;
+    return {};
+  }
+
+  std::string prefix;
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (m_wallet_impl->watchOnly())
+    prefix = tr("Opened watch-only wallet");
+  else if (ms_status.isMultisig)
+    prefix = (boost::format(tr("Opened %u/%u multisig wallet%s")) % ms_status.threshold % ms_status.total % (ms_status.isReady ? "" : " (not yet finalized)")).str();
+  else if (m_wallet_impl->isBackgroundWallet())
+    prefix = tr("Opened background wallet");
+  else
+    prefix = tr("Opened wallet");
+  message_writer(console_color_white, true) <<
+    prefix << ": " << m_wallet_impl->address();
+  if (m_wallet_impl->getDeviceType()) {
+     message_writer(console_color_white, true) << "Wallet is on device: " << m_wallet_impl->getDeviceState().device_name;
+  }
+
+  // If the wallet file is deprecated, we should ask for mnemonic language again and store
+  // everything in the new format.
+  // NOTE: this is_deprecated refers to the wallet file format before becoming JSON. It does not refer to the "old english" seed words form of "deprecated" used elsewhere.
+  if (m_wallet_impl->getWalletState().is_deprecated)
+  {
+    SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return {};);
+    if (m_wallet_impl->isDeterministic())
+    {
+      message_writer(console_color_green, false) << "\n" << tr("You had been using "
+        "a deprecated version of the wallet. Please proceed to upgrade your wallet.\n");
+      std::string mnemonic_language = get_mnemonic_language();
+      if (mnemonic_language.empty())
+        return {};
+      m_wallet_impl->setSeedLanguage(mnemonic_language);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd->password().data(), pwd->password().size()));
+
+      // Display the seed
+      std::string seed = m_wallet_impl->seed();
+      const epee::scope_guard seed_scope_exit_handler([&](){
+          memwipe(&seed[0], seed.size());
+      });
+      print_seed(epee::wipeable_string(seed));
+    }
+    else
+    {
+      message_writer(console_color_green, false) << "\n" << tr("You had been using "
+        "a deprecated version of the wallet. Your wallet file format is being upgraded now.\n");
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(pwd->password().data(), pwd->password().size()));
+    }
   }
   success_msg_writer() <<
     "**********************************************************************\n" <<
@@ -4964,7 +4959,7 @@ boost::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::p
     tr("Use \"help all\" to see the list of all available commands.\n") <<
     tr("Use \"help <command>\" to see a command's documentation.\n") <<
     "**********************************************************************";
-  return password;
+  return boost::optional<epee::wipeable_string>(pwd->password());
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::close_wallet()
@@ -4972,7 +4967,7 @@ bool simple_wallet::close_wallet()
   if (m_idle_run.load(std::memory_order_relaxed))
   {
     m_idle_run.store(false, std::memory_order_relaxed);
-    m_wallet->stop();
+    m_wallet_impl->stop();
     {
       boost::unique_lock<boost::mutex> lock(m_idle_mutex);
       m_idle_cond.notify_one();
@@ -4980,43 +4975,100 @@ bool simple_wallet::close_wallet()
     m_idle_thread.join();
   }
 
-  bool r = m_wallet->deinit();
-  if (!r)
+  if (!m_wallet_manager->closeWallet(m_wallet_impl.get(), /* store */ true, /* do_delete_pointer */ false))
   {
     fail_msg_writer() << tr("failed to deinitialize wallet");
-    return false;
-  }
-
-  try
-  {
-    m_wallet->store();
-  }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << e.what();
+    std::string error_msg = m_wallet_manager->errorString();
+    if (!error_msg.empty())
+      fail_msg_writer() << error_msg;
     return false;
   }
 
   return true;
 }
 //----------------------------------------------------------------------------------------------------
+bool simple_wallet::init_wallet(const boost::program_options::variables_map &vm)
+{
+  std::string daemon_address, daemon_username, daemon_password;
+  boost::optional<bool> is_trusted_daemon;
+  Monero::Wallet::SSLSupport ssl_support = Monero::Wallet::SSLSupport::SSLSupport_Autodetect;
+  std::string ssl_private_key_path, ssl_certificate_path, ssl_ca_file_path;
+  std::vector<std::string> ssl_allowed_fingerprints_str;
+  bool ssl_allow_any_cert = false;
+  std::string proxy;
+  try {
+    get_daemon_init_settings(vm,
+                             daemon_address,
+                             daemon_username,
+                             daemon_password,
+                             is_trusted_daemon,
+                             ssl_support,
+                             ssl_private_key_path,
+                             ssl_certificate_path,
+                             ssl_ca_file_path,
+                             ssl_allowed_fingerprints_str,
+                             ssl_allow_any_cert,
+                             proxy);
+  }
+  catch (const exception &e) {
+    fail_msg_writer() << tr("failed to initialize wallet: ") << e.what();
+    return false;
+  }
+
+  if (command_line::get_arg(vm, arg_offline))
+    m_wallet_impl->setOffline(true);
+
+  const std::string hw_device_name = command_line::get_arg(vm, arg_hw_device);
+  if (!hw_device_name.empty() && m_wallet_impl->getDeviceName().empty())
+    m_wallet_impl->setDeviceName(hw_device_name);
+  const std::string device_derivation_path = command_line::get_arg(vm, arg_hw_device_derivation_path);
+  if (!device_derivation_path.empty())
+    m_wallet_impl->setDeviceDerivationPath(device_derivation_path);
+  const std::string tx_notify = command_line::get_arg(vm, arg_tx_notify);
+  if (!tx_notify.empty())
+    m_wallet_impl->setTxNotify(tx_notify);
+
+  m_wallet_manager->setDaemonAddress(daemon_address);
+  if(!m_wallet_impl->init(daemon_address,
+                          /* upper_transaction_size_limit */ 0,
+                          daemon_username,
+                          daemon_password,
+                          /* use_ssl */ false,
+                          /* lightWallet */ false))
+  {
+    fail_msg_writer() << tr("failed to initialize wallet");
+    return false;
+  }
+  return m_wallet_impl->setDaemon(daemon_address,
+                                  daemon_username,
+                                  daemon_password,
+                                  is_trusted_daemon ? *is_trusted_daemon : false,
+                                  ssl_support,
+                                  ssl_private_key_path,
+                                  ssl_certificate_path,
+                                  ssl_ca_file_path,
+                                  ssl_allowed_fingerprints_str,
+                                  ssl_allow_any_cert,
+                                  proxy);
+}
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::save(const std::vector<std::string> &args)
 {
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
 
-  try
-  {
-    LOCK_IDLE_SCOPE();
-    m_wallet->store();
+  LOCK_IDLE_SCOPE();
+  if (m_wallet_impl->store(""))
     success_msg_writer() << tr("Wallet data saved");
-  }
-  catch (const std::exception& e)
+  else
   {
-    fail_msg_writer() << e.what();
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
   }
 
   return true;
@@ -5024,13 +5076,13 @@ bool simple_wallet::save(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::save_watch_only(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
 
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("wallet is multisig and cannot save a watch-only version");
     return true;
@@ -5044,46 +5096,28 @@ bool simple_wallet::save_watch_only(const std::vector<std::string> &args/* = std
     return true;
   }
 
-  try
-  {
-    std::string new_keys_filename;
-    m_wallet->write_watch_only_wallet(m_wallet_file, pwd_container->password(), new_keys_filename);
+  std::string new_keys_filename;
+  m_wallet_impl->writeWatchOnlyWallet(std::string_view(pwd_container->password().data(), pwd_container->password().size()), new_keys_filename);
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (!error_code)
     success_msg_writer() << tr("Watch only wallet saved as: ") << new_keys_filename;
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Failed to save watch only wallet: ") << e.what();
-    return true;
-  }
+  else
+    fail_msg_writer() << error_msg;
   return true;
 }
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::start_background_mining()
 {
-  COMMAND_RPC_MINING_STATUS::request reqq;
-  COMMAND_RPC_MINING_STATUS::response resq;
-  bool r = m_wallet->invoke_http_json("/mining_status", reqq, resq);
-  std::string err = interpret_rpc_response(r, resq.status);
-  if (!r)
-    return;
-  if (!err.empty())
+  if (!m_wallet_manager->isBackgroundMiningEnabled())
   {
-    fail_msg_writer() << tr("Failed to query mining status: ") << err;
-    return;
-  }
-  if (!resq.is_background_mining_enabled)
-  {
-    COMMAND_RPC_START_MINING::request req;
-    COMMAND_RPC_START_MINING::response res;
-    req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    req.threads_count = 1;
-    req.do_background_mining = true;
-    req.ignore_battery = false;
-    bool r = m_wallet->invoke_http_json("/start_mining", req, res);
-    std::string err = interpret_rpc_response(r, res.status);
-    if (!err.empty())
+    if (!m_wallet_manager->startMining(m_wallet_impl->address(),
+                                      /* threads */ 1,
+                                      /* do_background_mining */ true,
+                                      /* ignore_battery */ false))
     {
-      fail_msg_writer() << tr("Failed to setup background mining: ") << err;
+      fail_msg_writer() << tr("Failed to setup background mining: ") << m_wallet_manager->errorString();
       return;
     }
   }
@@ -5092,26 +5126,11 @@ void simple_wallet::start_background_mining()
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::stop_background_mining()
 {
-  COMMAND_RPC_MINING_STATUS::request reqq;
-  COMMAND_RPC_MINING_STATUS::response resq;
-  bool r = m_wallet->invoke_http_json("/mining_status", reqq, resq);
-  if (!r)
-    return;
-  std::string err = interpret_rpc_response(r, resq.status);
-  if (!err.empty())
+  if (m_wallet_manager->isBackgroundMiningEnabled())
   {
-    fail_msg_writer() << tr("Failed to query mining status: ") << err;
-    return;
-  }
-  if (resq.is_background_mining_enabled)
-  {
-    COMMAND_RPC_STOP_MINING::request req;
-    COMMAND_RPC_STOP_MINING::response res;
-    bool r = m_wallet->invoke_http_json("/stop_mining", req, res);
-    std::string err = interpret_rpc_response(r, res.status);
-    if (!err.empty())
+    if (!m_wallet_manager->stopMining())
     {
-      fail_msg_writer() << tr("Failed to setup background mining: ") << err;
+      fail_msg_writer() << tr("Failed to setup background mining: ") << m_wallet_manager->errorString();
       return;
     }
   }
@@ -5120,61 +5139,53 @@ void simple_wallet::stop_background_mining()
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::check_background_mining(const epee::wipeable_string &password)
 {
-  if (!m_wallet) return;
+  if (!m_wallet_impl) return;
 
   // Background mining can be toggled from the main wallet
-  if (m_wallet->is_background_wallet() || m_wallet->is_background_syncing())
+  if (m_wallet_impl->isBackgroundWallet() || m_wallet_impl->isBackgroundSyncing())
     return;
 
-  tools::wallet2::BackgroundMiningSetupType setup = m_wallet->setup_background_mining();
-  if (setup == tools::wallet2::BackgroundMiningNo)
+  Wallet::BackgroundMiningSetupType setup = m_wallet_impl->getSetupBackgroundMining();
+  if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_No)
   {
     message_writer(console_color_red, false) << tr("Background mining not enabled. Run \"set setup-background-mining 1\" to change.");
     return;
   }
 
-  if (!m_wallet->is_trusted_daemon())
+  if (!m_wallet_impl->trustedDaemon())
   {
     message_writer() << tr("Using an untrusted daemon, skipping background mining check");
     return;
   }
 
-  COMMAND_RPC_MINING_STATUS::request req;
-  COMMAND_RPC_MINING_STATUS::response res;
-  bool r = m_wallet->invoke_http_json("/mining_status", req, res);
-  std::string err = interpret_rpc_response(r, res.status);
-  bool is_background_mining_enabled = false;
-  if (err.empty())
-    is_background_mining_enabled = res.is_background_mining_enabled;
-
-  if (is_background_mining_enabled)
+  if (m_wallet_manager->isBackgroundMiningEnabled())
   {
     // already active, nice
-    if (setup == tools::wallet2::BackgroundMiningMaybe)
+    if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_Maybe)
     {
-      m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningYes);
-      m_wallet->rewrite(m_wallet_file, password);
+      m_wallet_impl->setSetupBackgroundMining(Wallet::BackgroundMiningSetupType::BackgroundMining_Yes);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(password.data(), password.size()));
     }
     start_background_mining();
     return;
   }
-  if (res.active)
+  if (m_wallet_manager->isMining())
     return;
 
-  if (setup == tools::wallet2::BackgroundMiningMaybe)
+  if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_Maybe)
   {
     message_writer() << tr("The daemon is not set up to background mine.");
     message_writer() << tr("With background mining enabled, the daemon will mine when idle and not on battery.");
     message_writer() << tr("Enabling this supports the network you are using, and makes you eligible for receiving new monero");
     std::string accepted = input_line(tr("Do you want to do it now? (Y/Yes/N/No)"));
     if (std::cin.eof() || !command_line::is_yes(accepted)) {
-      m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningNo);
-      m_wallet->rewrite(m_wallet_file, password);
+      m_wallet_impl->setSetupBackgroundMining(Wallet::BackgroundMiningSetupType::BackgroundMining_No);
+      m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(password.data(), password.size()));
       message_writer(console_color_red, false) << tr("Background mining not enabled. Set setup-background-mining to 1 to change.");
       return;
     }
-    m_wallet->setup_background_mining(tools::wallet2::BackgroundMiningYes);
-    m_wallet->rewrite(m_wallet_file, password);
+    m_wallet_impl->setSetupBackgroundMining(Wallet::BackgroundMiningSetupType::BackgroundMining_Yes);
+    m_wallet_impl->rewriteWalletFile(m_wallet_file, std::string_view(password.data(), password.size()));
     start_background_mining();
   }
   else
@@ -5186,13 +5197,13 @@ void simple_wallet::check_background_mining(const epee::wipeable_string &passwor
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::start_mining(const std::vector<std::string>& args)
 {
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
 
-  if (!m_wallet->is_trusted_daemon())
+  if (!m_wallet_impl->trustedDaemon())
   {
     fail_msg_writer() << tr("this command requires a trusted daemon. Enable with --trusted-daemon");
     return true;
@@ -5201,19 +5212,19 @@ bool simple_wallet::start_mining(const std::vector<std::string>& args)
   if (!try_connect_to_daemon())
     return true;
 
-  COMMAND_RPC_START_MINING::request req = AUTO_VAL_INIT(req); 
-  req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-
   bool ok = true;
   size_t arg_size = args.size();
+  bool do_ignore_battery = false;
+  bool do_background_mining = false;
+  uint32_t n_threads;
   if(arg_size >= 3)
   {
-    if (!parse_bool_and_use(args[2], [&](bool r) { req.ignore_battery = r; }))
+    if (!parse_bool_and_use(args[2], [&](bool r) { do_ignore_battery = r; }))
       return true;
   }
   if(arg_size >= 2)
   {
-    if (!parse_bool_and_use(args[1], [&](bool r) { req.do_background_mining = r; }))
+    if (!parse_bool_and_use(args[1], [&](bool r) { do_background_mining = r; }))
       return true;
   }
   if(arg_size >= 1)
@@ -5221,11 +5232,11 @@ bool simple_wallet::start_mining(const std::vector<std::string>& args)
     uint16_t num = 1;
     ok = string_tools::get_xtype_from_string(num, args[0]);
     ok = ok && 1 <= num;
-    req.threads_count = num;
+    n_threads = num;
   }
   else
   {
-    req.threads_count = 1;
+    n_threads = 1;
   }
 
   if (!ok)
@@ -5235,40 +5246,35 @@ bool simple_wallet::start_mining(const std::vector<std::string>& args)
   }
 
   const unsigned int hw_concurrency = boost::thread::hardware_concurrency();
-  if (hw_concurrency && req.threads_count > hw_concurrency)
+  if (hw_concurrency && n_threads > hw_concurrency)
   {
-    message_writer(console_color_yellow, false) << boost::format(tr("Warning: %u mining threads requested exceeds the %u hardware threads available on this CPU. Consider using %u for best performance.")) % req.threads_count % hw_concurrency % hw_concurrency;
+    message_writer(console_color_yellow, false) << boost::format(tr("Warning: %u mining threads requested exceeds the %u hardware threads available on this CPU. Consider using %u for best performance.")) % n_threads % hw_concurrency % hw_concurrency;
   }
 
-  COMMAND_RPC_START_MINING::response res;
-  bool r = m_wallet->invoke_http_json("/start_mining", req, res);
-  std::string err = interpret_rpc_response(r, res.status);
-  if (err.empty())
+  bool r = m_wallet_manager->startMining(m_wallet_impl->address(), n_threads, do_background_mining, do_ignore_battery);
+  if (r)
     success_msg_writer() << tr("Mining started in daemon");
   else
-    fail_msg_writer() << tr("mining has NOT been started: ") << err;
+    fail_msg_writer() << tr("mining has NOT been started: ") << m_wallet_manager->errorString();
   return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::stop_mining(const std::vector<std::string>& args)
 {
-  if (!try_connect_to_daemon())
-    return true;
-
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
 
-  COMMAND_RPC_STOP_MINING::request req;
-  COMMAND_RPC_STOP_MINING::response res;
-  bool r = m_wallet->invoke_http_json("/stop_mining", req, res);
-  std::string err = interpret_rpc_response(r, res.status);
-  if (err.empty())
+  if (!try_connect_to_daemon())
+    return true;
+
+  bool r = m_wallet_manager->stopMining();
+  if (r)
     success_msg_writer() << tr("Mining stopped in daemon");
   else
-    fail_msg_writer() << tr("mining has NOT been stopped: ") << err;
+    fail_msg_writer() << tr("mining has NOT been stopped: ") << m_wallet_manager->errorString();
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -5276,7 +5282,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
 {
   std::string daemon_url;
 
-  if (args.size() < 1)
+  if (args.size() < 1 || args.size() > 4)
   {
     PRINT_USAGE(USAGE_SET_DAEMON);
     return true;
@@ -5295,7 +5301,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
     // If no port has been provided, use the default from config
     if (!match[3].length())
     {
-      uint16_t daemon_port = get_config(m_wallet->nettype()).RPC_DEFAULT_PORT;
+      uint16_t daemon_port = get_config(static_cast<network_type>(m_wallet_impl->nettype())).RPC_DEFAULT_PORT;
       daemon_url = match[1] + match[2] + std::string(":") + std::to_string(daemon_port);
     } else {
       daemon_url = args[0];
@@ -5310,7 +5316,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
     }
 
     std::string trusted;
-    if (args.size() == 2)
+    if (args.size() >= 2)
     {
       if (args[1] == "trusted")
         trusted = "trusted";
@@ -5325,6 +5331,45 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
       }
     }
 
+    std::string daemon_username;
+    std::string daemon_password;
+    std::string proxy_address;
+    for (size_t i = 2; i < args.size(); ++i)
+    {
+      // daemon RPC login
+      if (args[i].rfind("login=", 0) == 0 && args[i].find(":") != std::string::npos)
+      {
+        std::function<boost::optional<tools::password_container>(const char *, bool)> pw_prompter = password_prompter;
+        auto parsed = tools::login::parse(args[i].substr(6), /* verify */ false, [pw_prompter](bool verify) {
+            if (!pw_prompter)
+            {
+              MERROR("Password needed without prompt function");
+              return boost::optional<tools::password_container>();
+            }
+            return pw_prompter("Daemon client password", verify);
+          }
+        );
+
+        if (!parsed)
+        {
+          fail_msg_writer() << tr("Failed to parse daemon rpc login");
+          return true;
+        }
+        daemon_username = std::move(parsed->username);
+        epee::wipeable_string daemon_pw = std::move(parsed->password).password();
+        daemon_password = std::string(daemon_pw.data(), daemon_pw.size());
+      }
+      // proxy address
+      else if (args[i].rfind("proxy=", 0) == 0)
+          proxy_address = args[i].substr(6);
+      else
+      {
+        fail_msg_writer() << tr("Expected either `") << "login=" << tr("<username>[:<password>]` or `") << "proxy=" << tr("[<ip>:]<port>` got ") << args[i];
+        return true;
+      }
+    }
+
+    bool use_ssl = false;
     if (!tools::is_privacy_preserving_network(parsed.host) && !tools::is_local_address(parsed.host))
     {
       if (trusted == "untrusted" || trusted == "")
@@ -5336,28 +5381,33 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
 
       if (parsed.schema != "https")
         message_writer(console_color_red) << tr("Warning: connecting to a non-local daemon without SSL, passive adversaries will be able to spy on you.");
+      else
+          use_ssl = true;
     }
 
     LOCK_IDLE_SCOPE();
-    m_wallet->init(daemon_url);
+    if (!m_wallet_impl->setDaemon(daemon_url,
+                                  daemon_username,
+                                  daemon_password,
+                                  trusted == "trusted",
+                                  use_ssl ? Wallet::SSLSupport::SSLSupport_Enabled : Wallet::SSLSupport::SSLSupport_Autodetect,
+                                  /* ssl_private_key_path */ "",
+                                  /* ssl_certificate_path */ "",
+                                  /* ssl_ca_file_path */ "",
+                                  /* ssl_allowed_fingerprints_str */ {},
+                                  /* ssl_allow_any_cert */ false,
+                                  proxy_address))
+    {
+        fail_msg_writer() << tr("Failed to set daemon");
+        return true;
+    }
 
     if (!trusted.empty())
     {
-      m_wallet->set_trusted_daemon(trusted == "trusted");
+      m_wallet_impl->setTrustedDaemon(trusted == "trusted");
     }
-    else
-    {
-      m_wallet->set_trusted_daemon(false);
-      try
-      {
-        if (tools::is_local_address(m_wallet->get_daemon_address()))
-        {
-          MINFO(tr("Daemon is local, assuming trusted"));
-          m_wallet->set_trusted_daemon(true);
-        }
-      }
-      catch (const std::exception &e) { }
-    }
+    else if (Utils::isAddressLocal(m_wallet_impl->getWalletState().daemon_address))
+      MINFO(tr("Daemon is local, assuming trusted"));
 
     if (!try_connect_to_daemon())
     {
@@ -5365,7 +5415,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
       return true;
     }
 
-    success_msg_writer() << boost::format("Daemon set to %s, %s") % daemon_url % (m_wallet->is_trusted_daemon() ? tr("trusted") : tr("untrusted"));
+    success_msg_writer() << boost::format("Daemon set to %s, %s") % daemon_url % (m_wallet_impl->trustedDaemon() ? tr("trusted") : tr("untrusted"));
   } else {
     fail_msg_writer() << tr("This does not seem to be a valid daemon URL.");
   }
@@ -5374,18 +5424,17 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::save_bc(const std::vector<std::string>& args)
 {
-  if (!try_connect_to_daemon())
-    return true;
-
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
-  COMMAND_RPC_SAVE_BC::request req;
-  COMMAND_RPC_SAVE_BC::response res;
-  bool r = m_wallet->invoke_http_json("/save_bc", req, res);
-  std::string err = interpret_rpc_response(r, res.status);
+
+  if (!try_connect_to_daemon())
+    return true;
+
+  m_wallet_manager->saveBlockchain();
+  std::string err = m_wallet_manager->errorString();
   if (err.empty())
     success_msg_writer() << tr("Blockchain saved");
   else
@@ -5393,7 +5442,7 @@ bool simple_wallet::save_bc(const std::vector<std::string>& args)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_new_block(uint64_t height, const cryptonote::block& block)
+void simple_wallet::newBlock(uint64_t height)
 {
   if (m_locked)
     return;
@@ -5401,95 +5450,109 @@ void simple_wallet::on_new_block(uint64_t height, const cryptonote::block& block
     m_refresh_progress_reporter.update(height, false);
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_money_received(uint64_t height, const crypto::hash &txid,
-  const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt,
-  const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change,
-  uint64_t unlock_time)
+void simple_wallet::moneyReceived(const std::string &txid,
+                                  uint64_t amount,
+                                  const uint64_t burnt,
+                                  const std::string &enote_pub_key,
+                                  const bool is_change /* = false */,
+                                  const bool is_coinbase /* = false */)
 {
   if (m_locked)
     return;
+
+  // Get latest enote details
+  std::unique_ptr<EnoteDetails> ed = m_wallet_impl->getEnoteDetails(enote_pub_key);
+
+  if (!ed || ed->txId() != txid)
+  {
+    fail_msg_writer() << "money received, but failed to get more information about tx <" << txid << ">";
+    return;
+  }
+
+  // Console output
   std::stringstream burn;
   if (burnt != 0) {
-    burn << " (" << print_money(amount) << " yet " << print_money(burnt) << " was burnt)";
+    burn << " (" << print_money(amount + burnt) << " yet " << print_money(burnt) << " was burnt)";
   }
   message_writer(console_color_green, false) << "\r" <<
-    tr("Height ") << height << ", " <<
-    tr("txid ") << txid << ", " <<
-    print_money(amount - burnt) << burn.str() << ", " <<
-    tr("idx ") << subaddr_index;
+    tr("Height ") << ed->blockHeight() << ", " <<
+    tr("txid <") << txid << ">, " <<
+    print_money(amount) << burn.str() << ", " <<
+    tr("idx ") << ed->subaddressIndexMajor() << "/" << ed->subaddressIndexMinor();
 
-  const uint64_t warn_height = m_wallet->nettype() == TESTNET ? 1000000 : m_wallet->nettype() == STAGENET ? 50000 : 1650000;
-  if (height >= warn_height && !is_change)
+  // Warnings
+  NetworkType nettype = m_wallet_impl->nettype();
+  const uint64_t warn_height = nettype == NetworkType::TESTNET  ? 1000000 :
+                               nettype == NetworkType::STAGENET ? 50000 : 1650000;
+  if (ed->blockHeight() >= warn_height && !is_change)
   {
-    std::vector<tx_extra_field> tx_extra_fields;
-    parse_tx_extra(tx.extra, tx_extra_fields); // failure ok
-    tx_extra_nonce extra_nonce;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    {
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        if (get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
-        {
-          memcpy(payment_id8.data, payment_id.data, sizeof(payment_id8));
-        }
-     }
-    }
-
-    if (payment_id8 != crypto::null_hash8)
+    // 8 bytes, encrypted payment id
+    if (ed->paymentId().size() == 16 && ed->paymentId() != "0000000000000000")
       message_writer() <<
         tr("NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead");
 
-    crypto::hash payment_id = crypto::null_hash;
-    if (get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+    // 32 bytes, unencrypted payment id
+    if (ed->paymentId().size() == 64)
       message_writer(console_color_red, false) <<
         tr("WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.");
   }
-  if (unlock_time && !cryptonote::is_coinbase(tx))
-    message_writer() << tr("NOTE: This transaction is locked, see details with: show_transfer ") + epee::string_tools::pod_to_hex(txid);
+  if (ed->unlockTime() && !is_coinbase)
+    message_writer() << tr("NOTE: This transaction is locked, see details with: show_transfer ") + txid;
   if (m_auto_refresh_refreshing)
     m_cmd_binder.print_prompt();
   else
-    m_refresh_progress_reporter.update(height, true);
+    m_refresh_progress_reporter.update(ed->blockHeight(), true);
+
+  m_wallet_impl->history()->refresh();
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index)
+void simple_wallet::unconfirmedMoneyReceived(const std::string &txid, uint64_t amount)
 {
   if (m_locked)
     return;
   // Not implemented in CLI wallet
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index)
+void simple_wallet::moneySpent(const std::string &txid,
+                               uint64_t amount,
+                               const std::string &enote_pub_key,
+                               std::pair<uint32_t, uint32_t> subaddr_index /* = {} */)
 {
   if (m_locked)
     return;
+
+  // Get latest enote details
+  std::unique_ptr<EnoteDetails> ed = m_wallet_impl->getEnoteDetails(enote_pub_key);
+
+  if (!ed)
+  {
+    fail_msg_writer() << "money spent, but failed to get more information about tx <" << txid << ">";
+    return;
+  }
+
   message_writer(console_color_magenta, false) << "\r" <<
-    tr("Height ") << height << ", " <<
-    tr("txid ") << txid << ", " <<
+    tr("Height ") << ed->blockHeight() << ", " <<
+    tr("txid <") << txid << ">, " <<
     tr("spent ") << print_money(amount) << ", " <<
-    tr("idx ") << subaddr_index;
+    tr("idx ") << subaddr_index.first << "/" << subaddr_index.second;
   if (m_auto_refresh_refreshing)
     m_cmd_binder.print_prompt();
   else
-    m_refresh_progress_reporter.update(height, true);
+    m_refresh_progress_reporter.update(ed->blockHeight(), true);
+
+  m_wallet_impl->history()->refresh();
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx)
+Monero::optional<std::string> simple_wallet::onGetPassword(const char *reason)
 {
   if (m_locked)
-    return;
-}
-//----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char *reason)
-{
-  if (m_locked)
-    return boost::none;
+    return Monero::optional<std::string>{};
   // can't ask for password from a background thread
   if (!m_in_manual_refresh.load(std::memory_order_relaxed))
   {
     message_writer(console_color_red, false) << boost::format(tr("Password needed (%s) - use the refresh command")) % reason;
     m_cmd_binder.print_prompt();
-    return boost::none;
+    return Monero::optional<std::string>{};
   }
 
   PAUSE_READLINE();
@@ -5500,34 +5563,34 @@ boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char
   if (!pwd_container)
   {
     MERROR("Failed to read password");
-    return boost::none;
+    return Monero::optional<std::string>{};
   }
 
-  return pwd_container->password();
+  return Monero::optional<std::string>{std::string(pwd_container->password().data(), pwd_container->password().size())};
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::on_device_button_request(uint64_t code)
+void simple_wallet::onDeviceButtonRequest(uint64_t code)
 {
   message_writer(console_color_white, false) << tr("Device requires attention");
 }
 //----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> simple_wallet::on_device_pin_request()
+Monero::optional<std::string> simple_wallet::onDevicePinRequest()
 {
   PAUSE_READLINE();
   std::string msg = tr("Enter device PIN");
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device PIN"));
-  return pwd_container->password();
+  return Monero::optional<std::string>{std::string(pwd_container->password().data(), pwd_container->password().size())};
 }
 //----------------------------------------------------------------------------------------------------
-boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_request(bool & on_device)
+Monero::optional<std::string> simple_wallet::onDevicePassphraseRequest(bool & on_device)
 {
   if (on_device) {
     std::string accepted = input_line(tr(
         "Device asks for passphrase. Do you want to enter the passphrase on device (Y) (or on the host (N))?"));
     if (std::cin.eof() || command_line::is_yes(accepted)) {
       message_writer(console_color_white, true) << tr("Please enter the device passphrase on the device");
-      return boost::none;
+      return Monero::optional<std::string>{};
     }
   }
 
@@ -5536,25 +5599,36 @@ boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_reque
   std::string msg = tr("Enter device passphrase");
   auto pwd_container = tools::password_container::prompt(false, msg.c_str());
   THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device passphrase"));
-  return pwd_container->password();
+  return Monero::optional<std::string>{std::string(pwd_container->password().data(), pwd_container->password().size())};
 }
+//----------------------------------------------------------------------------------------------------
+void simple_wallet::updated() {}
+//----------------------------------------------------------------------------------------------------
+void simple_wallet::refreshed() {}
+//----------------------------------------------------------------------------------------------------
+void simple_wallet::onReorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) {}
+//----------------------------------------------------------------------------------------------------
+void simple_wallet::onPoolTxRemoved(const std::string &txid) {}
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::on_refresh_finished(uint64_t start_height, uint64_t fetched_blocks, bool is_init, bool received_money)
 {
-  const uint64_t rfbh = m_wallet->get_refresh_from_block_height();
+  const uint64_t rfbh = m_wallet_impl->getRefreshFromBlockHeight();
   std::string err;
-  const uint64_t dh = m_wallet->get_daemon_blockchain_height(err);
+  int err_code;
+  const uint64_t dh = m_wallet_impl->daemonBlockChainHeight();
+  m_wallet_impl->statusWithErrorString(err_code, err);
   if (err.empty() && rfbh > dh)
   {
     message_writer(console_color_yellow, false) << tr("The wallet's refresh-from-block-height setting is higher than the daemon's height: this may mean your wallet will skip over transactions");
   }
 
   // Key image sync after the first refresh
-  if (!m_wallet->get_account().get_device().has_tx_cold_sign() || m_wallet->get_account().get_device().has_ki_live_refresh()) {
+  Wallet::DeviceState device_state = m_wallet_impl->getDeviceState();
+  if (!device_state.has_tx_cold_sign || device_state.has_ki_live_refresh) {
     return;
   }
 
-  if (!received_money || m_wallet->get_device_last_key_image_sync() != 0) {
+  if (!received_money || device_state.last_ki_sync != 0) {
     return;
   }
 
@@ -5577,45 +5651,56 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
 
   LOCK_IDLE_SCOPE();
 
-  crypto::hash transfer_hash_pre{};
+  std::string transfer_hash_pre{};
   uint64_t height_pre = 0, height_post;
-  if (reset != ResetNone)
-  {
-    if (reset == ResetSoftKeepKI)
-      height_pre = m_wallet->hash_m_transfers(boost::none, transfer_hash_pre);
-
-    m_wallet->rescan_blockchain(reset == ResetHard, false, reset == ResetSoftKeepKI);
-  }
 
   PAUSE_READLINE();
 
   message_writer() << tr("Starting refresh...");
 
+  if (reset != ResetNone)
+  {
+    if (reset == ResetSoftKeepKI)
+      height_pre = m_wallet_impl->hashEnotes(0, transfer_hash_pre);
+
+    m_wallet_impl->rescanBlockchain(reset == ResetHard, reset == ResetSoftKeepKI, /* do_skip_refresh */ true);
+  }
+
   uint64_t fetched_blocks = 0;
   bool received_money = false;
-  bool ok = false;
-  std::ostringstream ss;
-  try
-  {
+  // fake loop, so we can break out of the block on error
+  do {
     m_in_manual_refresh.store(true, std::memory_order_relaxed);
     const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
     // For manual refresh don't allow incremental checking of the pool: Because we did not process the txs
     // for us in the pool during automatic refresh we could miss some of them if we checked the pool
     // incrementally here
-    m_wallet->refresh(m_wallet->is_trusted_daemon(), start_height, fetched_blocks, received_money, true, false);
+    if (!m_wallet_impl->refresh(start_height,
+                                /* check_pool */ true,
+                                /* try_incremental */ false,
+                                /* max_blocks */ std::numeric_limits<uint64_t>::max(),
+                                /* skip_refresh_if_daemon_not_synced */ true,
+                                &fetched_blocks,
+                                &received_money))
+    {
+      int error_code;
+      std::string error_msg;
+      m_wallet_impl->statusWithErrorString(error_code, error_msg);
+      fail_msg_writer() << tr("refresh failed: ") << error_msg << ". " << tr("Blocks received: ") << fetched_blocks;
+      break;
+    }
 
     if (reset == ResetSoftKeepKI)
     {
-      m_wallet->finish_rescan_bc_keep_key_images(height_pre, transfer_hash_pre);
+      m_wallet_impl->finishRescanBcKeepKeyImages(height_pre, transfer_hash_pre);
 
-      height_post = m_wallet->get_num_transfer_details();
+      height_post = m_wallet_impl->getWalletState().n_enotes;
       if (height_pre != height_post)
       {
         message_writer() << tr("New transfer received since rescan was started. Key images are incomplete.");
       }
     }
 
-    ok = true;
     // Clear line "Height xxx of xxx"
     std::cout << "\r                                                                \r";
     success_msg_writer(true) << tr("Refresh done, blocks received: ") << fetched_blocks;
@@ -5623,49 +5708,7 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
       print_accounts();
     show_balance_unlocked();
     on_refresh_finished(start_height, fetched_blocks, is_init, received_money);
-  }
-  catch (const tools::error::daemon_busy&)
-  {
-    ss << tr("daemon is busy. Please try again later.");
-  }
-  catch (const tools::error::no_connection_to_daemon&)
-  {
-    ss << tr("no connection to daemon. Please make sure daemon is running.");
-  }
-  catch (const tools::error::deprecated_rpc_access&)
-  {
-    ss << tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722");
-  }
-  catch (const tools::error::wallet_rpc_error& e)
-  {
-    LOG_ERROR("RPC error: " << e.to_string());
-    ss << tr("RPC error: ") << e.what();
-  }
-  catch (const tools::error::refresh_error& e)
-  {
-    LOG_ERROR("refresh error: " << e.to_string());
-    ss << tr("refresh error: ") << e.what();
-  }
-  catch (const tools::error::wallet_internal_error& e)
-  {
-    LOG_ERROR("internal error: " << e.to_string());
-    ss << tr("internal error: ") << e.what();
-  }
-  catch (const std::exception& e)
-  {
-    LOG_ERROR("unexpected error: " << e.what());
-    ss << tr("unexpected error: ") << e.what();
-  }
-  catch (...)
-  {
-    LOG_ERROR("unknown error");
-    ss << tr("unknown error");
-  }
-
-  if (!ok)
-  {
-    fail_msg_writer() << tr("refresh failed: ") << ss.str() << ". " << tr("Blocks received: ") << fetched_blocks;
-  }
+  } while (false);
 
   // prevent it from triggering the idle screen due to waiting for a foreground refresh
   m_last_activity_time = time(NULL);
@@ -5692,15 +5735,15 @@ bool simple_wallet::refresh(const std::vector<std::string>& args)
 bool simple_wallet::show_balance_unlocked(bool detailed)
 {
   std::string extra;
-  if (m_wallet->has_multisig_partial_key_images())
+  if (m_wallet_impl->hasMultisigPartialKeyImages())
     extra = tr(" (Some owned outputs have partial key images - import_multisig_info needed)");
-  else if (m_wallet->has_unknown_key_images())
+  else if (m_wallet_impl->hasUnknownKeyImages())
     extra += tr(" (Some owned outputs have missing key images - export_outputs, import_outputs, export_key_images, and import_key_images needed)");
-  success_msg_writer() << tr("Currently selected account: [") << m_current_subaddress_account << tr("] ") << m_wallet->get_subaddress_label({m_current_subaddress_account, 0});
-  const std::string tag = m_wallet->get_account_tags().second[m_current_subaddress_account];
+  success_msg_writer() << tr("Currently selected account: [") << m_current_subaddress_account << tr("] ") << m_wallet_impl->getSubaddressLabel(m_current_subaddress_account, 0);
+  const std::string tag = m_wallet_impl->getAccountTags().second[m_current_subaddress_account];
   success_msg_writer() << tr("Tag: ") << (tag.empty() ? std::string{tr("(No tag assigned)")} : tag);
   uint64_t blocks_to_unlock, time_to_unlock;
-  uint64_t unlocked_balance = m_wallet->unlocked_balance(m_current_subaddress_account, false, &blocks_to_unlock, &time_to_unlock);
+  uint64_t unlocked_balance = m_wallet_impl->unlockedBalance(m_current_subaddress_account, &blocks_to_unlock, &time_to_unlock);
   std::string unlock_time_message;
   if (blocks_to_unlock > 0 && time_to_unlock > 0)
     unlock_time_message = (boost::format(" (%lu block(s) and %s to unlock)") % blocks_to_unlock % tools::get_human_readable_timespan(time_to_unlock)).str();
@@ -5708,22 +5751,21 @@ bool simple_wallet::show_balance_unlocked(bool detailed)
     unlock_time_message = (boost::format(" (%lu block(s) to unlock)") % blocks_to_unlock).str();
   else if (time_to_unlock > 0)
     unlock_time_message = (boost::format(" (%s to unlock)") % tools::get_human_readable_timespan(time_to_unlock)).str();
-  success_msg_writer() << tr("Balance: ") << print_money(m_wallet->balance(m_current_subaddress_account, false)) << ", "
+  success_msg_writer() << tr("Balance: ") << print_money(m_wallet_impl->balance(m_current_subaddress_account)) << ", "
     << tr("unlocked balance: ") << print_money(unlocked_balance) << unlock_time_message << extra;
-  std::map<uint32_t, uint64_t> balance_per_subaddress = m_wallet->balance_per_subaddress(m_current_subaddress_account, false);
-  std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress = m_wallet->unlocked_balance_per_subaddress(m_current_subaddress_account, false);
+  std::map<uint32_t, uint64_t> balance_per_subaddress = m_wallet_impl->balancePerSubaddress(m_current_subaddress_account);
+  std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress = m_wallet_impl->unlockedBalancePerSubaddress(m_current_subaddress_account);
   if (!detailed || balance_per_subaddress.empty())
     return true;
   success_msg_writer() << tr("Balance per address:");
   success_msg_writer() << boost::format("%15s %21s %21s %7s %21s") % tr("Address") % tr("Balance") % tr("Unlocked balance") % tr("Outputs") % tr("Label");
-  std::vector<tools::wallet2::transfer_details> transfers;
-  m_wallet->get_transfers(transfers);
+  std::vector<std::unique_ptr<EnoteDetails>> enote_details = m_wallet_impl->getEnoteDetails();
   for (const auto& i : balance_per_subaddress)
   {
     cryptonote::subaddress_index subaddr_index = {m_current_subaddress_account, i.first};
-    std::string address_str = m_wallet->get_subaddress_as_str(subaddr_index).substr(0, 6);
-    uint64_t num_unspent_outputs = std::count_if(transfers.begin(), transfers.end(), [&subaddr_index](const tools::wallet2::transfer_details& td) { return !td.m_spent && td.m_subaddr_index == subaddr_index; });
-    success_msg_writer() << boost::format(tr("%8u %6s %21s %21s %7u %21s")) % i.first % address_str % print_money(i.second) % print_money(unlocked_balance_per_subaddress[i.first].first) % num_unspent_outputs % m_wallet->get_subaddress_label(subaddr_index);
+    std::string address_str = m_wallet_impl->address(m_current_subaddress_account, i.first).substr(0, 6);
+    uint64_t num_unspent_outputs = std::count_if(enote_details.begin(), enote_details.end(), [&subaddr_index](const std::unique_ptr<EnoteDetails>& ed) { return !ed->isSpent() && ed->subaddressIndexMajor() == subaddr_index.major && ed->subaddressIndexMinor() == subaddr_index.minor; });
+    success_msg_writer() << boost::format(tr("%8u %6s %21s %21s %7u %21s")) % i.first % address_str % print_money(i.second) % print_money(unlocked_balance_per_subaddress[i.first].first) % num_unspent_outputs % m_wallet_impl->getSubaddressLabel(m_current_subaddress_account, i.first);
   }
   return true;
 }
@@ -5789,7 +5831,7 @@ bool simple_wallet::show_incoming_transfers(const std::vector<std::string>& args
     local_args.erase(local_args.begin());
   }
 
-  const uint64_t blockchain_height = m_wallet->get_blockchain_current_height();
+  const uint64_t blockchain_height = m_wallet_impl->blockChainHeight();
 
   PAUSE_READLINE();
 
@@ -5799,15 +5841,15 @@ bool simple_wallet::show_incoming_transfers(const std::vector<std::string>& args
     return true;
   }
 
-  tools::wallet2::transfer_container transfers;
-  m_wallet->get_transfers(transfers);
+  std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet_impl->getEnoteDetails();
 
   size_t transfers_found = 0;
-  for (const auto& td : transfers)
+  for (const auto& ed : eds)
   {
-    if (!filter || available != td.m_spent)
+    if (!filter || available != ed->isSpent())
     {
-      if (m_current_subaddress_account != td.m_subaddr_index.major || (!subaddr_indices.empty() && subaddr_indices.count(td.m_subaddr_index.minor) == 0))
+      if (m_current_subaddress_account != ed->subaddressIndexMajor()
+              || (!subaddr_indices.empty() && subaddr_indices.count(ed->subaddressIndexMinor()) == 0))
         continue;
       if (!transfers_found)
       {
@@ -5818,29 +5860,29 @@ bool simple_wallet::show_incoming_transfers(const std::vector<std::string>& args
       }
       std::string extra_string;
       if (verbose)
-        extra_string += (boost::format("%68s%68s") % td.get_public_key() % (td.m_key_image_known ? epee::string_tools::pod_to_hex(td.m_key_image) : td.m_key_image_partial ? (epee::string_tools::pod_to_hex(td.m_key_image) + "/p") : std::string(64, '?'))).str();
+        extra_string += (boost::format("  <%64s>%68s") % ed->onetimeAddress() % (ed->isKeyImageKnown() ? ed->keyImage() : ed->isKeyImagePartial() ? (ed->keyImage() + "/p") : std::string(64, '?'))).str();
       if (uses)
       {
         std::vector<uint64_t> heights;
         uint64_t idx = 0;
-        for (const auto &e: td.m_uses)
+        for (const auto &e: ed->uses())
         {
           heights.push_back(e.first);
-          if (e.first < td.m_spent_height)
+          if (e.first < ed->spentHeight())
             ++idx;
         }
         const std::pair<std::string, std::string> line = show_outputs_line(heights, blockchain_height, idx);
         extra_string += std::string("\n    ") + tr("Used at heights: ") + line.first + "\n    " + line.second;
       }
-      message_writer(td.m_spent ? console_color_magenta : console_color_green, false) <<
-        boost::format("%21s%8s%12s%8s%16u%68s%16u%s") %
-        print_money(td.amount()) %
-        (td.m_spent ? tr("T") : tr("F")) %
-        (m_wallet->frozen(td) ? tr("[frozen]") : m_wallet->is_transfer_unlocked(td) ? tr("unlocked") : tr("locked")) %
-        (td.is_rct() ? tr("RingCT") : tr("-")) %
-        td.m_global_output_index %
-        td.m_txid %
-        td.m_subaddr_index.minor %
+      message_writer(ed->isSpent() ? console_color_magenta : console_color_green, false) <<
+        boost::format("%21s%8s%12s%8s%16u  <%64s>%16u%s") %
+        print_money(ed->amount()) %
+        (ed->isSpent() ? tr("T") : tr("F")) %
+        (ed->isFrozen() ? tr("[frozen]") : ed->isUnlocked() ? tr("unlocked") : tr("locked")) %
+        (ed->protocolVersion() == EnoteDetails::TxProtocol::TxProtocol_RingCT ? tr("RingCT") : tr("-")) %
+        ed->globalEnoteIndex() %
+        ed->txId() %
+        ed->subaddressIndexMinor() %
         extra_string;
       ++transfers_found;
     }
@@ -5863,7 +5905,7 @@ bool simple_wallet::show_incoming_transfers(const std::vector<std::string>& args
   }
   else
   {
-    success_msg_writer() << boost::format("Found %u/%u transfers") % transfers_found % transfers.size();
+    success_msg_writer() << boost::format("Found %u/%u transfers") % transfers_found % eds.size();
   }
 
   return true;
@@ -5884,21 +5926,26 @@ bool simple_wallet::show_payments(const std::vector<std::string> &args)
   message_writer() << boost::format("%68s%68s%12s%21s%16s%16s") %
     tr("payment") % tr("transaction") % tr("height") % tr("amount") % tr("unlock time") % tr("addr index");
 
+  const auto &txs = m_wallet_impl->history()->getAll();
+  std::vector<TransactionInfo *> payments;
   bool payments_found = false;
-  for(std::string arg : args)
+  for(const std::string &payment_id : args)
   {
-    crypto::hash payment_id;
-    if(tools::wallet2::parse_payment_id(arg, payment_id))
+    payments.clear();
+    if(Wallet::paymentIdValid(payment_id))
     {
-      std::list<tools::wallet2::payment_details> payments;
-      m_wallet->get_payments(payment_id, payments);
+      for (const auto &tx : txs)
+      {
+        if (tx->direction() == TransactionInfo::Direction::Direction_In && tx->paymentId() == payment_id)
+          payments.push_back(tx);
+      }
       if(payments.empty())
       {
         success_msg_writer() << tr("No payments with id ") << payment_id;
         continue;
       }
 
-      for (const tools::wallet2::payment_details& pd : payments)
+      for (const auto &p : payments)
       {
         if(!payments_found)
         {
@@ -5907,16 +5954,16 @@ bool simple_wallet::show_payments(const std::vector<std::string> &args)
         success_msg_writer(true) <<
           boost::format("%68s%68s%12s%21s%16s%16s") %
           payment_id %
-          pd.m_tx_hash %
-          pd.m_block_height %
-          print_money(pd.m_amount) %
-          pd.m_unlock_time %
-          pd.m_subaddr_index.minor;
+          p->hash() %
+          p->blockHeight() %
+          print_money(p->amount()) %
+          p->unlockTime() %
+          *p->subaddrIndex().begin();
       }
     }
     else
     {
-      fail_msg_writer() << tr("payment ID has invalid format, expected 16 or 64 character hex string: ") << arg;
+      fail_msg_writer() << tr("payment ID has invalid format, expected 16 or 64 character hex string: ") << payment_id;
     }
   }
 
@@ -5925,11 +5972,14 @@ bool simple_wallet::show_payments(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 uint64_t simple_wallet::get_daemon_blockchain_height(std::string& err)
 {
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     throw std::runtime_error("simple_wallet null wallet");
   }
-  return m_wallet->get_daemon_blockchain_height(err);
+  int error_code;
+  uint64_t bc_height = m_wallet_impl->daemonBlockChainHeight();
+  m_wallet_impl->statusWithErrorString(error_code, err);
+  return bc_height;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::show_blockchain_height(const std::vector<std::string>& args)
@@ -5949,7 +5999,7 @@ bool simple_wallet::show_blockchain_height(const std::vector<std::string>& args)
 bool simple_wallet::rescan_spent(const std::vector<std::string> &args)
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot rescan spent");
-  if (!m_wallet->is_trusted_daemon())
+  if (!m_wallet_impl->trustedDaemon())
   {
     fail_msg_writer() << tr("this command requires a trusted daemon. Enable with --trusted-daemon");
     return true;
@@ -5958,42 +6008,15 @@ bool simple_wallet::rescan_spent(const std::vector<std::string> &args)
   if (!try_connect_to_daemon())
     return true;
 
-  try
   {
     LOCK_IDLE_SCOPE();
-    m_wallet->rescan_spent();
+    m_wallet_impl->rescanSpent();
   }
-  catch (const tools::error::daemon_busy&)
-  {
-    fail_msg_writer() << tr("daemon is busy. Please try again later.");
-  }
-  catch (const tools::error::no_connection_to_daemon&)
-  {
-    fail_msg_writer() << tr("no connection to daemon. Please make sure daemon is running.");
-  }
-  catch (const tools::error::deprecated_rpc_access&)
-  {
-    fail_msg_writer() << tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722");
-  }
-  catch (const tools::error::is_key_image_spent_error&)
-  {
-    fail_msg_writer() << tr("failed to get spent status");
-  }
-  catch (const tools::error::wallet_rpc_error& e)
-  {
-    LOG_ERROR("RPC error: " << e.to_string());
-    fail_msg_writer() << tr("RPC error: ") << e.what();
-  }
-  catch (const std::exception& e)
-  {
-    LOG_ERROR("unexpected error: " << e.what());
-    fail_msg_writer() << tr("unexpected error: ") << e.what();
-  }
-  catch (...)
-  {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
-  }
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
+    fail_msg_writer() << error_msg;
 
   return true;
 }
@@ -6025,7 +6048,7 @@ std::pair<std::string, std::string> simple_wallet::show_outputs_line(const std::
   return std::make_pair(ostr.str(), ring_str);
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pending_tx>& ptx_vector, std::ostream& ostr, bool verbose)
+bool simple_wallet::process_ring_members(const PendingTransaction &ptx_vector, std::ostream& ostr, bool verbose)
 {
   uint32_t version;
   if (!try_connect_to_daemon(false, &version))
@@ -6044,62 +6067,57 @@ bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pendi
     return false;
   }
   // for each transaction
-  for (size_t n = 0; n < ptx_vector.size(); ++n)
+  const std::vector<std::string> &tx_ids = ptx_vector.txid();
+  const std::vector<std::vector<std::uint64_t>> &vin_amounts = ptx_vector.vinAmounts();
+  const std::vector<std::vector<std::vector<std::uint64_t>>> &vin_offsets = ptx_vector.vinOffsets();
+  const std::vector<std::vector<std::uint64_t>> &construction_data_real_input_indices = ptx_vector.constructionDataRealOutputIndices();
+  if (construction_data_real_input_indices.empty())
   {
-    const cryptonote::transaction& tx = ptx_vector[n].tx;
-    const tools::wallet2::tx_construction_data& construction_data = ptx_vector[n].construction_data;
+    fail_msg_writer() << tr("failed to find construction data for tx input");
+    return false;
+  }
+  std::vector<std::vector<std::unique_ptr<EnoteDetails>>> eds = ptx_vector.getEnoteDetailsIn();
+  for (size_t n = 0; n < ptx_vector.txCount(); ++n)
+  {
     if (verbose)
-      ostr << boost::format(tr("\nTransaction %llu/%llu: txid=%s")) % (n + 1) % ptx_vector.size() % cryptonote::get_transaction_hash(tx);
+      ostr << boost::format(tr("\nTransaction %llu/%llu: txid=%s")) % (n + 1) % ptx_vector.txCount() % tx_ids[n];
     // for each input
-    std::vector<uint64_t>     spent_key_height(tx.vin.size());
-    std::vector<crypto::hash> spent_key_txid  (tx.vin.size());
-    for (size_t i = 0; i < tx.vin.size(); ++i)
+    std::vector<uint64_t>     spent_key_height(eds[n].size());
+    std::vector<std::string>  spent_key_txid  (eds[n].size());
+    for (size_t i = 0; i < eds[n].size(); ++i)
     {
-      if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
-        continue;
-      const cryptonote::txin_to_key& in_key = boost::get<cryptonote::txin_to_key>(tx.vin[i]);
-      const tools::wallet2::transfer_details &td = m_wallet->get_transfer_details(construction_data.selected_transfers[i]);
-      const cryptonote::tx_source_entry *sptr = NULL;
-      for (const auto &src: construction_data.sources)
-        if (src.outputs[src.real_output].second.dest == td.get_public_key())
-          sptr = &src;
-      if (!sptr)
-      {
-        fail_msg_writer() << tr("failed to find construction data for tx input");
-        return false;
-      }
-      const cryptonote::tx_source_entry& source = *sptr;
-
       if (verbose)
-        ostr << boost::format(tr("\nInput %llu/%llu (%s): amount=%s")) % (i + 1) % tx.vin.size() % epee::string_tools::pod_to_hex(in_key.k_image) % print_money(source.amount);
+        ostr << boost::format(tr("\nInput %llu/%llu (%s): amount=%s")) % (i + 1) % eds[n].size() % eds[n][i]->keyImage() % print_money(eds[n][i]->amount());
       // convert relative offsets of ring member keys into absolute offsets (indices) associated with the amount
-      std::vector<uint64_t> absolute_offsets = cryptonote::relative_output_offsets_to_absolute(in_key.key_offsets);
+      std::vector<uint64_t> absolute_offsets = cryptonote::relative_output_offsets_to_absolute(vin_offsets[n][i]);
       // get block heights from which those ring member keys originated
-      COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
-      req.outputs.resize(absolute_offsets.size());
+      std::vector<std::pair<std::uint64_t, std::uint64_t>> req;
+      req.resize(absolute_offsets.size());
       for (size_t j = 0; j < absolute_offsets.size(); ++j)
       {
-        req.outputs[j].amount = in_key.amount;
-        req.outputs[j].index = absolute_offsets[j];
+        req[j].first = vin_amounts[n][i];
+        req[j].second = absolute_offsets[j];
       }
-      COMMAND_RPC_GET_OUTPUTS_BIN::response res = AUTO_VAL_INIT(res);
-      req.get_txid = true;
-      bool r = m_wallet->invoke_http_bin("/get_outs.bin", req, res);
-      err = interpret_rpc_response(r, res.status);
-      if (!err.empty())
+      std::vector<std::string> ring_pub_keys;
+      std::vector<std::string> _rct_key_mask;
+      std::vector<bool> _unlocked;
+      std::vector<std::uint64_t> ring_heights;
+      std::vector<std::string> ring_tx_ids;
+      bool r = m_wallet_manager->getOutsBin(req, /* do_get_txid */ true, ring_pub_keys, _rct_key_mask, _unlocked, ring_heights, ring_tx_ids);
+      if (!r)
       {
-        fail_msg_writer() << tr("failed to get output: ") << err;
+        fail_msg_writer() << tr("failed to get output: ") << m_wallet_manager->errorString();
         return false;
       }
-      if (res.outs.size() != req.outputs.size())
+      if (ring_pub_keys.size() != req.size())
       {
         fail_msg_writer() << tr("daemon returned an invalid number of outputs");
         return false;
       }
       // make sure that returned block heights are less than blockchain height
-      for (auto& res_out : res.outs)
+      for (auto& height : ring_heights)
       {
-        if (res_out.height >= blockchain_height)
+        if (height >= blockchain_height)
         {
           fail_msg_writer() << tr("output key's originating block height shouldn't be higher than the blockchain height");
           return false;
@@ -6107,22 +6125,17 @@ bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pendi
       }
       if (verbose)
         ostr << tr("\nOriginating block heights: ");
-      spent_key_height[i] = res.outs[source.real_output].height;
-      spent_key_txid  [i] = res.outs[source.real_output].txid;
-      std::vector<uint64_t> heights(absolute_offsets.size(), 0);
-      for (size_t j = 0; j < absolute_offsets.size(); ++j)
-      {
-        heights[j] = res.outs[j].height;
-      }
-      std::pair<std::string, std::string> ring_str = show_outputs_line(heights, blockchain_height, source.real_output);
+      spent_key_height[i] = ring_heights[construction_data_real_input_indices[n][i]];
+      spent_key_txid  [i] = ring_tx_ids[construction_data_real_input_indices[n][i]];
+      std::pair<std::string, std::string> ring_str = show_outputs_line(ring_heights, blockchain_height, construction_data_real_input_indices[n][i]);
       if (verbose)
         ostr << ring_str.first << tr("\n|") << ring_str.second << tr("|\n");
     }
     // warn if rings contain keys originating from the same tx or temporally very close block heights
     bool are_keys_from_same_tx      = false;
     bool are_keys_from_close_height = false;
-    for (size_t i = 0; i < tx.vin.size(); ++i) {
-      for (size_t j = i + 1; j < tx.vin.size(); ++j)
+    for (size_t i = 0; i < eds[n].size(); ++i) {
+      for (size_t j = i + 1; j < eds[n].size(); ++j)
       {
         if (spent_key_txid[i] == spent_key_txid[j])
           are_keys_from_same_tx = true;
@@ -6142,7 +6155,7 @@ bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pendi
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> &ptx_vector)
+bool simple_wallet::prompt_if_old(const PendingTransaction &ptx)
 {
   // count the number of old outputs
   std::string err;
@@ -6151,13 +6164,13 @@ bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> 
     return true;
 
   int max_n_old = 0;
-  for (const auto &ptx: ptx_vector)
+  std::vector<std::vector<std::unique_ptr<EnoteDetails>>> eds = ptx.getEnoteDetailsIn();
+  for (const auto &eds_: eds)
   {
     int n_old = 0;
-    for (const auto i: ptx.selected_transfers)
+    for (const auto &ed: eds_)
     {
-      const tools::wallet2::transfer_details &td = m_wallet->get_transfer_details(i);
-      uint64_t age = bc_height - td.m_block_height;
+      uint64_t age = bc_height - ed->blockHeight();
       if (age > OLD_AGE_WARN_THRESHOLD)
         ++n_old;
     }
@@ -6211,11 +6224,11 @@ void simple_wallet::check_for_inactivity_lock(bool user)
     }
 
     bool started_background_sync = false;
-    if (!m_wallet->is_background_wallet() &&
-        m_wallet->background_sync_type() != tools::wallet2::BackgroundSyncOff)
+    if (!m_wallet_impl->isBackgroundWallet() &&
+        m_wallet_impl->getBackgroundSyncType() != Wallet::BackgroundSyncType::BackgroundSync_Off)
     {
       LOCK_IDLE_SCOPE();
-      m_wallet->start_background_sync();
+      m_wallet_impl->startBackgroundSync();
       started_background_sync = true;
     }
 
@@ -6223,37 +6236,33 @@ void simple_wallet::check_for_inactivity_lock(bool user)
     {
       const char *inactivity_msg = user ? "" : tr("Locked due to inactivity.");
       tools::msg_writer() << inactivity_msg << (inactivity_msg[0] ? " " : "") << (
-        (m_wallet->is_background_wallet() && m_wallet->background_sync_type() == tools::wallet2::BackgroundSyncCustomPassword)
+        (m_wallet_impl->isBackgroundWallet() && m_wallet_impl->getBackgroundSyncType() == Wallet::BackgroundSyncType::BackgroundSync_CustomPassword)
             ? tr("The background password is required to unlock the console.")
             : tr("The wallet password is required to unlock the console.")
       );
 
-      if (m_wallet->is_background_syncing())
+      if (m_wallet_impl->isBackgroundSyncing())
         tools::msg_writer() << tr("\nSyncing in the background while locked...") << std::endl;
 
-      const bool show_wallet_name = m_wallet->show_wallet_name_when_locked();
+      const bool show_wallet_name = m_wallet_impl->getShowWalletNameWhenLocked();
       if (show_wallet_name)
       {
-        tools::msg_writer() << tr("Filename: ") << m_wallet->get_wallet_file();
+        tools::msg_writer() << tr("Filename: ") << m_wallet_impl->filename();
         tools::msg_writer() << tr("Network type: ") << (
-          m_wallet->nettype() == cryptonote::TESTNET ? tr("Testnet") :
-          m_wallet->nettype() == cryptonote::STAGENET ? tr("Stagenet") : tr("Mainnet")
+          m_wallet_impl->nettype() == NetworkType::TESTNET ? tr("Testnet") :
+          m_wallet_impl->nettype() == NetworkType::STAGENET ? tr("Stagenet") : tr("Mainnet")
         );
       }
-      try
+      const auto pwd_container = get_and_verify_password();
+      if (pwd_container)
       {
-        const auto pwd_container = get_and_verify_password();
-        if (pwd_container)
+        if (started_background_sync)
         {
-          if (started_background_sync)
-          {
-            LOCK_IDLE_SCOPE();
-            m_wallet->stop_background_sync(pwd_container->password());
-          }
-          break;
+          LOCK_IDLE_SCOPE();
+          m_wallet_impl->stopBackgroundSync(std::string(pwd_container->password().data(), pwd_container->password().size()));
         }
+        break;
       }
-      catch (...) { /* do nothing, just let the loop loop */ }
     }
     m_last_activity_time = time(NULL);
     m_in_command = false;
@@ -6275,15 +6284,15 @@ bool simple_wallet::on_command(bool (simple_wallet::*cmd)(const std::vector<std:
   return (this->*cmd)(args);
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool called_by_mms)
+bool simple_wallet::transfer_main(const std::vector<std::string> &args_)
 {
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
 
-//  "transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> <amount> [<payment_id>]"
+//  "transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> <amount>"
   CHECK_IF_BACKGROUND_SYNCING("cannot transfer");
   if (!try_connect_to_daemon())
     return false;
@@ -6298,40 +6307,14 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
     local_args.erase(local_args.begin());
   }
 
-  fee_priority priority = m_wallet->get_default_priority();
+  uint32_t priority = m_wallet_impl->getDefaultPriority();
   if (local_args.size() > 0 && parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
-  priority = m_wallet->adjust_priority(priority);
 
-  size_t fake_outs_count = std::max<uint64_t>(m_wallet->get_min_ring_size(), 1) - 1;
-  if(local_args.size() > 0) {
-    size_t ring_size;
-    if(!epee::string_tools::get_xtype_from_string(ring_size, local_args[0]))
-    {
-    }
-    else if (ring_size == 0)
-    {
-      fail_msg_writer() << tr("Ring size must not be 0");
+  size_t fake_outs_count = 0;
+  if (!get_fake_outs_count(m_wallet_impl, local_args, fake_outs_count))
       return false;
-    }
-    else
-    {
-      fake_outs_count = ring_size - 1;
-      local_args.erase(local_args.begin());
-    }
-  }
-  uint64_t adjusted_fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
-  if (adjusted_fake_outs_count > fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too small, minimum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return false;
-  }
-  if (adjusted_fake_outs_count < fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too large, maximum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return false;
-  }
 
   const size_t min_args = 1;
   if(local_args.size() < min_args)
@@ -6344,22 +6327,20 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
   bool payment_id_seen = false;
   if (!local_args.empty())
   {
-    std::string payment_id_str = local_args.back();
-    crypto::hash payment_id;
-    bool r = true;
-    if (tools::wallet2::parse_long_payment_id(payment_id_str, payment_id))
+    // we do not allow the deprecated payment_id argument anymore,
+    // payment IDs are handled by integrated addresses
+    if (is_long_payment_id(local_args.back()))
     {
       LONG_PAYMENT_ID_SUPPORT_CHECK();
     }
-    if(!r)
+    else if (is_short_payment_id(local_args.back()))
     {
-      fail_msg_writer() << tr("payment id failed to encode");
-      return false;
+      SHORT_PAYMENT_ID_WITHOUT_INTEGRATED_ADDRESS_SUPPORT_CHECK();
     }
   }
 
   // Parse subtractfeefrom destination list
-  tools::wallet2::unique_index_container subtract_fee_from_outputs;
+  std::set<uint32_t> subtract_fee_from_outputs;
   bool subtract_fee_from_all = false;
   for (auto it = local_args.begin(); it < local_args.end();)
   {
@@ -6380,46 +6361,39 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
   }
 
   vector<cryptonote::address_parse_info> dsts_info;
-  vector<cryptonote::tx_destination_entry> dsts;
+  vector<std::string> dsts;
+  vector<uint64_t> amounts;
+  network_type nettype = static_cast<network_type>(m_wallet_impl->nettype());
   for (size_t i = 0; i < local_args.size(); )
   {
     dsts_info.emplace_back();
     cryptonote::address_parse_info & info = dsts_info.back();
-    cryptonote::tx_destination_entry de;
     bool r = true;
 
     // check for a URI
     std::string address_uri, payment_id_uri, tx_description, recipient_name, error;
     std::vector<std::string> unknown_parameters;
     uint64_t amount = 0;
-    bool has_uri = m_wallet->parse_uri(local_args[i], address_uri, payment_id_uri, amount, tx_description, recipient_name, unknown_parameters, error);
+    bool has_uri = m_wallet_impl->parse_uri(local_args[i], address_uri, payment_id_uri, amount, tx_description, recipient_name, unknown_parameters, error);
     if (has_uri)
     {
-      r = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), address_uri, oa_prompter);
-      if (payment_id_uri.size() == 16)
+      r = cryptonote::get_account_address_from_str_or_url(info, nettype, address_uri, oa_prompter);
+      if (is_long_payment_id(payment_id_uri))
       {
-        if (!tools::wallet2::parse_short_payment_id(payment_id_uri, info.payment_id))
-        {
-          fail_msg_writer() << tr("failed to parse short payment ID from URI");
-          return false;
-        }
-        info.has_payment_id = true;
+        LONG_PAYMENT_ID_SUPPORT_CHECK();
       }
-      de.amount = amount;
-      de.original = local_args[i];
       ++i;
     }
     else if (i + 1 < local_args.size())
     {
-      r = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args[i], oa_prompter);
-      bool ok = cryptonote::parse_amount(de.amount, local_args[i + 1]);
-      if(!ok || 0 == de.amount)
+      r = cryptonote::get_account_address_from_str_or_url(info, nettype, local_args[i], oa_prompter);
+      bool ok = cryptonote::parse_amount(amount, local_args[i + 1]);
+      if(!ok || 0 == amount)
       {
         fail_msg_writer() << tr("amount is wrong: ") << local_args[i] << ' ' << local_args[i + 1] <<
           ", " << tr("expected number from 0 to ") << print_money(std::numeric_limits<uint64_t>::max());
         return false;
       }
-      de.original = local_args[i];
       i += 2;
     }
     else
@@ -6436,11 +6410,8 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
       fail_msg_writer() << tr("failed to parse address");
       return false;
     }
-    de.addr = info.address;
-    de.is_subaddress = info.is_subaddress;
-    de.is_integrated = info.has_payment_id;
 
-    if (info.has_payment_id || !payment_id_uri.empty())
+    if (info.has_payment_id)
     {
       if (payment_id_seen)
       {
@@ -6448,21 +6419,8 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
         return false;
       }
 
-      crypto::hash payment_id;
       std::string extra_nonce;
-      if (info.has_payment_id)
-      {
-        set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, info.payment_id);
-      }
-      else if (tools::wallet2::parse_payment_id(payment_id_uri, payment_id))
-      {
-        LONG_PAYMENT_ID_SUPPORT_CHECK();
-      }
-      else
-      {
-        fail_msg_writer() << tr("failed to parse payment id, though it was detected");
-        return false;
-      }
+      set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, info.payment_id);
       bool r = add_extra_nonce_to_tx_extra(extra, extra_nonce);
       if(!r)
       {
@@ -6472,7 +6430,11 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
       payment_id_seen = true;
     }
 
-    dsts.push_back(de);
+    if (info.has_payment_id)
+        dsts.push_back(get_account_integrated_address_as_str(nettype, info.address, info.payment_id));
+    else
+        dsts.push_back(get_account_address_as_str(nettype, info.is_subaddress, info.address));
+    amounts.push_back(amount);
   }
 
   if (subtract_fee_from_all)
@@ -6484,210 +6446,158 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
-  try
+  // figure out what tx will be necessary
+  // Note: short encrypted payment IDs are handled by integrated addresses
+  // therefore we just ignore the argument here
+  auto ptx = m_wallet_impl->createTransactionMultDest(dsts,
+                                                      /* [deprecated] payment_id */ "",
+                                                      amounts,
+                                                      fake_outs_count,
+                                                      static_cast<PendingTransaction::Priority>(priority),
+                                                      m_current_subaddress_account,
+                                                      subaddr_indices,
+                                                      subtract_fee_from_outputs);
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions_2(dsts, fake_outs_count, priority, extra,
-      m_current_subaddress_account, subaddr_indices, subtract_fee_from_outputs);
+    fail_msg_writer() << tr("failed to create transaction: ") << error_msg;
+    return false;
+  }
 
-    if (ptx_vector.empty())
+  if (ptx->txCount() == 0)
+  {
+    fail_msg_writer() << tr("No outputs found, or daemon is not ready");
+    return false;
+  }
+
+  // if we need to check for backlog, check the worst case tx
+  if (m_wallet_impl->getConfirmBacklog())
+  {
+    std::stringstream prompt;
+    double worst_fee_per_byte = ptx->getWorstFeePerByte();
+
+    std::vector<std::pair<uint64_t, uint64_t>> nblocks = m_wallet_impl->estimateBacklog({std::make_pair(worst_fee_per_byte, worst_fee_per_byte)});
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
     {
-      fail_msg_writer() << tr("No outputs found, or daemon is not ready");
-      return false;
-    }
-
-    // if we need to check for backlog, check the worst case tx
-    if (m_wallet->confirm_backlog())
-    {
-      std::stringstream prompt;
-      double worst_fee_per_byte = std::numeric_limits<double>::max();
-      for (size_t n = 0; n < ptx_vector.size(); ++n)
-      {
-        const uint64_t blob_size = cryptonote::tx_to_blob(ptx_vector[n].tx).size();
-        const double fee_per_byte = ptx_vector[n].fee / (double)blob_size;
-        if (fee_per_byte < worst_fee_per_byte)
-        {
-          worst_fee_per_byte = fee_per_byte;
-        }
-      }
-      try
-      {
-        std::vector<std::pair<uint64_t, uint64_t>> nblocks = m_wallet->estimate_backlog({std::make_pair(worst_fee_per_byte, worst_fee_per_byte)});
-        if (nblocks.size() != 1)
-        {
-          prompt << "Internal error checking for backlog. " << tr("Is this okay anyway?");
-        }
-        else
-        {
-          if (nblocks[0].first > m_wallet->get_confirm_backlog_threshold())
-            prompt << (boost::format(tr("There is currently a %u block backlog at that fee level. Is this okay?")) % nblocks[0].first).str();
-        }
-      }
-      catch (const std::exception &e)
-      {
-        prompt << tr("Failed to check for backlog: ") << e.what() << ENDL << tr("Is this okay anyway?");
-      }
-
-      std::string prompt_str = prompt.str();
-      if (!prompt_str.empty())
-      {
-        std::string accepted = input_line(prompt_str, true);
-        if (std::cin.eof())
-          return false;
-        if (!command_line::is_yes(accepted))
-        {
-          fail_msg_writer() << tr("transaction cancelled.");
-
-          return false; 
-        }
-      }
-    }
-
-    if (!prompt_if_old(ptx_vector))
-    {
-      fail_msg_writer() << tr("transaction cancelled.");
-      return false;
-    }
-
-    // if more than one tx necessary, prompt user to confirm
-    if (m_wallet->always_confirm_transfers() || ptx_vector.size() > 1)
-    {
-        uint64_t total_sent = 0;
-        uint64_t total_fee = 0;
-        uint64_t dust_not_in_fee = 0;
-        uint64_t dust_in_fee = 0;
-        for (size_t n = 0; n < ptx_vector.size(); ++n)
-        {
-          total_fee += ptx_vector[n].fee;
-          for (auto i: ptx_vector[n].selected_transfers)
-            total_sent += m_wallet->get_transfer_details(i).amount();
-          total_sent -= ptx_vector[n].change_dts.amount + ptx_vector[n].fee;
-
-          if (ptx_vector[n].dust_added_to_fee)
-            dust_in_fee += ptx_vector[n].dust;
-          else
-            dust_not_in_fee += ptx_vector[n].dust;
-        }
-
-        std::stringstream prompt;
-        for (size_t n = 0; n < ptx_vector.size(); ++n)
-        {
-          prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx_vector.size() << ":\n";
-          subaddr_indices.clear();
-          for (uint32_t i : ptx_vector[n].construction_data.subaddr_indices)
-            subaddr_indices.insert(i);
-          for (uint32_t i : subaddr_indices)
-            prompt << boost::format(tr("Spending from address index %d\n")) % i;
-          if (subaddr_indices.size() > 1)
-            prompt << tr("WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.\n");
-        }
-        prompt << boost::format(tr("Sending %s.  ")) % print_money(total_sent);
-        if (ptx_vector.size() > 1)
-        {
-          prompt << boost::format(tr("Your transaction needs to be split into %llu transactions.  "
-            "This will result in a transaction fee being applied to each transaction, for a total fee of %s")) %
-            ((unsigned long long)ptx_vector.size()) % print_money(total_fee);
-        }
-        else
-        {
-          prompt << boost::format(tr("The transaction fee is %s")) %
-            print_money(total_fee);
-        }
-        if (dust_in_fee != 0) prompt << boost::format(tr(", of which %s is dust from change")) % print_money(dust_in_fee);
-        if (dust_not_in_fee != 0)  prompt << tr(".") << ENDL << boost::format(tr("A total of %s from dust change will be sent to dust address")) 
-                                                   % print_money(dust_not_in_fee);
-        if (!process_ring_members(ptx_vector, prompt, m_wallet->print_ring_members()))
-          return false;
-
-        prompt << ENDL << tr("Is this okay?");
-        
-        std::string accepted = input_line(prompt.str(), true);
-        if (std::cin.eof())
-          return false;
-        if (!command_line::is_yes(accepted))
-        {
-          fail_msg_writer() << tr("transaction cancelled.");
-
-          return false;
-        }
-    }
-
-    // actually commit the transactions
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
-    if (ms_status.multisig_is_active && called_by_mms)
-    {
-      std::string ciphertext = m_wallet->save_multisig_tx(ptx_vector);
-      if (!ciphertext.empty())
-      {
-        get_message_store().process_wallet_created_data(get_multisig_wallet_state(), mms::message_type::partially_signed_tx, ciphertext);
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to MMS");
-      }
-    }
-    else if (ms_status.multisig_is_active)
-    {
-      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-        return false;
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
-      }
-    }
-    else if (m_wallet->get_account().get_device().has_tx_cold_sign())
-    {
-      try
-      {
-        tools::wallet2::signed_tx_set signed_tx;
-        if (!cold_sign_tx(ptx_vector, signed_tx, dsts_info, [&](const tools::wallet2::signed_tx_set &tx){ return accept_loaded_tx(tx); })){
-          fail_msg_writer() << tr("Failed to cold sign transaction with HW wallet");
-          return false;
-        }
-
-        commit_or_save(signed_tx.ptx, m_do_not_relay);
-      }
-      catch (const std::exception& e)
-      {
-        handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-        return false;
-      }
-      catch (...)
-      {
-        LOG_ERROR("Unknown error");
-        fail_msg_writer() << tr("unknown error");
-        return false;
-      }
-    }
-    else if (m_wallet->watch_only())
-    {
-      bool r = m_wallet->save_tx(ptx_vector, "unsigned_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-        return false;
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
-      }
+      prompt << error_msg << ENDL << tr("Is this okay anyway?");
     }
     else
     {
-      commit_or_save(ptx_vector, m_do_not_relay);
+      if (nblocks.size() != 1)
+      {
+        prompt << "Internal error checking for backlog. " << tr("Is this okay anyway?");
+      }
+      else
+      {
+        if (nblocks[0].first > m_wallet_impl->getConfirmBacklogThreshold())
+          prompt << (boost::format(tr("There is currently a %u block backlog at that fee level. Is this okay?")) % nblocks[0].first).str();
+      }
+    }
+    std::string prompt_str = prompt.str();
+    if (!prompt_str.empty())
+    {
+      std::string accepted = input_line(prompt_str, true);
+      if (std::cin.eof())
+        return false;
+      if (!command_line::is_yes(accepted))
+      {
+        fail_msg_writer() << tr("transaction cancelled.");
+
+        return false;
+      }
     }
   }
-  catch (const std::exception &e)
+
+  if (!prompt_if_old(*ptx))
   {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
+    fail_msg_writer() << tr("transaction cancelled.");
     return false;
   }
-  catch (...)
+
+  // if more than one tx necessary, prompt user to confirm
+  if (m_wallet_impl->getAlwaysConfirmTransfers() || ptx->txCount() > 1)
   {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
-    return false;
+      uint64_t total_sent = ptx->amount() + ptx->fee();
+      uint64_t total_fee = ptx->fee();
+      uint64_t total_change = ptx->change();
+      uint64_t dust_not_in_fee = ptx->dust() - ptx->dustInFee();
+      uint64_t dust_in_fee = ptx->dustInFee();
+      std::vector<std::set<uint32_t>> tmp_subaddr_indices = ptx->subaddrIndices();
+
+      std::stringstream prompt;
+      for (size_t n = 0; n < ptx->txCount(); ++n)
+      {
+        prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx->txCount() << ":\n";
+        subaddr_indices.clear();
+        for (uint32_t i : tmp_subaddr_indices[n])
+          subaddr_indices.insert(i);
+        for (uint32_t i : subaddr_indices)
+          prompt << boost::format(tr("Spending from address index %d\n")) % i;
+        if (subaddr_indices.size() > 1)
+          prompt << tr("WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.\n");
+      }
+      prompt << boost::format(tr("Sending %s.  ")) % print_money(total_sent-total_fee);
+      if (ptx->txCount() > 1)
+      {
+        prompt << boost::format(tr("Your transaction needs to be split into %llu transactions.  "
+          "This will result in a transaction fee being applied to each transaction, for a total fee of %s")) %
+          ((unsigned long long)ptx->txCount()) % print_money(total_fee);
+      }
+      else
+      {
+        prompt << boost::format(tr("The transaction fee is %s")) %
+          print_money(total_fee);
+      }
+      if (dust_in_fee != 0) prompt << boost::format(tr(", of which %s is dust from change")) % print_money(dust_in_fee);
+      if (dust_not_in_fee != 0)  prompt << tr(".") << ENDL << boost::format(tr("A total of %s from dust change will be sent to dust address"))
+                                                 % print_money(dust_not_in_fee);
+      prompt << boost::format(tr(". The overall total is %s")) %
+          print_money(total_sent);
+      prompt << boost::format(tr(". The change is %s.")) %
+          print_money(total_change);
+      if (!process_ring_members(*ptx, prompt, m_wallet_impl->getPrintRingMembers()))
+        return false;
+      prompt << ENDL << tr("Is this okay?");
+
+      std::string accepted = input_line(prompt.str(), true);
+      if (std::cin.eof())
+        return false;
+      if (!command_line::is_yes(accepted))
+      {
+        fail_msg_writer() << tr("transaction cancelled.");
+
+        return false;
+      }
+  }
+  // actually commit the transactions
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (ms_status.isMultisig)
+  {
+    bool r = m_wallet_impl->saveMultisigTx(*ptx, "multisig_monero_tx");
+    if (!r)
+    {
+      fail_msg_writer() << tr("Failed to write transaction(s) to file");
+      return false;
+    }
+    else
+    {
+      success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
+    }
+  }
+  else
+  {
+    if (m_wallet_impl->getDeviceState().has_tx_cold_sign
+            && !ptx->confirmationMessage().empty()
+            && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
+    {
+      fail_msg_writer() << tr("transaction cancelled.");
+      return true;
+    }
+    commit_or_save(*ptx, m_do_not_relay);
   }
 
   return true;
@@ -6701,116 +6611,7 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
     PRINT_USAGE(USAGE_TRANSFER);
     return true;
   }
-  transfer_main(args_, false);
-  return true;
-}
-//----------------------------------------------------------------------------------------------------
-
-bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
-{
-  CHECK_IF_BACKGROUND_SYNCING("cannot sweep");
-  if (!try_connect_to_daemon())
-    return true;
-
-  SCOPED_WALLET_UNLOCK();
-
-  try
-  {
-    // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_unmixable_sweep_transactions();
-
-    if (ptx_vector.empty())
-    {
-      fail_msg_writer() << tr("No unmixable outputs found");
-      return true;
-    }
-
-    // give user total and fee, and prompt to confirm
-    uint64_t total_fee = 0, total_unmixable = 0;
-    for (size_t n = 0; n < ptx_vector.size(); ++n)
-    {
-      total_fee += ptx_vector[n].fee;
-      for (auto i: ptx_vector[n].selected_transfers)
-        total_unmixable += m_wallet->get_transfer_details(i).amount();
-    }
-
-    std::string prompt_str = tr("Sweeping ") + print_money(total_unmixable);
-    if (ptx_vector.size() > 1) {
-      prompt_str = (boost::format(tr("Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?")) %
-        print_money(total_unmixable) %
-        ((unsigned long long)ptx_vector.size()) %
-        print_money(total_fee)).str();
-    }
-    else {
-      prompt_str = (boost::format(tr("Sweeping %s for a total fee of %s.  Is this okay?")) %
-        print_money(total_unmixable) %
-        print_money(total_fee)).str();
-    }
-    std::string accepted = input_line(prompt_str, true);
-    if (std::cin.eof())
-      return true;
-    if (!command_line::is_yes(accepted))
-    {
-      fail_msg_writer() << tr("transaction cancelled.");
-
-      return true;
-    }
-
-    // actually commit the transactions
-    if (m_wallet->get_multisig_status().multisig_is_active)
-    {
-      CHECK_MULTISIG_ENABLED();
-      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
-      }
-    }
-    else if (m_wallet->watch_only())
-    {
-      bool r = m_wallet->save_tx(ptx_vector, "unsigned_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
-      }
-    }
-    else
-    {
-      commit_or_save(ptx_vector, m_do_not_relay);
-    }
-  }
-  catch (const tools::error::not_enough_unlocked_money& e)
-  {
-    fail_msg_writer() << tr("Not enough money in unlocked balance");
-    std::string accepted = input_line((boost::format(tr("Discarding %s of unmixable outputs that cannot be spent, which can be undone by \"rescan_spent\".  Is this okay?")) % print_money(e.available())).str(), true);
-    if (std::cin.eof())
-      return true;
-    if (command_line::is_yes(accepted))
-    {
-      try
-      {
-        m_wallet->discard_unmixable_outputs();
-      } catch (...) {}
-    }
-  }
-  catch (const std::exception &e)
-  {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-  }
-  catch (...)
-  {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
-  }
-
+  transfer_main(args_);
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -6849,7 +6650,7 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
   {
     if (local_args[0] == "index=all")
     {
-      for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(m_current_subaddress_account); ++i)
+      for (uint32_t i = 0; i < m_wallet_impl->numSubaddresses(m_current_subaddress_account); ++i)
         subaddr_indices.insert(i);
     }
     else if (!parse_subaddress_indices(local_args[0], subaddr_indices))
@@ -6860,40 +6661,15 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
     local_args.erase(local_args.begin());
   }
 
-  fee_priority priority = fee_priority::Default;
+  uint32_t priority = m_wallet_impl->getDefaultPriority();
   if (local_args.size() > 0 && parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
-  priority = m_wallet->adjust_priority(priority);
+  priority = m_wallet_impl->adjustPriority(priority);
 
-  size_t fake_outs_count = std::max<uint64_t>(m_wallet->get_min_ring_size(), 1) - 1;
-  if(local_args.size() > 0) {
-    size_t ring_size;
-    if(!epee::string_tools::get_xtype_from_string(ring_size, local_args[0]))
-    {
-    }
-    else if (ring_size == 0)
-    {
-      fail_msg_writer() << tr("Ring size must not be 0");
+  size_t fake_outs_count = 0;
+  if (!get_fake_outs_count(m_wallet_impl, local_args, fake_outs_count))
       return true;
-    }
-    else
-    {
-      fake_outs_count = ring_size - 1;
-      local_args.erase(local_args.begin());
-    }
-  }
-  uint64_t adjusted_fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
-  if (adjusted_fake_outs_count > fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too small, minimum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return true;
-  }
-  if (adjusted_fake_outs_count < fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too large, maximum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return true;
-  }
 
   size_t outputs = 1;
   if (local_args.size() > 0 && local_args[0].substr(0, 8) == "outputs=")
@@ -6915,182 +6691,143 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
   }
 
   std::vector<uint8_t> extra;
-  bool payment_id_seen = false;
   if (local_args.size() >= 2)
   {
-    std::string payment_id_str = local_args.back();
-
-    crypto::hash payment_id;
-    bool r = tools::wallet2::parse_long_payment_id(payment_id_str, payment_id);
-    if(r)
+    // we do not allow the deprecated payment_id argument anymore,
+    // payment IDs are handled by integrated addresses
+    if(is_long_payment_id(local_args.back()))
     {
       LONG_PAYMENT_ID_SUPPORT_CHECK();
     }
-
-    if(!r && local_args.size() == 3)
+    else if (is_short_payment_id(local_args.back()))
     {
-      fail_msg_writer() << tr("payment id has invalid format, expected 16 or 64 character hex string: ") << payment_id_str;
-      print_usage();
-      return true;
+      SHORT_PAYMENT_ID_WITHOUT_INTEGRATED_ADDRESS_SUPPORT_CHECK();
     }
-    if (payment_id_seen)
-      local_args.pop_back();
   }
 
   cryptonote::address_parse_info info;
-  if (!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args[0], oa_prompter))
+  if (!cryptonote::get_account_address_from_str_or_url(info, static_cast<network_type>(m_wallet_impl->nettype()), local_args[0], oa_prompter))
   {
     fail_msg_writer() << tr("failed to parse address");
     print_usage();
     return true;
   }
+  std::string destination_addr = local_args[0];
 
   if (info.has_payment_id)
   {
-    if (payment_id_seen)
-    {
-      fail_msg_writer() << tr("a single transaction cannot use more than one payment id: ") << local_args[0];
-      return true;
-    }
-
     std::string extra_nonce;
     set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, info.payment_id);
-    bool r = add_extra_nonce_to_tx_extra(extra, extra_nonce);
-    if(!r)
+    if (!add_extra_nonce_to_tx_extra(extra, extra_nonce))
     {
       fail_msg_writer() << tr("failed to set up payment id, though it was decoded correctly");
       return true;
     }
-    payment_id_seen = true;
   }
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  // figure out what tx will be necessary
+  // Note: short encrypted payment IDs are handled by integrated addresses,
+  // therefore we just ignore the argument here
+  auto ptx = m_wallet_impl->createTransactionMultDest({destination_addr},
+                                                      /* [deprecated] payment_id */ "",
+                                                      /* amount */ Monero::optional<std::vector<uint64_t>>(),
+                                                      fake_outs_count,
+                                                      static_cast<PendingTransaction::Priority>(priority),
+                                                      account,
+                                                      subaddr_indices,
+                                                      /* subtract_fee_from_outputs */ {},
+                                                      /* key_image */ "",
+                                                      outputs,
+                                                      below);
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, fake_outs_count, priority, extra, account, subaddr_indices);
+    fail_msg_writer() << tr("failed to create sweep transaction: ") << error_msg;
+    return true;
+  }
 
-    if (ptx_vector.empty())
-    {
-      fail_msg_writer() << tr("No outputs found, or daemon is not ready");
-      return true;
-    }
+  if (ptx->txCount() == 0)
+  {
+    fail_msg_writer() << tr("No outputs found, or daemon is not ready");
+    return true;
+  }
 
-    if (!prompt_if_old(ptx_vector))
+  if (!prompt_if_old(*ptx))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
+
+  // give user total and fee, and prompt to confirm
+  uint64_t total_fee = ptx->fee();
+  uint64_t total_sent = ptx->amount();
+  std::vector<std::set<uint32_t>> tmp_subaddr_indices = ptx->subaddrIndices();
+  std::ostringstream prompt;
+  for (size_t n = 0; n < ptx->txCount(); ++n)
+  {
+    prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx->txCount() << ":\n";
+    subaddr_indices.clear();
+    for (uint32_t i : tmp_subaddr_indices[n])
+      subaddr_indices.insert(i);
+    for (uint32_t i : subaddr_indices)
+      prompt << boost::format(tr("Spending from address index %d\n")) % i;
+    if (subaddr_indices.size() > 1)
+      prompt << tr("WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.\n");
+  }
+  if (!process_ring_members(*ptx, prompt, m_wallet_impl->getPrintRingMembers()))
+    return true;
+  if (ptx->txCount() > 1) {
+    prompt << boost::format(tr("Sweeping %s in %llu transactions for a total fee of %s, overall total %s.  Is this okay?")) %
+      print_money(total_sent) %
+      ((unsigned long long)ptx->txCount()) %
+      print_money(total_fee) %
+      print_money(total_sent+total_fee);
+  }
+  else {
+    prompt << boost::format(tr("Sweeping %s for a total fee of %s, overall total %s.  Is this okay?")) %
+      print_money(total_sent) %
+      print_money(total_fee) %
+      print_money(total_sent+total_fee);
+  }
+  std::string accepted = input_line(prompt.str(), true);
+  if (std::cin.eof())
+    return true;
+  if (!command_line::is_yes(accepted))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+
+    return true;
+  }
+
+  // actually commit the transactions
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (ms_status.isMultisig)
+  {
+    bool r = m_wallet_impl->saveMultisigTx(*ptx, "multisig_monero_tx");
+    if (!r)
     {
-      fail_msg_writer() << tr("transaction cancelled.");
+      fail_msg_writer() << tr("Failed to write transaction(s) to file");
       return false;
-    }
-
-    // give user total and fee, and prompt to confirm
-    uint64_t total_fee = 0, total_sent = 0;
-    for (size_t n = 0; n < ptx_vector.size(); ++n)
-    {
-      total_fee += ptx_vector[n].fee;
-      for (auto i: ptx_vector[n].selected_transfers)
-        total_sent += m_wallet->get_transfer_details(i).amount();
-    }
-
-    std::ostringstream prompt;
-    for (size_t n = 0; n < ptx_vector.size(); ++n)
-    {
-      prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx_vector.size() << ":\n";
-      subaddr_indices.clear();
-      for (uint32_t i : ptx_vector[n].construction_data.subaddr_indices)
-        subaddr_indices.insert(i);
-      for (uint32_t i : subaddr_indices)
-        prompt << boost::format(tr("Spending from address index %d\n")) % i;
-      if (subaddr_indices.size() > 1)
-        prompt << tr("WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.\n");
-    }
-    if (!process_ring_members(ptx_vector, prompt, m_wallet->print_ring_members()))
-      return true;
-    if (ptx_vector.size() > 1) {
-      prompt << boost::format(tr("Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?")) %
-        print_money(total_sent) %
-        ((unsigned long long)ptx_vector.size()) %
-        print_money(total_fee);
-    }
-    else {
-      prompt << boost::format(tr("Sweeping %s for a total fee of %s.  Is this okay?")) %
-        print_money(total_sent) %
-        print_money(total_fee);
-    }
-    std::string accepted = input_line(prompt.str(), true);
-    if (std::cin.eof())
-      return true;
-    if (!command_line::is_yes(accepted))
-    {
-      fail_msg_writer() << tr("transaction cancelled.");
-
-      return true;
-    }
-
-    // actually commit the transactions
-    if (m_wallet->get_multisig_status().multisig_is_active)
-    {
-      CHECK_MULTISIG_ENABLED();
-      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
-      }
-    }
-    else if (m_wallet->get_account().get_device().has_tx_cold_sign())
-    {
-      try
-      {
-        tools::wallet2::signed_tx_set signed_tx;
-        std::vector<cryptonote::address_parse_info> dsts_info;
-        dsts_info.push_back(info);
-
-        if (!cold_sign_tx(ptx_vector, signed_tx, dsts_info, [&](const tools::wallet2::signed_tx_set &tx){ return accept_loaded_tx(tx); })){
-          fail_msg_writer() << tr("Failed to cold sign transaction with HW wallet");
-          return true;
-        }
-
-        commit_or_save(signed_tx.ptx, m_do_not_relay);
-      }
-      catch (const std::exception& e)
-      {
-        handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-      }
-      catch (...)
-      {
-        LOG_ERROR("Unknown error");
-        fail_msg_writer() << tr("unknown error");
-      }
-    }
-    else if (m_wallet->watch_only())
-    {
-      bool r = m_wallet->save_tx(ptx_vector, "unsigned_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
-      }
     }
     else
     {
-      commit_or_save(ptx_vector, m_do_not_relay);
+      success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
     }
   }
-  catch (const std::exception& e)
+  else
   {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-  }
-  catch (...)
-  {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
+    if (m_wallet_impl->getDeviceState().has_tx_cold_sign
+            && !ptx->confirmationMessage().empty()
+            && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
+    {
+      fail_msg_writer() << tr("transaction cancelled.");
+      return true;
+    }
+    commit_or_save(*ptx, m_do_not_relay);
   }
 
   return true;
@@ -7104,40 +6841,15 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
 
   std::vector<std::string> local_args = args_;
 
-  fee_priority priority = fee_priority::Default;
+  uint32_t priority = m_wallet_impl->getDefaultPriority();
   if (local_args.size() > 0 && parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
 
-  priority = m_wallet->adjust_priority(priority);
+  priority = m_wallet_impl->adjustPriority(priority);
 
-  size_t fake_outs_count = std::max<uint64_t>(m_wallet->get_min_ring_size(), 1) - 1;
-  if(local_args.size() > 0) {
-    size_t ring_size;
-    if(!epee::string_tools::get_xtype_from_string(ring_size, local_args[0]))
-    {
-    }
-    else if (ring_size == 0)
-    {
-      fail_msg_writer() << tr("Ring size must not be 0");
+  size_t fake_outs_count = 0;
+  if (!get_fake_outs_count(m_wallet_impl, local_args, fake_outs_count))
       return true;
-    }
-    else
-    {
-      fake_outs_count = ring_size - 1;
-      local_args.erase(local_args.begin());
-    }
-  }
-  uint64_t adjusted_fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
-  if (adjusted_fake_outs_count > fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too small, minimum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return true;
-  }
-  if (adjusted_fake_outs_count < fake_outs_count)
-  {
-    fail_msg_writer() << (boost::format(tr("ring size %u is too large, maximum is %u")) % (fake_outs_count+1) % (adjusted_fake_outs_count+1)).str();
-    return true;
-  }
 
   size_t outputs = 1;
   if (local_args.size() > 0 && local_args[0].substr(0, 8) == "outputs=")
@@ -7159,29 +6871,18 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   }
 
   std::vector<uint8_t> extra;
-  bool payment_id_seen = false;
   if (local_args.size() == 3)
   {
-    crypto::hash payment_id;
-    std::string extra_nonce;
-    if (tools::wallet2::parse_long_payment_id(local_args.back(), payment_id))
+    // we do not allow the deprecated payment_id argument anymore,
+    // payment IDs are handled by integrated addresses
+    if (is_long_payment_id(local_args.back()))
     {
       LONG_PAYMENT_ID_SUPPORT_CHECK();
     }
-    else
+    else if (is_short_payment_id(local_args.back()))
     {
-      fail_msg_writer() << tr("failed to parse Payment ID");
-      return true;
+      SHORT_PAYMENT_ID_WITHOUT_INTEGRATED_ADDRESS_SUPPORT_CHECK();
     }
-
-    if (!add_extra_nonce_to_tx_extra(extra, extra_nonce))
-    {
-      fail_msg_writer() << tr("failed to set up payment id, though it was decoded correctly");
-      return true;
-    }
-
-    local_args.pop_back();
-    payment_id_seen = true;
   }
 
   if (local_args.size() != 2)
@@ -7196,22 +6897,18 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
     fail_msg_writer() << tr("failed to parse key image");
     return true;
   }
+  std::string key_image = local_args[0];
 
   cryptonote::address_parse_info info;
-  if (!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args[1], oa_prompter))
+  if (!cryptonote::get_account_address_from_str_or_url(info, static_cast<network_type>(m_wallet_impl->nettype()), local_args[1], oa_prompter))
   {
     fail_msg_writer() << tr("failed to parse address");
     return true;
   }
+  std::string destination_addr = local_args[1];
 
   if (info.has_payment_id)
   {
-    if (payment_id_seen)
-    {
-      fail_msg_writer() << tr("a single transaction cannot use more than one payment id: ") << local_args[0];
-      return true;
-    }
-
     std::string extra_nonce;
     set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, info.payment_id);
     if (!add_extra_nonce_to_tx_extra(extra, extra_nonce))
@@ -7219,115 +6916,93 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
       fail_msg_writer() << tr("failed to set up payment id, though it was decoded correctly");
       return true;
     }
-    payment_id_seen = true;
   }
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  // figure out what tx will be necessary
+  // Note: short encrypted payment IDs are handled by integrated addresses
+  // therefore we just ignore the argument here
+  auto ptx = m_wallet_impl->createTransactionMultDest({destination_addr},
+                                                      /* [deprecated] payment_id */ "",
+                                                      /* amount */ Monero::optional<std::vector<uint64_t>>(),
+                                                      fake_outs_count,
+                                                      static_cast<PendingTransaction::Priority>(priority),
+                                                      m_current_subaddress_account,
+                                                      /* subaddr_indices */ {},
+                                                      /* subtract_fee_from_outputs */ {},
+                                                      key_image,
+                                                      outputs,
+                                                      /* below */ 0);
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_transactions_single(ki, info.address, info.is_subaddress, outputs, fake_outs_count, priority, extra);
+    fail_msg_writer() << tr("failed to create sweep single transaction: ") << error_msg;
+    return true;
+  }
 
-    if (ptx_vector.empty())
-    {
-      fail_msg_writer() << tr("No outputs found");
-      return true;
-    }
-    if (ptx_vector.size() > 1)
-    {
-      fail_msg_writer() << tr("Multiple transactions are created, which is not supposed to happen");
-      return true;
-    }
-    if (ptx_vector[0].selected_transfers.size() != 1)
-    {
-      fail_msg_writer() << tr("The transaction uses multiple or no inputs, which is not supposed to happen");
-      return true;
-    }
+  if (ptx->txCount() == 0)
+  {
+    fail_msg_writer() << tr("No outputs found");
+    return true;
+  }
+  if (ptx->txCount() > 1)
+  {
+    fail_msg_writer() << tr("Multiple transactions are created, which is not supposed to happen");
+    return true;
+  }
+  if (ptx->getEnoteDetailsIn().size() != 1 || ptx->getEnoteDetailsIn()[0].size() != 1)
+  {
+    fail_msg_writer() << tr("The transaction uses multiple or no inputs, which is not supposed to happen");
+    return true;
+  }
+  uint64_t total_fee = ptx->fee();
+  uint64_t total_sent = ptx->amount();
+  std::vector<std::set<uint32_t>> tmp_subaddr_indices = ptx->subaddrIndices();
+  std::ostringstream prompt;
+  if (!process_ring_members(*ptx, prompt, m_wallet_impl->getPrintRingMembers()))
+    return true;
+  prompt << boost::format(tr("Sweeping %s for a total fee of %s, overall total %s.  Is this okay?")) %
+    print_money(total_sent) %
+    print_money(total_fee) %
+    print_money(total_sent+total_fee);
+  std::string accepted = input_line(prompt.str(), true);
+  if (std::cin.eof())
+    return true;
+  if (!command_line::is_yes(accepted))
+  {
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
 
-    // give user total and fee, and prompt to confirm
-    uint64_t total_fee = ptx_vector[0].fee;
-    uint64_t total_sent = m_wallet->get_transfer_details(ptx_vector[0].selected_transfers.front()).amount();
-    std::ostringstream prompt;
-    if (!process_ring_members(ptx_vector, prompt, m_wallet->print_ring_members()))
-      return true;
-    prompt << boost::format(tr("Sweeping %s for a total fee of %s.  Is this okay?")) %
-      print_money(total_sent) %
-      print_money(total_fee);
-    std::string accepted = input_line(prompt.str(), true);
-    if (std::cin.eof())
-      return true;
-    if (!command_line::is_yes(accepted))
+  // actually commit the transactions
+  const MultisigState ms_status{m_wallet_impl->multisig()};
+  if (ms_status.isMultisig)
+  {
+    bool r = m_wallet_impl->saveMultisigTx(*ptx, "multisig_monero_tx");
+    if (!r)
+    {
+      fail_msg_writer() << tr("Failed to write transaction(s) to file");
+      return false;
+    }
+    else
+    {
+      success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
+    }
+  }
+  else
+  {
+    if (m_wallet_impl->getDeviceState().has_tx_cold_sign
+            && !ptx->confirmationMessage().empty()
+            && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
     {
       fail_msg_writer() << tr("transaction cancelled.");
       return true;
     }
-
-    // actually commit the transactions
-    if (m_wallet->get_multisig_status().multisig_is_active)
-    {
-      CHECK_MULTISIG_ENABLED();
-      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
-      }
-    }
-    else if (m_wallet->get_account().get_device().has_tx_cold_sign())
-    {
-      try
-      {
-        tools::wallet2::signed_tx_set signed_tx;
-        std::vector<cryptonote::address_parse_info> dsts_info;
-        dsts_info.push_back(info);
-
-        if (!cold_sign_tx(ptx_vector, signed_tx, dsts_info, [&](const tools::wallet2::signed_tx_set &tx){ return accept_loaded_tx(tx); })){
-          fail_msg_writer() << tr("Failed to cold sign transaction with HW wallet");
-          return true;
-        }
-
-        commit_or_save(signed_tx.ptx, m_do_not_relay);
-      }
-      catch (const std::exception& e)
-      {
-        handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-      }
-      catch (...)
-      {
-        LOG_ERROR("Unknown error");
-        fail_msg_writer() << tr("unknown error");
-      }
-    }
-    else if (m_wallet->watch_only())
-    {
-      bool r = m_wallet->save_tx(ptx_vector, "unsigned_monero_tx");
-      if (!r)
-      {
-        fail_msg_writer() << tr("Failed to write transaction(s) to file");
-      }
-      else
-      {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
-      }
-    }
-    else
-    {
-      commit_or_save(ptx_vector, m_do_not_relay);
-    }
-
-  }
-  catch (const std::exception& e)
-  {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
-  }
-  catch (...)
-  {
-    LOG_ERROR("unknown error");
-    fail_msg_writer() << tr("unknown error");
+    commit_or_save(*ptx, m_do_not_relay);
   }
 
   return true;
@@ -7405,16 +7080,17 @@ bool simple_wallet::donate(const std::vector<std::string> &args_)
   }
   // push back address, amount
   std::string address_str;
-  if (m_wallet->nettype() != cryptonote::MAINNET)
+  NetworkType nettype = m_wallet_impl->nettype();
+  if (nettype != NetworkType::MAINNET)
   {
     // if not mainnet, convert donation address string to the relevant network type
     address_parse_info info;
-    if (!cryptonote::get_account_address_from_str(info, cryptonote::MAINNET, MONERO_DONATION_ADDR))
+    if (!cryptonote::get_account_address_from_str(info, static_cast<network_type>(NetworkType::MAINNET), MONERO_DONATION_ADDR))
     {
       fail_msg_writer() << tr("Failed to parse donation address: ") << MONERO_DONATION_ADDR;
       return true;
     }
-    address_str = cryptonote::get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address);
+    address_str = cryptonote::get_account_address_as_str(static_cast<network_type>(nettype), info.is_subaddress, info.address);
   }
   else
   {
@@ -7422,7 +7098,7 @@ bool simple_wallet::donate(const std::vector<std::string> &args_)
   }
   local_args.push_back(address_str);
   local_args.push_back(amount_str);
-  if (m_wallet->nettype() == cryptonote::MAINNET)
+  if (nettype == NetworkType::MAINNET)
     message_writer() << (boost::format(tr("Donating %s %s to The Monero Project (donate.getmonero.org or %s).")) % amount_str % cryptonote::get_unit(cryptonote::get_default_decimal_point()) % MONERO_DONATION_ADDR).str();
   else
     message_writer() << (boost::format(tr("Donating %s %s to %s.")) % amount_str % cryptonote::get_unit(cryptonote::get_default_decimal_point()) % address_str).str();
@@ -7430,187 +7106,19 @@ bool simple_wallet::donate(const std::vector<std::string> &args_)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
-{
-  CHECK_IF_BACKGROUND_SYNCING("cannot load tx");
-  // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
-  size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
-  int first_known_non_zero_change_index = -1;
-  std::string payment_id_string = "";
-  for (size_t n = 0; n < get_num_txes(); ++n)
-  {
-    const tools::wallet2::tx_construction_data &cd = get_tx(n);
-
-    std::vector<tx_extra_field> tx_extra_fields;
-    bool has_encrypted_payment_id = false;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
-    {
-      tx_extra_nonce extra_nonce;
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        crypto::hash payment_id;
-        if(get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
-        {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-
-          // if none of the addresses are integrated addresses, it's a dummy one
-          bool is_dummy = true;
-          for (const auto &e: cd.dests)
-            if (e.is_integrated)
-              is_dummy = false;
-
-          CHECK_AND_ASSERT_MES(is_dummy == (payment_id8 == crypto::null_hash8), false, "Bad loaded tx: mismatched payment ID info");
-
-          if (is_dummy)
-          {
-            payment_id_string += std::string("dummy encrypted payment ID");
-          }
-          else
-          {
-            payment_id_string += std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-            has_encrypted_payment_id = true;
-          }
-        }
-        else if (get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
-        {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-          payment_id_string += std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
-          payment_id_string += " (OBSOLETE)";
-        }
-      }
-    }
-
-    for (size_t s = 0; s < cd.sources.size(); ++s)
-    {
-      amount += cd.sources[s].amount;
-      size_t ring_size = cd.sources[s].outputs.size();
-      if (ring_size < min_ring_size)
-        min_ring_size = ring_size;
-    }
-    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-    {
-      const tx_destination_entry &entry = cd.splitted_dsts[d];
-      std::string address, standard_address = get_account_address_as_str(m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress)
-      {
-        address = get_account_integrated_address_as_str(m_wallet->nettype(), entry.addr, payment_id8);
-        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
-      }
-      else
-        address = standard_address;
-      auto i = dests.find(entry.addr);
-      if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-      else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
-    }
-    if (cd.change_dts.amount > 0)
-    {
-      auto it = dests.find(cd.change_dts.addr);
-      if (it == dests.end())
-      {
-        fail_msg_writer() << tr("Claimed change does not go to a paid address");
-        return false;
-      }
-      if (it->second.second < cd.change_dts.amount)
-      {
-        fail_msg_writer() << tr("Claimed change is larger than payment to the change address");
-        return false;
-      }
-      if (cd.change_dts.amount > 0)
-      {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
-        {
-          fail_msg_writer() << tr("Change goes to more than one address");
-          return false;
-        }
-      }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
-    }
-  }
-
-  if (payment_id_string.empty())
-    payment_id_string = "no payment ID";
-
-  std::string dest_string;
-  size_t n_dummy_outputs = 0;
-  for (auto i = dests.begin(); i != dests.end(); )
-  {
-    if (i->second.second > 0)
-    {
-      if (!dest_string.empty())
-        dest_string += ", ";
-      dest_string += (boost::format(tr("sending %s to %s")) % print_money(i->second.second) % i->second.first).str();
-    }
-    else
-      ++n_dummy_outputs;
-    ++i;
-  }
-  if (n_dummy_outputs > 0)
-  {
-    if (!dest_string.empty())
-      dest_string += ", ";
-    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
-  }
-  if (dest_string.empty())
-    dest_string = tr("with no destinations");
-
-  std::string change_string;
-  if (change > 0)
-  {
-    std::string address = get_account_address_as_str(m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % print_money(change) % address).str();
-  }
-  else
-    change_string += tr("no change");
-
-  uint64_t fee = amount - amount_to_dests;
-  std::string prompt_str = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?")) % (unsigned long)get_num_txes() % print_money(amount) % print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
-  return command_line::is_yes(input_line(prompt_str, true));
-}
-//----------------------------------------------------------------------------------------------------
-bool simple_wallet::accept_loaded_tx(const tools::wallet2::unsigned_tx_set &txs)
-{
-  std::string extra_message;
-  if (!std::get<2>(txs.new_transfers).empty())
-    extra_message = (boost::format("%u outputs to import. ") % (unsigned)std::get<2>(txs.new_transfers).size()).str();
-  else if (!std::get<2>(txs.transfers).empty())
-    extra_message = (boost::format("%u outputs to import. ") % (unsigned)std::get<2>(txs.transfers).size()).str();
-  return accept_loaded_tx([&txs](){return txs.txes.size();}, [&txs](size_t n)->const tools::wallet2::tx_construction_data&{return txs.txes[n];}, extra_message);
-}
-//----------------------------------------------------------------------------------------------------
-bool simple_wallet::accept_loaded_tx(const tools::wallet2::signed_tx_set &txs)
-{
-  std::string extra_message;
-  if (!txs.key_images.empty())
-    extra_message = (boost::format("%u key images to import. ") % (unsigned)txs.key_images.size()).str();
-  return accept_loaded_tx([&txs](){return txs.ptx.size();}, [&txs](size_t n)->const tools::wallet2::tx_construction_data&{return txs.ptx[n].construction_data;}, extra_message);
-}
-//----------------------------------------------------------------------------------------------------
 bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
-  if(m_wallet->get_multisig_status().multisig_is_active)
+  if(m_wallet_impl->multisig().isMultisig)
   {
      fail_msg_writer() << tr("This is a multisig wallet, it can only sign with sign_multisig");
      return true;
   }
-  if(m_wallet->watch_only())
+  if(m_wallet_impl->watchOnly())
   {
      fail_msg_writer() << tr("This is a watch only wallet");
      return true;
@@ -7619,6 +7127,7 @@ bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)
 
   bool export_raw = false;
   std::string unsigned_filename = "unsigned_monero_tx";
+  const std::string signed_filename = "signed_monero_tx";
   if (args_.size() > 2 || (args_.size() == 2 && args_[0] != "export_raw"))
   {
     PRINT_USAGE(USAGE_SIGN_TRANSFER);
@@ -7639,38 +7148,42 @@ bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)
 
   SCOPED_WALLET_UNLOCK();
 
-  std::vector<tools::wallet2::pending_tx> ptx;
-  try
+  UnsignedTransaction *unsigned_tx = m_wallet_impl->loadUnsignedTx(unsigned_filename);
+  if (unsigned_tx->status() != UnsignedTransaction::Status_Ok)
   {
-    bool r = m_wallet->sign_tx(unsigned_filename, "signed_monero_tx", ptx, [&](const tools::wallet2::unsigned_tx_set &tx){ return accept_loaded_tx(tx); }, export_raw);
-    if (!r)
-    {
-      fail_msg_writer() << tr("Failed to sign transaction");
-      return true;
-    }
+    fail_msg_writer() << unsigned_tx->errorString();
+    return true;
   }
-  catch (const std::exception &e)
+  // Confirm loaded tx
+  if (!unsigned_tx->confirmationMessage().empty() && !command_line::is_yes(input_line(unsigned_tx->confirmationMessage(), /* yesno */ true)))
   {
-    fail_msg_writer() << tr("Failed to sign transaction: ") << e.what();
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
+  }
+
+  std::vector<std::string> tx_ids;
+  if (!unsigned_tx->sign(signed_filename, export_raw, &tx_ids))
+  {
+    fail_msg_writer() << unsigned_tx->errorString();
     return true;
   }
 
   std::string txids_as_text;
-  for (const auto &t: ptx)
+  for (const auto &tx_id: tx_ids)
   {
     if (!txids_as_text.empty())
       txids_as_text += (", ");
-    txids_as_text += epee::string_tools::pod_to_hex(get_transaction_hash(t.tx));
+    txids_as_text += tx_id;
   }
   success_msg_writer(true) << tr("Transaction successfully signed to file ") << "signed_monero_tx" << ", txid " << txids_as_text;
   if (export_raw)
   {
     std::string rawfiles_as_text;
-    for (size_t i = 0; i < ptx.size(); ++i)
+    for (size_t i = 0; i < tx_ids.size(); ++i)
     {
       if (i > 0)
         rawfiles_as_text += ", ";
-      rawfiles_as_text += "signed_monero_tx_raw" + (ptx.size() == 1 ? "" : ("_" + std::to_string(i)));
+      rawfiles_as_text += signed_filename + "_raw" + (tx_ids.size() == 1 ? "" : ("_" + std::to_string(i)));
     }
     success_msg_writer(true) << tr("Transaction raw hex data exported to ") << rawfiles_as_text;
   }
@@ -7679,7 +7192,7 @@ bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::submit_transfer(const std::vector<std::string> &args_)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -7687,47 +7200,45 @@ bool simple_wallet::submit_transfer(const std::vector<std::string> &args_)
   if (!try_connect_to_daemon())
     return true;
 
-  try
+  const std::string signed_monero_tx_file = "signed_monero_tx";
+  std::string signed_monero_tx_str;
+  if (!load_from_file(signed_monero_tx_file, signed_monero_tx_str))
   {
-    std::vector<tools::wallet2::pending_tx> ptx_vector;
-    bool r = m_wallet->load_tx("signed_monero_tx", ptx_vector, [&](const tools::wallet2::signed_tx_set &tx){ return accept_loaded_tx(tx); });
-    if (!r)
-    {
-      fail_msg_writer() << tr("Failed to load transaction from file");
-      return true;
-    }
+    fail_msg_writer() << tr("failed to load ") << "`" << signed_monero_tx_file << "`";
+    return true;
+  }
 
-    commit_or_save(ptx_vector, false);
-  }
-  catch (const std::exception& e)
+  int error_code;
+  std::string error_msg;
+  PendingTransaction *ptx = m_wallet_impl->parseTxFromStr(signed_monero_tx_str);
+
+  if (!ptx)
   {
-    handle_transfer_exception(std::current_exception(), m_wallet->is_trusted_daemon());
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
+    return true;
   }
-  catch (...)
+  // Confirm loaded tx
+  if (!ptx->confirmationMessage().empty() && !command_line::is_yes(input_line(ptx->confirmationMessage(), /* yesno */ true)))
   {
-    LOG_ERROR("Unknown error");
-    fail_msg_writer() << tr("unknown error");
+    fail_msg_writer() << tr("transaction cancelled.");
+    return true;
   }
+  ptx->finishParsingTx();
+
+  commit_or_save(*ptx, /* do_not_relay */ false, /* do_force_commit */ true);
 
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-std::string get_tx_key_stream(crypto::secret_key tx_key, std::vector<crypto::secret_key> additional_tx_keys)
-{
-  ostringstream oss;
-  oss << epee::string_tools::pod_to_hex(unwrap(unwrap(tx_key)));
-  for (size_t i = 0; i < additional_tx_keys.size(); ++i)
-    oss << epee::string_tools::pod_to_hex(unwrap(unwrap(additional_tx_keys[i])));
-  return oss.str();
-}
-
 bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot get tx key");
 
   std::vector<std::string> local_args = args_;
 
-  if (m_wallet->key_on_device() && m_wallet->get_account().get_device().get_type() != hw::device::TREZOR)
+  if (m_wallet_impl->getDeviceState().key_on_device
+      && m_wallet_impl->getDeviceState().device_type != Wallet::DeviceState::DeviceType::DeviceType_Trezor)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -7737,30 +7248,20 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
     return true;
   }
 
-  crypto::hash txid;
-  if (!epee::string_tools::hex_to_pod(local_args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-
   SCOPED_WALLET_UNLOCK();
 
-  crypto::secret_key tx_key;
-  std::vector<crypto::secret_key> additional_tx_keys;
+  std::string tx_key_stream = m_wallet_impl->getTxKey(args_[0]);
+  if (tx_key_stream.empty())
+  {
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
+    return true;
+  }
 
-  bool found_tx_key = m_wallet->get_tx_key(txid, tx_key, additional_tx_keys);
-  if (found_tx_key)
-  {
-    std::string stream = get_tx_key_stream(tx_key, additional_tx_keys);
-    success_msg_writer() << tr("Tx key: ") << stream;
-    return true;
-  }
-  else
-  {
-    fail_msg_writer() << tr("no tx keys found for this txid");
-    return true;
-  }
+  success_msg_writer() << tr("Tx key: ") << tx_key_stream;
+  return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::set_tx_key(const std::vector<std::string> &args_)
@@ -7774,70 +7275,51 @@ bool simple_wallet::set_tx_key(const std::vector<std::string> &args_)
     return true;
   }
 
-  boost::optional<cryptonote::account_public_address> single_destination_subaddress;
+  std::string single_destination_subaddress;
   if (local_args.size() > 1)
   {
     cryptonote::address_parse_info info;
-    if (cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args.back(), oa_prompter))
+    if (cryptonote::get_account_address_from_str_or_url(info, static_cast<network_type>(m_wallet_impl->nettype()), local_args.back(), oa_prompter))
     {
       if (!info.is_subaddress)
       {
         fail_msg_writer() << tr("Last argument is an address, but not a subaddress");
         return true;
       }
-      single_destination_subaddress = info.address;
+      single_destination_subaddress = local_args.back();
       local_args.pop_back();
     }
   }
 
-  crypto::hash txid;
-  if (!epee::string_tools::hex_to_pod(local_args[0], txid))
+  std::string tx_id = local_args[0];
+  std::string tx_key = local_args[1].substr(0, 64);
+  std::vector<std::string> additional_tx_keys;
+  while(true)
   {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-
-  crypto::secret_key tx_key;
-  std::vector<crypto::secret_key> additional_tx_keys;
-  try
-  {
-    if (!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), tx_key))
-    {
-      fail_msg_writer() << tr("failed to parse tx_key");
-      return true;
-    }
-    while(true)
-    {
-      local_args[1] = local_args[1].substr(64);
-      if (local_args[1].empty())
-        break;
-      additional_tx_keys.resize(additional_tx_keys.size() + 1);
-      if (!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), additional_tx_keys.back()))
-      {
-        fail_msg_writer() << tr("failed to parse tx_key");
-        return true;
-      }
-    }
-  }
-  catch (const std::out_of_range &e)
-  {
-    fail_msg_writer() << tr("failed to parse tx_key");
-    return true;
+    // additional_tx_keys are concatenated onto tx_keys, each one is 32 bytes (64 char hex string)
+    // local_args[1]: "tx_key [| additional_tx_key_1 | ... | additional_tx_key_n ]"
+    local_args[1] = local_args[1].substr(64);
+    if (local_args[1].empty())
+      break;
+    additional_tx_keys.push_back(local_args[1].substr(0, 64));
   }
 
   LOCK_IDLE_SCOPE();
 
-  try
+  m_wallet_impl->setTxKey(tx_id, tx_key, additional_tx_keys, single_destination_subaddress);
+
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    m_wallet->set_tx_key(txid, tx_key, additional_tx_keys, single_destination_subaddress);
-    success_msg_writer() << tr("Tx key successfully stored.");
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Failed to store tx key: ") << e.what();
-    if (!single_destination_subaddress)
+    fail_msg_writer() << tr("Failed to store tx key: ") << error_msg;
+    if (single_destination_subaddress.empty())
       fail_msg_writer() << tr("It could be because the transfer was to a subaddress. If this is the case, pass the subaddress last");
+    return true;
   }
+
+  success_msg_writer() << tr("Tx key successfully stored.");
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -7851,35 +7333,24 @@ bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  crypto::hash txid;
-  if(!epee::string_tools::hex_to_pod(args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-
-  cryptonote::address_parse_info info;
-  if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[1], oa_prompter))
-  {
-    fail_msg_writer() << tr("failed to parse address");
-    return true;
-  }
-
   SCOPED_WALLET_UNLOCK();
 
-  try
+  std::string sig_str = m_wallet_impl->getTxProof(/* txid */ args[0],
+                                                  /* address */ args[1],
+                                                  /* message */ args.size() == 3 ? args[2] : "");
+  if (sig_str.empty())
   {
-    std::string sig_str = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, args.size() == 3 ? args[2] : "");
-    const std::string filename = "monero_tx_proof";
-    if (m_wallet->save_to_file(filename, sig_str, true))
-      success_msg_writer() << tr("signature file saved to: ") << filename;
-    else
-      fail_msg_writer() << tr("failed to save signature file");
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to get tx proof: ") << error_msg;
+    return true;
   }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("error: ") << e.what();
-  }
+  const std::string filename = "monero_tx_proof";
+  if (save_to_file(filename, sig_str, /* is_printable */ true))
+    success_msg_writer() << tr("signature file saved to: ") << filename;
+  else
+    fail_msg_writer() << tr("failed to save signature file");
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -7895,55 +7366,128 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
   if (!try_connect_to_daemon())
     return true;
 
-  if (!m_wallet)
+  if (!m_wallet_impl)
   {
     fail_msg_writer() << tr("wallet is null");
     return true;
   }
-  crypto::hash txid;
-  if(!epee::string_tools::hex_to_pod(local_args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
 
-  crypto::secret_key tx_key;
-  std::vector<crypto::secret_key> additional_tx_keys;
-  if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), tx_key))
+  std::string tx_id = local_args[0];
+  std::string tx_key = local_args[1].substr(0, 64);
+  std::vector<std::string> additional_tx_keys;
+  while(true)
   {
-    fail_msg_writer() << tr("failed to parse tx key");
-    return true;
-  }
-  local_args[1] = local_args[1].substr(64);
-  while (!local_args[1].empty())
-  {
-    additional_tx_keys.resize(additional_tx_keys.size() + 1);
-    if(!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), additional_tx_keys.back()))
-    {
-      fail_msg_writer() << tr("failed to parse tx key");
-      return true;
-    }
+    // additional_tx_keys are concatenated onto tx_keys, each one is 32 bytes (64 char hex string)
+    // local_args[1]: "tx_key [| additional_tx_key_1 | ... | additional_tx_key_n ]"
     local_args[1] = local_args[1].substr(64);
+    if (local_args[1].empty())
+      break;
+    additional_tx_keys.push_back(local_args[1].substr(0, 64));
   }
 
   cryptonote::address_parse_info info;
-  if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args[2], oa_prompter))
+  network_type nettype = static_cast<network_type>(m_wallet_impl->nettype());
+  if(!cryptonote::get_account_address_from_str_or_url(info, nettype, local_args[2], oa_prompter))
   {
     fail_msg_writer() << tr("failed to parse address");
     return true;
   }
 
-  try
+  string address = epee::string_tools::pod_to_hex(info.address);
+  uint64_t received, confirmations;
+  bool is_in_pool;
+  if (!m_wallet_impl->checkTxKey(tx_id,
+                                 tx_key,
+                                 address,
+                                 received,
+                                 is_in_pool,
+                                 confirmations))
   {
-    uint64_t received;
-    bool in_pool;
-    uint64_t confirmations;
-    m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, received, in_pool, confirmations);
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to check tx proof: ") << error_msg;
+    return true;
+  }
 
+  if (received > 0)
+  {
+    success_msg_writer() << get_account_address_as_str(nettype, info.is_subaddress, info.address) << " " << tr("received") << " " << print_money(received) << " " << tr("in txid") << " " << tx_id;
+    if (is_in_pool)
+    {
+      success_msg_writer() << tr("WARNING: this transaction is not yet included in the blockchain!");
+    }
+    else
+    {
+      if (confirmations != (uint64_t)-1)
+      {
+        success_msg_writer() << boost::format(tr("This transaction has %u confirmations")) % confirmations;
+      }
+      else
+      {
+        success_msg_writer() << tr("WARNING: failed to determine number of confirmations!");
+      }
+    }
+  }
+  else
+  {
+    fail_msg_writer() << get_account_address_as_str(nettype, info.is_subaddress, info.address) << " " << tr("received nothing in txid") << " " << tx_id;
+  }
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
+{
+  if(args.size() != 3 && args.size() != 4) {
+    PRINT_USAGE(USAGE_CHECK_TX_PROOF);
+    return true;
+  }
+
+  if (!try_connect_to_daemon())
+    return true;
+
+  std::string sig_str;
+  // read signature string
+  if (args[2].substr(0, 7) == "InProof" || args[2].substr(0, 8) == "OutProof")
+      sig_str = args[2];
+  else
+  {
+    // read signature file
+    if (!load_from_file(args[2], sig_str))
+    {
+      fail_msg_writer() << tr("failed to load signature file");
+      return true;
+    }
+    // strip whitespace
+    sig_str.erase(remove_if(sig_str.begin(), sig_str.end(), ::isspace), sig_str.end());
+  }
+
+  string txid = args[0];
+  string address = args[1];
+  uint64_t received, confirmations;
+  bool is_proof_verified, is_in_pool;
+  if (!m_wallet_impl->checkTxProof(txid,
+                                   address,
+                                   /* message */ args.size() == 4 ? args[3] : "",
+                                   sig_str,
+                                   is_proof_verified,
+                                   received,
+                                   is_in_pool,
+                                   confirmations))
+  {
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to check tx proof: ") << error_msg;
+    return true;
+  }
+  if (is_proof_verified)
+  {
+    success_msg_writer() << tr("Good signature");
     if (received > 0)
     {
-      success_msg_writer() << get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address) << " " << tr("received") << " " << print_money(received) << " " << tr("in txid") << " " << txid;
-      if (in_pool)
+      success_msg_writer() << address << " " << tr("received") << " " << print_money(received) << " " << tr("in txid") << " " << txid;
+      if (is_in_pool)
       {
         success_msg_writer() << tr("WARNING: this transaction is not yet included in the blockchain!");
       }
@@ -7961,90 +7505,12 @@ bool simple_wallet::check_tx_key(const std::vector<std::string> &args_)
     }
     else
     {
-      fail_msg_writer() << get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address) << " " << tr("received nothing in txid") << " " << txid;
+      fail_msg_writer() << address << " " << tr("received nothing in txid") << " " << txid;
     }
   }
-  catch (const std::exception &e)
+  else
   {
-    fail_msg_writer() << tr("error: ") << e.what();
-  }
-  return true;
-}
-//----------------------------------------------------------------------------------------------------
-bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
-{
-  if(args.size() != 3 && args.size() != 4) {
-    PRINT_USAGE(USAGE_CHECK_TX_PROOF);
-    return true;
-  }
-
-  if (!try_connect_to_daemon())
-    return true;
-
-  // parse txid
-  crypto::hash txid;
-  if(!epee::string_tools::hex_to_pod(args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-
-  // parse address
-  cryptonote::address_parse_info info;
-  if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[1], oa_prompter))
-  {
-    fail_msg_writer() << tr("failed to parse address");
-    return true;
-  }
-
-  // read signature file
-  std::string sig_str;
-  if (!m_wallet->load_from_file(args[2], sig_str))
-  {
-    fail_msg_writer() << tr("failed to load signature file");
-    return true;
-  }
-
-  try
-  {
-    uint64_t received;
-    bool in_pool;
-    uint64_t confirmations;
-    if (m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, args.size() == 4 ? args[3] : "", sig_str, received, in_pool, confirmations))
-    {
-      success_msg_writer() << tr("Good signature");
-      if (received > 0)
-      {
-        success_msg_writer() << get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address) << " " << tr("received") << " " << print_money(received) << " " << tr("in txid") << " " << txid;
-        if (in_pool)
-        {
-          success_msg_writer() << tr("WARNING: this transaction is not yet included in the blockchain!");
-        }
-        else
-        {
-          if (confirmations != (uint64_t)-1)
-          {
-            success_msg_writer() << boost::format(tr("This transaction has %u confirmations")) % confirmations;
-          }
-          else
-          {
-            success_msg_writer() << tr("WARNING: failed to determine number of confirmations!");
-          }
-        }
-      }
-      else
-      {
-        fail_msg_writer() << get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address) << " " << tr("received nothing in txid") << " " << txid;
-      }
-    }
-    else
-    {
-      fail_msg_writer() << tr("Bad signature");
-    }
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("error: ") << e.what();
+    fail_msg_writer() << tr("Bad signature");
   }
   return true;
 }
@@ -8052,7 +7518,7 @@ bool simple_wallet::check_tx_proof(const std::vector<std::string> &args)
 bool simple_wallet::get_spend_proof(const std::vector<std::string> &args)
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot get spend proof");
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -8062,16 +7528,9 @@ bool simple_wallet::get_spend_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot generate the proof");
-    return true;
-  }
-
-  crypto::hash txid;
-  if (!epee::string_tools::hex_to_pod(args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
     return true;
   }
 
@@ -8080,19 +7539,21 @@ bool simple_wallet::get_spend_proof(const std::vector<std::string> &args)
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  const std::string sig_str = m_wallet_impl->getSpendProof(/* txid */ args[0],
+                                                           /* message */ args.size() == 2 ? args[1] : "");
+  if (sig_str.empty())
   {
-    const std::string sig_str = m_wallet->get_spend_proof(txid, args.size() == 2 ? args[1] : "");
-    const std::string filename = "monero_spend_proof";
-    if (m_wallet->save_to_file(filename, sig_str, true))
-      success_msg_writer() << tr("signature file saved to: ") << filename;
-    else
-      fail_msg_writer() << tr("failed to save signature file");
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to get spend proof: ") << error_msg;
+    return true;
   }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << e.what();
-  }
+  const std::string filename = "monero_spend_proof";
+  if (save_to_file(filename, sig_str, true))
+    success_msg_writer() << tr("signature file saved to: ") << filename;
+  else
+    fail_msg_writer() << tr("failed to save signature file");
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -8103,41 +7564,41 @@ bool simple_wallet::check_spend_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  crypto::hash txid;
-  if (!epee::string_tools::hex_to_pod(args[0], txid))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-
   if (!try_connect_to_daemon())
     return true;
 
   std::string sig_str;
-  if (!m_wallet->load_from_file(args[1], sig_str))
+  if (!load_from_file(args[1], sig_str))
   {
     fail_msg_writer() << tr("failed to load signature file");
     return true;
   }
+  // strip whitespace
+  sig_str.erase(remove_if(sig_str.begin(), sig_str.end(), ::isspace), sig_str.end());
 
-  try
+  bool is_proof_verified;
+  if (!m_wallet_impl->checkSpendProof(/* txid */ args[0],
+                                      /* message */ args.size() == 3 ? args[2] : "",
+                                      sig_str,
+                                      is_proof_verified))
   {
-    if (m_wallet->check_spend_proof(txid, args.size() == 3 ? args[2] : "", sig_str))
-      success_msg_writer() << tr("Good signature");
-    else
-      fail_msg_writer() << tr("Bad signature");
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to check spend proof: ") << error_msg;
+    return true;
   }
-  catch (const std::exception& e)
-  {
-    fail_msg_writer() << e.what();
-  }
+  if (is_proof_verified)
+    success_msg_writer() << tr("Good signature");
+  else
+    fail_msg_writer() << tr("Bad signature");
   return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::get_reserve_proof(const std::vector<std::string> &args)
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot get reserve proof");
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -8147,18 +7608,16 @@ bool simple_wallet::get_reserve_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  if (m_wallet->watch_only() || m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->watchOnly() || m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("The reserve proof can be generated only by a full wallet");
     return true;
   }
 
-  boost::optional<std::pair<uint32_t, uint64_t>> account_minreserve;
+  uint64_t amount;
   if (args[0] != "all")
   {
-    account_minreserve = std::pair<uint32_t, uint64_t>();
-    account_minreserve->first = m_current_subaddress_account;
-    if (!cryptonote::parse_amount(account_minreserve->second, args[0]))
+    if (!cryptonote::parse_amount(amount, args[0]))
     {
       fail_msg_writer() << tr("amount is wrong: ") << args[0];
       return true;
@@ -8170,19 +7629,23 @@ bool simple_wallet::get_reserve_proof(const std::vector<std::string> &args)
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  const std::string sig_str = m_wallet_impl->getReserveProof(args[0] == "all",
+                                                             m_current_subaddress_account,
+                                                             amount,
+                                                             args.size() == 2 ? args[1] : "");
+  if (sig_str.empty())
   {
-    const std::string sig_str = m_wallet->get_reserve_proof(account_minreserve, args.size() == 2 ? args[1] : "");
-    const std::string filename = "monero_reserve_proof";
-    if (m_wallet->save_to_file(filename, sig_str, true))
-      success_msg_writer() << tr("signature file saved to: ") << filename;
-    else
-      fail_msg_writer() << tr("failed to save signature file");
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to get reserve proof: ") << error_msg;
+    return true;
   }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << e.what();
-  }
+  const std::string filename = "monero_reserve_proof";
+  if (save_to_file(filename, sig_str, /* is_printable */ true))
+    success_msg_writer() << tr("signature file saved to: ") << filename;
+  else
+    fail_msg_writer() << tr("failed to save signature file");
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -8196,42 +7659,39 @@ bool simple_wallet::check_reserve_proof(const std::vector<std::string> &args)
   if (!try_connect_to_daemon())
     return true;
 
-  cryptonote::address_parse_info info;
-  if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[0], oa_prompter))
-  {
-    fail_msg_writer() << tr("failed to parse address");
-    return true;
-  }
-  if (info.is_subaddress)
-  {
-    fail_msg_writer() << tr("Address must not be a subaddress");
-    return true;
-  }
-
   std::string sig_str;
-  if (!m_wallet->load_from_file(args[1], sig_str))
+  if (!load_from_file(args[1], sig_str))
   {
     fail_msg_writer() << tr("failed to load signature file");
     return true;
   }
+  // strip whitespace
+  sig_str.erase(remove_if(sig_str.begin(), sig_str.end(), ::isspace), sig_str.end());
 
   LOCK_IDLE_SCOPE();
 
-  try
+  uint64_t total, spent;
+  bool is_proof_verified;
+  if (!m_wallet_impl->checkReserveProof(/* address */ args[0],
+                                        /* message */ args.size() == 3 ? args[2] : "",
+                                        sig_str,
+                                        is_proof_verified,
+                                        total,
+                                        spent))
   {
-    uint64_t total, spent;
-    if (m_wallet->check_reserve_proof(info.address, args.size() == 3 ? args[2] : "", sig_str, total, spent))
-    {
-      success_msg_writer() << boost::format(tr("Good signature -- total: %s, spent: %s, unspent: %s")) % print_money(total) % print_money(spent) % print_money(total - spent);
-    }
-    else
-    {
-      fail_msg_writer() << tr("Bad signature");
-    }
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << tr("failed to check reserve proof: ") << error_msg;
+    return true;
   }
-  catch (const std::exception& e)
+  if (is_proof_verified)
   {
-    fail_msg_writer() << e.what();
+    success_msg_writer() << boost::format(tr("Good signature -- total: %s, spent: %s, unspent: %s")) % print_money(total) % print_money(spent) % print_money(total - spent);
+  }
+  else
+  {
+    fail_msg_writer() << tr("Bad signature");
   }
   return true;
 }
@@ -8313,169 +7773,186 @@ bool simple_wallet::get_transfers(std::vector<std::string>& local_args, std::vec
     local_args.erase(local_args.begin());
   }
 
-  const uint64_t last_block_height = m_wallet->get_blockchain_current_height();
+  const uint64_t last_block_height = m_wallet_impl->blockChainHeight();
 
+  TransactionHistory *tx_history = m_wallet_impl->history();
+  tx_history->refresh();
   if (in || coinbase) {
-    std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-    m_wallet->get_payments(payments, min_height, max_height, m_current_subaddress_account, subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-      const tools::wallet2::payment_details &pd = i->second;
-      if (!pd.m_coinbase && !in)
+    std::vector<TransactionInfo *> payments;
+    for (const auto &tx_info : tx_history->getAll())
+    {
+      if (tx_info->direction() == Monero::TransactionInfo::Direction_In
+              && min_height < tx_info->blockHeight() && max_height >= tx_info->blockHeight()
+              && m_current_subaddress_account == tx_info->subaddrAccount()
+              && (subaddr_indices.empty() || subaddr_indices.count(*tx_info->subaddrIndex().begin()) == 1))
+        payments.push_back(tx_info);
+    }
+    for (const auto &tx_info : payments) {
+      if (!tx_info->isCoinbase() && !in)
         continue;
-      std::string payment_id = string_tools::pod_to_hex(i->first);
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
-      std::string note = m_wallet->get_tx_note(pd.m_tx_hash);
-      std::string destination = m_wallet->get_subaddress_as_str({m_current_subaddress_account, pd.m_subaddr_index.minor});
-      const std::string type = pd.m_coinbase ? tr("block") : tr("in");
-      const bool unlocked = m_wallet->is_transfer_unlocked(pd.m_unlock_time, pd.m_block_height);
+      std::string destination = m_wallet_impl->address(m_current_subaddress_account, *tx_info->subaddrIndex().begin());
+      const std::string type = tx_info->isCoinbase() ? tr("block") : tr("in");
+      const bool unlocked = tx_info->isUnlocked();
       std::string locked_msg = "unlocked";
       if (!unlocked)
       {
         locked_msg = "locked";
-        if (pd.m_unlock_time < CRYPTONOTE_MAX_BLOCK_NUMBER)
+        if (tx_info->unlockTime() < CRYPTONOTE_MAX_BLOCK_NUMBER)
         {
-          uint64_t bh = std::max(pd.m_unlock_time, pd.m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
+          uint64_t bh = std::max(tx_info->unlockTime(), tx_info->blockHeight() + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
           if (bh >= last_block_height)
             locked_msg = std::to_string(bh - last_block_height) + " blks";
         }
         else
         {
-          const uint64_t adjusted_time = m_wallet->get_daemon_adjusted_time();
-          uint64_t threshold = adjusted_time + (m_wallet->use_fork_rules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
-          if (threshold < pd.m_unlock_time)
-            locked_msg = tools::get_human_readable_timespan(std::chrono::seconds(pd.m_unlock_time - threshold));
+          const uint64_t adjusted_time = m_wallet_impl->getDaemonAdjustedTime();
+          uint64_t threshold = adjusted_time + (m_wallet_impl->useForkRules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
+          if (threshold < tx_info->unlockTime())
+            locked_msg = tools::get_human_readable_timespan(std::chrono::seconds(tx_info->unlockTime() - threshold));
         }
       }
+      crypto::hash tx_id;
+      epee::string_tools::hex_to_pod(tx_info->hash(), tx_id);
       transfers.push_back({
         type,
-        pd.m_block_height,
-        pd.m_timestamp,
-        type,
-        true,
-        pd.m_amount,
-        pd.m_tx_hash,
+        tx_info->blockHeight(),
+        (uint64_t) tx_info->timestamp(),
+        /* direction */ type,
+        /* confirmed */ true,
+        tx_info->amount(),
+        tx_id,
         payment_id,
-        0,
-        {{destination, pd.m_amount}},
-        {pd.m_subaddr_index.minor},
-        note,
+        /* fee */ 0,
+        {{destination, tx_info->amount()}},
+        tx_info->subaddrIndex(),
+        tx_info->description(),
         locked_msg
       });
     }
   }
 
   if (out) {
-    std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments;
-    m_wallet->get_payments_out(payments, min_height, max_height, m_current_subaddress_account, subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-      const tools::wallet2::confirmed_transfer_details &pd = i->second;
-      uint64_t change = pd.m_change == (uint64_t)-1 ? 0 : pd.m_change; // change may not be known
-      uint64_t fee = pd.m_amount_in - pd.m_amount_out;
+    std::vector<TransactionInfo *> payments;
+    for (const auto &tx_info : tx_history->getAll())
+    {
+      if (tx_info->direction() == Monero::TransactionInfo::Direction_Out
+              && tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Confirmed
+              && min_height < tx_info->blockHeight() && max_height >= tx_info->blockHeight()
+              && m_current_subaddress_account == tx_info->subaddrAccount()
+              && (subaddr_indices.empty() || std::count_if(tx_info->subaddrIndex().begin(), tx_info->subaddrIndex().end(), [&subaddr_indices](uint32_t index) { return subaddr_indices.count(index) == 1; }) != 0))
+          payments.push_back(tx_info);
+    }
+    for (const auto &tx_info : payments) {
       std::vector<std::pair<std::string, uint64_t>> destinations;
-      for (const auto &d: pd.m_dests) {
-        destinations.push_back({d.address(m_wallet->nettype(), pd.m_payment_id), d.amount});
+      for (const auto &d: tx_info->transfers()) {
+        destinations.push_back({d.address, d.amount});
       }
-      std::string payment_id = string_tools::pod_to_hex(i->second.m_payment_id);
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
-      std::string note = m_wallet->get_tx_note(i->first);
+      crypto::hash tx_id;
+      epee::string_tools::hex_to_pod(tx_info->hash(), tx_id);
       transfers.push_back({
-        "out",
-        pd.m_block_height,
-        pd.m_timestamp,
-        "out",
-        true,
-        pd.m_amount_in - change - fee,
-        i->first,
+        /* type */ "out",
+        tx_info->blockHeight(),
+        (uint64_t) tx_info->timestamp(),
+        /* direction */ "out",
+        /* confirmed */ true,
+        tx_info->amount(),
+        tx_id,
         payment_id,
-        fee,
+        tx_info->fee(),
         destinations,
-        pd.m_subaddr_indices,
-        note,
-        "-"
+        tx_info->subaddrIndex(),
+        tx_info->description(),
+        /* locked_msg */ "-"
       });
     }
   }
 
   if (pool) {
-    try
+    std::vector<TransactionInfo *> payments;
+    for (const auto &tx_info : tx_history->getAll())
     {
-      m_in_manual_refresh.store(true, std::memory_order_relaxed);
-      const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
-
-      std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs;
-      m_wallet->update_pool_state(process_txs);
-      if (!process_txs.empty())
-        m_wallet->process_pool_state(process_txs);
-
-      std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> payments;
-      m_wallet->get_unconfirmed_payments(payments, m_current_subaddress_account, subaddr_indices);
-      for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-        const tools::wallet2::payment_details &pd = i->second.m_pd;
-        std::string payment_id = string_tools::pod_to_hex(i->first);
-        if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-          payment_id = payment_id.substr(0,16);
-        std::string note = m_wallet->get_tx_note(pd.m_tx_hash);
-        std::string destination = m_wallet->get_subaddress_as_str({m_current_subaddress_account, pd.m_subaddr_index.minor});
-        std::string double_spend_note;
-        if (i->second.m_double_spend_seen)
-          double_spend_note = tr("[Double spend seen on the network: this transaction may or may not end up being mined] ");
-        transfers.push_back({
-          "pool",
-          "pool",
-          pd.m_timestamp,
-          "in",
-          false,
-          pd.m_amount,
-          pd.m_tx_hash,
-          payment_id,
-          0,
-          {{destination, pd.m_amount}},
-          {pd.m_subaddr_index.minor},
-          note + double_spend_note,
-          "locked"
-        });
-      }
+      if (tx_info->direction() == Monero::TransactionInfo::Direction_In
+              && tx_info->txState() == Monero::TransactionInfo::TxState::TxState_PendingInPool
+              && m_current_subaddress_account == tx_info->subaddrAccount()
+              && (subaddr_indices.empty() || subaddr_indices.count(*tx_info->subaddrIndex().begin()) == 1))
+        payments.push_back(tx_info);
     }
-    catch (const std::exception& e)
-    {
-      fail_msg_writer() << "Failed to get pool state:" << e.what();
+    for (const auto &tx_info : payments) {
+      std::string payment_id = tx_info->paymentId();
+      if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+        payment_id = payment_id.substr(0,16);
+      std::string destination = m_wallet_impl->address(m_current_subaddress_account, *tx_info->subaddrIndex().begin());
+      std::string double_spend_note;
+      if (tx_info->isDoubleSpendSeen())
+        double_spend_note = tr("[Double spend seen on the network: this transaction may or may not end up being mined] ");
+      crypto::hash tx_id;
+      epee::string_tools::hex_to_pod(tx_info->hash(), tx_id);
+      transfers.push_back({
+        /* type */ "pool",
+        /* block_height */ "pool",
+        (uint64_t) tx_info->timestamp(),
+        /* direction */ "in",
+        /* confirmed */ false,
+        tx_info->amount(),
+        tx_id,
+        payment_id,
+        /* fee */ 0,
+        {{destination, tx_info->amount()}},
+        tx_info->subaddrIndex(),
+        tx_info->description() + double_spend_note,
+        /* locked_msg */ "locked"
+      });
     }
   }
 
   // print unconfirmed last
   if (pending || failed) {
-    std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> upayments;
-    m_wallet->get_unconfirmed_payments_out(upayments, m_current_subaddress_account, subaddr_indices);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = upayments.begin(); i != upayments.end(); ++i) {
-      const tools::wallet2::unconfirmed_transfer_details &pd = i->second;
-      uint64_t amount = pd.m_amount_in;
-      uint64_t fee = amount - pd.m_amount_out;
+    std::vector<TransactionInfo *> payments;
+    for (const auto &tx_info : tx_history->getAll())
+    {
+      if (tx_info->direction() == Monero::TransactionInfo::Direction_Out
+              && (tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Pending
+              ||  tx_info->txState() == Monero::TransactionInfo::TxState::TxState_PendingInPool
+              ||  tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Failed)
+              && m_current_subaddress_account == tx_info->subaddrAccount()
+              && (subaddr_indices.empty()
+              ||  std::count_if(tx_info->subaddrIndex().begin(),
+                                tx_info->subaddrIndex().end(),
+                                [&subaddr_indices](uint32_t index) { return subaddr_indices.count(index) == 1; }) != 0))
+        payments.push_back(tx_info);
+    }
+    for (const auto &tx_info : payments) {
       std::vector<std::pair<std::string, uint64_t>> destinations;
-      for (const auto &d: pd.m_dests) {
-        destinations.push_back({d.address(m_wallet->nettype(), pd.m_payment_id), d.amount});
+      for (const auto &d: tx_info->transfers()) {
+        destinations.push_back({d.address, d.amount});
       }
-      std::string payment_id = string_tools::pod_to_hex(i->second.m_payment_id);
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
-      std::string note = m_wallet->get_tx_note(i->first);
-      bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
+      crypto::hash tx_id;
+      epee::string_tools::hex_to_pod(tx_info->hash(), tx_id);
+      bool is_failed = tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Failed;
       if ((failed && is_failed) || (!is_failed && pending)) {
         transfers.push_back({
-          (is_failed ? "failed" : "pending"),
-          (is_failed ? "failed" : "pending"),
-          pd.m_timestamp,
-          "out",
-          false,
-          amount - pd.m_change - fee,
-          i->first,
+          /* type */ (is_failed ? "failed" : "pending"),
+          /* block_height */ (is_failed ? "failed" : "pending"),
+          (uint64_t) tx_info->timestamp(),
+          /* direction */ "out",
+          /* confirmed */ false,
+          tx_info->amount(),
+          tx_id,
           payment_id,
-          fee,
+          tx_info->fee(),
           destinations,
-          pd.m_subaddr_indices,
-          note,
-          "-"
+          tx_info->subaddrIndex(),
+          tx_info->description(),
+          /* locked_msg */ "-"
         });
       }
     }
@@ -8590,7 +8067,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
   }
   if (export_keys)
   {
-    if (m_wallet->key_on_device() && m_wallet->get_account().get_device().get_type() != hw::device::TREZOR)
+    if (m_wallet_impl->getDeviceState().key_on_device && m_wallet_impl->getDeviceState().device_type != Wallet::DeviceState::DeviceType::DeviceType_Trezor)
     {
       fail_msg_writer() << tr("command not supported by HW wallet");
       return true;
@@ -8630,10 +8107,14 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
     std::string key_string;
     if (export_keys)
     {
-      crypto::secret_key tx_key;
-      std::vector<crypto::secret_key> additional_tx_keys;
-      if (m_wallet->get_tx_key(transfer.hash, tx_key, additional_tx_keys))
-        key_string = get_tx_key_stream(tx_key, additional_tx_keys);
+      key_string = m_wallet_impl->getTxKey(epee::string_tools::pod_to_hex(transfer.hash));
+      if (key_string.empty())
+      {
+        int error_code;
+        std::string error_msg;
+        m_wallet_impl->statusWithErrorString(error_code, error_msg);
+        fail_msg_writer() << error_msg;
+      }
     }
 
     file << formatter
@@ -8726,42 +8207,46 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
       return true;
     }
   }
-  tools::wallet2::transfer_container transfers;
-  m_wallet->get_transfers(transfers);
-  std::map<uint64_t, tools::wallet2::transfer_container> amount_to_tds;
+  std::vector<std::unique_ptr<EnoteDetails>> enote_details = m_wallet_impl->getEnoteDetails();
+  std::map<uint64_t, std::vector<std::unique_ptr<EnoteDetails>>> amount_to_eds;
   uint64_t min_height = std::numeric_limits<uint64_t>::max();
   uint64_t max_height = 0;
   uint64_t found_min_amount = std::numeric_limits<uint64_t>::max();
   uint64_t found_max_amount = 0;
   uint64_t found_sum_amount = 0;
   uint64_t count = 0;
-  for (const auto& td : transfers)
+  for (auto& ed : enote_details)
   {
-    uint64_t amount = td.amount();
-    if (td.m_spent || amount < min_amount || amount > max_amount || td.m_subaddr_index.major != m_current_subaddress_account || (subaddr_indices.count(td.m_subaddr_index.minor) == 0 && !subaddr_indices.empty()))
+    uint64_t amount = ed->amount();
+    if (ed->isSpent()
+            || amount < min_amount
+            || amount > max_amount
+            || ed->subaddressIndexMajor() != m_current_subaddress_account
+            || (subaddr_indices.count(ed->subaddressIndexMinor()) == 0 && !subaddr_indices.empty()))
       continue;
-    amount_to_tds[amount].push_back(td);
-    if (min_height > td.m_block_height) min_height = td.m_block_height;
-    if (max_height < td.m_block_height) max_height = td.m_block_height;
+    std::uint64_t block_height = ed->blockHeight();
+    amount_to_eds[amount].push_back(std::move(ed));
+    if (min_height > block_height) min_height = block_height;
+    if (max_height < block_height) max_height = block_height;
     if (found_min_amount > amount) found_min_amount = amount;
     if (found_max_amount < amount) found_max_amount = amount;
     found_sum_amount += amount;
     ++count;
   }
-  if (amount_to_tds.empty())
+  if (amount_to_eds.empty())
   {
     success_msg_writer() << tr("There is no unspent output in the specified address");
     return true;
   }
-  for (const auto& amount_tds : amount_to_tds)
+  for (const auto& amount_eds : amount_to_eds)
   {
-    auto& tds = amount_tds.second;
-    success_msg_writer() << tr("\nAmount: ") << print_money(amount_tds.first) << tr(", number of keys: ") << tds.size();
-    for (size_t i = 0; i < tds.size(); )
+    auto& eds = amount_eds.second;
+    success_msg_writer() << tr("\nAmount: ") << print_money(amount_eds.first) << tr(", number of keys: ") << eds.size();
+    for (size_t i = 0; i < eds.size(); )
     {
       std::ostringstream oss;
-      for (size_t j = 0; j < 8 && i < tds.size(); ++i, ++j)
-        oss << tds[i].m_block_height << tr(" ");
+      for (size_t j = 0; j < 8 && i < eds.size(); ++i, ++j)
+        oss << eds[i]->blockHeight() << tr(" ");
       success_msg_writer() << oss.str();
     }
   }
@@ -8777,11 +8262,11 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
   double bin_size = (max_height - min_height + 1.0) / histogram_width;
   size_t max_bin_count = 0;
   std::vector<size_t> histogram(histogram_width, 0);
-  for (const auto& amount_tds : amount_to_tds)
+  for (const auto& amount_eds : amount_to_eds)
   {
-    for (auto& td : amount_tds.second)
+    for (auto& ed : amount_eds.second)
     {
-      uint64_t bin_index = (td.m_block_height - min_height + 1) / bin_size;
+      uint64_t bin_index = (ed->blockHeight() - min_height + 1) / bin_size;
       if (bin_index >= histogram_width)
         bin_index = histogram_width - 1;
       histogram[bin_index]++;
@@ -8877,7 +8362,7 @@ bool simple_wallet::rescan_blockchain(const std::vector<std::string> &args_)
     }
   }
 
-  const uint64_t wallet_from_height = m_wallet->get_refresh_from_block_height();
+  const uint64_t wallet_from_height = m_wallet_impl->getRefreshFromBlockHeight();
   if (start_height > wallet_from_height)
   {
     message_writer() << tr("Warning: your restore height is higher than wallet restore height: ") << wallet_from_height;
@@ -8892,22 +8377,6 @@ bool simple_wallet::rescan_blockchain(const std::vector<std::string> &args_)
   m_in_manual_refresh.store(true, std::memory_order_relaxed);
   const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
   return refresh_main(start_height, reset_type, true);
-}
-//----------------------------------------------------------------------------------------------------
-void simple_wallet::check_for_messages()
-{
-  try
-  {
-    std::vector<mms::message> new_messages;
-    bool new_message = get_message_store().check_for_messages(get_multisig_wallet_state(), new_messages);
-    if (new_message)
-    {
-      message_writer(console_color_magenta, true) << tr("MMS received new message");
-      list_mms_messages(new_messages);
-      m_cmd_binder.print_prompt();
-    }
-  }
-  catch(...) {}
 }
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::wallet_idle_thread()
@@ -8935,7 +8404,6 @@ void simple_wallet::wallet_idle_thread()
       m_inactivity_checker.do_call(boost::bind(&simple_wallet::check_inactivity, this));
 #endif
       m_refresh_checker.do_call(boost::bind(&simple_wallet::check_refresh, this));
-      m_mms_checker.do_call(boost::bind(&simple_wallet::check_mms, this));
 
       if (!m_idle_run.load(std::memory_order_relaxed))
         break;
@@ -8954,7 +8422,7 @@ bool simple_wallet::check_inactivity()
     // inactivity lock
     if (!m_locked && !m_in_command)
     {
-      const uint32_t seconds = m_wallet->inactivity_lock_timeout();
+      const uint32_t seconds = m_wallet_impl->getInactivityLockTimeout();
       if (seconds > 0 && time(NULL) - m_last_activity_time > seconds)
       {
         m_locked = true;
@@ -8970,27 +8438,11 @@ bool simple_wallet::check_refresh()
     if (m_auto_refresh_enabled)
     {
       m_auto_refresh_refreshing = true;
-      try
-      {
-        uint64_t fetched_blocks;
-        bool received_money;
-        if (try_connect_to_daemon(true))
-          m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, fetched_blocks, received_money, false); // don't check the pool in background mode
-      }
-      catch(...) {}
+      if (try_connect_to_daemon(true))
+        m_wallet_impl->refresh(/* start_height */ 0,
+                               /* check_pool */ false,
+                               /* try_incremental */ true);
       m_auto_refresh_refreshing = false;
-    }
-    return true;
-}
-//----------------------------------------------------------------------------------------------------
-bool simple_wallet::check_mms()
-{
-    // Check for new MMS messages;
-    // For simplicity auto message check is ALSO controlled by "m_auto_refresh_enabled" and has no
-    // separate thread either; thread syncing is tricky enough with only this one idle thread here
-    if (m_auto_refresh_enabled && get_message_store().get_active())
-    {
-      check_for_messages();
     }
     return true;
 }
@@ -8999,11 +8451,11 @@ std::string simple_wallet::get_prompt() const
 {
   if (m_locked)
     return std::string("[") + tr("locked due to inactivity") + "]";
-  std::string addr_start = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0}).substr(0, 6);
+  std::string addr_start = m_wallet_impl->address(m_current_subaddress_account, 0).substr(0, 6);
   std::string prompt = std::string("[") + tr("wallet") + " " + addr_start;
-  if (!m_wallet->check_connection(NULL))
+  if (!m_wallet_impl->connectToDaemon(NULL))
     prompt += tr(" (no daemon)");
-  else if (!m_wallet->is_synced())
+  else if (!m_wallet_impl->daemonSynced())
     prompt += tr(" (out of sync)");
   prompt += "]: ";
   return prompt;
@@ -9016,7 +8468,7 @@ bool simple_wallet::run()
 
   refresh_main(0, ResetNone, true);
 
-  m_auto_refresh_enabled = !m_wallet->is_offline() && m_wallet->auto_refresh();
+  m_auto_refresh_enabled = !m_wallet_impl->isOffline() && m_wallet_impl->getAutoRefresh();
   m_idle_thread = boost::thread([&]{wallet_idle_thread();});
 
   message_writer(console_color_green, false) << "Background refresh thread started";
@@ -9049,6 +8501,8 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
 
   std::vector<std::string> local_args = args;
   std::string command = local_args[0];
+  int error_code;
+  std::string error_msg;
   local_args.erase(local_args.begin());
   if (command == "new")
   {
@@ -9057,8 +8511,8 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
     std::string label = boost::join(local_args, " ");
     if (label.empty())
       label = tr("(Untitled account)");
-    m_wallet->add_subaddress_account(label);
-    m_current_subaddress_account = m_wallet->get_num_subaddress_accounts() - 1;
+    m_wallet_impl->addSubaddressAccount(label);
+    m_current_subaddress_account = m_wallet_impl->numSubaddressAccounts() - 1;
     // update_prompt();
     LOCK_IDLE_SCOPE();
     print_accounts();
@@ -9072,9 +8526,9 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
       fail_msg_writer() << tr("failed to parse index: ") << local_args[0];
       return true;
     }
-    if (index_major >= m_wallet->get_num_subaddress_accounts())
+    if (index_major >= m_wallet_impl->numSubaddressAccounts())
     {
-      fail_msg_writer() << tr("specify an index between 0 and ") << (m_wallet->get_num_subaddress_accounts() - 1);
+      fail_msg_writer() << tr("specify an index between 0 and ") << (m_wallet_impl->numSubaddressAccounts() - 1);
       return true;
     }
     m_current_subaddress_account = index_major;
@@ -9093,16 +8547,15 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
     }
     local_args.erase(local_args.begin());
     std::string label = boost::join(local_args, " ");
-    try
+    m_wallet_impl->setSubaddressLabel(index_major, 0, label);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (!error_code)
     {
-      m_wallet->set_subaddress_label({index_major, 0}, label);
       LOCK_IDLE_SCOPE();
       print_accounts();
     }
-    catch (const std::exception& e)
-    {
-      fail_msg_writer() << e.what();
-    }
+    else
+      fail_msg_writer() << error_msg;
   }
   else if (command == "tag" && local_args.size() >= 2)
   {
@@ -9119,15 +8572,12 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
       }
       account_indices.insert(account_index);
     }
-    try
-    {
-      m_wallet->set_account_tag(account_indices, tag);
+    m_wallet_impl->setAccountTag(account_indices, tag);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (!error_code)
       print_accounts(tag);
-    }
-    catch (const std::exception& e)
-    {
-      fail_msg_writer() << e.what();
-    }
+    else
+      fail_msg_writer() << error_msg;
   }
   else if (command == "untag" && local_args.size() >= 1)
   {
@@ -9143,15 +8593,12 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
       }
       account_indices.insert(account_index);
     }
-    try
-    {
-      m_wallet->set_account_tag(account_indices, "");
+    m_wallet_impl->setAccountTag(account_indices, "");
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (!error_code)
       print_accounts();
-    }
-    catch (const std::exception& e)
-    {
-      fail_msg_writer() << e.what();
-    }
+    else
+      fail_msg_writer() << error_msg;
   }
   else if (command == "tag_description" && local_args.size() >= 1)
   {
@@ -9163,15 +8610,12 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
       local_args.erase(local_args.begin());
       description = boost::join(local_args, " ");
     }
-    try
-    {
-      m_wallet->set_account_tag_description(tag, description);
+    m_wallet_impl->setAccountTagDescription(tag, description);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (!error_code)
       print_accounts(tag);
-    }
-    catch (const std::exception& e)
-    {
-      fail_msg_writer() << e.what();
-    }
+    else
+      fail_msg_writer() << error_code;
   }
   else
   {
@@ -9182,8 +8626,8 @@ bool simple_wallet::account(const std::vector<std::string> &args/* = std::vector
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::print_accounts()
 {
-  const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& account_tags = m_wallet->get_account_tags();
-  size_t num_untagged_accounts = m_wallet->get_num_subaddress_accounts();
+  const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& account_tags = m_wallet_impl->getAccountTags();
+  size_t num_untagged_accounts = m_wallet_impl->numSubaddressAccounts();
   for (const std::pair<const std::string, std::string>& p : account_tags.first)
   {
     const std::string& tag = p.first;
@@ -9195,13 +8639,14 @@ void simple_wallet::print_accounts()
   if (num_untagged_accounts > 0)
     print_accounts("");
 
-  if (num_untagged_accounts < m_wallet->get_num_subaddress_accounts())
-    success_msg_writer() << tr("\nGrand total:\n  Balance: ") << print_money(m_wallet->balance_all(false)) << tr(", unlocked balance: ") << print_money(m_wallet->unlocked_balance_all(false));
+  if (num_untagged_accounts < m_wallet_impl->numSubaddressAccounts())
+    success_msg_writer() << tr("\nGrand total:\n  Balance: ") << print_money(m_wallet_impl->balanceAll()) <<
+                            tr(", unlocked balance: ") << print_money(m_wallet_impl->unlockedBalanceAll());
 }
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::print_accounts(const std::string& tag)
 {
-  const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& account_tags = m_wallet->get_account_tags();
+  const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& account_tags = m_wallet_impl->getAccountTags();
   if (tag.empty())
   {
     success_msg_writer() << tr("Untagged accounts:");
@@ -9218,19 +8663,21 @@ void simple_wallet::print_accounts(const std::string& tag)
   }
   success_msg_writer() << boost::format("  %15s %21s %21s %21s") % tr("Account") % tr("Balance") % tr("Unlocked balance") % tr("Label");
   uint64_t total_balance = 0, total_unlocked_balance = 0;
-  for (uint32_t account_index = 0; account_index < m_wallet->get_num_subaddress_accounts(); ++account_index)
+  for (uint32_t account_index = 0; account_index < m_wallet_impl->numSubaddressAccounts(); ++account_index)
   {
+    uint64_t balance = m_wallet_impl->balance(account_index);
+    uint64_t unlocked_balance = m_wallet_impl->unlockedBalance(account_index);
     if (account_tags.second[account_index] != tag)
       continue;
     success_msg_writer() << boost::format(tr(" %c%8u %6s %21s %21s %21s"))
       % (m_current_subaddress_account == account_index ? '*' : ' ')
       % account_index
-      % m_wallet->get_subaddress_as_str({account_index, 0}).substr(0, 6)
-      % print_money(m_wallet->balance(account_index, false))
-      % print_money(m_wallet->unlocked_balance(account_index, false))
-      % m_wallet->get_subaddress_label({account_index, 0});
-    total_balance += m_wallet->balance(account_index, false);
-    total_unlocked_balance += m_wallet->unlocked_balance(account_index, false);
+      % m_wallet_impl->address(account_index, 0).substr(0, 6)
+      % print_money(balance)
+      % print_money(unlocked_balance)
+      % m_wallet_impl->getSubaddressLabel(account_index, 0);
+    total_balance += balance;
+    total_unlocked_balance += unlocked_balance;
   }
   success_msg_writer() << tr("------------------------------------------------------------------------------------");
   success_msg_writer() << boost::format(tr("%15s   %21s %21s")) % "Total" % print_money(total_balance) % print_money(total_unlocked_balance);
@@ -9247,17 +8694,17 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
   //  address device [<index>]
 
   std::vector<std::string> local_args = args;
-  tools::wallet2::transfer_container transfers;
-  m_wallet->get_transfers(transfers);
+  std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet_impl->getEnoteDetails();
 
-  auto print_address_sub = [this, &transfers](uint32_t index)
+  auto print_address_sub = [this, &eds](uint32_t index)
   {
     bool used = std::find_if(
-      transfers.begin(), transfers.end(),
-      [this, &index](const tools::wallet2::transfer_details& td) {
-        return td.m_subaddr_index == cryptonote::subaddress_index{ m_current_subaddress_account, index };
-      }) != transfers.end();
-    success_msg_writer() << index << "  " << m_wallet->get_subaddress_as_str({m_current_subaddress_account, index}) << "  " << (index == 0 ? tr("Primary address") : m_wallet->get_subaddress_label({m_current_subaddress_account, index})) << " " << (used ? tr("(used)") : "");
+      eds.begin(), eds.end(),
+      [this, &index](const std::unique_ptr<EnoteDetails>& ed) {
+        return ed->subaddressIndexMajor() ==  m_current_subaddress_account
+            && ed->subaddressIndexMinor() == index;
+      }) != eds.end();
+    success_msg_writer() << index << "  " << m_wallet_impl->address(m_current_subaddress_account, index) << "  " << (index == 0 ? tr("Primary address") : m_wallet_impl->getSubaddressLabel(m_current_subaddress_account, index)) << " " << (used ? tr("(used)") : "");
   };
 
   uint32_t index = 0;
@@ -9268,7 +8715,7 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
   else if (local_args.size() == 1 && local_args[0] == "all")
   {
     local_args.erase(local_args.begin());
-    for (; index < m_wallet->get_num_subaddresses(m_current_subaddress_account); ++index)
+    for (; index < m_wallet_impl->numSubaddresses(m_current_subaddress_account); ++index)
       print_address_sub(index);
   }
   else if (local_args[0] == "new")
@@ -9280,9 +8727,9 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
       label = boost::join(local_args, " ");
     if (label.empty())
       label = tr("(Untitled address)");
-    m_wallet->add_subaddress(m_current_subaddress_account, label);
-    print_address_sub(m_wallet->get_num_subaddresses(m_current_subaddress_account) - 1);
-    m_wallet->device_show_address(m_current_subaddress_account, m_wallet->get_num_subaddresses(m_current_subaddress_account) - 1, boost::none);
+    m_wallet_impl->addSubaddress(m_current_subaddress_account, label);
+    print_address_sub(m_wallet_impl->numSubaddresses(m_current_subaddress_account) - 1);
+    m_wallet_impl->deviceShowAddress(m_current_subaddress_account, m_wallet_impl->numSubaddresses(m_current_subaddress_account) - 1, /* paymentId */ "");
   }
   else if (local_args[0] == "mnew")
   {
@@ -9306,8 +8753,8 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
     }
     for (uint32_t i = 0; i < n; ++i)
     {
-      m_wallet->add_subaddress(m_current_subaddress_account, tr("(Untitled address)"));
-      print_address_sub(m_wallet->get_num_subaddresses(m_current_subaddress_account) - 1);
+      m_wallet_impl->addSubaddress(m_current_subaddress_account, tr("(Untitled address)"));
+      print_address_sub(m_wallet_impl->numSubaddresses(m_current_subaddress_account) - 1);
     }
   }
   else if (local_args[0] == "one-off")
@@ -9326,8 +8773,8 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
       fail_msg_writer() << tr("failed to parse index: ") << local_args[0] << " " << local_args[1];
       return true;
     }
-    m_wallet->create_one_off_subaddress({major, minor});
-    success_msg_writer() << boost::format(tr("Address at %u %u: %s")) % major % minor % m_wallet->get_subaddress_as_str({major, minor});
+    m_wallet_impl->createOneOffSubaddress(major, minor);
+    success_msg_writer() << boost::format(tr("Address at %u %u: %s")) % major % minor % m_wallet_impl->address(major, minor);
   }
   else if (local_args.size() >= 2 && local_args[0] == "label")
   {
@@ -9337,15 +8784,15 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
       fail_msg_writer() << tr("failed to parse index: ") << local_args[1];
       return true;
     }
-    if (index >= m_wallet->get_num_subaddresses(m_current_subaddress_account))
+    if (index >= m_wallet_impl->numSubaddresses(m_current_subaddress_account))
     {
-      fail_msg_writer() << tr("specify an index between 0 and ") << (m_wallet->get_num_subaddresses(m_current_subaddress_account) - 1);
+      fail_msg_writer() << tr("specify an index between 0 and ") << (m_wallet_impl->numSubaddresses(m_current_subaddress_account) - 1);
       return true;
     }
     local_args.erase(local_args.begin());
     local_args.erase(local_args.begin());
     std::string label = boost::join(local_args, " ");
-    m_wallet->set_subaddress_label({m_current_subaddress_account, index}, label);
+    m_wallet_impl->setSubaddressLabel(m_current_subaddress_account, index, label);
     print_address_sub(index);
   }
   else if (local_args.size() <= 2 && epee::string_tools::get_xtype_from_string(index, local_args[0]))
@@ -9353,6 +8800,7 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
     local_args.erase(local_args.begin());
     uint32_t index_min = index;
     uint32_t index_max = index_min;
+    size_t n_subaddresses = m_wallet_impl->numSubaddresses(m_current_subaddress_account);
     if (local_args.size() > 0)
     {
       if (!epee::string_tools::get_xtype_from_string(index_max, local_args[0]))
@@ -9364,15 +8812,15 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
     }
     if (index_max < index_min)
       std::swap(index_min, index_max);
-    if (index_min >= m_wallet->get_num_subaddresses(m_current_subaddress_account))
+    if (index_min >= n_subaddresses)
     {
       fail_msg_writer() << tr("<index_min> is already out of bound");
       return true;
     }
-    if (index_max >= m_wallet->get_num_subaddresses(m_current_subaddress_account))
+    if (index_max >= n_subaddresses)
     {
       message_writer() << tr("<index_max> exceeds the bound");
-      index_max = m_wallet->get_num_subaddresses(m_current_subaddress_account) - 1;
+      index_max = n_subaddresses - 1;
     }
     for (index = index_min; index <= index_max; ++index)
       print_address_sub(index);
@@ -9388,7 +8836,7 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
         fail_msg_writer() << tr("failed to parse index: ") << local_args[0];
         return true;
       }
-      if (index >= m_wallet->get_num_subaddresses(m_current_subaddress_account))
+      if (index >= m_wallet_impl->numSubaddresses(m_current_subaddress_account))
       {
         fail_msg_writer() << tr("<index> is out of bounds");
         return true;
@@ -9396,7 +8844,7 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
     }
 
     print_address_sub(index);
-    m_wallet->device_show_address(m_current_subaddress_account, index, boost::none);
+    m_wallet_impl->deviceShowAddress(m_current_subaddress_account, index, /* paymentId */ "");
   }
   else
   {
@@ -9408,7 +8856,7 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::print_integrated_address(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  crypto::hash8 payment_id;
+  std::string payment_id;
   bool display_on_device = false;
   std::vector<std::string> local_args = args;
 
@@ -9418,11 +8866,11 @@ bool simple_wallet::print_integrated_address(const std::vector<std::string> &arg
     display_on_device = true;
   }
 
-  auto device_show_integrated = [this, display_on_device](crypto::hash8 payment_id)
+  auto device_show_integrated = [this, display_on_device](const std::string &payment_id)
   {
     if (display_on_device)
     {
-      m_wallet->device_show_address(m_current_subaddress_account, 0, payment_id);
+      m_wallet_impl->deviceShowAddress(m_current_subaddress_account, 0, payment_id);
     }
   };
 
@@ -9438,37 +8886,39 @@ bool simple_wallet::print_integrated_address(const std::vector<std::string> &arg
       fail_msg_writer() << tr("Integrated addresses can only be created for account 0");
       return true;
     }
-    payment_id = crypto::rand<crypto::hash8>();
+    payment_id = Wallet::genPaymentId();
     success_msg_writer() << tr("Random payment ID: ") << payment_id;
-    success_msg_writer() << tr("Matching integrated address: ") << m_wallet->get_account().get_public_integrated_address_str(payment_id, m_wallet->nettype());
+    success_msg_writer() << tr("Matching integrated address: ") << m_wallet_impl->integratedAddress(payment_id);
     device_show_integrated(payment_id);
     return true;
   }
-  if(tools::wallet2::parse_short_payment_id(local_args.back(), payment_id))
+  if(m_wallet_impl->paymentIdValid(local_args.back()))
   {
+    payment_id = local_args.back();
     if (m_current_subaddress_account != 0)
     {
       fail_msg_writer() << tr("Integrated addresses can only be created for account 0");
       return true;
     }
-    success_msg_writer() << m_wallet->get_account().get_public_integrated_address_str(payment_id, m_wallet->nettype());
+    success_msg_writer() << m_wallet_impl->integratedAddress(payment_id);
     device_show_integrated(payment_id);
     return true;
   }
   else {
-    address_parse_info info;
-    if(get_account_address_from_str(info, m_wallet->nettype(), local_args.back()))
+    payment_id = Wallet::paymentIdFromAddress(local_args.back(), m_wallet_impl->nettype());
+    std::string account_address = Wallet::getAddressFromIntegrated(local_args.back(), m_wallet_impl->nettype());
+    if(!payment_id.empty())
     {
-      if (info.has_payment_id)
-      {
-        success_msg_writer() << boost::format(tr("Standard address: %s, payment ID: %s")) %
-          get_account_address_as_str(m_wallet->nettype(), false, info.address) % epee::string_tools::pod_to_hex(info.payment_id);
-        device_show_integrated(info.payment_id);
-      }
-      else
-      {
-        success_msg_writer() << (info.is_subaddress ? tr("Subaddress: ") : tr("Standard address: ")) << get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address);
-      }
+      success_msg_writer() << boost::format(tr("Standard address: %s, payment ID: %s"))
+                                % account_address % payment_id;
+      device_show_integrated(payment_id);
+      return true;
+    }
+    else if (!account_address.empty())
+    {
+      success_msg_writer() << (Wallet::isSubaddress(local_args.back(), m_wallet_impl->nettype())
+                              ? tr("Subaddress: ") : tr("Standard address: "))
+                           << account_address;
       return true;
     }
   }
@@ -9480,6 +8930,8 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot get address book");
 
+  AddressBook *address_book = m_wallet_impl->addressBook();
+
   if (args.size() == 0)
   {
   }
@@ -9490,8 +8942,7 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
   }
   else if (args[0] == "add")
   {
-    cryptonote::address_parse_info info;
-    if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[1], oa_prompter))
+    if(!Wallet::addressValid(/* address */ args[1], m_wallet_impl->nettype()))
     {
       fail_msg_writer() << tr("failed to parse address");
       return true;
@@ -9504,7 +8955,14 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
         description += " ";
       description += args[i];
     }
-    m_wallet->add_address_book_row(info.address, info.has_payment_id ? &info.payment_id : NULL, description, info.is_subaddress);
+    address_book->addRow(args[1],
+                         /* [deprecated] payment_id */ "",
+                         description);
+    if (address_book->errorCode())
+    {
+      fail_msg_writer() << address_book->errorString();
+      return true;
+    }
   }
   else
   {
@@ -9514,25 +8972,20 @@ bool simple_wallet::address_book(const std::vector<std::string> &args/* = std::v
       fail_msg_writer() << tr("failed to parse index");
       return true;
     }
-    m_wallet->delete_address_book_row(row_id);
+    address_book->deleteRow(row_id);
   }
-  auto address_book = m_wallet->get_address_book();
-  if (address_book.empty())
+  std::vector<AddressBookRow *> address_book_entries = address_book->getAll();
+  if (address_book_entries.empty())
   {
     success_msg_writer() << tr("Address book is empty.");
   }
   else
   {
-    for (size_t i = 0; i < address_book.size(); ++i) {
-      auto& row = address_book[i];
+    for (size_t i = 0; i < address_book_entries.size(); ++i) {
+      auto& row = address_book_entries[i];
       success_msg_writer() << tr("Index: ") << i;
-      std::string address;
-      if (row.m_has_payment_id)
-        address = cryptonote::get_account_integrated_address_as_str(m_wallet->nettype(), row.m_address, row.m_payment_id);
-      else
-        address = get_account_address_as_str(m_wallet->nettype(), row.m_is_subaddress, row.m_address);
-      success_msg_writer() << tr("Address: ") << address;
-      success_msg_writer() << tr("Description: ") << row.m_description << "\n";
+      success_msg_writer() << tr("Address: ") << row->getAddress();
+      success_msg_writer() << tr("Description: ") << row->getDescription() << "\n";
     }
   }
   return true;
@@ -9548,14 +9001,6 @@ bool simple_wallet::set_tx_note(const std::vector<std::string> &args)
     return true;
   }
 
-  cryptonote::blobdata txid_data;
-  if(!epee::string_tools::parse_hexstr_to_binbuff(args.front(), txid_data) || txid_data.size() != sizeof(crypto::hash))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-  crypto::hash txid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
-
   std::string note = "";
   for (size_t n = 1; n < args.size(); ++n)
   {
@@ -9563,7 +9008,8 @@ bool simple_wallet::set_tx_note(const std::vector<std::string> &args)
       note += " ";
     note += args[n];
   }
-  m_wallet->set_tx_note(txid, note);
+  if (!m_wallet_impl->setUserNote(/* txid */ args.front(), note))
+    fail_msg_writer() << m_wallet_impl->errorString();
 
   return true;
 }
@@ -9578,17 +9024,17 @@ bool simple_wallet::get_tx_note(const std::vector<std::string> &args)
     return true;
   }
 
-  cryptonote::blobdata txid_data;
-  if(!epee::string_tools::parse_hexstr_to_binbuff(args.front(), txid_data) || txid_data.size() != sizeof(crypto::hash))
-  {
-    fail_msg_writer() << tr("failed to parse txid");
-    return true;
-  }
-  crypto::hash txid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
-
-  std::string note = m_wallet->get_tx_note(txid);
+  std::string note = m_wallet_impl->getUserNote(/* txid */ args.front());
   if (note.empty())
-    success_msg_writer() << "no note found";
+  {
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+        fail_msg_writer() << error_msg;
+    else
+        success_msg_writer() << "no note found";
+  }
   else
     success_msg_writer() << "note found: " << note;
 
@@ -9608,7 +9054,8 @@ bool simple_wallet::set_description(const std::vector<std::string> &args)
       description += " ";
     description += args[n];
   }
-  m_wallet->set_description(description);
+  // Info about "Attribute system": https://github.com/monero-project/monero/pull/2605
+  m_wallet_impl->setCacheAttribute(/* key */ "wallet2.description", description);
 
   return true;
 }
@@ -9623,7 +9070,7 @@ bool simple_wallet::get_description(const std::vector<std::string> &args)
     return true;
   }
 
-  std::string description = m_wallet->get_description();
+  std::string description = m_wallet_impl->getCacheAttribute(/* key */ "wallet2.description");
   if (description.empty())
     success_msg_writer() << tr("no description found");
   else
@@ -9634,10 +9081,10 @@ bool simple_wallet::get_description(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::status(const std::vector<std::string> &args)
 {
-  uint64_t local_height = m_wallet->get_blockchain_current_height();
+  uint64_t local_height = m_wallet_impl->blockChainHeight();
   uint32_t version = 0;
   bool ssl = false;
-  if (!m_wallet->check_connection(&version, &ssl))
+  if (!m_wallet_impl->connectToDaemon(&version, &ssl))
   {
     success_msg_writer() << "Refreshed " << local_height << "/?, no daemon connected";
     return true;
@@ -9660,36 +9107,36 @@ bool simple_wallet::status(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::wallet_info(const std::vector<std::string> &args)
 {
-  const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+  MultisigState ms_status = m_wallet_impl->multisig();
 
-  std::string description = m_wallet->get_description();
+  std::string description = m_wallet_impl->getCacheAttribute(/* key */ "wallet2.description");
   if (description.empty())
   {
     description = "<Not set>"; 
   }
-  message_writer() << tr("Filename: ") << m_wallet->get_wallet_file();
+  message_writer() << tr("Filename: ") << m_wallet_impl->filename();
   message_writer() << tr("Description: ") << description;
-  message_writer() << tr("Address: ") << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
+  message_writer() << tr("Address: ") << m_wallet_impl->address();
   std::string type;
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
     type = tr("Watch only");
-  else if (ms_status.multisig_is_active)
-    type = (boost::format(tr("%u/%u multisig%s")) % ms_status.threshold % ms_status.total % (ms_status.is_ready ? "" : " (not yet finalized)")).str();
-  else if (m_wallet->is_background_wallet())
+  else if (ms_status.isMultisig)
+    type = (boost::format(tr("%u/%u multisig%s")) % ms_status.threshold % ms_status.total % (ms_status.isReady ? "" : " (not yet finalized)")).str();
+  else if (m_wallet_impl->isBackgroundWallet())
     type = tr("Background wallet");
   else
     type = tr("Normal");
   message_writer() << tr("Type: ") << type;
   message_writer() << tr("Network type: ") << (
-    m_wallet->nettype() == cryptonote::TESTNET ? tr("Testnet") :
-    m_wallet->nettype() == cryptonote::STAGENET ? tr("Stagenet") : tr("Mainnet"));
+    m_wallet_impl->nettype() == Monero::NetworkType::TESTNET ? tr("Testnet") :
+    m_wallet_impl->nettype() == Monero::NetworkType::STAGENET ? tr("Stagenet") : tr("Mainnet"));
   return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sign(const std::vector<std::string> &args)
 {
   CHECK_IF_BACKGROUND_SYNCING("cannot sign");
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -9699,18 +9146,18 @@ bool simple_wallet::sign(const std::vector<std::string> &args)
     PRINT_USAGE(USAGE_SIGN);
     return true;
   }
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot sign");
     return true;
   }
-  if (m_wallet->get_multisig_status().multisig_is_active)
+  if (m_wallet_impl->multisig().isMultisig)
   {
     fail_msg_writer() << tr("This wallet is multisig and cannot sign");
     return true;
   }
 
-  tools::wallet2::message_signature_type_t message_signature_type = tools::wallet2::sign_with_spend_key;
+  bool do_sign_with_spend_key = true;
   subaddress_index index{0, 0};
   for (unsigned int idx = 0; idx + 1 < args.size(); ++idx)
   {
@@ -9722,11 +9169,11 @@ bool simple_wallet::sign(const std::vector<std::string> &args)
     }
     else if (args[idx] == "--spend")
     {
-      message_signature_type = tools::wallet2::sign_with_spend_key;
+      do_sign_with_spend_key = true;
     }
     else if (args[idx] == "--view")
     {
-      message_signature_type = tools::wallet2::sign_with_view_key;
+      do_sign_with_spend_key = false;
     }
     else
     {
@@ -9737,7 +9184,7 @@ bool simple_wallet::sign(const std::vector<std::string> &args)
 
   const std::string &filename = args.back();
   std::string data;
-  bool r = m_wallet->load_from_file(filename, data);
+  bool r = load_from_file(filename, data);
   if (!r)
   {
     fail_msg_writer() << tr("failed to read file ") << filename;
@@ -9746,7 +9193,7 @@ bool simple_wallet::sign(const std::vector<std::string> &args)
 
   SCOPED_WALLET_UNLOCK();
 
-  std::string signature = m_wallet->sign(data, message_signature_type, index);
+  std::string signature = m_wallet_impl->signMessage(data, m_wallet_impl->address(index.major, index.minor), do_sign_with_spend_key);
   success_msg_writer() << signature;
   return true;
 }
@@ -9763,35 +9210,30 @@ bool simple_wallet::verify(const std::vector<std::string> &args)
   std::string signature= args[2];
 
   std::string data;
-  bool r = m_wallet->load_from_file(filename, data);
+  bool r = load_from_file(filename, data);
   if (!r)
   {
     fail_msg_writer() << tr("failed to read file ") << filename;
     return true;
   }
 
-  cryptonote::address_parse_info info;
-  if(!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), address_string, oa_prompter))
-  {
-    fail_msg_writer() << tr("failed to parse address");
-    return true;
-  }
-
-  tools::wallet2::message_signature_result_t result = m_wallet->verify(data, info.address, signature);
-  if (!result.valid)
+  bool is_old;
+  std::string signature_type;
+  if (!m_wallet_impl->verifySignedMessage(data, address_string, signature, &is_old, &signature_type))
   {
     fail_msg_writer() << tr("Bad signature from ") << address_string;
   }
   else
   {
-    success_msg_writer() << tr("Good signature from ") << address_string << (result.old ? " (using old signature algorithm)" : "") << " with " << (result.type == tools::wallet2::sign_with_spend_key ? "spend key" : result.type == tools::wallet2::sign_with_view_key ? "view key" : "unknown key combination (suspicious)");
+    std::string signature_type_str = signature_type != "invalid" ? signature_type + " key" : tr("unknown key combination (suspicious)");
+    success_msg_writer() << tr("Good signature from ") << address_string << (is_old ? " (using old signature algorithm)" : "") << " with " << signature_type_str;
   }
   return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::export_key_images(const std::vector<std::string> &args_)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -9799,7 +9241,7 @@ bool simple_wallet::export_key_images(const std::vector<std::string> &args_)
   CHECK_IF_BACKGROUND_SYNCING("cannot export key images");
   auto args = args_;
 
-  if (m_wallet->watch_only())
+  if (m_wallet_impl->watchOnly())
   {
     fail_msg_writer() << tr("wallet is watch-only and cannot export key images");
     return true;
@@ -9819,23 +9261,15 @@ bool simple_wallet::export_key_images(const std::vector<std::string> &args_)
   }
 
   std::string filename = args[0];
-  if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
+  if (m_wallet_impl->getConfirmExportOverwrite() && !check_file_overwrite(filename))
     return true;
 
   SCOPED_WALLET_UNLOCK();
 
-  try
+  if (!m_wallet_impl->exportKeyImages(filename, all))
   {
-    if (!m_wallet->export_key_images(filename, all))
-    {
-      fail_msg_writer() << tr("failed to save file ") << filename;
-      return true;
-    }
-  }
-  catch (const std::exception &e)
-  {
-    LOG_ERROR("Error exporting key images: " << e.what());
-    fail_msg_writer() << "Error exporting key images: " << e.what();
+    LOG_ERROR("Error exporting key images: " << m_wallet_impl->errorString());
+    fail_msg_writer() << tr("Error exporting key images: ") << m_wallet_impl->errorString();
     return true;
   }
 
@@ -9845,13 +9279,13 @@ bool simple_wallet::export_key_images(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::import_key_images(const std::vector<std::string> &args)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
   CHECK_IF_BACKGROUND_SYNCING("cannot import key images");
-  if (!m_wallet->is_trusted_daemon())
+  if (!m_wallet_impl->trustedDaemon())
   {
     fail_msg_writer() << tr("this command requires a trusted daemon. Enable with --trusted-daemon");
     return true;
@@ -9865,16 +9299,18 @@ bool simple_wallet::import_key_images(const std::vector<std::string> &args)
   std::string filename = args[0];
 
   LOCK_IDLE_SCOPE();
-  try
+  uint64_t spent = 0, unspent = 0, height;
+  if (m_wallet_impl->importKeyImages(filename, &spent, &unspent, &height))
   {
-    uint64_t spent = 0, unspent = 0;
-    uint64_t height = m_wallet->import_key_images(filename, spent, unspent);
-    success_msg_writer() << "Signed key images imported to height " << height << ", "
-        << print_money(spent) << " spent, " << print_money(unspent) << " unspent"; 
+      success_msg_writer() << "Signed key images imported to height " << height << ", "
+          << print_money(spent) << " spent, " << print_money(unspent) << " unspent";
   }
-  catch (const std::exception &e)
+  else
   {
-    fail_msg_writer() << "Failed to import key images: " << e.what();
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    fail_msg_writer() << error_msg;
     return true;
   }
 
@@ -9883,12 +9319,12 @@ bool simple_wallet::import_key_images(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::hw_key_images_sync(const std::vector<std::string> &args)
 {
-  if (!m_wallet->key_on_device())
+  if (!m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command only supported by HW wallet");
     return true;
   }
-  if (!m_wallet->get_account().get_device().has_ki_cold_sync())
+  if (!m_wallet_impl->getDeviceState().has_ki_cold_sync)
   {
     fail_msg_writer() << tr("hw wallet does not support cold KI sync");
     return true;
@@ -9905,11 +9341,11 @@ void simple_wallet::key_images_sync_intern(){
     message_writer(console_color_white, false) << tr("Please confirm the key image sync on the device");
 
     uint64_t spent = 0, unspent = 0;
-    uint64_t height = m_wallet->cold_key_image_sync(spent, unspent);
+    uint64_t height = m_wallet_impl->coldKeyImageSync(spent, unspent);
     if (height > 0)
     {
       success_msg_writer() << tr("Key images synchronized to height ") << height;
-      if (!m_wallet->is_trusted_daemon())
+      if (!m_wallet_impl->trustedDaemon())
       {
         message_writer() << tr("Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent");
       } else
@@ -9929,24 +9365,23 @@ void simple_wallet::key_images_sync_intern(){
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::hw_reconnect(const std::vector<std::string> &args)
 {
-  if (!m_wallet->key_on_device())
+  if (!m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command only supported by HW wallet");
     return true;
   }
 
   LOCK_IDLE_SCOPE();
-  try
-  {
-    bool r = m_wallet->reconnect_device();
-    if (!r){
-      fail_msg_writer() << tr("Failed to reconnect device");
-    }
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Failed to reconnect device: ") << tr(e.what());
-    return true;
+  bool r = m_wallet_impl->reconnectDevice();
+  if (!r){
+    std::stringstream fail_msg;
+    fail_msg << tr("Failed to reconnect device");
+    int error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code)
+        fail_msg << ": " << error_msg;
+    fail_msg_writer()  << fail_msg.str();
   }
 
   return true;
@@ -9954,7 +9389,7 @@ bool simple_wallet::hw_reconnect(const std::vector<std::string> &args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::export_outputs(const std::vector<std::string> &args_)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -9976,25 +9411,27 @@ bool simple_wallet::export_outputs(const std::vector<std::string> &args_)
   }
 
   std::string filename = args[0];
-  if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
+  if (m_wallet_impl->getConfirmExportOverwrite() && !check_file_overwrite(filename))
     return true;
 
-  SCOPED_WALLET_UNLOCK();
 
-  try
+  std::string data;
   {
-    std::string data = m_wallet->export_outputs_to_str(all);
-    bool r = m_wallet->save_to_file(filename, data);
-    if (!r)
-    {
-      fail_msg_writer() << tr("failed to save file ") << filename;
-      return true;
-    }
+     SCOPED_WALLET_UNLOCK();
+     data = m_wallet_impl->exportEnotesToStr(all);
   }
-  catch (const std::exception &e)
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    LOG_ERROR("Error exporting outputs: " << e.what());
-    fail_msg_writer() << "Error exporting outputs: " << e.what();
+    fail_msg_writer() << error_msg;
+    return true;
+  }
+  bool r = save_to_file(filename, data);
+  if (!r)
+  {
+    fail_msg_writer() << tr("failed to save file ") << filename;
     return true;
   }
 
@@ -10004,7 +9441,7 @@ bool simple_wallet::export_outputs(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::import_outputs(const std::vector<std::string> &args)
 {
-  if (m_wallet->key_on_device())
+  if (m_wallet_impl->getDeviceState().key_on_device)
   {
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
@@ -10018,25 +9455,28 @@ bool simple_wallet::import_outputs(const std::vector<std::string> &args)
   std::string filename = args[0];
 
   std::string data;
-  bool r = m_wallet->load_from_file(filename, data);
+  bool r = load_from_file(filename, data);
   if (!r)
   {
     fail_msg_writer() << tr("failed to read file ") << filename;
     return true;
   }
 
-  try
+  size_t n_outputs;
   {
     SCOPED_WALLET_UNLOCK();
-    size_t n_outputs = m_wallet->import_outputs_from_str(data);
-    success_msg_writer() << boost::lexical_cast<std::string>(n_outputs) << " outputs imported";
+    n_outputs = m_wallet_impl->importEnotesFromStr(data);
   }
-  catch (const std::exception &e)
+  int error_code;
+  std::string error_msg;
+  m_wallet_impl->statusWithErrorString(error_code, error_msg);
+  if (error_code)
   {
-    fail_msg_writer() << "Failed to import outputs " << filename << ": " << e.what();
+    fail_msg_writer() << error_msg;
     return true;
   }
 
+  success_msg_writer() << boost::lexical_cast<std::string>(n_outputs) << " outputs imported";
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -10054,29 +9494,34 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
     fail_msg_writer() << tr("failed to parse txid");
     return true;
   }
-  crypto::hash txid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
+  std::string txid = args.front();
 
-  const uint64_t last_block_height = m_wallet->get_blockchain_current_height();
+  const uint64_t last_block_height = m_wallet_impl->blockChainHeight();
+  TransactionHistory *tx_history = m_wallet_impl->history();
 
-  std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-  m_wallet->get_payments(payments, 0, (uint64_t)-1, m_current_subaddress_account);
-  for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-    const tools::wallet2::payment_details &pd = i->second;
-    if (pd.m_tx_hash == txid) {
-      std::string payment_id = string_tools::pod_to_hex(i->first);
+  for (const auto &tx_info : tx_history->getAll())
+  {
+    if (tx_info->hash() != txid)
+      continue;
+
+    // Payment = confirmed incoming transfer
+    if (tx_info->direction() == Monero::TransactionInfo::Direction_In
+          && tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Confirmed)
+    {
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
       success_msg_writer() << "Incoming transaction found";
-      success_msg_writer() << "txid: " << txid;
-      success_msg_writer() << "Height: " << pd.m_block_height;
-      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(pd.m_timestamp);
-      success_msg_writer() << "Amount: " << print_money(pd.m_amount);
+      success_msg_writer() << "txid: <" << txid << ">";
+      success_msg_writer() << "Height: " << tx_info->blockHeight();
+      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(tx_info->timestamp());
+      success_msg_writer() << "Amount: " << print_money(tx_info->amount());
       success_msg_writer() << "Payment ID: " << payment_id;
-      if (pd.m_unlock_time < CRYPTONOTE_MAX_BLOCK_NUMBER)
+      if (tx_info->unlockTime() < CRYPTONOTE_MAX_BLOCK_NUMBER)
       {
-        uint64_t bh = std::max(pd.m_unlock_time, pd.m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
-        uint64_t last_block_reward = m_wallet->get_last_block_reward();
-        uint64_t suggested_threshold = last_block_reward ? (pd.m_amount + last_block_reward - 1) / last_block_reward : 0;
+        uint64_t bh = std::max(tx_info->unlockTime(), tx_info->blockHeight() + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
+        uint64_t last_block_reward = m_wallet_impl->getLastBlockReward();
+        uint64_t suggested_threshold = last_block_reward ? (tx_info->amount() + last_block_reward - 1) / last_block_reward : 0;
         if (bh >= last_block_height)
           success_msg_writer() << "Locked: " << (bh - last_block_height) << " blocks to unlock";
         else if (suggested_threshold > 0)
@@ -10086,109 +9531,89 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
       }
       else
       {
-        const uint64_t adjusted_time = m_wallet->get_daemon_adjusted_time();
-        uint64_t threshold = adjusted_time + (m_wallet->use_fork_rules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
-        if (threshold >= pd.m_unlock_time)
-          success_msg_writer() << "unlocked for " << tools::get_human_readable_timespan(std::chrono::seconds(threshold - pd.m_unlock_time));
+        const uint64_t adjusted_time = m_wallet_impl->getDaemonAdjustedTime();
+        uint64_t threshold = adjusted_time + (m_wallet_impl->useForkRules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
+        if (threshold >= tx_info->unlockTime())
+          success_msg_writer() << "unlocked for " << tools::get_human_readable_timespan(std::chrono::seconds(threshold - tx_info->unlockTime()));
         else
-          success_msg_writer() << "locked for " << tools::get_human_readable_timespan(std::chrono::seconds(pd.m_unlock_time - threshold));
+          success_msg_writer() << "locked for " << tools::get_human_readable_timespan(std::chrono::seconds(tx_info->unlockTime() - threshold));
       }
-      success_msg_writer() << "Address index: " << pd.m_subaddr_index.minor;
-      success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
+      success_msg_writer() << "Address index: " << *tx_info->subaddrIndex().begin();
+      success_msg_writer() << "Note: " << tx_info->description();
       return true;
-    }
-  }
 
-  std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments_out;
-  m_wallet->get_payments_out(payments_out, 0, (uint64_t)-1, m_current_subaddress_account);
-  for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments_out.begin(); i != payments_out.end(); ++i) {
-    if (i->first == txid)
+    }
+    // Confirmed outgoing transfer
+    else if (tx_info->direction() == Monero::TransactionInfo::Direction_Out
+          && tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Confirmed)
     {
-      const tools::wallet2::confirmed_transfer_details &pd = i->second;
-      uint64_t change = pd.m_change == (uint64_t)-1 ? 0 : pd.m_change; // change may not be known
-      uint64_t fee = pd.m_amount_in - pd.m_amount_out;
+      uint64_t change = tx_info->receivedChangeAmount() == (uint64_t)-1 ? 0 : tx_info->receivedChangeAmount(); // change may not be known
       std::string dests;
-      for (const auto &d: pd.m_dests) {
+      for (const auto &d: tx_info->transfers()) {
         if (!dests.empty())
           dests += ", ";
-        dests +=  d.address(m_wallet->nettype(), pd.m_payment_id) + ": " + print_money(d.amount);
+        dests +=  d.address + ": " + print_money(d.amount);
       }
-      std::string payment_id = string_tools::pod_to_hex(i->second.m_payment_id);
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
       success_msg_writer() << "Outgoing transaction found";
       success_msg_writer() << "txid: " << txid;
-      success_msg_writer() << "Height: " << pd.m_block_height;
-      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(pd.m_timestamp);
-      success_msg_writer() << "Amount: " << print_money(pd.m_amount_in - change - fee);
+      success_msg_writer() << "Height: " << tx_info->blockHeight();
+      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(tx_info->timestamp());
+      success_msg_writer() << "Amount: " << print_money(tx_info->amount());
       success_msg_writer() << "Payment ID: " << payment_id;
       success_msg_writer() << "Change: " << print_money(change);
-      success_msg_writer() << "Fee: " << print_money(fee);
+      success_msg_writer() << "Fee: " << print_money(tx_info->fee());
       success_msg_writer() << "Destinations: " << dests;
-      success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
+      success_msg_writer() << "Note: " << tx_info->description();
       return true;
     }
-  }
-
-  try
-  {
-    std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs;
-    m_wallet->update_pool_state(process_txs);
-    if (!process_txs.empty())
-      m_wallet->process_pool_state(process_txs);
-
-    std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> pool_payments;
-    m_wallet->get_unconfirmed_payments(pool_payments, m_current_subaddress_account);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = pool_payments.begin(); i != pool_payments.end(); ++i) {
-      const tools::wallet2::payment_details &pd = i->second.m_pd;
-      if (pd.m_tx_hash == txid)
-      {
-        std::string payment_id = string_tools::pod_to_hex(i->first);
-        if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-          payment_id = payment_id.substr(0,16);
-        success_msg_writer() << "Unconfirmed incoming transaction found in the txpool";
-        success_msg_writer() << "txid: " << txid;
-        success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(pd.m_timestamp);
-        success_msg_writer() << "Amount: " << print_money(pd.m_amount);
-        success_msg_writer() << "Payment ID: " << payment_id;
-        success_msg_writer() << "Address index: " << pd.m_subaddr_index.minor;
-        success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
-        if (i->second.m_double_spend_seen)
-          success_msg_writer() << tr("Double spend seen on the network: this transaction may or may not end up being mined");
-        return true;
-      }
-    }
-  }
-  catch (...)
-  {
-    fail_msg_writer() << "Failed to get pool state";
-  }
-
-  std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> upayments;
-  m_wallet->get_unconfirmed_payments_out(upayments, m_current_subaddress_account);
-  for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = upayments.begin(); i != upayments.end(); ++i) {
-    if (i->first == txid)
+    // Unconfirmed incoming transfer in pool
+    else if (tx_info->direction() == Monero::TransactionInfo::Direction_In
+          && tx_info->txState() == Monero::TransactionInfo::TxState::TxState_PendingInPool)
     {
-      const tools::wallet2::unconfirmed_transfer_details &pd = i->second;
-      uint64_t amount = pd.m_amount_in;
-      uint64_t fee = amount - pd.m_amount_out;
-      std::string payment_id = string_tools::pod_to_hex(i->second.m_payment_id);
+      std::string payment_id = tx_info->paymentId();
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
-      bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
+      success_msg_writer() << "Unconfirmed incoming transaction found in the txpool";
+      success_msg_writer() << "txid: " << txid;
+      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(tx_info->timestamp());
+      success_msg_writer() << "Amount: " << print_money(tx_info->amount());
+      success_msg_writer() << "Payment ID: " << payment_id;
+      success_msg_writer() << "Address index: " << *tx_info->subaddrIndex().begin();
+      success_msg_writer() << "Note: " << tx_info->description();
+      if (tx_info->isDoubleSpendSeen())
+        success_msg_writer() << tr("Double spend seen on the network: this transaction may or may not end up being mined");
+      return true;
+    }
+    // Unconfirmed (failed | pending) outgoing transfer
+    else if (tx_info->direction() == Monero::TransactionInfo::Direction_Out
+          && (tx_info->txState() == Monero::TransactionInfo::TxState::TxState_PendingInPool
+           || tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Pending
+           || tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Failed))
+    {
+      uint64_t fee = tx_info->fee();
+      std::string payment_id = tx_info->paymentId();
+      if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
+        payment_id = payment_id.substr(0,16);
+      bool is_failed = tx_info->txState() == Monero::TransactionInfo::TxState::TxState_Failed;
 
       success_msg_writer() << (is_failed ? "Failed" : "Pending") << " outgoing transaction found";
       success_msg_writer() << "txid: " << txid;
-      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(pd.m_timestamp);
-      success_msg_writer() << "Amount: " << print_money(amount - pd.m_change - fee);
+      success_msg_writer() << "Timestamp: " << tools::get_human_readable_timestamp(tx_info->timestamp());
+      success_msg_writer() << "Amount: " << print_money(tx_info->amount());
       success_msg_writer() << "Payment ID: " << payment_id;
-      success_msg_writer() << "Change: " << print_money(pd.m_change);
+      success_msg_writer() << "Change: " << print_money(tx_info->receivedChangeAmount());
       success_msg_writer() << "Fee: " << print_money(fee);
-      success_msg_writer() << "Note: " << m_wallet->get_tx_note(txid);
+      success_msg_writer() << "Note: " << tx_info->description();
       return true;
     }
-  }
+    else
+        fail_msg_writer() << tr("unknown transfer type");
 
+    return true;
+  }
   fail_msg_writer() << tr("Transaction ID not found");
   return true;
 }
@@ -10202,7 +9627,7 @@ void simple_wallet::interrupt()
 {
   if (m_in_manual_refresh.load(std::memory_order_relaxed))
   {
-    m_wallet->stop();
+    m_wallet_impl->stop();
   }
   else
   {
@@ -10210,32 +9635,125 @@ void simple_wallet::interrupt()
   }
 }
 //----------------------------------------------------------------------------------------------------
-void simple_wallet::commit_or_save(std::vector<tools::wallet2::pending_tx>& ptx_vector, bool do_not_relay)
+void simple_wallet::commit_or_save(PendingTransaction &ptx, bool do_not_relay, bool do_force_commit /* = false */)
 {
-  size_t i = 0;
-  while (!ptx_vector.empty())
+  if (do_not_relay)
   {
-    auto & ptx = ptx_vector.back();
-    const crypto::hash txid = get_transaction_hash(ptx.tx);
-    if (do_not_relay)
-    {
-      cryptonote::blobdata blob;
-      tx_to_blob(ptx.tx, blob);
-      const std::string blob_hex = epee::string_tools::buff_to_hex_nodelimer(blob);
-      const std::string filename = "raw_monero_tx" + (ptx_vector.size() == 1 ? "" : ("_" + std::to_string(i++)));
-      if (m_wallet->save_to_file(filename, blob_hex, true))
-        success_msg_writer(true) << tr("Transaction successfully saved to ") << filename << tr(", txid ") << txid;
+    const std::string filename = "raw_monero_tx";
+    if (!check_file_overwrite(filename))
+      return;
+    std::vector<std::string> tx_blobs = ptx.convertTxToRawBlobStr();
+    std::vector<std::string> tx_ids = ptx.txid();
+    for (size_t i = 0; i < ptx.txCount(); ++i) {
+      const std::string blob_hex = epee::string_tools::buff_to_hex_nodelimer(tx_blobs[i]);
+      const std::string filename = "raw_monero_tx" + (ptx.txCount() == 1 ? "" : ("_" + std::to_string(i++)));
+      if (save_to_file(filename, blob_hex, /* is_printable */ true))
+        success_msg_writer(true) << tr("Transaction successfully saved to ") << filename << tr(", txid <") << tx_ids[i] << ">";
       else
-        fail_msg_writer() << tr("Failed to save transaction to ") << filename << tr(", txid ") << txid;
+        fail_msg_writer() << tr("Failed to save transaction to ") << filename << tr(", txid <") << tx_ids[i] << "> : " << ptx.errorString();
+    }
+  }
+  else
+  {
+    std::string error_msg;
+    if (m_wallet_impl->watchOnly() && !do_force_commit)
+    {
+      if (ptx.commit("unsigned_monero_tx"))
+        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
+      else
+        fail_msg_writer() << ptx.errorString();
     }
     else
     {
-      m_wallet->commit_tx(ptx);
-      success_msg_writer(true) << tr("Transaction successfully submitted, transaction ") << txid << ENDL
-      << tr("You can check its status by using the `show_transfers` command.");
+      // ptx.commit() pops the pending txs after successfully committing them, therefore we cache the txids before
+      std::vector<std::string> txids = ptx.txid();
+      if (ptx.commit())
+        for (const auto &txid : txids)
+          success_msg_writer(true) << tr("Transaction successfully submitted, transaction <") << txid << ">" << ENDL
+            << tr("You can check its status by using the `show_transfers` command.");
+      else
+        fail_msg_writer() << ptx.errorString();
     }
-    // if no exception, remove element from vector
-    ptx_vector.pop_back();
+  }
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::save_to_file(const std::string& path_to_file, const std::string& raw, bool is_printable /* = false */) const
+{
+  if (is_printable || m_wallet_impl->getExportFormat() == Monero::Wallet::ExportFormat::ExportFormat_Binary)
+  {
+    return epee::file_io_utils::save_string_to_file(path_to_file, raw);
+  }
+
+  FILE *fp = fopen(path_to_file.c_str(), "w+");
+  if (!fp)
+  {
+    MERROR("Failed to open wallet file for writing: " << path_to_file << ": " << strerror(errno));
+    return false;
+  }
+
+  // Save the result b/c we need to close the fp before returning success/failure.
+  int write_result = PEM_write(fp, ASCII_OUTPUT_MAGIC.c_str(), "", (const unsigned char *) raw.c_str(), raw.length());
+  fclose(fp);
+
+  if (write_result == 0)
+  {
+    return false;
+  }
+  else
+  {
+    return true;
+  }
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::load_from_file(const std::string& path_to_file, std::string& target_str, size_t max_size /* = 1000000000 */)
+{
+  std::string data;
+  bool r = epee::file_io_utils::load_file_to_string(path_to_file, data, max_size);
+  if (!r)
+  {
+    return false;
+  }
+
+  if (!boost::algorithm::contains(boost::make_iterator_range(data.begin(), data.end()), ASCII_OUTPUT_MAGIC))
+  {
+    // It's NOT our ascii dump.
+    target_str = std::move(data);
+    return true;
+  }
+
+  // Creating a BIO and calling PEM_read_bio instead of simpler PEM_read
+  // to avoid reading the file from disk twice.
+  BIO* b = BIO_new_mem_buf((const void*) data.data(), data.length());
+
+  char *name = NULL;
+  char *header = NULL;
+  unsigned char *openssl_data = NULL;
+  long len = 0;
+
+  // Save the result b/c we need to free the data before returning success/failure.
+  int success = PEM_read_bio(b, &name, &header, &openssl_data, &len);
+
+  try
+  {
+    target_str = std::string((const char*) openssl_data, len);
+  }
+  catch (...)
+  {
+    success = 0;
+  }
+
+  OPENSSL_free((void *) name);
+  OPENSSL_free((void *) header);
+  OPENSSL_free((void *) openssl_data);
+  BIO_free(b);
+
+  if (success == 0)
+  {
+    return false;
+  }
+  else
+  {
+    return true;
   }
 }
 //----------------------------------------------------------------------------------------------------
@@ -10251,7 +9769,6 @@ int main(int argc, char* argv[])
   setlocale(LC_CTYPE, "");
 
   po::options_description desc_params(wallet_args::tr("Wallet options"));
-  tools::wallet2::init_options(desc_params);
   command_line::add_arg(desc_params, arg_wallet_file);
   command_line::add_arg(desc_params, arg_wallet_dir);
   command_line::add_arg(desc_params, arg_generate_new_wallet);
@@ -10262,19 +9779,45 @@ int main(int argc, char* argv[])
   command_line::add_arg(desc_params, arg_generate_from_multisig_keys);
   command_line::add_arg(desc_params, arg_generate_from_json);
   command_line::add_arg(desc_params, arg_mnemonic_language);
-  command_line::add_arg(desc_params, arg_command);
-
+  command_line::add_arg(desc_params, arg_electrum_seed );
   command_line::add_arg(desc_params, arg_restore_deterministic_wallet );
   command_line::add_arg(desc_params, arg_restore_from_seed );
   command_line::add_arg(desc_params, arg_restore_multisig_wallet );
   command_line::add_arg(desc_params, arg_non_deterministic );
-  command_line::add_arg(desc_params, arg_electrum_seed );
   command_line::add_arg(desc_params, arg_restore_height);
   command_line::add_arg(desc_params, arg_restore_date);
   command_line::add_arg(desc_params, arg_do_not_relay);
   command_line::add_arg(desc_params, arg_create_address_file);
   command_line::add_arg(desc_params, arg_subaddress_lookahead);
   command_line::add_arg(desc_params, arg_use_english_language_names);
+
+  command_line::add_arg(desc_params, arg_daemon_address );
+  command_line::add_arg(desc_params, arg_daemon_host );
+  command_line::add_arg(desc_params, arg_proxy );
+  command_line::add_arg(desc_params, arg_trusted_daemon );
+  command_line::add_arg(desc_params, arg_untrusted_daemon );
+  command_line::add_arg(desc_params, arg_password );
+  command_line::add_arg(desc_params, arg_password_file );
+  command_line::add_arg(desc_params, arg_daemon_port );
+  command_line::add_arg(desc_params, arg_daemon_login );
+  command_line::add_arg(desc_params, arg_daemon_ssl );
+  command_line::add_arg(desc_params, arg_daemon_ssl_private_key );
+  command_line::add_arg(desc_params, arg_daemon_ssl_certificate );
+  command_line::add_arg(desc_params, arg_daemon_ssl_ca_certificates );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allowed_fingerprints );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allow_any_cert );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allow_chained );
+
+  command_line::add_arg(desc_params, arg_allow_mismatched_daemon_version );
+  command_line::add_arg(desc_params, arg_testnet );
+  command_line::add_arg(desc_params, arg_stagenet );
+  command_line::add_arg(desc_params, arg_kdf_rounds );
+  command_line::add_arg(desc_params, arg_hw_device );
+  command_line::add_arg(desc_params, arg_hw_device_derivation_path );
+  command_line::add_arg(desc_params, arg_tx_notify );
+  command_line::add_arg(desc_params, arg_offline );
+  command_line::add_arg(desc_params, arg_extra_entropy );
+  command_line::add_arg(desc_params, arg_command);
 
   po::positional_options_description positional_options;
   positional_options.add(arg_command.name, -1);
@@ -10343,1050 +9886,3 @@ int main(int argc, char* argv[])
   CATCH_ENTRY_L0("main", 1);
 }
 
-// MMS ---------------------------------------------------------------------------------------------------
-
-// Access to the message store, or more exactly to the list of the messages that can be changed
-// by the idle thread, is guarded by the same mutex-based mechanism as access to the wallet
-// as a whole and thus e.g. uses the "LOCK_IDLE_SCOPE" macro. This is a little over-cautious, but
-// simple and safe. Care has to be taken however where MMS methods call other simplewallet methods
-// that use "LOCK_IDLE_SCOPE" as this cannot be nested!
-
-// Methods for commands like "export_multisig_info" usually read data from file(s) or write data
-// to files. The MMS calls now those methods as well, to produce data for messages and to process data
-// from messages. As it would be quite inconvenient for the MMS to write data for such methods to files
-// first or get data out of result files after the call, those methods detect a call from the MMS and
-// expect data as arguments instead of files and give back data by calling 'process_wallet_created_data'.
-
-bool simple_wallet::user_confirms(const std::string &question)
-{
-   std::string answer = input_line(question + tr(" (Y/Yes/N/No): "));
-   return !std::cin.eof() && command_line::is_yes(answer);
-}
-
-bool simple_wallet::user_confirms_auto_config()
-{
-  message_writer(console_color_red, true) << tr("WARNING: Using MMS auto-config mechanisms is not trustless");
-  message_writer() << tr("A malicious auto-config manager could send you info about own wallets instead of other signers' info");
-  message_writer() << tr("If in doubt do not use auto-config or at least compare configs using the \"mms config_checksum\" command");
-  return user_confirms("Accept the risks and continue?");
-}
-
-bool simple_wallet::get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound)
-{
-  bool valid = false;
-  try
-  {
-    number = boost::lexical_cast<uint32_t>(arg);
-    valid = (number >= lower_bound) && (number <= upper_bound);
-  }
-  catch(const boost::bad_lexical_cast &)
-  {
-  }
-  return valid;
-}
-
-bool simple_wallet::choose_mms_processing(const std::vector<mms::processing_data> &data_list, uint32_t &choice)
-{
-  size_t choices = data_list.size();
-  if (choices == 1)
-  {
-    choice = 0;
-    return true;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  message_writer() << tr("Choose processing:");
-  std::string text;
-  for (size_t i = 0; i < choices; ++i)
-  {
-    const mms::processing_data &data = data_list[i];
-    text = std::to_string(i+1) + ": ";
-    switch (data.processing)
-    {
-    case mms::message_processing::sign_tx:
-      text += tr("Sign tx");
-      break;
-    case mms::message_processing::send_tx:
-    {
-      mms::message m;
-      ms.get_message_by_id(data.message_ids[0], m);
-      if (m.type == mms::message_type::fully_signed_tx)
-      {
-        text += tr("Send the tx for submission to ");
-      }
-      else
-      {
-        text += tr("Send the tx for signing to ");
-      }
-      mms::authorized_signer signer = ms.get_signer(data.receiving_signer_index);
-      text += ms.signer_to_string(signer, 50);
-      break;
-    }
-    case mms::message_processing::submit_tx:
-      text += tr("Submit tx");
-      break;
-    default:
-      text += tr("unknown");
-      break;
-    }
-    message_writer() << text;
-  }
-
-  std::string line = input_line(tr("Choice: "));
-  if (std::cin.eof() || line.empty())
-  {
-    return false;
-  }
-  bool choice_ok = get_number_from_arg(line, choice, 1, choices);
-  if (choice_ok)
-  {
-    choice--;
-  }
-  else
-  {
-    fail_msg_writer() << tr("Wrong choice");
-  }
-  return choice_ok;
-}
-
-void simple_wallet::list_mms_messages(const std::vector<mms::message> &messages)
-{
-  message_writer() << boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") % tr("Id") % tr("I/O") % tr("Authorized Signer")
-          % tr("Message Type") % tr("Height") % tr("R") % tr("Message State") % tr("Since");
-  mms::message_store& ms = m_wallet->get_message_store();
-  uint64_t now = (uint64_t)time(NULL);
-  for (size_t i = 0; i < messages.size(); ++i)
-  {
-    const mms::message &m = messages[i];
-    const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
-    bool highlight = (m.state == mms::message_state::ready_to_send) || (m.state == mms::message_state::waiting);
-    message_writer(m.direction == mms::message_direction::out ? console_color_green : console_color_magenta, highlight) <<
-            boost::format("%4s %-4s %-30s %-21s %7s %3s %-15s %-40s") %
-            m.id %
-            ms.message_direction_to_string(m.direction) %
-            ms.signer_to_string(signer, 30) %
-            ms.message_type_to_string(m.type) %
-            m.wallet_height %
-            m.round %
-            ms.message_state_to_string(m.state) %
-            (tools::get_human_readable_timestamp(m.modified) + ", " + tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified)) + tr(" ago"));
-  }
-}
-
-void simple_wallet::list_signers(const std::vector<mms::authorized_signer> &signers)
-{
-  message_writer() << boost::format("%2s %-20s %-s") % tr("#") % tr("Label") % tr("Transport Address");
-  message_writer() << boost::format("%2s %-20s %-s") % "" % tr("Auto-Config Token") % tr("Monero Address");
-  for (size_t i = 0; i < signers.size(); ++i)
-  {
-    const mms::authorized_signer &signer = signers[i];
-    std::string label = signer.label.empty() ? tr("<not set>") : signer.label;
-    std::string monero_address;
-    if (signer.monero_address_known)
-    {
-      monero_address = get_account_address_as_str(m_wallet->nettype(), false, signer.monero_address);
-    }
-    else
-    {
-      monero_address = tr("<not set>");
-    }
-    std::string transport_address = signer.transport_address.empty() ? tr("<not set>") : signer.transport_address;
-    message_writer() << boost::format("%2s %-20s %-s") % (i + 1) % label % transport_address;
-    message_writer() << boost::format("%2s %-20s %-s") % "" % signer.auto_config_token % monero_address;
-    message_writer() << "";
-  }
-}
-
-void simple_wallet::add_signer_config_messages()
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::string signer_config;
-  ms.get_signer_config(signer_config);
-
-  const std::vector<mms::authorized_signer> signers = ms.get_all_signers();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  uint32_t num_authorized_signers = ms.get_num_authorized_signers();
-  for (uint32_t i = 1 /* without me */; i < num_authorized_signers; ++i)
-  {
-    ms.add_message(state, i, mms::message_type::signer_config, mms::message_direction::out, signer_config);
-  }
-}
-
-void simple_wallet::show_message(const mms::message &m)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  const mms::authorized_signer &signer = ms.get_signer(m.signer_index);
-  bool display_content;
-  std::string sanitized_text;
-  switch (m.type)
-  {
-  case mms::message_type::key_set:
-  case mms::message_type::additional_key_set:
-  case mms::message_type::note:
-    display_content = true;
-    sanitized_text = mms::message_store::get_sanitized_text(m.content, 1000);
-    break;
-  default:
-    display_content = false;
-  }
-  uint64_t now = (uint64_t)time(NULL);
-  message_writer() << "";
-  message_writer() << tr("Message ") << m.id;
-  message_writer() << tr("In/out: ") << ms.message_direction_to_string(m.direction);
-  message_writer() << tr("Type: ") << ms.message_type_to_string(m.type);
-  message_writer() << tr("State: ") << boost::format(tr("%s since %s, %s ago")) %
-          ms.message_state_to_string(m.state) % tools::get_human_readable_timestamp(m.modified) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.modified));
-  if (m.sent == 0)
-  {
-    message_writer() << tr("Sent: Never");
-  }
-  else
-  {
-    message_writer() << boost::format(tr("Sent: %s, %s ago")) %
-            tools::get_human_readable_timestamp(m.sent) % tools::get_human_readable_timespan(std::chrono::seconds(now - m.sent));
-  }
-  message_writer() << tr("Authorized signer: ") << ms.signer_to_string(signer, 100);
-  message_writer() << tr("Content size: ") << m.content.length() << tr(" bytes");
-  message_writer() << tr("Content: ") << (display_content ? sanitized_text : tr("(binary data)"));
-
-  if (m.type == mms::message_type::note)
-  {
-    // Showing a note and read its text is "processing" it: Set the state accordingly
-    // which will also delete it from Bitmessage as a side effect
-    // (Without this little "twist" it would never change the state, and never get deleted)
-    ms.set_message_processed_or_sent(m.id);
-  }
-}
-
-void simple_wallet::ask_send_all_ready_messages()
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::vector<mms::message> ready_messages;
-  const std::vector<mms::message> &messages = ms.get_all_messages();
-  for (size_t i = 0; i < messages.size(); ++i)
-  {
-    const mms::message &m = messages[i];
-    if (m.state == mms::message_state::ready_to_send)
-    {
-      ready_messages.push_back(m);
-    }
-  }
-  if (ready_messages.size() != 0)
-  {
-    list_mms_messages(ready_messages);
-    bool send = ms.get_auto_send();
-    if (!send)
-    {
-      send = user_confirms(tr("Send these messages now?"));
-    }
-    if (send)
-    {
-      mms::multisig_wallet_state state = get_multisig_wallet_state();
-      for (size_t i = 0; i < ready_messages.size(); ++i)
-      {
-        ms.send_message(state, ready_messages[i].id);
-        ms.set_message_processed_or_sent(ready_messages[i].id);
-      }
-      success_msg_writer() << tr("Queued for sending.");
-    }
-  }
-}
-
-bool simple_wallet::get_message_from_arg(const std::string &arg, mms::message &m)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  bool valid_id = false;
-  uint32_t id;
-  try
-  {
-    id = (uint32_t)boost::lexical_cast<uint32_t>(arg);
-    valid_id = ms.get_message_by_id(id, m);
-  }
-  catch (const boost::bad_lexical_cast &)
-  {
-  }
-  if (!valid_id)
-  {
-    fail_msg_writer() << tr("Invalid message id");
-  }
-  return valid_id;
-}
-
-void simple_wallet::mms_init(const std::vector<std::string> &args)
-{
-  if (args.size() != 3)
-  {
-    fail_msg_writer() << tr("usage: mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (ms.get_active())
-  {
-    if (!user_confirms(tr("The MMS is already initialized. Re-initialize by deleting all signer info and messages?")))
-    {
-      return;
-    }
-  }
-  uint32_t num_required_signers;
-  uint32_t num_authorized_signers;
-  const std::string &mn = args[0];
-  std::vector<std::string> numbers;
-  boost::split(numbers, mn, boost::is_any_of("/"));
-  bool mn_ok = (numbers.size() == 2)
-               && get_number_from_arg(numbers[1], num_authorized_signers, 2, config::MULTISIG_MAX_SIGNERS)
-               && get_number_from_arg(numbers[0], num_required_signers, 1, num_authorized_signers);
-  if (!mn_ok)
-  {
-    fail_msg_writer() << tr("Error in the number of required signers and/or authorized signers");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  ms.init(get_multisig_wallet_state(), args[1], args[2], num_authorized_signers, num_required_signers);
-}
-
-void simple_wallet::mms_info(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (ms.get_active())
-  {
-    message_writer() << boost::format("The MMS is active for %s/%s multisig.")
-            % ms.get_num_required_signers() % ms.get_num_authorized_signers();
-  }
-  else
-  {
-    message_writer() << tr("The MMS is not active.");
-  }
-}
-
-void simple_wallet::mms_signer(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  const std::vector<mms::authorized_signer> &signers = ms.get_all_signers();
-  if (args.size() == 0)
-  {
-    // Without further parameters list all defined signers
-    list_signers(signers);
-    return;
-  }
-
-  uint32_t index;
-  bool index_valid = get_number_from_arg(args[0], index, 1, ms.get_num_authorized_signers());
-  if (index_valid)
-  {
-    index--;
-  }
-  else
-  {
-    fail_msg_writer() << tr("Invalid signer number ") + args[0];
-    return;
-  }
-  if ((args.size() < 2) || (args.size() > 4))
-  {
-    fail_msg_writer() << tr("mms signer [<number> <label> [<transport_address> [<monero_address>]]]");
-    return;
-  }
-
-  boost::optional<string> label = args[1];
-  boost::optional<string> transport_address;
-  if (args.size() >= 3)
-  {
-    transport_address = args[2];
-  }
-  boost::optional<cryptonote::account_public_address> monero_address;
-  LOCK_IDLE_SCOPE();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  if (args.size() == 4)
-  {
-    cryptonote::address_parse_info info;
-    bool ok = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), args[3], oa_prompter);
-    if (!ok)
-    {
-      fail_msg_writer() << tr("Invalid Monero address");
-      return;
-    }
-    monero_address = info.address;
-    const std::vector<mms::message> &messages = ms.get_all_messages();
-    if ((messages.size() > 0) || state.multisig)
-    {
-      fail_msg_writer() << tr("Wallet state does not allow changing Monero addresses anymore");
-      return;
-    }
-  }
-  ms.set_signer(state, index, label, transport_address, monero_address);
-}
-
-void simple_wallet::mms_list(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms list");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  const std::vector<mms::message> &messages = ms.get_all_messages();
-  list_mms_messages(messages);
-}
-
-void simple_wallet::mms_next(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if ((args.size() > 1) || ((args.size() == 1) && (args[0] != "sync")))
-  {
-    fail_msg_writer() << tr("Usage: mms next [sync]");
-    return;
-  }
-  bool avail = false;
-  std::vector<mms::processing_data> data_list;
-  bool force_sync = false;
-  uint32_t choice = 0;
-  {
-    LOCK_IDLE_SCOPE();
-    if ((args.size() == 1) && (args[0] == "sync"))
-    {
-      // Force the MMS to process any waiting sync info although on its own it would just ignore
-      // those messages because no need to process them can be seen
-      force_sync = true;
-    }
-    string wait_reason;
-    {
-      avail = ms.get_processable_messages(get_multisig_wallet_state(), force_sync, data_list, wait_reason);
-    }
-    if (avail)
-    {
-      avail = choose_mms_processing(data_list, choice);
-    }
-    else if (!wait_reason.empty())
-    {
-      message_writer() << tr("No next step: ") << wait_reason;
-    }
-  }
-  if (avail)
-  {
-    mms::processing_data data = data_list[choice];
-    bool command_successful = false;
-    switch(data.processing)
-    {
-    case mms::message_processing::prepare_multisig:
-      message_writer() << tr("prepare_multisig");
-      command_successful = prepare_multisig_main(std::vector<std::string>(), true);
-      break;
-
-    case mms::message_processing::make_multisig:
-    {
-      message_writer() << tr("make_multisig");
-      size_t number_of_key_sets = data.message_ids.size();
-      std::vector<std::string> sig_args(number_of_key_sets + 1);
-      sig_args[0] = std::to_string(ms.get_num_required_signers());
-      for (size_t i = 0; i < number_of_key_sets; ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        sig_args[i+1] = m.content;
-      }
-      command_successful = make_multisig_main(sig_args, true);
-      break;
-    }
-
-    case mms::message_processing::exchange_multisig_keys:
-    {
-      message_writer() << tr("exchange_multisig_keys");
-      size_t number_of_key_sets = data.message_ids.size();
-      // Other than "make_multisig" only the key sets as parameters, no num_required_signers
-      std::vector<std::string> sig_args(number_of_key_sets);
-      for (size_t i = 0; i < number_of_key_sets; ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        sig_args[i] = m.content;
-      }
-      // todo: update mms to enable 'key exchange force updating'
-      command_successful = exchange_multisig_keys_main(sig_args, false, true);
-      break;
-    }
-
-    case mms::message_processing::create_sync_data:
-    {
-      message_writer() << tr("export_multisig_info");
-      std::vector<std::string> export_args;
-      export_args.push_back("MMS");  // dummy filename
-      command_successful = export_multisig_main(export_args, true);
-      break;
-    }
-
-    case mms::message_processing::process_sync_data:
-    {
-      message_writer() << tr("import_multisig_info");
-      std::vector<std::string> import_args;
-      for (size_t i = 0; i < data.message_ids.size(); ++i)
-      {
-        mms::message m = ms.get_message_by_id(data.message_ids[i]);
-        import_args.push_back(m.content);
-      }
-      command_successful = import_multisig_main(import_args, true);
-      break;
-    }
-
-    case mms::message_processing::sign_tx:
-    {
-      message_writer() << tr("sign_multisig");
-      std::vector<std::string> sign_args;
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      sign_args.push_back(m.content);
-      command_successful = sign_multisig_main(sign_args, true);
-      break;
-    }
-
-    case mms::message_processing::submit_tx:
-    {
-      message_writer() << tr("submit_multisig");
-      std::vector<std::string> submit_args;
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      submit_args.push_back(m.content);
-      command_successful = submit_multisig_main(submit_args, true);
-      break;
-    }
-
-    case mms::message_processing::send_tx:
-    {
-      message_writer() << tr("Send tx");
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      LOCK_IDLE_SCOPE();
-      ms.add_message(get_multisig_wallet_state(), data.receiving_signer_index, m.type, mms::message_direction::out,
-                     m.content);
-      command_successful = true;
-      break;
-    }
-
-    case mms::message_processing::process_signer_config:
-    {
-      message_writer() << tr("Process signer config");
-      LOCK_IDLE_SCOPE();
-      mms::message m = ms.get_message_by_id(data.message_ids[0]);
-      mms::authorized_signer me = ms.get_signer(0);
-      mms::multisig_wallet_state state = get_multisig_wallet_state();
-      if (!me.auto_config_running)
-      {
-        // If no auto-config is running, the config sent may be unsolicited or problematic
-        // so show what arrived and ask for confirmation before taking it in
-        std::vector<mms::authorized_signer> signers;
-        ms.unpack_signer_config(state, m.content, signers);
-        list_signers(signers);
-        if (!user_confirms(tr("Replace current signer config with the one displayed above?")))
-        {
-          break;
-        }
-        if (!user_confirms_auto_config())
-        {
-          message_writer() << tr("You can use the \"mms delete\" command to delete any unwanted message");
-          break;
-        }
-      }
-      ms.process_signer_config(state, m.content);
-      ms.stop_auto_config();
-      list_signers(ms.get_all_signers());
-      command_successful = true;
-      break;
-    }
-
-    case mms::message_processing::process_auto_config_data:
-    {
-      message_writer() << tr("Process auto config data");
-      LOCK_IDLE_SCOPE();
-      for (size_t i = 0; i < data.message_ids.size(); ++i)
-      {
-        ms.process_auto_config_data_message(data.message_ids[i]);
-      }
-      ms.stop_auto_config();
-      list_signers(ms.get_all_signers());
-      add_signer_config_messages();
-      command_successful = true;
-      break;
-    }
-
-    default:
-      message_writer() << tr("Nothing ready to process");
-      break;
-    }
-
-    if (command_successful)
-    {
-      {
-        LOCK_IDLE_SCOPE();
-        ms.set_messages_processed(data);
-        ask_send_all_ready_messages();
-      }
-    }
-  }
-}
-
-void simple_wallet::mms_sync(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms sync");
-    return;
-  }
-  // Force the start of a new sync round, for exceptional cases where something went wrong
-  // Can e.g. solve the problem "This signature was made with stale data" after trying to
-  // create 2 transactions in a row somehow
-  // Code is identical to the code for 'message_processing::create_sync_data'
-  message_writer() << tr("export_multisig_info");
-  std::vector<std::string> export_args;
-  export_args.push_back("MMS");  // dummy filename
-  export_multisig_main(export_args, true);
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_transfer(const std::vector<std::string> &args)
-{
-  // It's too complicated to check any arguments here, just let 'transfer_main' do the whole job
-  transfer_main(args, true);
-}
-
-void simple_wallet::mms_delete(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms delete (<message_id> | all)");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args[0] == "all")
-  {
-    if (user_confirms(tr("Delete all messages?")))
-    {
-      ms.delete_all_messages();
-    }
-  }
-  else
-  {
-    mms::message m;
-    bool valid_id = get_message_from_arg(args[0], m);
-    if (valid_id)
-    {
-      // If only a single message and not all delete even if unsent / unprocessed
-      ms.delete_message(m.id);
-    }
-  }
-}
-
-void simple_wallet::mms_send(const std::vector<std::string> &args)
-{
-  if (args.size() == 0)
-  {
-    ask_send_all_ready_messages();
-    return;
-  }
-  else if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms send [<message_id>]");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    ms.send_message(get_multisig_wallet_state(), m.id);
-  }
-}
-
-void simple_wallet::mms_receive(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms receive");
-    return;
-  }
-  std::vector<mms::message> new_messages;
-  LOCK_IDLE_SCOPE();
-  mms::message_store& ms = m_wallet->get_message_store();
-  bool avail = ms.check_for_messages(get_multisig_wallet_state(), new_messages);
-  if (avail)
-  {
-    list_mms_messages(new_messages);
-  }
-}
-
-void simple_wallet::mms_export(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms export <message_id>");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    const std::string filename = "mms_message_content";
-    if (m_wallet->save_to_file(filename, m.content))
-    {
-      success_msg_writer() << tr("Message content saved to: ") << filename;
-    }
-    else
-    {
-      fail_msg_writer() << tr("Failed to save message content");
-    }
-  }
-}
-
-void simple_wallet::mms_note(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (args.size() == 0)
-  {
-    LOCK_IDLE_SCOPE();
-    const std::vector<mms::message> &messages = ms.get_all_messages();
-    for (size_t i = 0; i < messages.size(); ++i)
-    {
-      const mms::message &m = messages[i];
-      if ((m.type == mms::message_type::note) && (m.state == mms::message_state::waiting))
-      {
-        show_message(m);
-      }
-    }
-    return;
-  }
-  if (args.size() < 2)
-  {
-    fail_msg_writer() << tr("Usage: mms note [<label> <text>]");
-    return;
-  }
-  uint32_t signer_index;
-  bool found = ms.get_signer_index_by_label(args[0], signer_index);
-  if (!found)
-  {
-    fail_msg_writer() << tr("No signer found with label ") << args[0];
-    return;
-  }
-  std::string note = "";
-  for (size_t n = 1; n < args.size(); ++n)
-  {
-    if (n > 1)
-    {
-      note += " ";
-    }
-    note += args[n];
-  }
-  LOCK_IDLE_SCOPE();
-  ms.add_message(get_multisig_wallet_state(), signer_index, mms::message_type::note,
-                 mms::message_direction::out, note);
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_show(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms show <message_id>");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  mms::message m;
-  bool valid_id = get_message_from_arg(args[0], m);
-  if (valid_id)
-  {
-    show_message(m);
-  }
-}
-
-void simple_wallet::mms_set(const std::vector<std::string> &args)
-{
-  bool set = args.size() == 2;
-  bool query = args.size() == 1;
-  if (!set && !query)
-  {
-    fail_msg_writer() << tr("Usage: mms set <option_name> [<option_value>]");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  LOCK_IDLE_SCOPE();
-  if (args[0] == "auto-send")
-  {
-    if (set)
-    {
-      bool result;
-      bool ok = parse_bool(args[1], result);
-      if (ok)
-      {
-        ms.set_auto_send(result);
-      }
-      else
-      {
-        fail_msg_writer() << tr("Wrong option value");
-      }
-    }
-    else
-    {
-      message_writer() << (ms.get_auto_send() ? tr("Auto-send is on") : tr("Auto-send is off"));
-    }
-  }
-  else
-  {
-    fail_msg_writer() << tr("Unknown option");
-  }
-}
-
-void simple_wallet::mms_help(const std::vector<std::string> &args)
-{
-  if (args.size() > 1)
-  {
-    fail_msg_writer() << tr("Usage: help mms [<subcommand>]");
-    return;
-  }
-  std::vector<std::string> help_args;
-  help_args.push_back("mms");
-  if (args.size() == 1)
-  {
-    help_args.push_back(args[0]);
-  }
-  help(help_args);
-}
-
-void simple_wallet::mms_send_signer_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms send_signer_config");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  if (!ms.signer_config_complete())
-  {
-    fail_msg_writer() << tr("Signer config not yet complete");
-    return;
-  }
-  LOCK_IDLE_SCOPE();
-  add_signer_config_messages();
-  ask_send_all_ready_messages();
-}
-
-void simple_wallet::mms_start_auto_config(const std::vector<std::string> &args)
-{
-  mms::message_store& ms = m_wallet->get_message_store();
-  uint32_t other_signers = ms.get_num_authorized_signers() - 1;
-  size_t args_size = args.size();
-  if ((args_size != 0) && (args_size != other_signers))
-  {
-    fail_msg_writer() << tr("Usage: mms start_auto_config [<label> <label> ...]");
-    return;
-  }
-  if ((args_size == 0) && !ms.signer_labels_complete())
-  {
-    fail_msg_writer() << tr("There are signers without a label set. Complete labels before auto-config or specify them as parameters here.");
-    return;
-  }
-  mms::authorized_signer me = ms.get_signer(0);
-  if (me.auto_config_running)
-  {
-    if (!user_confirms(tr("Auto-config is already running. Cancel and restart?")))
-    {
-      return;
-    }
-  }
-  LOCK_IDLE_SCOPE();
-  mms::multisig_wallet_state state = get_multisig_wallet_state();
-  if (args_size != 0)
-  {
-    // Set (or overwrite) all the labels except "me" from the arguments
-    for (uint32_t i = 1; i < (other_signers + 1); ++i)
-    {
-      ms.set_signer(state, i, args[i - 1], boost::none, boost::none);
-    }
-  }
-  ms.start_auto_config(state);
-  // List the signers to show the generated auto-config tokens
-  list_signers(ms.get_all_signers());
-}
-
-void simple_wallet::mms_config_checksum(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms config_checksum");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  LOCK_IDLE_SCOPE();
-  message_writer() << ms.get_config_checksum();
-}
-
-void simple_wallet::mms_stop_auto_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 0)
-  {
-    fail_msg_writer() << tr("Usage: mms stop_auto_config");
-    return;
-  }
-  if (!user_confirms(tr("Delete any auto-config tokens and stop auto-config?")))
-  {
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  LOCK_IDLE_SCOPE();
-  ms.stop_auto_config();
-}
-
-void simple_wallet::mms_auto_config(const std::vector<std::string> &args)
-{
-  if (args.size() != 1)
-  {
-    fail_msg_writer() << tr("Usage: mms auto_config <auto_config_token>");
-    return;
-  }
-  mms::message_store& ms = m_wallet->get_message_store();
-  std::string adjusted_token;
-  if (!ms.check_auto_config_token(args[0], adjusted_token))
-  {
-    fail_msg_writer() << tr("Invalid auto-config token");
-    return;
-  }
-  if (!user_confirms_auto_config())
-  {
-    return;
-  }
-  mms::authorized_signer me = ms.get_signer(0);
-  if (me.auto_config_running)
-  {
-    if (!user_confirms(tr("Auto-config already running. Cancel and restart?")))
-    {
-      return;
-    }
-  }
-  LOCK_IDLE_SCOPE();
-  ms.add_auto_config_data_message(get_multisig_wallet_state(), adjusted_token);
-  ask_send_all_ready_messages();
-}
-
-bool simple_wallet::mms(const std::vector<std::string> &args)
-{
-  CHECK_MULTISIG_ENABLED();
-  try
-  {
-    m_wallet->get_multisig_wallet_state();
-  }
-  catch(const std::exception &e)
-  {
-    fail_msg_writer() << tr("MMS not available in this wallet");
-    return true;
-  }
-
-  try
-  {
-    mms::message_store& ms = m_wallet->get_message_store();
-    if (args.size() == 0)
-    {
-      mms_info(args);
-      return true;
-    }
-
-    const std::string &sub_command = args[0];
-    std::vector<std::string> mms_args = args;
-    mms_args.erase(mms_args.begin());
-
-    if (sub_command == "init")
-    {
-      mms_init(mms_args);
-      return true;
-    }
-    if (!ms.get_active())
-    {
-      fail_msg_writer() << tr("The MMS is not active. Activate using the \"mms init\" command");
-      return true;
-    }
-    else if (sub_command == "info")
-    {
-      mms_info(mms_args);
-    }
-    else if (sub_command == "signer")
-    {
-      mms_signer(mms_args);
-    }
-    else if (sub_command == "list")
-    {
-      mms_list(mms_args);
-    }
-    else if (sub_command == "next")
-    {
-      mms_next(mms_args);
-    }
-    else if (sub_command == "sync")
-    {
-      mms_sync(mms_args);
-    }
-    else if (sub_command == "transfer")
-    {
-      mms_transfer(mms_args);
-    }
-    else if (sub_command == "delete")
-    {
-      mms_delete(mms_args);
-    }
-    else if (sub_command == "send")
-    {
-      mms_send(mms_args);
-    }
-    else if (sub_command == "receive")
-    {
-      mms_receive(mms_args);
-    }
-    else if (sub_command == "export")
-    {
-      mms_export(mms_args);
-    }
-    else if (sub_command == "note")
-    {
-      mms_note(mms_args);
-    }
-    else if (sub_command == "show")
-    {
-      mms_show(mms_args);
-    }
-    else if (sub_command == "set")
-    {
-      mms_set(mms_args);
-    }
-    else if (sub_command == "help")
-    {
-      mms_help(mms_args);
-    }
-    else if (sub_command == "send_signer_config")
-    {
-      mms_send_signer_config(mms_args);
-    }
-    else if (sub_command == "start_auto_config")
-    {
-      mms_start_auto_config(mms_args);
-    }
-    else if (sub_command == "config_checksum")
-    {
-      mms_config_checksum(mms_args);
-    }
-    else if (sub_command == "stop_auto_config")
-    {
-      mms_stop_auto_config(mms_args);
-    }
-    else if (sub_command == "auto_config")
-    {
-      mms_auto_config(mms_args);
-    }
-    else
-    {
-      fail_msg_writer() << tr("Invalid MMS subcommand");
-    }
-  }
-  catch (const tools::error::no_connection_to_daemon &e)
-  {
-    fail_msg_writer() << tr("Error in MMS command: ") << e.what() << " " << e.request();
-  }
-  catch (const std::exception &e)
-  {
-    fail_msg_writer() << tr("Error in MMS command: ") << e.what();
-    PRINT_USAGE(USAGE_MMS);
-    return true;
-  }
-  return true;
-}
-// End MMS ------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -42,7 +42,7 @@
 
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
-#include "wallet/wallet2.h"
+#include "wallet/api/wallet2_api.h"
 #include "console_handler.h"
 #include "math_helper.h"
 #include "wipeable_string.h"
@@ -64,7 +64,7 @@ namespace cryptonote
   /*!
    * \brief Manages wallet operations. This is the most abstracted wallet class.
    */
-  class simple_wallet : public tools::i_wallet2_callback
+  class simple_wallet : public Monero::WalletListener
   {
   public:
     static const char *tr(const char *str) { return i18n_translate(str, "cryptonote::simple_wallet"); }
@@ -103,8 +103,10 @@ namespace cryptonote
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
         const epee::wipeable_string &multisig_keys, const epee::wipeable_string &seed_pass, const std::string &old_language);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm);
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const std::string &json_file);
     boost::optional<epee::wipeable_string> open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
+    bool init_wallet(const boost::program_options::variables_map &vm);
 
     bool viewkey(const std::vector<std::string> &args = std::vector<std::string>());
     bool spendkey(const std::vector<std::string> &args = std::vector<std::string>());
@@ -168,14 +170,14 @@ namespace cryptonote
     bool show_incoming_transfers(const std::vector<std::string> &args);
     bool show_payments(const std::vector<std::string> &args);
     bool show_blockchain_height(const std::vector<std::string> &args);
-    bool transfer_main(const std::vector<std::string> &args, bool called_by_mms);
+    bool transfer_main(const std::vector<std::string> &args);
     bool transfer(const std::vector<std::string> &args);
     bool sweep_main(uint32_t account, uint64_t below, const std::vector<std::string> &args);
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_account(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);
     bool sweep_single(const std::vector<std::string> &args);
-    bool sweep_unmixable(const std::vector<std::string> &args);
+    // removed: sweep_unmixable(); reason: not needed anymore after FCMP++ fork, discussed in "Monero Tech Meeting #140" https://github.com/monero-project/meta/issues/1277
     bool donate(const std::vector<std::string> &args);
     bool sign_transfer(const std::vector<std::string> &args);
     bool submit_transfer(const std::vector<std::string> &args);
@@ -227,26 +229,27 @@ namespace cryptonote
     bool payment_id(const std::vector<std::string> &args);
     bool print_fee_info(const std::vector<std::string> &args);
     bool prepare_multisig(const std::vector<std::string>& args);
-    bool prepare_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool prepare_multisig_main(const std::vector<std::string>& args);
     bool make_multisig(const std::vector<std::string>& args);
-    bool make_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool make_multisig_main(const std::vector<std::string>& args);
     bool exchange_multisig_keys(const std::vector<std::string> &args);
-    bool exchange_multisig_keys_main(const std::vector<std::string> &args, const bool force_update_use_with_caution, const bool called_by_mms);
+    bool exchange_multisig_keys_main(const std::vector<std::string> &args, const bool force_update_use_with_caution);
     bool export_multisig(const std::vector<std::string>& args);
-    bool export_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool export_multisig_main(const std::vector<std::string>& args);
     bool import_multisig(const std::vector<std::string>& args);
-    bool import_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
-    bool accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs);
+    bool import_multisig_main(const std::vector<std::string>& args);
     bool sign_multisig(const std::vector<std::string>& args);
-    bool sign_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool sign_multisig_main(const std::vector<std::string>& args);
     bool submit_multisig(const std::vector<std::string>& args);
-    bool submit_multisig_main(const std::vector<std::string>& args, bool called_by_mms);
+    bool submit_multisig_main(const std::vector<std::string>& args);
     bool export_raw_multisig(const std::vector<std::string>& args);
-    bool mms(const std::vector<std::string>& args);
     bool print_ring(const std::vector<std::string>& args);
     bool set_ring(const std::vector<std::string>& args);
-    bool unset_ring(const std::vector<std::string>& args);
-    bool save_known_rings(const std::vector<std::string>& args);
+    // removed: unset_ring(); reason: not needed anymore after FCMP++ fork, discussed in "Monero Tech Meeting #130" https://github.com/monero-project/meta/issues/1245
+    // removed: save_known_rings(); reason: deprecated https://github.com/monero-project/monero/pull/10014
+    // removed: blackball(); reason: deprecated https://github.com/monero-project/monero/pull/8758
+    // removed: unblackball(); reason: deprecated https://github.com/monero-project/monero/pull/8758
+    // removed: blackballed(); reason: deprecated https://github.com/monero-project/monero/pull/8758
     bool freeze(const std::vector<std::string>& args);
     bool thaw(const std::vector<std::string>& args);
     bool frozen(const std::vector<std::string>& args);
@@ -258,21 +261,19 @@ namespace cryptonote
     bool version(const std::vector<std::string>& args);
     bool on_unknown_command(const std::vector<std::string>& args);
 
-    bool cold_sign_tx(const std::vector<tools::wallet2::pending_tx>& ptx_vector, tools::wallet2::signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::function<bool(const tools::wallet2::signed_tx_set &)> accept_func);
+    // removed: cold_sign_tx(); reason: now handled by Wallet APIs WalletImpl::pendingTxPostProcess()
     uint64_t get_daemon_blockchain_height(std::string& err);
     bool try_connect_to_daemon(bool silent = false, uint32_t* version = nullptr);
     bool ask_wallet_create_if_needed(const std::string &wallet_dir);
-    bool accept_loaded_tx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message = std::string());
-    bool accept_loaded_tx(const tools::wallet2::unsigned_tx_set &txs);
-    bool accept_loaded_tx(const tools::wallet2::signed_tx_set &txs);
-    bool process_ring_members(const std::vector<tools::wallet2::pending_tx>& ptx_vector, std::ostream& ostr, bool verbose);
+    // removed: accept_loaded_tx(); reason: now handled by Wallet APIs [Unsigned/Pending]Transaction::checkLoadedTx()
+    bool process_ring_members(const Monero::PendingTransaction &ptx_vector, std::ostream& ostr, bool verbose);
     std::string get_prompt() const;
     bool print_seed(bool encrypted);
     void key_images_sync_intern();
     void on_refresh_finished(uint64_t start_height, uint64_t fetched_blocks, bool is_init, bool received_money);
     std::pair<std::string, std::string> show_outputs_line(const std::vector<uint64_t> &heights, uint64_t blockchain_height, uint64_t highlight_idx = std::numeric_limits<uint64_t>::max()) const;
     bool freeze_thaw(const std::vector<std::string>& args, bool freeze);
-    bool prompt_if_old(const std::vector<tools::wallet2::pending_tx> &ptx_vector);
+    bool prompt_if_old(const Monero::PendingTransaction &ptx_vector);
     bool on_command(bool (simple_wallet::*cmd)(const std::vector<std::string>&), const std::vector<std::string> &args);
     bool on_empty_command();
     bool on_cancelled_command();
@@ -312,10 +313,15 @@ namespace cryptonote
     std::string get_mnemonic_language();
 
     /*!
-     * \brief When --do-not-relay option is specified, save the raw tx hex blob to a file instead of calling m_wallet->commit_tx(ptx).
+     * \brief When wallet is watch-only, save the tx as `unsigned_monero_tx`
+     *        When --do-not-relay option is specified, save the signed tx hex blob as `raw_monero_tx`
+     *        Else submit the signed tx to the daemon
      * \param ptx_vector Pending tx(es) created by transfer/sweep_all
+     * \param do_not_relay - if true save tx as raw_monero_tx
+     * \param do_force_commit - use when calling submit_transfer from watch-only wallet
+     *                          else this method saves the ptx as unsinged_monero_tx file
      */
-    void commit_or_save(std::vector<tools::wallet2::pending_tx>& ptx_vector, bool do_not_relay);
+    void commit_or_save(Monero::PendingTransaction &ptx_vector, bool do_not_relay, bool do_force_commit = false);
 
     /*!
      * \brief checks whether background mining is enabled, and asks to configure it if not
@@ -327,22 +333,28 @@ namespace cryptonote
     // idle thread workers
     bool check_inactivity();
     bool check_refresh();
-    bool check_mms();
 
     void handle_transfer_exception(const std::exception_ptr &e, bool trusted_daemon);
 
     bool check_daemon_rpc_prices(const std::string &daemon_url, uint32_t &actual_cph, uint32_t &claimed_cph);
 
-    //----------------- i_wallet2_callback ---------------------
-    virtual void on_new_block(uint64_t height, const cryptonote::block& block);
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time);
-    virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index);
-    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index);
-    virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx);
-    virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason);
-    virtual void on_device_button_request(uint64_t code);
-    virtual boost::optional<epee::wipeable_string> on_device_pin_request();
-    virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device);
+    bool save_to_file(const std::string& path_to_file, const std::string& raw, bool is_printable = false) const;
+    bool load_from_file(const std::string& path_to_file, std::string& target_str, size_t max_size = 1000000000);
+
+    //----------------- WalletListener callback ---------------------
+    void newBlock(uint64_t height) override;
+    void moneyReceived(const std::string &txid, uint64_t amount, const uint64_t burnt, const std::string &enote_pub_key, const bool is_change /* = false */, const bool is_coinbase /* = false */) override;
+    void unconfirmedMoneyReceived(const std::string &txid, uint64_t amount) override;
+    void moneySpent(const std::string &txid, uint64_t amount, const std::string &enote_pub_key, std::pair<uint32_t, uint32_t> subaddr_index /* = {} */) override;
+    Monero::optional<std::string> onGetPassword(const char *reason) override;
+    void onDeviceButtonRequest(uint64_t code) override;
+    Monero::optional<std::string> onDevicePinRequest() override;
+    Monero::optional<std::string> onDevicePassphraseRequest(bool & on_device) override;
+    // Callbacks not implemented, but needed to override all functions from pure abstract base class WalletListener
+    void updated() override;
+    void refreshed() override;
+    void onReorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) override;
+    void onPoolTxRemoved(const std::string &txid) override;
     //----------------------------------------------------------
 
     friend class refresh_progress_reporter_t;
@@ -425,7 +437,8 @@ namespace cryptonote
 
     epee::console_handlers_binder m_cmd_binder;
 
-    std::unique_ptr<tools::wallet2> m_wallet;
+    std::unique_ptr<Monero::Wallet> m_wallet_impl;
+    std::unique_ptr<Monero::WalletManager> m_wallet_manager;
     refresh_progress_reporter_t m_refresh_progress_reporter;
 
     std::atomic<bool> m_idle_run;
@@ -446,43 +459,7 @@ namespace cryptonote
 
     epee::math_helper::once_a_time_seconds<1> m_inactivity_checker;
     epee::math_helper::once_a_time_seconds_range<get_random_interval<80 * 1000000, 100 * 1000000>> m_refresh_checker;
-    epee::math_helper::once_a_time_seconds_range<get_random_interval<90 * 1000000, 110 * 1000000>> m_mms_checker;
 
-    // MMS
-    mms::message_store& get_message_store() const { return m_wallet->get_message_store(); };
-    mms::multisig_wallet_state get_multisig_wallet_state() const { return m_wallet->get_multisig_wallet_state(); };
-    bool mms_active() const { return get_message_store().get_active(); };
-    bool choose_mms_processing(const std::vector<mms::processing_data> &data_list, uint32_t &choice);
-    void list_mms_messages(const std::vector<mms::message> &messages);
-    void list_signers(const std::vector<mms::authorized_signer> &signers);
-    void add_signer_config_messages();
-    void show_message(const mms::message &m);
-    void ask_send_all_ready_messages();
-    void check_for_messages();
-    bool user_confirms(const std::string &question);
-    bool user_confirms_auto_config();
-    bool get_message_from_arg(const std::string &arg, mms::message &m);
-    bool get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound); 
-
-    void mms_init(const std::vector<std::string> &args);
-    void mms_info(const std::vector<std::string> &args);
-    void mms_signer(const std::vector<std::string> &args);
-    void mms_list(const std::vector<std::string> &args);
-    void mms_next(const std::vector<std::string> &args);
-    void mms_sync(const std::vector<std::string> &args);
-    void mms_transfer(const std::vector<std::string> &args);
-    void mms_delete(const std::vector<std::string> &args);
-    void mms_send(const std::vector<std::string> &args);
-    void mms_receive(const std::vector<std::string> &args);
-    void mms_export(const std::vector<std::string> &args);
-    void mms_note(const std::vector<std::string> &args);
-    void mms_show(const std::vector<std::string> &args);
-    void mms_set(const std::vector<std::string> &args);
-    void mms_help(const std::vector<std::string> &args);
-    void mms_send_signer_config(const std::vector<std::string> &args);
-    void mms_start_auto_config(const std::vector<std::string> &args);
-    void mms_config_checksum(const std::vector<std::string> &args);
-    void mms_stop_auto_config(const std::vector<std::string> &args);
-    void mms_auto_config(const std::vector<std::string> &args);
+    // removed: entire MMS (Multisig Messsaging System); reason: not functioning anymore
   };
 }

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(wallet_api_sources
   wallet.cpp
   wallet_manager.cpp
+  enote_details.cpp
   transaction_info.cpp
   transaction_history.cpp
   pending_transaction.cpp
@@ -48,6 +49,7 @@ set(wallet_api_headers
 set(wallet_api_private_headers
   wallet.h
   wallet_manager.h
+  enote_details.h
   transaction_info.h
   transaction_history.h
   pending_transaction.h

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -70,6 +70,31 @@ bool AddressBookImpl::addRow(const std::string &dst_addr , const std::string &pa
   return r;
 }
 
+bool AddressBookImpl::setAddress(std::size_t index, const std::string &address)
+{
+    clearStatus();
+
+    const auto ab = m_wallet->m_wallet->get_address_book();
+    if (index >= ab.size()){
+        return false;
+    }
+
+    cryptonote::address_parse_info info;
+    if (!cryptonote::get_account_address_from_str(info, m_wallet->m_wallet->nettype(), address)) {
+      m_errorString = tr("Invalid destination address");
+      m_errorCode = Invalid_Address;
+      return false;
+    }
+
+    tools::wallet2::address_book_row entry = ab[index];
+    bool r =  m_wallet->m_wallet->set_address_book_row(index, info.address, info.has_payment_id ? &info.payment_id : nullptr, entry.m_description, info.is_subaddress);
+    if (r)
+        refresh();
+    else
+        m_errorCode = General_Error;
+    return r;
+}
+
 bool AddressBookImpl::setDescription(std::size_t index, const std::string &description)
 {
     clearStatus();

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -45,6 +45,7 @@ public:
     void refresh() override;
     std::vector<AddressBookRow*> getAll() const override;
     bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) override;
+    bool setAddress(std::size_t index, const std::string &address) override;
     bool setDescription(std::size_t index, const std::string &description) override;
     bool deleteRow(std::size_t rowId) override;
      

--- a/src/wallet/api/enote_details.cpp
+++ b/src/wallet/api/enote_details.cpp
@@ -36,13 +36,14 @@ EnoteDetails::~EnoteDetails() {}
 
 EnoteDetailsImpl::EnoteDetailsImpl():
     m_block_height(0),
+    m_unlock_time(0),
     m_internal_enote_index(0),
     m_global_enote_index(0),
     m_spent(false),
     m_frozen(false),
     m_spent_height(0),
     m_amount(0),
-    m_protocol_version(TxProtocol_CryptoNote),
+    m_protocol_version(TxProtocol::TxProtocol_CryptoNote),
     m_key_image_known(false),
     m_key_image_request(false),
     m_pk_index(0),
@@ -56,8 +57,14 @@ std::string EnoteDetailsImpl::onetimeAddress() const
 { return m_onetime_address; }
 std::string EnoteDetailsImpl::viewTag() const
 { return m_view_tag; }
+std::string EnoteDetailsImpl::paymentId() const
+{ return m_payment_id; }
 std::uint64_t EnoteDetailsImpl::blockHeight() const
 { return m_block_height; }
+std::uint64_t EnoteDetailsImpl::unlockTime() const
+{ return m_unlock_time; }
+bool EnoteDetailsImpl::isUnlocked() const
+{ return m_is_unlocked; }
 std::string EnoteDetailsImpl::txId() const
 { return m_tx_id; }
 std::uint64_t EnoteDetailsImpl::internalEnoteIndex() const
@@ -86,9 +93,13 @@ std::uint64_t EnoteDetailsImpl::pkIndex() const
 { return m_pk_index; }
 std::vector<std::pair<std::uint64_t, std::string>> EnoteDetailsImpl::uses() const
 { return m_uses; }
+std::uint32_t EnoteDetailsImpl::subaddressIndexMajor() const
+{ return m_subaddress_index_major; }
+std::uint32_t EnoteDetailsImpl::subaddressIndexMinor() const
+{ return m_subaddress_index_minor; }
 
 // Multisig
 bool EnoteDetailsImpl::isKeyImagePartial() const
 { return m_key_image_partial; }
 
-} // namespace
+} // namespace Monero

--- a/src/wallet/api/enote_details.cpp
+++ b/src/wallet/api/enote_details.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2014-2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "enote_details.h"
+
+
+namespace Monero {
+
+EnoteDetails::~EnoteDetails() {}
+
+
+EnoteDetailsImpl::EnoteDetailsImpl():
+    m_block_height(0),
+    m_internal_enote_index(0),
+    m_global_enote_index(0),
+    m_spent(false),
+    m_frozen(false),
+    m_spent_height(0),
+    m_amount(0),
+    m_protocol_version(TxProtocol_CryptoNote),
+    m_key_image_known(false),
+    m_key_image_request(false),
+    m_pk_index(0),
+    m_key_image_partial(false)
+{
+}
+
+EnoteDetailsImpl::~EnoteDetailsImpl() {}
+
+std::string EnoteDetailsImpl::onetimeAddress() const
+{ return m_onetime_address; }
+std::string EnoteDetailsImpl::viewTag() const
+{ return m_view_tag; }
+std::uint64_t EnoteDetailsImpl::blockHeight() const
+{ return m_block_height; }
+std::string EnoteDetailsImpl::txId() const
+{ return m_tx_id; }
+std::uint64_t EnoteDetailsImpl::internalEnoteIndex() const
+{ return m_internal_enote_index; }
+std::uint64_t EnoteDetailsImpl::globalEnoteIndex() const
+{ return m_global_enote_index; }
+bool EnoteDetailsImpl::isSpent() const
+{ return m_spent; }
+bool EnoteDetailsImpl::isFrozen() const
+{ return m_frozen; }
+std::uint64_t EnoteDetailsImpl::spentHeight() const
+{ return m_spent_height; }
+std::string EnoteDetailsImpl::keyImage() const
+{ return m_key_image; }
+std::string EnoteDetailsImpl::mask() const
+{ return m_mask; }
+std::uint64_t EnoteDetailsImpl::amount() const
+{ return m_amount; }
+EnoteDetails::TxProtocol EnoteDetailsImpl::protocolVersion() const
+{ return m_protocol_version; }
+bool EnoteDetailsImpl::isKeyImageKnown() const
+{ return m_key_image_known; }
+bool EnoteDetailsImpl::isKeyImageRequest() const
+{ return m_key_image_request; }
+std::uint64_t EnoteDetailsImpl::pkIndex() const
+{ return m_pk_index; }
+std::vector<std::pair<std::uint64_t, std::string>> EnoteDetailsImpl::uses() const
+{ return m_uses; }
+
+// Multisig
+bool EnoteDetailsImpl::isKeyImagePartial() const
+{ return m_key_image_partial; }
+
+} // namespace

--- a/src/wallet/api/enote_details.h
+++ b/src/wallet/api/enote_details.h
@@ -26,6 +26,8 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
 #include "wallet/api/wallet2_api.h"
 
 
@@ -38,7 +40,10 @@ public:
     ~EnoteDetailsImpl() override;
     std::string onetimeAddress() const override;
     std::string viewTag() const override;
+    std::string paymentId() const override;
     std::uint64_t blockHeight() const override;
+    std::uint64_t unlockTime() const override;
+    bool isUnlocked() const override;
     std::string txId() const override;
     std::uint64_t internalEnoteIndex() const override;
     std::uint64_t globalEnoteIndex() const override;
@@ -53,6 +58,8 @@ public:
     bool isKeyImageRequest() const override;
     std::uint64_t pkIndex() const override;
     std::vector<std::pair<std::uint64_t, std::string>> uses() const override;
+    std::uint32_t subaddressIndexMajor() const override;
+    std::uint32_t subaddressIndexMinor() const override;
 
     // Multisig
     bool isKeyImagePartial() const override;
@@ -60,48 +67,31 @@ public:
 private:
     friend class WalletImpl;
 
-    // Ko
     std::string m_onetime_address;
-    // view_tag
     std::string m_view_tag;
-    // this enote was received at block height
+    std::string m_payment_id;
     std::uint64_t m_block_height;
-    // tx id in which tx enote was received
+    std::uint64_t m_unlock_time;
+    bool m_is_unlocked;
     std::string m_tx_id;
-    // relative index in tx
     std::uint64_t m_internal_enote_index;
-    // absolute index from `cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry.output_indices`
     std::uint64_t m_global_enote_index;
-    // is spent
     bool m_spent;
-    // is frozen
     bool m_frozen;
-    // blockchain height, set if spent
     std::uint64_t m_spent_height;
-    // key image
     std::string m_key_image;
-    // x, blinding factor in amount commitment C = x G + a H
     std::string m_mask;
-    // a
     std::uint64_t m_amount;
-    // protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
     TxProtocol m_protocol_version;
-    // is key image known
     bool m_key_image_known;
-    // view wallets: we want to request it; cold wallets: it was requested
     bool m_key_image_request;
-    // public key index in tx_extra
     std::uint64_t m_pk_index;
-    // track uses of this enote in the blockchain in the format [ [block_height, tx_id], ... ] if `wallet2::m_track_uses` is true (default is false)
     std::vector<std::pair<std::uint64_t, std::string>> m_uses;
+    std::uint32_t m_subaddress_index_major;
+    std::uint32_t m_subaddress_index_minor;
 
     // Multisig
     bool m_key_image_partial;
-    // NOTE : These multisig members are part of wallet2 transfer_details and may need to get added here.
-/*
-    std::vector<rct::key> m_multisig_k;
-    std::vector<multisig_info> m_multisig_info; // one per other participant
-*/
 };
 
-} // namespace
+} // namespace Monero

--- a/src/wallet/api/enote_details.h
+++ b/src/wallet/api/enote_details.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2014-2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "wallet/api/wallet2_api.h"
+
+
+namespace Monero {
+
+class EnoteDetailsImpl : public EnoteDetails
+{
+public:
+    EnoteDetailsImpl();
+    ~EnoteDetailsImpl() override;
+    std::string onetimeAddress() const override;
+    std::string viewTag() const override;
+    std::uint64_t blockHeight() const override;
+    std::string txId() const override;
+    std::uint64_t internalEnoteIndex() const override;
+    std::uint64_t globalEnoteIndex() const override;
+    bool isSpent() const override;
+    bool isFrozen() const override;
+    std::uint64_t spentHeight() const override;
+    std::string keyImage() const override;
+    std::string mask() const override;
+    std::uint64_t amount() const override;
+    TxProtocol protocolVersion() const override;
+    bool isKeyImageKnown() const override;
+    bool isKeyImageRequest() const override;
+    std::uint64_t pkIndex() const override;
+    std::vector<std::pair<std::uint64_t, std::string>> uses() const override;
+
+    // Multisig
+    bool isKeyImagePartial() const override;
+
+private:
+    friend class WalletImpl;
+
+    // Ko
+    std::string m_onetime_address;
+    // view_tag
+    std::string m_view_tag;
+    // this enote was received at block height
+    std::uint64_t m_block_height;
+    // tx id in which tx enote was received
+    std::string m_tx_id;
+    // relative index in tx
+    std::uint64_t m_internal_enote_index;
+    // absolute index from `cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry.output_indices`
+    std::uint64_t m_global_enote_index;
+    // is spent
+    bool m_spent;
+    // is frozen
+    bool m_frozen;
+    // blockchain height, set if spent
+    std::uint64_t m_spent_height;
+    // key image
+    std::string m_key_image;
+    // x, blinding factor in amount commitment C = x G + a H
+    std::string m_mask;
+    // a
+    std::uint64_t m_amount;
+    // protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
+    TxProtocol m_protocol_version;
+    // is key image known
+    bool m_key_image_known;
+    // view wallets: we want to request it; cold wallets: it was requested
+    bool m_key_image_request;
+    // public key index in tx_extra
+    std::uint64_t m_pk_index;
+    // track uses of this enote in the blockchain in the format [ [block_height, tx_id], ... ] if `wallet2::m_track_uses` is true (default is false)
+    std::vector<std::pair<std::uint64_t, std::string>> m_uses;
+
+    // Multisig
+    bool m_key_image_partial;
+    // NOTE : These multisig members are part of wallet2 transfer_details and may need to get added here.
+/*
+    std::vector<rct::key> m_multisig_k;
+    std::vector<multisig_info> m_multisig_info; // one per other participant
+*/
+};
+
+} // namespace

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -162,6 +162,29 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     return m_status == Status_Ok;
 }
 
+std::string PendingTransactionImpl::convertTxToStr()
+{
+    std::string tx;
+    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
+
+    try {
+        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
+        m_status = Status_Ok;
+        return tx;
+    } catch (const tools::error::wallet_internal_error&) {
+        m_errorString = tr("Wallet internal eror.");
+        m_status = Status_Error;
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("Unknown exception: ")) + e.what();
+        m_status = Status_Error;
+    } catch (...) {
+        m_errorString = tr("Unhandled exception");
+        LOG_ERROR(m_errorString);
+        m_status = Status_Error;
+    }
+    return ""; // m_status != Status_Ok
+}
+
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "pending_transaction.h"
+#include "string_tools.h"
 #include "wallet.h"
 #include "common_defines.h"
 
@@ -83,6 +84,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
 
     LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
 
+    bool warn_of_possible_attack = !m_wallet.trustedDaemon();
     try {
       // Save tx to file
       if (!filename.empty()) {
@@ -134,13 +136,57 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
             m_pending_tx.pop_back();
         } // TODO: extract method;
       }
-    } catch (const tools::error::daemon_busy&) {
-        // TODO: make it translatable with "tr"?
-        m_errorString = tr("daemon is busy. Please try again later.");
+    } catch (const tools::error::deprecated_rpc_access&) {
+        m_errorString = tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722");
         m_status = Status_Error;
     } catch (const tools::error::no_connection_to_daemon&) {
         m_errorString = tr("no connection to daemon. Please make sure daemon is running.");
         m_status = Status_Error;
+    } catch (const tools::error::daemon_busy&) {
+        m_errorString = tr("daemon is busy. Please try again later.");
+        m_status = Status_Error;
+    } catch (const tools::error::wallet_rpc_error& e) {
+        m_errorString = (boost::format(tr("RPC error: %s")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR(tr("RPC error: ") << e.what());
+    } catch (const tools::error::get_outs_error &e) {
+        m_errorString = (boost::format(tr("failed to get random outputs to mix: %s")) % e.what()).str();
+        m_status = Status_Error;
+    } catch (const tools::error::not_enough_unlocked_money& e) {
+        m_errorString = (boost::format("not enough unlocked money to transfer, available only %s, sent amount %s")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::not_enough_money& e) {
+        m_errorString = (boost::format("not enough money to transfer, available only %s, sent amount %s")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::tx_not_possible& e) {
+        m_errorString = (boost::format("Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees, available only %s, transaction amount %s = %s + %s (fee)")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount() + e.fee())
+                            % cryptonote::print_money(e.tx_amount())
+                            % cryptonote::print_money(e.fee())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::not_enough_outs_to_mix& e) {
+        std::ostringstream writer(m_errorString);
+        writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+        for (std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs())
+            writer << "\n" << tr("output amount") << " = " << cryptonote::print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+        m_errorString = writer.str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+    } catch (const tools::error::tx_not_constructed&) {
+        m_errorString = tr("transaction was not constructed");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
     } catch (const tools::error::tx_rejected& e) {
         std::ostringstream writer(m_errorString);
         writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) <<  e.status();
@@ -149,6 +195,35 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
         m_errorString = writer.str();
         if (!reason.empty())
           m_errorString  += string(tr(". Reason: ")) + reason;
+    } catch (const tools::error::tx_sum_overflow& e) {
+        m_errorString = e.what();
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::zero_amount&) {
+        m_errorString = tr("destination amount is zero");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::zero_destination&) {
+        m_errorString = tr("transaction has no destination");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::tx_too_big& e) {
+        m_errorString = tr("failed to find a suitable way to split transactions");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::transfer_error& e) {
+        m_errorString = (boost::format(tr("unknown transfer error: %s")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("unknown transfer error: " << e.to_string());
+    } catch (const tools::error::multisig_export_needed& e) {
+        m_errorString = (boost::format(tr("Multisig error: ")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("Multisig error: " << e.to_string());
+        warn_of_possible_attack = false;
+    } catch (const tools::error::wallet_internal_error& e) {
+        m_errorString = (boost::format(tr("internal error: ")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("internal error: " << e.to_string());
     } catch (const std::exception &e) {
         m_errorString = string(tr("Unknown exception: ")) + e.what();
         m_status = Status_Error;
@@ -157,32 +232,11 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
         LOG_ERROR(m_errorString);
         m_status = Status_Error;
     }
+    if (warn_of_possible_attack && m_status != Status_Ok)
+      m_errorString += tr("\nThere was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.");
 
     m_wallet.startRefresh();
     return m_status == Status_Ok;
-}
-
-std::string PendingTransactionImpl::convertTxToStr()
-{
-    std::string tx;
-    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
-
-    try {
-        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
-        m_status = Status_Ok;
-        return tx;
-    } catch (const tools::error::wallet_internal_error&) {
-        m_errorString = tr("Wallet internal eror.");
-        m_status = Status_Error;
-    } catch (const std::exception &e) {
-        m_errorString = string(tr("Unknown exception: ")) + e.what();
-        m_status = Status_Error;
-    } catch (...) {
-        m_errorString = tr("Unhandled exception");
-        LOG_ERROR(m_errorString);
-        m_status = Status_Error;
-    }
-    return ""; // m_status != Status_Ok
 }
 
 uint64_t PendingTransactionImpl::amount() const
@@ -205,11 +259,30 @@ uint64_t PendingTransactionImpl::dust() const
     return result;
 }
 
+uint64_t PendingTransactionImpl::dustInFee() const
+{
+    uint64_t result = 0;
+    for (const auto & ptx : m_pending_tx) {
+        if (ptx.dust_added_to_fee)
+            result += ptx.dust;
+    }
+    return result;
+}
+
 uint64_t PendingTransactionImpl::fee() const
 {
     uint64_t result = 0;
     for (const auto &ptx : m_pending_tx) {
         result += ptx.fee;
+    }
+    return result;
+}
+
+uint64_t PendingTransactionImpl::change() const
+{
+    uint64_t result = 0;
+    for (const auto &ptx : m_pending_tx) {
+        result += ptx.change_dts.amount;
     }
     return result;
 }
@@ -235,6 +308,147 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
     return result;
 }
 
+std::string PendingTransactionImpl::convertTxToStr()
+{
+    std::string tx;
+    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
+
+    try {
+        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
+        m_status = Status_Ok;
+        return tx;
+    } catch (const tools::error::wallet_internal_error &e) {
+        m_errorString = std::string(tr("wallet internal error: ")) + e.what();
+        m_status = Status_Error;
+        LOG_ERROR(std::string(tr("wallet internal error: ")) + e.to_string());
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("Unknown exception: ")) + e.what();
+        m_status = Status_Error;
+    } catch (...) {
+        m_errorString = tr("Unhandled exception");
+        m_status = Status_Error;
+    }
+    return ""; // m_status != Status_Ok
+}
+
+std::vector<std::string> PendingTransactionImpl::convertTxToRawBlobStr()
+{
+    std::vector<std::string> tx_blobs{};
+    m_status = Status_Ok;
+    m_errorString = "";
+    for (const auto &ptx : m_pending_tx)
+    {
+        std::string tx_blob;
+        if (cryptonote::tx_to_blob(ptx.tx, tx_blob))
+            tx_blobs.push_back(tx_blob);
+        else
+        {
+            m_status = Status_Error;
+            m_errorString = tr("failed to serialize tx");
+            return {};
+        }
+    }
+    return tx_blobs;
+}
+
+double PendingTransactionImpl::getWorstFeePerByte() const
+{
+    double worst_fee_per_byte = std::numeric_limits<double>::max();
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const uint64_t blob_size = cryptonote::tx_to_blob(m_pending_tx[n].tx).size();
+        const double fee_per_byte = m_pending_tx[n].fee / (double)blob_size;
+        if (fee_per_byte < worst_fee_per_byte)
+            worst_fee_per_byte = fee_per_byte;
+    }
+    return worst_fee_per_byte;
+}
+
+std::vector<std::vector<std::vector<std::uint64_t>>> PendingTransactionImpl::vinOffsets() const
+{
+    std::vector<std::vector<std::vector<std::uint64_t>>> vin_offsets;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const cryptonote::transaction &tx = m_pending_tx[n].tx;
+        vin_offsets.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const cryptonote::txin_to_key& in_key = boost::get<cryptonote::txin_to_key>(tx.vin[i]);
+            vin_offsets[n].push_back(in_key.key_offsets);
+        }
+    }
+    return vin_offsets;
+}
+
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::constructionDataRealOutputIndices() const
+{
+    std::vector<std::vector<std::uint64_t>> vin_real_output_indices;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const cryptonote::transaction &tx = m_pending_tx[n].tx;
+        const tools::wallet2::tx_construction_data &construction_data = m_pending_tx[n].construction_data;
+        vin_real_output_indices.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const tools::wallet2::transfer_details &td = m_wallet.m_wallet->get_transfer_details(construction_data.selected_transfers[i]);
+            const cryptonote::tx_source_entry *sptr = NULL;
+            for (const auto &src: construction_data.sources)
+                if (src.outputs[src.real_output].second.dest == td.get_public_key())
+                    sptr = &src;
+            if (!sptr)
+                return {};
+            vin_real_output_indices[n].push_back(sptr->real_output);
+        }
+    }
+    return vin_real_output_indices;
+}
+
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::vinAmounts() const
+{
+    std::vector<std::vector<std::uint64_t>> vin_amounts;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        cryptonote::transaction tx = m_pending_tx[n].tx;
+        vin_amounts.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const cryptonote::txin_to_key& in_key = boost::get<cryptonote::txin_to_key>(tx.vin[i]);
+            vin_amounts[n].push_back(in_key.amount);
+        }
+    }
+    return vin_amounts;
+}
+
+std::vector<std::vector<std::unique_ptr<EnoteDetails>>> PendingTransactionImpl::getEnoteDetailsIn() const
+{
+    std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet.getEnoteDetails();
+    std::vector<std::vector<std::unique_ptr<EnoteDetails>>> eds_out;
+    for (const auto &ptx: m_pending_tx)
+    {
+        eds_out.push_back({});
+        for (const auto i: ptx.selected_transfers)
+            eds_out.back().push_back(std::move(eds[i]));
+    }
+    return eds_out;
+}
+
+bool PendingTransactionImpl::finishParsingTx()
+{
+    // import key images
+    bool r = m_wallet.m_wallet->import_key_images(m_key_images);
+    if (!r) return false;
+
+    // remember key images for this tx, for when we get those txes from the blockchain
+    m_wallet.m_wallet->insert_cold_key_images(m_tx_key_images);
+    return true;
+}
+
 std::string PendingTransactionImpl::multisigSignData() {
     try {
         if (!m_wallet.multisig().isMultisig) {
@@ -255,7 +469,7 @@ std::string PendingTransactionImpl::multisigSignData() {
     return std::string();
 }
 
-void PendingTransactionImpl::signMultisigTx() {
+void PendingTransactionImpl::signMultisigTx(std::vector<std::string> *txids /* = nullptr */) {
     try {
         std::vector<crypto::hash> ignore;
 
@@ -267,6 +481,11 @@ void PendingTransactionImpl::signMultisigTx() {
             throw std::runtime_error("couldn't sign multisig transaction");
         }
 
+        if (txids && !ignore.empty())
+        {
+            for (const auto &txid : ignore)
+                txids->emplace_back(epee::string_tools::pod_to_hex(txid));
+        }
         std::swap(m_pending_tx, txSet.m_ptx);
         std::swap(m_signers, txSet.m_signers);
     } catch (const std::exception& e) {
@@ -285,5 +504,161 @@ std::vector<std::string> PendingTransactionImpl::signersKeys() const {
 
     return keys;
 }
+
+void PendingTransactionImpl::finishRestoringMultisigTransaction() {
+    tools::wallet2::multisig_tx_set exported_txs;
+    exported_txs.m_ptx = m_pending_tx;
+    exported_txs.m_signers = m_signers;
+    m_wallet.m_wallet->finish_loading_accepted_multisig_tx(exported_txs);
+}
+
+//----------------------------------------------------------------------------------------------------
+bool PendingTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
+{
+  // gather info to ask the user
+  uint64_t amount = 0, amount_to_dests = 0, change = 0;
+  size_t min_ring_size = ~0;
+  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+  int first_known_non_zero_change_index = -1;
+  std::string payment_id_string = "";
+  for (size_t n = 0; n < get_num_txes(); ++n)
+  {
+    const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+    bool has_encrypted_payment_id = false;
+    crypto::hash8 payment_id8 = crypto::null_hash8;
+    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    {
+      cryptonote::tx_extra_nonce extra_nonce;
+      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+      {
+        crypto::hash payment_id;
+        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        {
+          if (!payment_id_string.empty())
+            payment_id_string += ", ";
+
+          // if none of the addresses are integrated addresses, it's a dummy one
+          bool is_dummy = true;
+          for (const auto &e: cd.dests)
+            if (e.is_integrated)
+              is_dummy = false;
+
+          if (is_dummy)
+            payment_id_string += std::string("dummy encrypted payment ID");
+          else
+          {
+            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+            has_encrypted_payment_id = true;
+          }
+        }
+        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+        {
+          if (!payment_id_string.empty())
+            payment_id_string += ", ";
+          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+          payment_id_string += " (OBSOLETE)";
+        }
+      }
+    }
+
+    for (size_t s = 0; s < cd.sources.size(); ++s)
+    {
+      amount += cd.sources[s].amount;
+      size_t ring_size = cd.sources[s].outputs.size();
+      if (ring_size < min_ring_size)
+        min_ring_size = ring_size;
+    }
+    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
+    {
+      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+      if (has_encrypted_payment_id && !entry.is_subaddress)
+      {
+        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+      }
+      else
+        address = standard_address;
+      auto i = dests.find(entry.addr);
+      if (i == dests.end())
+        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+      else
+        i->second.second += entry.amount;
+      amount_to_dests += entry.amount;
+    }
+    if (cd.change_dts.amount > 0)
+    {
+      auto it = dests.find(cd.change_dts.addr);
+      if (it == dests.end())
+      {
+        m_status = Status_Error;
+        m_errorString = tr("Claimed change does not go to a paid address");
+        return false;
+      }
+      if (it->second.second < cd.change_dts.amount)
+      {
+        m_status = Status_Error;
+        m_errorString = tr("Claimed change is larger than payment to the change address");
+        return  false;
+      }
+      if (cd.change_dts.amount > 0)
+      {
+        if (first_known_non_zero_change_index == -1)
+          first_known_non_zero_change_index = n;
+        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        {
+          m_status = Status_Error;
+          m_errorString = tr("Change goes to more than one address");
+          return false;
+        }
+      }
+      change += cd.change_dts.amount;
+      it->second.second -= cd.change_dts.amount;
+      if (it->second.second == 0)
+        dests.erase(cd.change_dts.addr);
+    }
+  }
+
+  if (payment_id_string.empty())
+    payment_id_string = "no payment ID";
+
+  std::string dest_string;
+  size_t n_dummy_outputs = 0;
+  for (auto i = dests.begin(); i != dests.end(); )
+  {
+    if (i->second.second > 0)
+    {
+      if (!dest_string.empty())
+        dest_string += ", ";
+      dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+    }
+    else
+      ++n_dummy_outputs;
+    ++i;
+  }
+  if (n_dummy_outputs > 0)
+  {
+    if (!dest_string.empty())
+      dest_string += ", ";
+    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+  }
+  if (dest_string.empty())
+    dest_string = tr("with no destinations");
+
+  std::string change_string;
+  if (change > 0)
+  {
+    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
+  }
+  else
+    change_string += tr("no change");
+  uint64_t fee = amount - amount_to_dests;
+  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+  return true;
+}
+
 
 }

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -66,6 +66,11 @@ int PendingTransactionImpl::status() const
     return m_status;
 }
 
+int PendingTransactionImpl::extendedStatus() const
+{
+    return m_extendedStatus;
+}
+
 string PendingTransactionImpl::errorString() const
 {
     return m_errorString;
@@ -142,9 +147,11 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     } catch (const tools::error::no_connection_to_daemon&) {
         m_errorString = tr("no connection to daemon. Please make sure daemon is running.");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NoDaemonConnection;
     } catch (const tools::error::daemon_busy&) {
         m_errorString = tr("daemon is busy. Please try again later.");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_DaemonIsBusy;
     } catch (const tools::error::wallet_rpc_error& e) {
         m_errorString = (boost::format(tr("RPC error: %s")) % e.what()).str();
         m_status = Status_Error;
@@ -157,6 +164,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.available())
                             % cryptonote::print_money(e.tx_amount())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughUnlockedMoney;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::not_enough_money& e) {
@@ -164,6 +172,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.available())
                             % cryptonote::print_money(e.tx_amount())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughMoney;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::tx_not_possible& e) {
@@ -173,6 +182,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.tx_amount())
                             % cryptonote::print_money(e.fee())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_TxNotPossible;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::not_enough_outs_to_mix& e) {
@@ -182,6 +192,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
             writer << "\n" << tr("output amount") << " = " << cryptonote::print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
         m_errorString = writer.str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughOutsToMix;
         LOG_PRINT_L0(m_errorString);
     } catch (const tools::error::tx_not_constructed&) {
         m_errorString = tr("transaction was not constructed");
@@ -202,10 +213,12 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     } catch (const tools::error::zero_amount&) {
         m_errorString = tr("destination amount is zero");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_ZeroAmount;
         warn_of_possible_attack = false;
     } catch (const tools::error::zero_destination&) {
         m_errorString = tr("transaction has no destination");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_ZeroDestination;
         warn_of_possible_attack = false;
     } catch (const tools::error::tx_too_big& e) {
         m_errorString = tr("failed to find a suitable way to split transactions");
@@ -250,6 +263,19 @@ uint64_t PendingTransactionImpl::amount() const
     return result;
 }
 
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::amountsPerDestination() const
+{
+    std::vector<std::vector<std::uint64_t>> result{};
+    for (const auto &ptx : m_pending_tx)   {
+        std::vector<std::uint64_t> amounts_per_tx{};
+        for (const auto &dest : ptx.dests) {
+            amounts_per_tx.push_back(dest.amount);
+        }
+        result.push_back(amounts_per_tx);
+    }
+    return result;
+}
+
 uint64_t PendingTransactionImpl::dust() const
 {
     uint64_t result = 0;
@@ -274,6 +300,15 @@ uint64_t PendingTransactionImpl::fee() const
     uint64_t result = 0;
     for (const auto &ptx : m_pending_tx) {
         result += ptx.fee;
+    }
+    return result;
+}
+
+std::vector<std::uint64_t> PendingTransactionImpl::fees() const
+{
+    std::vector<std::uint64_t> result{};
+    for (const auto &ptx : m_pending_tx) {
+        result.push_back(ptx.fee);
     }
     return result;
 }
@@ -351,6 +386,50 @@ std::vector<std::string> PendingTransactionImpl::convertTxToRawBlobStr()
     return tx_blobs;
 }
 
+std::vector<std::string> PendingTransactionImpl::asHexStr()
+{
+    std::vector<std::string> tx_hex_strings{};
+    m_status = Status_Ok;
+    m_errorString = "";
+    for (const auto &ptx : m_pending_tx)
+    {
+        std::ostringstream oss;
+        binary_archive<true> ar(oss);
+        try
+        {
+            if (::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx)))
+                tx_hex_strings.push_back(epee::string_tools::buff_to_hex_nodelimer(oss.str()));
+            else
+            {
+                m_status = Status_Error;
+                m_errorString = tr("failed to serialize tx");
+                return {};
+            }
+        }
+        catch (...)
+        {
+            m_status = Status_Error;
+            m_errorString = tr("failed to serialize tx");
+            return {};
+        }
+    }
+    return tx_hex_strings;
+}
+
+std::vector<std::uint64_t> PendingTransactionImpl::txWeights()
+{
+    std::vector<std::uint64_t> tx_weights{};
+    try {
+        for (const auto &ptx : m_pending_tx)
+            tx_weights.push_back(cryptonote::get_transaction_weight(ptx.tx));
+        m_status = Status_Ok;
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("failed to get transaction weight: ")) + e.what();
+        m_status = Status_Error;
+    }
+    return tx_weights;
+}
+
 double PendingTransactionImpl::getWorstFeePerByte() const
 {
     double worst_fee_per_byte = std::numeric_limits<double>::max();
@@ -425,6 +504,18 @@ std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::vinAmounts() con
     return vin_amounts;
 }
 
+std::vector<std::string> PendingTransactionImpl::getTxKeys() const
+{
+    std::vector<std::string> tx_keys{};
+    for (const auto &ptx : m_pending_tx)
+    {
+        epee::wipeable_string s = epee::to_hex::wipeable_string(ptx.tx_key);
+        for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys)
+            s += epee::to_hex::wipeable_string(additional_tx_key);
+        tx_keys.push_back(std::string(s.data(), s.size()));
+    }
+    return tx_keys;
+}
 std::vector<std::vector<std::unique_ptr<EnoteDetails>>> PendingTransactionImpl::getEnoteDetailsIn() const
 {
     std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet.getEnoteDetails();
@@ -447,6 +538,15 @@ bool PendingTransactionImpl::finishParsingTx()
     // remember key images for this tx, for when we get those txes from the blockchain
     m_wallet.m_wallet->insert_cold_key_images(m_tx_key_images);
     return true;
+}
+
+std::unique_ptr<TransactionDescription> PendingTransactionImpl::getTransactionDescription()
+{
+    std::vector<tools::wallet2::tx_construction_data> tx_construction_data;
+    for (size_t i = 0; i < m_pending_tx.size(); ++i)
+        tx_construction_data.push_back(m_pending_tx[i].construction_data);
+
+    return m_wallet.getTxDescription(tx_construction_data, m_status, m_errorString);
 }
 
 std::string PendingTransactionImpl::multisigSignData() {
@@ -515,149 +615,149 @@ void PendingTransactionImpl::finishRestoringMultisigTransaction() {
 //----------------------------------------------------------------------------------------------------
 bool PendingTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
-  // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
-  size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
-  int first_known_non_zero_change_index = -1;
-  std::string payment_id_string = "";
-  for (size_t n = 0; n < get_num_txes(); ++n)
-  {
-    const tools::wallet2::tx_construction_data &cd = get_tx(n);
-
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    bool has_encrypted_payment_id = false;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    // gather info to ask the user
+    uint64_t amount = 0, amount_to_dests = 0, change = 0;
+    size_t min_ring_size = ~0;
+    std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+    int first_known_non_zero_change_index = -1;
+    std::string payment_id_string = "";
+    for (size_t n = 0; n < get_num_txes(); ++n)
     {
-      cryptonote::tx_extra_nonce extra_nonce;
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        crypto::hash payment_id;
-        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+        std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+        bool has_encrypted_payment_id = false;
+        crypto::hash8 payment_id8 = crypto::null_hash8;
+        if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
+            cryptonote::tx_extra_nonce extra_nonce;
+            if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+            {
+                crypto::hash payment_id;
+                if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
 
-          // if none of the addresses are integrated addresses, it's a dummy one
-          bool is_dummy = true;
-          for (const auto &e: cd.dests)
-            if (e.is_integrated)
-              is_dummy = false;
+                    // if none of the addresses are integrated addresses, it's a dummy one
+                    bool is_dummy = true;
+                    for (const auto &e: cd.dests)
+                        if (e.is_integrated)
+                            is_dummy = false;
 
-          if (is_dummy)
-            payment_id_string += std::string("dummy encrypted payment ID");
-          else
-          {
-            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-            has_encrypted_payment_id = true;
-          }
+                    if (is_dummy)
+                        payment_id_string += std::string("dummy encrypted payment ID");
+                    else
+                    {
+                        payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+                        has_encrypted_payment_id = true;
+                    }
+                }
+                else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
+                    payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+                    payment_id_string += " (OBSOLETE)";
+                }
+            }
         }
-        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+
+        for (size_t s = 0; s < cd.sources.size(); ++s)
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
-          payment_id_string += " (OBSOLETE)";
+            amount += cd.sources[s].amount;
+            size_t ring_size = cd.sources[s].outputs.size();
+            if (ring_size < min_ring_size)
+                min_ring_size = ring_size;
         }
-      }
-    }
-
-    for (size_t s = 0; s < cd.sources.size(); ++s)
-    {
-      amount += cd.sources[s].amount;
-      size_t ring_size = cd.sources[s].outputs.size();
-      if (ring_size < min_ring_size)
-        min_ring_size = ring_size;
-    }
-    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-    {
-      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
-      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress)
-      {
-        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
-        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
-      }
-      else
-        address = standard_address;
-      auto i = dests.find(entry.addr);
-      if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-      else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
-    }
-    if (cd.change_dts.amount > 0)
-    {
-      auto it = dests.find(cd.change_dts.addr);
-      if (it == dests.end())
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change does not go to a paid address");
-        return false;
-      }
-      if (it->second.second < cd.change_dts.amount)
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change is larger than payment to the change address");
-        return  false;
-      }
-      if (cd.change_dts.amount > 0)
-      {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
         {
-          m_status = Status_Error;
-          m_errorString = tr("Change goes to more than one address");
-          return false;
+            const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+            std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+            if (has_encrypted_payment_id && !entry.is_subaddress)
+            {
+                address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+                address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+            }
+            else
+                address = standard_address;
+            auto i = dests.find(entry.addr);
+            if (i == dests.end())
+                dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+            else
+                i->second.second += entry.amount;
+            amount_to_dests += entry.amount;
         }
-      }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
+        if (cd.change_dts.amount > 0)
+        {
+            auto it = dests.find(cd.change_dts.addr);
+            if (it == dests.end())
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change does not go to a paid address");
+                return false;
+            }
+            if (it->second.second < cd.change_dts.amount)
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change is larger than payment to the change address");
+                return  false;
+            }
+            if (cd.change_dts.amount > 0)
+            {
+                if (first_known_non_zero_change_index == -1)
+                    first_known_non_zero_change_index = n;
+                if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+                {
+                    m_status = Status_Error;
+                    m_errorString = tr("Change goes to more than one address");
+                    return false;
+                }
+            }
+            change += cd.change_dts.amount;
+            it->second.second -= cd.change_dts.amount;
+            if (it->second.second == 0)
+                dests.erase(cd.change_dts.addr);
+        }
     }
-  }
 
-  if (payment_id_string.empty())
-    payment_id_string = "no payment ID";
+    if (payment_id_string.empty())
+        payment_id_string = "no payment ID";
 
-  std::string dest_string;
-  size_t n_dummy_outputs = 0;
-  for (auto i = dests.begin(); i != dests.end(); )
-  {
-    if (i->second.second > 0)
+    std::string dest_string;
+    size_t n_dummy_outputs = 0;
+    for (auto i = dests.begin(); i != dests.end(); )
     {
-      if (!dest_string.empty())
-        dest_string += ", ";
-      dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        if (i->second.second > 0)
+        {
+            if (!dest_string.empty())
+                dest_string += ", ";
+            dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        }
+        else
+            ++n_dummy_outputs;
+        ++i;
+    }
+    if (n_dummy_outputs > 0)
+    {
+        if (!dest_string.empty())
+            dest_string += ", ";
+        dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+    }
+    if (dest_string.empty())
+        dest_string = tr("with no destinations");
+
+    std::string change_string;
+    if (change > 0)
+    {
+        std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+        change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
     }
     else
-      ++n_dummy_outputs;
-    ++i;
-  }
-  if (n_dummy_outputs > 0)
-  {
-    if (!dest_string.empty())
-      dest_string += ", ";
-    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
-  }
-  if (dest_string.empty())
-    dest_string = tr("with no destinations");
-
-  std::string change_string;
-  if (change > 0)
-  {
-    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
-  }
-  else
-    change_string += tr("no change");
-  uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
-  return true;
+        change_string += tr("no change");
+    uint64_t fee = amount - amount_to_dests;
+    m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+    return true;
 }
 
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -45,27 +45,42 @@ public:
     ~PendingTransactionImpl();
     int status() const override;
     std::string errorString() const override;
+    std::string confirmationMessage() const override { return m_confirmationMessage; }
     bool commit(const std::string &filename = "", bool overwrite = false) override;
     uint64_t amount() const override;
     uint64_t dust() const override;
+    uint64_t dustInFee() const override;
     uint64_t fee() const override;
+    uint64_t change() const override;
     std::vector<std::string> txid() const override;
     uint64_t txCount() const override;
     std::vector<uint32_t> subaddrAccount() const override;
     std::vector<std::set<uint32_t>> subaddrIndices() const override;
+    std::string convertTxToStr() override;
+    std::vector<std::string> convertTxToRawBlobStr() override;
+    double getWorstFeePerByte() const override;
+    std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const override;
+    std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const override;
+    std::vector<std::vector<std::uint64_t>> vinAmounts() const override;
+    std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const override;
+    bool finishParsingTx() override;
     // TODO: continue with interface;
 
     std::string multisigSignData() override;
-    void signMultisigTx() override;
+    void signMultisigTx(std::vector<std::string> *txids = nullptr) override;
     std::vector<std::string> signersKeys() const override;
-    std::string convertTxToStr() override;
+    void finishRestoringMultisigTransaction() override;
 
 private:
+    // Callback function to check all loaded tx's and generate confirmationMessage
+    bool checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message);
+
     friend class WalletImpl;
     WalletImpl &m_wallet;
 
     int  m_status;
     std::string m_errorString;
+    std::string m_confirmationMessage;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;
     std::unordered_set<crypto::public_key> m_signers;
     std::vector<std::string> m_tx_device_aux;

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -58,6 +58,7 @@ public:
     std::string multisigSignData() override;
     void signMultisigTx() override;
     std::vector<std::string> signersKeys() const override;
+    std::string convertTxToStr() override;
 
 private:
     friend class WalletImpl;
@@ -69,6 +70,8 @@ private:
     std::unordered_set<crypto::public_key> m_signers;
     std::vector<std::string> m_tx_device_aux;
     std::vector<crypto::key_image> m_key_images;
+    // wallet2 m_cold_key_images
+    std::unordered_map<crypto::public_key, crypto::key_image> m_tx_key_images;
 };
 
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -45,12 +45,15 @@ public:
     ~PendingTransactionImpl();
     int status() const override;
     std::string errorString() const override;
+    int extendedStatus() const override;
     std::string confirmationMessage() const override { return m_confirmationMessage; }
     bool commit(const std::string &filename = "", bool overwrite = false) override;
     uint64_t amount() const override;
+    std::vector<std::vector<uint64_t>> amountsPerDestination() const override;
     uint64_t dust() const override;
     uint64_t dustInFee() const override;
     uint64_t fee() const override;
+    std::vector<std::uint64_t> fees() const override;
     uint64_t change() const override;
     std::vector<std::string> txid() const override;
     uint64_t txCount() const override;
@@ -58,12 +61,16 @@ public:
     std::vector<std::set<uint32_t>> subaddrIndices() const override;
     std::string convertTxToStr() override;
     std::vector<std::string> convertTxToRawBlobStr() override;
+    std::vector<std::string> asHexStr() override;
+    std::vector<std::uint64_t> txWeights() override;
     double getWorstFeePerByte() const override;
     std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const override;
     std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const override;
     std::vector<std::vector<std::uint64_t>> vinAmounts() const override;
+    std::vector<std::string> getTxKeys() const override;
     std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const override;
     bool finishParsingTx() override;
+    std::unique_ptr<TransactionDescription> getTransactionDescription() override;
     // TODO: continue with interface;
 
     std::string multisigSignData() override;
@@ -79,6 +86,7 @@ private:
     WalletImpl &m_wallet;
 
     int  m_status;
+    int  m_extendedStatus;
     std::string m_errorString;
     std::string m_confirmationMessage;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -150,6 +150,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        // not used for payment_details
+        ti->m_change = 0;
+        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        // not used for payment_details
+        ti->m_double_spend_seen = false;
         m_history.push_back(ti);
 
     }
@@ -193,6 +198,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
+        ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_change = pd.m_change;
+        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        // not used for confirmed_transfer_details
+        ti->m_double_spend_seen = false;
 
         // single output transaction might contain multiple transfers
         for (const auto &d: pd.m_dests) {
@@ -229,6 +239,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
+        ti->m_unlock_time = pd.m_tx.unlock_time;
+        ti->m_change = pd.m_change;
+        ti->m_tx_state = (TransactionInfo::TxState) pd.m_state;
+        // not used for unconfirmed_transfer_details
+        ti->m_double_spend_seen = false;
         for (const auto &d : pd.m_dests)
         {
             ti->m_transfers.push_back({d.amount, d.address(m_wallet->m_wallet->nettype(), pd.m_payment_id)});
@@ -258,6 +273,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label     = m_wallet->m_wallet->get_subaddress_label(pd.m_subaddr_index);
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
+        ti->m_unlock_time = pd.m_unlock_time;
+        // not used for pool_payment_details
+        ti->m_change = 0;
+        ti->m_tx_state = TransactionInfo::TxState_PendingInPool;
+        ti->m_double_spend_seen = i->second.m_double_spend_seen;
         m_history.push_back(ti);
         
         LOG_PRINT_L1(__FUNCTION__ << ": Unconfirmed payment found " << pd.m_amount);

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -150,9 +150,10 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = m_wallet->m_wallet->is_transfer_unlocked(pd.m_unlock_time, pd.m_block_height);
         // not used for payment_details
         ti->m_change = 0;
-        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_Confirmed;
         // not used for payment_details
         ti->m_double_spend_seen = false;
         m_history.push_back(ti);
@@ -199,8 +200,9 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = true;
         ti->m_change = pd.m_change;
-        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_Confirmed;
         // not used for confirmed_transfer_details
         ti->m_double_spend_seen = false;
 
@@ -240,6 +242,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
         ti->m_unlock_time = pd.m_tx.unlock_time;
+        ti->m_is_unlocked = true;
         ti->m_change = pd.m_change;
         ti->m_tx_state = (TransactionInfo::TxState) pd.m_state;
         // not used for unconfirmed_transfer_details
@@ -251,7 +254,9 @@ void TransactionHistoryImpl::refresh()
         m_history.push_back(ti);
     }
     
-    
+    // simplewallet called m_wallet.update_pool_state() & m_wallet.process_pool_state() before getting unconfirmed incoming transfers from the tx pool
+    // src: https://github.com/monero-project/monero/blob/8d4c625713e3419573dfcc7119c8848f47cabbaa/src/simplewallet/simplewallet.cpp#L10293-L10296
+    m_wallet->refreshPoolOnly();
     // unconfirmed payments (tx pool)
     std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> upayments;
     m_wallet->m_wallet->get_unconfirmed_payments(upayments);
@@ -274,9 +279,10 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = false;
         // not used for pool_payment_details
         ti->m_change = 0;
-        ti->m_tx_state = TransactionInfo::TxState_PendingInPool;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_PendingInPool;
         ti->m_double_spend_seen = i->second.m_double_spend_seen;
         m_history.push_back(ti);
         

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -86,8 +86,10 @@ TransactionInfo *TransactionHistoryImpl::transaction(const std::string &id) cons
     return itr != m_history.end() ? *itr : nullptr;
 }
 
-std::vector<TransactionInfo *> TransactionHistoryImpl::getAll() const
+std::vector<TransactionInfo *> TransactionHistoryImpl::getAll(bool do_refresh /* = false */)
 {
+    if (do_refresh)
+        refresh();
     boost::shared_lock<boost::shared_mutex> lock(m_historyMutex);
     return m_history;
 }
@@ -268,6 +270,7 @@ void TransactionHistoryImpl::refresh()
         TransactionInfoImpl * ti = new TransactionInfoImpl();
         ti->m_paymentid = payment_id;
         ti->m_amount    = pd.m_amount;
+        ti->m_fee       = pd.m_fee;
         ti->m_direction = TransactionInfo::Direction_In;
         ti->m_hash      = string_tools::pod_to_hex(pd.m_tx_hash);
         ti->m_blockheight = pd.m_block_height;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -258,7 +258,7 @@ void TransactionHistoryImpl::refresh()
     
     // simplewallet called m_wallet.update_pool_state() & m_wallet.process_pool_state() before getting unconfirmed incoming transfers from the tx pool
     // src: https://github.com/monero-project/monero/blob/8d4c625713e3419573dfcc7119c8848f47cabbaa/src/simplewallet/simplewallet.cpp#L10293-L10296
-    m_wallet->refreshPoolOnly();
+//    m_wallet->refreshPoolOnly();
     // unconfirmed payments (tx pool)
     std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> upayments;
     m_wallet->m_wallet->get_unconfirmed_payments(upayments);

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -43,7 +43,7 @@ public:
     virtual int count() const;
     virtual TransactionInfo * transaction(int index)  const;
     virtual TransactionInfo * transaction(const std::string &id) const;
-    virtual std::vector<TransactionInfo*> getAll() const;
+    virtual std::vector<TransactionInfo*> getAll(bool do_refresh = false);
     virtual void refresh();
     virtual void setTxNote(const std::string &txid, const std::string &note);
 

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -149,4 +149,19 @@ uint64_t TransactionInfoImpl::unlockTime() const
     return m_unlock_time;
 }
 
+std::uint64_t TransactionInfoImpl::receivedChangeAmount() const
+{
+    return m_change;
+}
+
+TransactionInfo::TxState TransactionInfoImpl::txState() const
+{
+    return m_tx_state;
+}
+
+bool TransactionInfoImpl::isDoubleSpendSeen() const
+{
+    return m_double_spend_seen;
+}
+
 } // namespace

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -83,6 +83,11 @@ bool TransactionInfoImpl::isCoinbase() const
     return m_coinbase;
 }
 
+bool TransactionInfoImpl::isUnlocked() const
+{
+    return m_is_unlocked;
+}
+
 uint64_t TransactionInfoImpl::amount() const
 {
     return m_amount;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -47,6 +47,7 @@ public:
     virtual bool isPending() const override;
     virtual bool isFailed() const override;
     virtual bool isCoinbase() const override;
+    virtual bool isUnlocked() const override;
     virtual uint64_t amount() const override;
     //! always 0 for incoming txes
     virtual uint64_t fee() const override;
@@ -72,6 +73,7 @@ private:
     bool        m_pending;
     bool        m_failed;
     bool        m_coinbase;
+    bool        m_is_unlocked;
     uint64_t    m_amount;
     uint64_t    m_fee;
     uint64_t    m_blockheight;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -63,6 +63,10 @@ public:
     virtual uint64_t confirmations() const override;
     virtual uint64_t unlockTime() const override;
 
+    std::uint64_t receivedChangeAmount() const override;
+    TxState txState() const override;
+    bool isDoubleSpendSeen() const override;
+
 private:
     int         m_direction;
     bool        m_pending;
@@ -81,6 +85,12 @@ private:
     std::vector<Transfer> m_transfers;
     uint64_t    m_confirmations;
     uint64_t    m_unlock_time;
+    // received change amount from outgoing transaction
+    std::uint64_t m_change;
+    // tx state : TxState_Pending / TxState_PendingInPool / TxState_Failed / TxState_Confirmed
+    TxState m_tx_state;
+    // is double spend seen
+    bool m_double_spend_seen;
 
     friend class TransactionHistoryImpl;
 

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -68,7 +68,7 @@ string UnsignedTransactionImpl::errorString() const
     return m_errorString;
 }
 
-bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
+bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_export_raw /* = false */, std::vector<std::string> *tx_ids_out /* = nullptr */)
 {
   if(m_wallet.watchOnly())
   {
@@ -79,7 +79,7 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
   std::vector<tools::wallet2::pending_tx> ptx;
   try
   {
-    bool r = m_wallet.m_wallet->sign_tx(m_unsigned_tx_set, signedFileName, ptx);
+    bool r = m_wallet.m_wallet->sign_tx(m_unsigned_tx_set, signedFileName, ptx, do_export_raw);
     if (!r)
     {
       m_errorString = tr("Failed to sign transaction");
@@ -89,9 +89,17 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
   }
   catch (const std::exception &e)
   {
-    m_errorString = string(tr("Failed to sign transaction")) + e.what();
+    m_errorString = string(tr("Failed to sign transaction: ")) + e.what();
     m_status = Status_Error;
     return false;
+  }
+  if (tx_ids_out)
+  {
+    std::string tx_id_str;
+    for (const auto &tx : ptx)
+    {
+      (*tx_ids_out).push_back(epee::string_tools::pod_to_hex(get_transaction_hash(tx.tx)));
+    }
   }
   return true;
 }
@@ -122,13 +130,18 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
         {
           if (!payment_id_string.empty())
             payment_id_string += ", ";
-          if (payment_id8 == crypto::null_hash8)
-          {
+
+          // if none of the addresses are integrated addresses, it's a dummy one
+          bool is_dummy = true;
+          for (const auto &e: cd.dests)
+            if (e.is_integrated)
+              is_dummy = false;
+
+          if (is_dummy)
             payment_id_string += std::string("dummy encrypted payment ID");
-          }
           else
           {
-            payment_id_string += std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
             has_encrypted_payment_id = true;
           }
         }
@@ -198,6 +211,10 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
         dests.erase(cd.change_dts.addr);
     }
   }
+
+  if (payment_id_string.empty())
+    payment_id_string = "no payment ID";
+
   std::string dest_string;
   for (auto i = dests.begin(); i != dests.end(); )
   {
@@ -218,7 +235,7 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
   else
     change_string += tr("no change");
   uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % extra_message).str();
+  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
   return true;
 }
 

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -37,7 +37,6 @@
 
 #include <memory>
 #include <vector>
-#include <sstream>
 #include <boost/format.hpp>
 
 using namespace std;
@@ -95,7 +94,6 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_ex
   }
   if (tx_ids_out)
   {
-    std::string tx_id_str;
     for (const auto &tx : ptx)
     {
       (*tx_ids_out).push_back(epee::string_tools::pod_to_hex(get_transaction_hash(tx.tx)));
@@ -107,136 +105,149 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_ex
 //----------------------------------------------------------------------------------------------------
 bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
-  // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
-  size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
-  int first_known_non_zero_change_index = -1;
-  std::string payment_id_string = "";
-  for (size_t n = 0; n < get_num_txes(); ++n)
-  {
-    const tools::wallet2::tx_construction_data &cd = get_tx(n);
-
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    bool has_encrypted_payment_id = false;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    // gather info to ask the user
+    uint64_t amount = 0, amount_to_dests = 0, change = 0;
+    size_t min_ring_size = ~0;
+    std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+    int first_known_non_zero_change_index = -1;
+    std::string payment_id_string = "";
+    for (size_t n = 0; n < get_num_txes(); ++n)
     {
-      cryptonote::tx_extra_nonce extra_nonce;
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        crypto::hash payment_id;
-        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+        std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+        bool has_encrypted_payment_id = false;
+        crypto::hash8 payment_id8 = crypto::null_hash8;
+        if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
+            cryptonote::tx_extra_nonce extra_nonce;
+            if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+            {
+                crypto::hash payment_id;
+                if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
 
-          // if none of the addresses are integrated addresses, it's a dummy one
-          bool is_dummy = true;
-          for (const auto &e: cd.dests)
-            if (e.is_integrated)
-              is_dummy = false;
+                    // if none of the addresses are integrated addresses, it's a dummy one
+                    bool is_dummy = true;
+                    for (const auto &e: cd.dests)
+                        if (e.is_integrated)
+                            is_dummy = false;
 
-          if (is_dummy)
-            payment_id_string += std::string("dummy encrypted payment ID");
-          else
-          {
-            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-            has_encrypted_payment_id = true;
-          }
+                    if (is_dummy)
+                        payment_id_string += std::string("dummy encrypted payment ID");
+                    else
+                    {
+                        payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+                        has_encrypted_payment_id = true;
+                    }
+                }
+                else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
+                    payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+                    payment_id_string += " (OBSOLETE)";
+                }
+            }
         }
-        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+
+        for (size_t s = 0; s < cd.sources.size(); ++s)
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+            amount += cd.sources[s].amount;
+            size_t ring_size = cd.sources[s].outputs.size();
+            if (ring_size < min_ring_size)
+                min_ring_size = ring_size;
         }
-      }
-    }
-
-    for (size_t s = 0; s < cd.sources.size(); ++s)
-    {
-      amount += cd.sources[s].amount;
-      size_t ring_size = cd.sources[s].outputs.size();
-      if (ring_size < min_ring_size)
-        min_ring_size = ring_size;
-    }
-    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-    {
-      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
-      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress)
-      {
-        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
-        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
-      }
-      else
-        address = standard_address;
-      auto i = dests.find(entry.addr);
-      if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-      else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
-    }
-    if (cd.change_dts.amount > 0)
-    {
-      auto it = dests.find(cd.change_dts.addr);
-      if (it == dests.end())
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change does not go to a paid address");
-        return false;
-      }
-      if (it->second.second < cd.change_dts.amount)
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change is larger than payment to the change address");
-        return  false;
-      }
-      if (cd.change_dts.amount > 0)
-      {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
         {
-          m_status = Status_Error;
-          m_errorString = tr("Change goes to more than one address");
-          return false;
+            const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+            std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+            if (has_encrypted_payment_id && !entry.is_subaddress)
+            {
+                address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+                address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+            }
+            else
+                address = standard_address;
+            auto i = dests.find(entry.addr);
+            if (i == dests.end())
+                dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+            else
+                i->second.second += entry.amount;
+            amount_to_dests += entry.amount;
         }
-      }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
+        if (cd.change_dts.amount > 0)
+        {
+            auto it = dests.find(cd.change_dts.addr);
+            if (it == dests.end())
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change does not go to a paid address");
+                return false;
+            }
+            if (it->second.second < cd.change_dts.amount)
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change is larger than payment to the change address");
+                return  false;
+            }
+            if (cd.change_dts.amount > 0)
+            {
+                if (first_known_non_zero_change_index == -1)
+                    first_known_non_zero_change_index = n;
+                if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+                {
+                    m_status = Status_Error;
+                    m_errorString = tr("Change goes to more than one address");
+                    return false;
+                }
+            }
+            change += cd.change_dts.amount;
+            it->second.second -= cd.change_dts.amount;
+            if (it->second.second == 0)
+                dests.erase(cd.change_dts.addr);
+        }
     }
-  }
 
-  if (payment_id_string.empty())
-    payment_id_string = "no payment ID";
+    if (payment_id_string.empty())
+        payment_id_string = "no payment ID";
 
-  std::string dest_string;
-  for (auto i = dests.begin(); i != dests.end(); )
-  {
-    dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
-    ++i;
-    if (i != dests.end())
-      dest_string += ", ";
-  }
-  if (dest_string.empty())
-    dest_string = tr("with no destinations");
+    std::string dest_string;
+    size_t n_dummy_outputs = 0;
+    for (auto i = dests.begin(); i != dests.end(); )
+    {
+        if (i->second.second > 0)
+        {
+            if (!dest_string.empty())
+                dest_string += ", ";
+            dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        }
+        else
+            ++n_dummy_outputs;
+        ++i;
+    }
+    if (n_dummy_outputs > 0)
+    {
+        if (!dest_string.empty())
+            dest_string += ", ";
+        dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+    }
+    if (dest_string.empty())
+        dest_string = tr("with no destinations");
 
-  std::string change_string;
-  if (change > 0)
-  {
-    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
-  }
-  else
-    change_string += tr("no change");
-  uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
-  return true;
+    std::string change_string;
+    if (change > 0)
+    {
+        std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+        change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
+    }
+    else
+        change_string += tr("no change");
+    uint64_t fee = amount - amount_to_dests;
+    m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+    return true;
 }
 
 std::vector<uint64_t> UnsignedTransactionImpl::amount() const
@@ -361,6 +372,15 @@ std::string UnsignedTransactionImpl::signAsString()
         m_status = Status_Error;
         return "";
     }
+}
+
+std::unique_ptr<TransactionDescription> UnsignedTransactionImpl::getTransactionDescription()
+{
+    std::vector<tools::wallet2::tx_construction_data> tx_construction_data;
+    for (size_t i = 0; i < m_unsigned_tx_set.txes.size(); ++i)
+        tx_construction_data.push_back(m_unsigned_tx_set.txes[i]);
+
+    return m_wallet.getTxDescription(tx_construction_data, m_status, m_errorString);
 }
 
 } // namespace

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -324,4 +324,26 @@ uint64_t UnsignedTransactionImpl::minMixinCount() const
     return min_mixin;
 }
 
+std::string UnsignedTransactionImpl::signAsString()
+{
+    if(m_wallet.watchOnly())
+    {
+        m_errorString = tr("This is a watch only wallet");
+        m_status = Status_Error;
+        return "";
+    }
+    tools::wallet2::signed_tx_set signed_txes;
+    std::vector<tools::wallet2::pending_tx> ptx;
+    try
+    {
+        return m_wallet.m_wallet->sign_tx_dump_to_str(m_unsigned_tx_set, ptx, signed_txes);
+    }
+    catch (const std::exception &e)
+    {
+        m_errorString = string(tr("Failed to sign transaction ")) + e.what();
+        m_status = Status_Error;
+        return "";
+    }
+}
+
 } // namespace

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -52,7 +52,7 @@ public:
     std::vector<std::string> recipientAddress() const override;
     uint64_t txCount() const override;
     // sign txs and save to file
-    bool sign(const std::string &signedFileName) override;
+    bool sign(const std::string &signedFileName, bool do_export_raw = false, std::vector<std::string> *tx_ids_out = nullptr) override;
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
     std::string signAsString() override;

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -55,6 +55,7 @@ public:
     bool sign(const std::string &signedFileName) override;
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
+    std::string signAsString() override;
 
 private:
     // Callback function to check all loaded tx's and generate confirmationMessage

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -56,6 +56,7 @@ public:
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
     std::string signAsString() override;
+    std::unique_ptr<TransactionDescription> getTransactionDescription() override;
 
 private:
     // Callback function to check all loaded tx's and generate confirmationMessage

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -33,6 +33,8 @@
 #include "device/device.hpp"
 #include "crypto/crypto.h"
 #include "enote_details.h"
+#include "device/device.hpp"
+#include "net/net_ssl.h"
 #include "pending_transaction.h"
 #include "string_tools.h"
 #include "unsigned_transaction.h"
@@ -46,6 +48,7 @@
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
+#include "wallet/fee_priority.h"
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -198,13 +201,11 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid,
-        const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt,
-        const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id,
-        bool is_change, uint64_t unlock_time)
+    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time, const crypto::public_key& enote_pub_key)
     {
 
         std::string tx_hash =  epee::string_tools::pod_to_hex(txid);
+        std::string enote_pub_key_str = epee::string_tools::pod_to_hex(enote_pub_key);
 
         LOG_PRINT_L3(__FUNCTION__ << ": money received. height:  " << height
                      << ", tx: " << tx_hash
@@ -212,9 +213,9 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", burnt: " << print_money(burnt)
                      << ", raw_output_value: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
-            m_listener->moneyReceived(tx_hash, amount - burnt);
+        // do not signal on received tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
+            m_listener->moneyReceived(tx_hash, amount - burnt, burnt, enote_pub_key_str, is_change, cryptonote::is_coinbase(tx));
             m_listener->updated();
         }
     }
@@ -228,25 +229,27 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
+        // do not signal on received tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
             m_listener->unconfirmedMoneyReceived(tx_hash, amount);
             m_listener->updated();
         }
     }
 
     virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx,
-                                uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index)
+                                uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index,
+                                const crypto::public_key& enote_pub_key)
     {
         // TODO;
         std::string tx_hash = epee::string_tools::pod_to_hex(txid);
+        std::string enote_pub_key_str = epee::string_tools::pod_to_hex(enote_pub_key);
         LOG_PRINT_L3(__FUNCTION__ << ": money spent. height:  " << height
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on sent tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
-            m_listener->moneySpent(tx_hash, amount);
+        // do not signal on sent tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
+            m_listener->moneySpent(tx_hash, amount, enote_pub_key_str, std::make_pair(subaddr_index.major, subaddr_index.minor));
             m_listener->updated();
         }
     }
@@ -331,6 +334,19 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
     WalletImpl     * m_wallet;
 };
 
+WalletKeysDecryptGuard::~WalletKeysDecryptGuard() {}
+
+struct WalletKeysDecryptGuardImpl: public WalletKeysDecryptGuard
+{
+    WalletKeysDecryptGuardImpl(tools::wallet2 &w, const epee::wipeable_string &password):
+        u(w, &password)
+    {}
+
+    ~WalletKeysDecryptGuardImpl() override = default;
+
+    tools::wallet_keys_unlocker u;
+};
+
 Wallet::~Wallet() {}
 
 WalletListener::~WalletListener() {}
@@ -371,6 +387,20 @@ bool Wallet::paymentIdValid(const string &paiment_id)
     if (tools::wallet2::parse_long_payment_id(paiment_id, pid))
         return true;
     return false;
+}
+
+bool Wallet::isSubaddress(const std::string &address, NetworkType nettype)
+{
+  cryptonote::address_parse_info info;
+  return get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), address) ? info.is_subaddress : false;
+}
+
+std::string Wallet::getAddressFromIntegrated(const std::string &address, NetworkType nettype)
+{
+  cryptonote::address_parse_info info;
+  if (!get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), address))
+    return "";
+  return get_account_address_as_str(static_cast<cryptonote::network_type>(nettype), info.is_subaddress, info.address);
 }
 
 bool Wallet::addressValid(const std::string &str, NetworkType nettype)
@@ -463,7 +493,7 @@ void Wallet::error(const std::string &category, const std::string &str) {
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
-WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
+WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds, const bool unattended /* = true */)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok)
     , m_wallet2Callback(nullptr)
@@ -473,8 +503,9 @@ WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     , m_rebuildWalletCache(false)
     , m_is_connected(false)
     , m_refreshShouldRescan(false)
+    , m_kdf_rounds(kdf_rounds)
 {
-    m_wallet.reset(new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds, true));
+    m_wallet.reset(new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds, unattended));
     m_history.reset(new TransactionHistoryImpl(this));
     m_wallet2Callback.reset(new Wallet2CallbackImpl(this));
     m_wallet->callback(m_wallet2Callback.get());
@@ -512,7 +543,7 @@ WalletImpl::~WalletImpl()
     LOG_PRINT_L1(__FUNCTION__ << " finished");
 }
 
-bool WalletImpl::create(const std::string &path, const std::string &password, const std::string &language)
+bool WalletImpl::create(const std::string &path, const std::string &password, const std::string &language, bool create_address_file /* = false */, bool non_deterministic /* = false */)
 {
 
     clearStatus();
@@ -533,13 +564,13 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
         setStatusCritical(error);
         return false;
     }
-    setSeedLanguage(language);
+    if (!non_deterministic)
+        setSeedLanguage(language);
     if (!statusOk())
         return false;
     crypto::secret_key recovery_val, secret_key;
     try {
-        recovery_val = m_wallet->generate(path, password, secret_key, false, false);
-        m_password = password;
+        recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -708,7 +739,7 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         if(has_spendkey && !has_viewkey) {
-           m_wallet->generate(path, password, spendkey, true, false);
+           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false);
            setSeedLanguage(language);
            if (!statusOk())
                return false;
@@ -721,6 +752,70 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         return false;
     }
     m_password = password;
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
+    return true;
+}
+
+bool WalletImpl::createFromJson(const std::string &json_file_path, std::string &pw_out)
+{
+    try
+    {
+        boost::program_options::variables_map vm;
+        boost::program_options::store(
+            boost::program_options::command_line_parser({
+                nettype() == TESTNET ? "--testnet" : nettype() == STAGENET ? "--stagenet" : "",
+            }).options([]{
+                boost::program_options::options_description options_description{};
+                tools::wallet2::init_options(options_description);
+                return options_description;
+            }()
+            ).run(),
+            vm
+        );
+        auto r = m_wallet->make_from_json(vm, m_wallet->is_unattended(), json_file_path, /* password_promper */ {});
+        if (!r.first) {
+            setStatusError(tr("failed to generate new wallet from json"));
+            return false;
+        }
+        m_wallet = std::move(r.first);
+        pw_out = std::string(r.second.password().data(), r.second.password().size());
+        LOG_PRINT_L1("Generated new wallet from json");
+    }
+    catch (const std::exception& e) {
+        setStatusError(string(tr("failed to generate new wallet from json: ")) + e.what());
+        return false;
+    }
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
+    return true;
+}
+
+bool WalletImpl::recoverFromMultisigSeed(const std::string &path,
+                                         const std::string &password,
+                                         const std::string &language,
+                                         const std::string &multisig_seed,
+                                         const std::string seed_pass /* = "" */,
+                                         const bool do_create_address_file /* = false */)
+{
+    try
+    {
+        if (seed_pass.empty())
+            m_wallet->generate(path, password, multisig_seed, do_create_address_file);
+        else
+        {
+            crypto::secret_key key;
+            crypto::cn_slow_hash(seed_pass.data(), seed_pass.size(), (crypto::hash&)key);
+            sc_reduce32((unsigned char*)key.data);
+            const epee::wipeable_string &msig_keys = m_wallet->decrypt<epee::wipeable_string>(std::string(multisig_seed.data(), multisig_seed.size()), key, true);
+            m_wallet->generate(path, password, msig_keys, do_create_address_file);
+        }
+        setSeedLanguage(language);
+        LOG_PRINT_L1("Generated new multisig wallet from multisig seed");
+    }
+    catch (const std::exception& e) {
+        setStatusError(string(tr("failed to generate new multisig wallet: ")) + e.what());
+        return false;
+    }
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
     return true;
 }
 
@@ -853,22 +948,6 @@ std::string WalletImpl::seed(const std::string& seed_offset) const
     if (m_wallet)
         m_wallet->get_seed(seed, seed_offset);
     return std::string(seed.data(), seed.size()); // TODO
-}
-
-std::string WalletImpl::getSeedLanguage() const
-{
-    return m_wallet->get_seed_language();
-}
-
-void WalletImpl::setSeedLanguage(const std::string &arg)
-{
-    if (checkBackgroundSync("cannot set seed language"))
-        return;
-
-    if (crypto::ElectrumWords::is_valid_language(arg))
-        m_wallet->set_seed_language(arg);
-    else
-        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
 }
 
 int WalletImpl::status() const
@@ -1020,21 +1099,9 @@ bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transact
     return doInit(daemon_address, proxy_address, upper_transaction_size_limit, use_ssl);
 }
 
-void WalletImpl::allowMismatchedDaemonVersion(bool allow_mismatch)
-{
-    m_wallet->allow_mismatched_daemon_version(allow_mismatch);
-}
-
 void WalletImpl::setRingDatabase(const std::string &path)
 {
     m_wallet->set_ring_database(path);
-}
-
-void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
-{
-    if (checkBackgroundSync("cannot change refresh height"))
-        return;
-    m_wallet->set_refresh_from_block_height(refresh_from_block_height);
 }
 
 void WalletImpl::setRecoveringFromSeed(bool recoveringFromSeed)
@@ -1047,19 +1114,26 @@ void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
-void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
-{
-    m_wallet->set_subaddress_lookahead(major, minor);
-}
-
 uint64_t WalletImpl::balance(uint32_t accountIndex) const
 {
     return m_wallet->balance(accountIndex, false);
 }
 
-uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
+std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */) const
 {
-    return m_wallet->unlocked_balance(accountIndex, false);
+    return m_wallet->balance_per_subaddress(accountIndex, false);
+}
+
+uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex /* = 0 */,
+                                     uint64_t *blocks_to_unlock /* = NULL */,
+                                     uint64_t *time_to_unlock /* = NULL */) const
+{
+    return m_wallet->unlocked_balance(accountIndex, false, blocks_to_unlock, time_to_unlock);
+}
+
+std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+{
+    return m_wallet->unlocked_balance_per_subaddress(accountIndex, false);
 }
 
 uint64_t WalletImpl::blockChainHeight() const
@@ -1124,13 +1198,17 @@ bool WalletImpl::synchronized() const
     return m_synchronized;
 }
 
-bool WalletImpl::refresh()
+bool WalletImpl::refresh(std::uint64_t start_height /* = 0 */,
+                         bool check_pool /* = true */,
+                         bool try_incremental /* = false */,
+                         std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                         std::uint64_t *blocks_fetched_out /* = nullptr */,
+                         bool *received_money_out /* = nullptr */)
 {
     clearStatus();
-    //TODO: make doRefresh return bool to know whether the error occurred during refresh or not
-    //otherwise one may try, say, to send transaction, transfer fails and this method returns false
-    doRefresh();
-    return statusOk();
+    bool did_error_occur;
+    doRefresh(start_height, check_pool, try_incremental, max_blocks, &did_error_occur, blocks_fetched_out, received_money_out);
+    return !did_error_occur;
 }
 
 void WalletImpl::refreshAsync()
@@ -1140,21 +1218,26 @@ void WalletImpl::refreshAsync()
     m_refreshCV.notify_one();
 }
 
-bool WalletImpl::rescanBlockchain()
+bool WalletImpl::rescanBlockchain(bool do_hard_rescan /* = false */, bool do_keep_key_images /* = false */, bool do_skip_refresh /* = false */)
 {
     if (checkBackgroundSync("cannot rescan blockchain"))
         return false;
     clearStatus();
     m_refreshShouldRescan = true;
-    doRefresh();
+    m_do_hard_rescan = do_hard_rescan;
+    m_do_keep_key_images_on_rescan = do_keep_key_images;
+    if (!do_skip_refresh)
+        doRefresh();
     return statusOk();
 }
 
-void WalletImpl::rescanBlockchainAsync()
+void WalletImpl::rescanBlockchainAsync(bool do_hard_rescan /* = false */, bool do_keep_key_images /* = false */)
 {
     if (checkBackgroundSync("cannot rescan blockchain"))
         return;
     m_refreshShouldRescan = true;
+    m_do_hard_rescan = do_hard_rescan;
+    m_do_keep_key_images_on_rescan = do_keep_key_images;
     refreshAsync();
 }
 
@@ -1229,7 +1312,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
     setStatusError(tr("Failed to load transaction from file"));
     return false;
   }
-  
+
   if(!transaction->commit()) {
     setStatusError(transaction->m_errorString);
     return false;
@@ -1289,7 +1372,7 @@ std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
     return "";
 }
 
-bool WalletImpl::importKeyImages(const string &filename)
+bool WalletImpl::importKeyImages(const std::string &filename, std::uint64_t *spent_out /* = nullptr */, std::uint64_t *unspent_out /* = nullptr */, std::uint64_t *import_height /* = nullptr */)
 {
   if (checkBackgroundSync("cannot import key images"))
     return false;
@@ -1299,10 +1382,16 @@ bool WalletImpl::importKeyImages(const string &filename)
   }
   try
   {
-    uint64_t spent = 0, unspent = 0;
-    uint64_t height = m_wallet->import_key_images(filename, spent, unspent);
-    LOG_PRINT_L2("Signed key images imported to height " << height << ", "
-        << print_money(spent) << " spent, " << print_money(unspent) << " unspent");
+    uint64_t spent = 0, unspent = 0, height;
+    if (!spent_out)
+        spent_out = &spent;
+    if (!unspent_out)
+        unspent_out = &unspent;
+    if (!import_height)
+        import_height = &height;
+    *import_height = m_wallet->import_key_images(filename, *spent_out, *unspent_out);
+    LOG_PRINT_L2("Signed key images imported to height " << *import_height << ", "
+        << print_money(*spent_out) << " spent, " << print_money(*unspent_out) << " unspent");
   }
   catch (const std::exception &e)
   {
@@ -1352,8 +1441,8 @@ bool WalletImpl::exportOutputs(const string &filename, bool all)
 
     try
     {
-        std::string data = exportEnotesToStr(all);
-        bool r = saveToFile(filename, data);
+        std::string data = m_wallet->export_outputs_to_str(all);
+        bool r = m_wallet->save_to_file(filename, data);
         if (!r)
         {
             LOG_ERROR("Failed to save file " << filename);
@@ -1383,7 +1472,7 @@ bool WalletImpl::importOutputs(const string &filename)
     }
 
     std::string data;
-    bool r = loadFromFile(filename, data);
+    bool r = m_wallet->load_from_file(filename, data);
     if (!r)
     {
         LOG_ERROR("Failed to read file: " << filename);
@@ -1393,7 +1482,7 @@ bool WalletImpl::importOutputs(const string &filename)
 
     try
     {
-        size_t n_outputs = importEnotesFromStr(data);
+        size_t n_outputs = m_wallet->import_outputs_from_str(data);
         if (!statusOk())
             throw runtime_error(errorString());
         LOG_PRINT_L2(std::to_string(n_outputs) << " outputs imported");
@@ -1408,7 +1497,7 @@ bool WalletImpl::importOutputs(const string &filename)
     return true;
 }
 
-bool WalletImpl::scanTransactions(const std::vector<std::string> &txids)
+bool WalletImpl::scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon /* = nullptr */ )
 {
     if (checkBackgroundSync("cannot scan transactions"))
         return false;
@@ -1437,6 +1526,8 @@ bool WalletImpl::scanTransactions(const std::vector<std::string> &txids)
     }
     catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e)
     {
+        if (wont_reprocess_recent_txs_via_untrusted_daemon)
+            *wont_reprocess_recent_txs_via_untrusted_daemon = true;
         setStatusError(e.what());
         return false;
     }
@@ -1712,7 +1803,7 @@ bool WalletImpl::hasMultisigPartialKeyImages() const {
     return false;
 }
 
-PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signData) {
+PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signData, bool ask_for_confirmation /* = false */) {
     try {
         clearStatus();
         checkMultisigWalletReady(m_wallet);
@@ -1723,13 +1814,20 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
         }
 
         tools::wallet2::multisig_tx_set txSet;
-        if (!m_wallet->load_multisig_tx(binary, txSet, {})) {
+        if (!m_wallet->load_multisig_tx(binary, txSet, {}, ask_for_confirmation)) {
           throw runtime_error("couldn't parse multisig transaction data");
         }
 
         auto ptx = new PendingTransactionImpl(*this);
         ptx->m_pending_tx = txSet.m_ptx;
         ptx->m_signers = txSet.m_signers;
+
+        // Check tx data and construct confirmation message
+        if (ask_for_confirmation) {
+            std::string extra_message;
+            ptx->checkLoadedTx([&ptx](){return ptx->txCount();}, [&ptx](size_t n)->const tools::wallet2::tx_construction_data&{return ptx->m_pending_tx[n].construction_data;}, extra_message);
+            setStatus(ptx->status(), ptx->errorString());
+        }
 
         return ptx;
     } catch (exception& e) {
@@ -1750,7 +1848,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
 //    - unconfirmed_transfer_details;
 //    - confirmed_transfer_details)
 
-PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<string> &dst_addr, const string &payment_id, optional<std::vector<uint64_t>> amount, uint32_t mixin_count, PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<string> &dst_addr, const string &payment_id, optional<std::vector<uint64_t>> amount, uint32_t mixin_count, PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices /* = {} */, std::set<uint32_t> subtract_fee_from_outputs /* = {} */, const std::string key_image /* = "" */, const size_t outputs /* = 1 */, const std::uint64_t below /* = 0 */)
 
 {
     clearStatus();
@@ -1763,7 +1861,6 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
-    uint32_t adjusted_priority = adjustPriority(static_cast<uint32_t>(priority));
     if (!statusOk())
         return transaction;
 
@@ -1832,14 +1929,29 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         }
         try {
             size_t fake_outs_count = mixin_count > 0 ? mixin_count : defaultMixin();
-            fake_outs_count = m_wallet->adjust_mixin(mixin_count);
+            fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
 
             if (amount) {
                 transaction->m_pending_tx = m_wallet->create_transactions_2(dsts, fake_outs_count,
                                                                             adjusted_priority,
-                                                                            extra, subaddr_account, subaddr_indices);
-            } else {
-                transaction->m_pending_tx = m_wallet->create_transactions_all(0, info.address, info.is_subaddress, 1, fake_outs_count,
+                                                                            extra, subaddr_account, subaddr_indices, subtract_fee_from_outputs);
+            }
+            else if (!key_image.empty()) { // sweep_single
+                crypto::key_image ki;
+                if (!epee::string_tools::hex_to_pod(key_image, ki))
+                {
+                    setStatusError(tr("Failed to parse key image"));
+                    break;
+                }
+                transaction->m_pending_tx = m_wallet->create_transactions_single(ki,
+                                                                                 info.address,
+                                                                                 info.is_subaddress,
+                                                                                 outputs,
+                                                                                 fake_outs_count,
+                                                                                 tools::fee_priority_utilities::from_integral(priority),
+                                                                                 extra);
+            } else { // sweep_account, sweep_all, sweep_below
+                transaction->m_pending_tx = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, fake_outs_count,
                                                                               adjusted_priority,
                                                                               extra, subaddr_account, subaddr_indices);
             }
@@ -1915,8 +2027,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
     } while (false);
 
     statusWithErrorString(transaction->m_status, transaction->m_errorString);
-    // Resume refresh thread
-    startRefresh();
+    // Resume refresh thread for unattended wallet (like GUI).
+    // A non-unattended wallet (like CLI) could be waiting for confirmation prompt
+    // and a refresh could mess up the output
+    if (m_wallet->is_unattended())
+        startRefresh();
     return transaction;
 }
 
@@ -1955,7 +2070,7 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             setStatusError("");
             std::ostringstream writer;
 
-            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+            writer << boost::format(tr("not enough unlocked money to transfer, available only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
             setStatusError(writer.str());
@@ -2097,7 +2212,10 @@ bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
         return false;
     cryptonote::blobdata txid_data;
     if(!epee::string_tools::parse_hexstr_to_binbuff(txid, txid_data) || txid_data.size() != sizeof(crypto::hash))
+    {
+      setStatusError(tr("failed to parse tx_id"));
       return false;
+    }
     const crypto::hash htxid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
 
     m_wallet->set_tx_note(htxid, note);
@@ -2110,7 +2228,10 @@ std::string WalletImpl::getUserNote(const std::string &txid) const
         return "";
     cryptonote::blobdata txid_data;
     if(!epee::string_tools::parse_hexstr_to_binbuff(txid, txid_data) || txid_data.size() != sizeof(crypto::hash))
+    {
+      setStatusError(tr("failed to parse tx_id"));
       return "";
+    }
     const crypto::hash htxid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
 
     return m_wallet->get_tx_note(htxid);
@@ -2381,14 +2502,24 @@ std::string WalletImpl::signMessage(const std::string &message, const std::strin
     return m_wallet->sign(message, sig_type, *index);
 }
 
-bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
+bool WalletImpl::verifySignedMessage(const std::string &message,
+                                     const std::string &address,
+                                     const std::string &signature,
+                                     bool *is_old_out /* = nullptr */,
+                                     std::string *signature_type_out /* = nullptr */) const
 {
   cryptonote::address_parse_info info;
 
   if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), address))
     return false;
-
-  return m_wallet->verify(message, info.address, signature).valid;
+  tools::wallet2::message_signature_result_t result = m_wallet->verify(message, info.address, signature);
+  if (is_old_out)
+      *is_old_out = result.old;
+  if (signature_type_out)
+      *signature_type_out = (result.type == tools::wallet2::sign_with_spend_key
+                        ? "spend key" : result.type == tools::wallet2::sign_with_view_key
+                        ? "view key" : "unknown key combination (suspicious)");
+  return result.valid;
 }
 
 std::string WalletImpl::signMultisigParticipant(const std::string &message) const
@@ -2435,9 +2566,13 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
     return false;
 }
 
-bool WalletImpl::connectToDaemon()
+bool WalletImpl::connectToDaemon(uint32_t *version /* = NULL*/,
+                                 bool *ssl /* = NULL */,
+                                 uint32_t timeout /* = 20000 */, // TODO : can we put DEFAULT_CONNECTION_TIMEOUT_MILLIS into wallet2_api.h and have it as default param?
+                                 bool *wallet_is_outdated /* = NULL */,
+                                 bool *daemon_is_outdated /* = NULL */)
 {
-    bool result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    bool result = m_wallet->check_connection(version, ssl, timeout, wallet_is_outdated, daemon_is_outdated);
     if (!result) {
         setStatusError("Error connecting to daemon at " + m_wallet->get_daemon_address());
     } else {
@@ -2554,8 +2689,16 @@ void WalletImpl::refreshThreadFunc()
     LOG_PRINT_L3(__FUNCTION__ << ": refresh thread stopped");
 }
 
-void WalletImpl::doRefresh()
+void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
+                           bool check_pool /* = true */,
+                           bool try_incremental /* = false */,
+                           std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                           bool *error_out /* = nullptr */,
+                           std::uint64_t *blocks_fetched_out /* = nullptr */,
+                           bool *received_money_out /* = nullptr */)
 {
+    if (error_out)
+        *error_out = false;
     bool rescan = m_refreshShouldRescan.exchange(false);
     // synchronizing async and sync refresh calls
     boost::lock_guard<boost::mutex> guarg(m_refreshMutex2);
@@ -2565,8 +2708,16 @@ void WalletImpl::doRefresh()
         // Disable refresh if wallet is disconnected or daemon isn't synced.
         if (daemonSynced()) {
             if(rescan)
-                m_wallet->rescan_blockchain(false);
-            m_wallet->refresh(trustedDaemon());
+                m_wallet->rescan_blockchain(m_do_hard_rescan, /* refresh */ false, m_do_keep_key_images_on_rescan);
+            std::uint64_t blocks_fetched_ignored;
+            bool received_money_ignored;
+            m_wallet->refresh(trustedDaemon(),
+                              start_height,
+                              (blocks_fetched_out ? *blocks_fetched_out : blocks_fetched_ignored),
+                              (received_money_out ? *received_money_out : received_money_ignored),
+                              check_pool,
+                              try_incremental,
+                              max_blocks);
             m_synchronized = m_wallet->is_synced();
             // assuming if we have empty history, it wasn't initialized yet
             // for further history changes client need to update history in
@@ -2577,10 +2728,39 @@ void WalletImpl::doRefresh()
         } else {
            LOG_PRINT_L3(__FUNCTION__ << ": skipping refresh - daemon is not synced");
         }
-    } catch (const std::exception &e) {
-        setStatusError(e.what());
+    } catch (const tools::error::daemon_busy&) {
+        setStatusError(tr("daemon is busy. Please try again later."));
+        break;
+    } catch (const tools::error::no_connection_to_daemon&) {
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        break;
+    } catch (const tools::error::deprecated_rpc_access&) {
+        setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
+        break;
+    } catch (const tools::error::wallet_rpc_error& e) {
+        LOG_ERROR("RPC error: " << e.to_string());
+        setStatusError(std::string(tr("RPC error: ")) + e.what());
+        break;
+    } catch (const tools::error::refresh_error& e) {
+        LOG_ERROR("refresh error: " << e.to_string());
+        setStatusError(std::string(tr("refresh error: ")) + e.what());
+        break;
+    } catch (const tools::error::wallet_internal_error& e) {
+        LOG_ERROR("internal error: " << e.to_string());
+        setStatusError(std::string(tr("internal error: ")) + e.what());
+        break;
+    } catch (const std::exception& e) {
+        LOG_ERROR("unexpected error: " << e.what());
+        setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        break;
+    } catch (...) {
+        LOG_ERROR("unknown error");
+        setStatusError(tr("unknown error"));
         break;
     }while(!rescan && (rescan=m_refreshShouldRescan.exchange(false))); // repeat if not rescanned and rescan was requested
+
+   if (error_out)
+       *error_out = !statusOk();
 
     if (m_wallet2Callback->getListener()) {
         m_wallet2Callback->getListener()->refreshed();
@@ -2642,6 +2822,11 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
   m_wallet->cold_sign_tx(pending->m_pending_tx, exported_txs, dsts_info, pending->m_tx_device_aux);
   pending->m_key_images = exported_txs.key_images;
   pending->m_pending_tx = exported_txs.ptx;
+
+  std::string extra_message;
+  if (!exported_txs.key_images.empty())
+    extra_message = (boost::format("%u key images to import. ") % (unsigned)exported_txs.key_images.size()).str();
+  pending->checkLoadedTx([&pending](){return pending->txCount();}, [&pending](size_t n)->const tools::wallet2::tx_construction_data&{return pending->m_pending_tx[n].construction_data;}, extra_message);
 }
 
 bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit, bool ssl)
@@ -2704,21 +2889,61 @@ std::string WalletImpl::getDefaultDataDir() const
 
 bool WalletImpl::rescanSpent()
 {
-  clearStatus();
-  if (checkBackgroundSync("cannot rescan spent"))
-    return false;
-  if (!trustedDaemon()) {
-    setStatusError(tr("Rescan spent can only be used with a trusted daemon"));
-    return false;
-  }
-  try {
-      m_wallet->rescan_spent();
-  } catch (const std::exception &e) {
-      LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-      setStatusError(e.what());
-      return false;
-  }
-  return true;
+    clearStatus();
+    if (checkBackgroundSync("cannot rescan spent"))
+        return false;
+    if (!trustedDaemon()) {
+        setStatusError(tr("Rescan spent can only be used with a trusted daemon"));
+        return false;
+    }
+    try {
+        m_wallet->rescan_spent();
+    }
+    catch (const tools::error::daemon_busy&)
+    {
+        setStatusError(tr("daemon is busy. Please try again later."));
+        return false;
+    }
+    catch (const tools::error::no_connection_to_daemon&)
+    {
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        return false;
+    }
+    catch (const tools::error::deprecated_rpc_access&)
+    {
+        setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
+        return false;
+    }
+    catch (const tools::error::is_key_image_spent_error&)
+    {
+        setStatusError(tr("failed to get spent status"));
+        return false;
+    }
+    catch (const tools::error::wallet_rpc_error& e)
+    {
+        LOG_ERROR("RPC error: " << e.to_string());
+        setStatusError(std::string(tr("RPC error: ")) + e.to_string());
+        return false;
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR(__FUNCTION__ << "unexpected error: " << e.what());
+        setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        return false;
+    }
+    catch (...)
+    {
+        LOG_ERROR(__FUNCTION__ << "unknown error");
+        setStatusError(tr("unknonw error: "));
+        return false;
+    }
+
+    return true;
+}
+
+NetworkType WalletImpl::nettype() const
+{
+    return static_cast<NetworkType>(m_wallet->nettype());
 }
 
 void WalletImpl::setOffline(bool offline)
@@ -2838,6 +3063,11 @@ bool WalletImpl::isKeysFileLocked()
     return m_wallet->is_keys_file_locked();
 }
 
+std::unique_ptr<WalletKeysDecryptGuard> WalletImpl::createKeysDecryptGuard(const std::string_view &password)
+{
+    return std::unique_ptr<WalletKeysDecryptGuard>(new WalletKeysDecryptGuardImpl(*m_wallet, epee::wipeable_string(password.data(), password.size())));
+}
+
 uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 {
     return m_wallet->cold_key_image_sync(spent, unspent);
@@ -2845,6 +3075,7 @@ uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 
 void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId)
 {
+    clearStatus();
     boost::optional<crypto::hash8> payment_id_param = boost::none;
     if (!paymentId.empty())
     {
@@ -2852,7 +3083,8 @@ void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex,
         bool res = tools::wallet2::parse_short_payment_id(paymentId, payment_id);
         if (!res)
         {
-            throw runtime_error("Invalid payment ID");
+            setStatusError(tr("Invalid payment ID"));
+            return;
         }
         payment_id_param = payment_id;
     }
@@ -2954,14 +3186,14 @@ void WalletImpl::freeze(const std::string &key_image)
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::freezeByPubKey(const std::string &public_key)
+void WalletImpl::freezeByPubKey(const std::string &enote_pub_key)
 {
     clearStatus();
 
     crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
     {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
         return;
     }
 
@@ -2972,7 +3204,7 @@ void WalletImpl::freezeByPubKey(const std::string &public_key)
     catch (const std::exception &e)
     {
         LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % public_key % e.what()).str());
+        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % enote_pub_key % e.what()).str());
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -2998,14 +3230,14 @@ void WalletImpl::thaw(const std::string &key_image)
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::thawByPubKey(const std::string &public_key)
+void WalletImpl::thawByPubKey(const std::string &enote_pub_key)
 {
     clearStatus();
 
     crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
     {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
         return;
     }
 
@@ -3016,7 +3248,7 @@ void WalletImpl::thawByPubKey(const std::string &public_key)
     catch (const std::exception &e)
     {
         LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % public_key % e.what()).str());
+        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % enote_pub_key % e.what()).str());
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -3044,29 +3276,6 @@ bool WalletImpl::isFrozen(const std::string &key_image) const
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::isFrozenByPubKey(const std::string &public_key)
-{
-    clearStatus();
-
-    crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
-    {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
-        return false;
-    }
-
-    try
-    {
-        return m_wallet->frozen(m_wallet->get_output_index(pk));
-    }
-    catch (const std::exception &e)
-    {
-        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to determine if enote with public key `%s` is frozen: %s")) % public_key % e.what()).str());
-    }
-    return false;
-}
-//-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index)
 {
     m_wallet->create_one_off_subaddress({account_index, address_index});
@@ -3076,14 +3285,33 @@ Wallet::WalletState WalletImpl::getWalletState() const
 {
     WalletState wallet_state{};
 
-    wallet_state.is_deprecated = m_wallet->is_deprecated();
-    wallet_state.ring_size = 16;
+    wallet_state.is_deprecated  = m_wallet->is_deprecated();
+    wallet_state.is_unattended  = m_wallet->is_unattended();
     wallet_state.daemon_address = m_wallet->get_daemon_address();
+    wallet_state.ring_database  = m_wallet->get_ring_database();
+    wallet_state.n_enotes       = m_wallet->get_num_transfer_details();
 
     return wallet_state;
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string &password)
+Wallet::DeviceState WalletImpl::getDeviceState() const
+{
+    DeviceState device_state{};
+    auto &device = m_wallet->get_account().get_device();
+
+    device_state.key_on_device       = m_wallet->key_on_device();
+    device_state.device_name         = device.get_name();
+    device_state.has_tx_cold_sign    = device.has_tx_cold_sign();
+    device_state.has_ki_live_refresh = device.has_ki_live_refresh();
+    device_state.has_ki_cold_sync    = device.has_ki_cold_sync();
+    device_state.last_ki_sync        = m_wallet->get_device_last_key_image_sync();
+    device_state.protocol            = static_cast<DeviceState::DeviceProtocol>(device.device_protocol());
+    device_state.device_type         = static_cast<DeviceState::DeviceType>(device.get_type());
+
+    return device_state;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string_view &password)
 {
     clearStatus();
 
@@ -3098,7 +3326,7 @@ void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::st
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name)
+void WalletImpl::writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name)
 {
     clearStatus();
 
@@ -3145,46 +3373,86 @@ void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental 
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const
+std::vector<std::unique_ptr<EnoteDetails>> WalletImpl::getEnoteDetails() const
 {
-    tools::wallet2::transfer_container tc;
-    m_wallet->get_transfers(tc);
-    enote_details.reserve(tc.size());
+    std::vector<std::unique_ptr<EnoteDetails>> enotes_details{};
+    std::size_t n_transfers = m_wallet->get_num_transfer_details();
+    enotes_details.reserve(n_transfers);
 
-    for (const auto &td : tc)
+    for (std::size_t i = 0; i < n_transfers; ++i)
     {
-        auto ed = std::make_unique<EnoteDetailsImpl>();
-
-        cryptonote::txout_target_v txout_v = td.m_tx.vout[td.m_internal_output_index].target;
-        if (txout_v.type() == typeid(cryptonote::txout_to_key))
-            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_key>(txout_v).key);
-        else if (txout_v.type() == typeid(cryptonote::txout_to_tagged_key))
-        {
-            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).key);
-            ed->m_view_tag = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).view_tag);
-        }
-
-        ed->m_block_height = td.m_block_height;
-        ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
-        ed->m_internal_enote_index = td.m_internal_output_index;
-        ed->m_global_enote_index = td.m_global_output_index;
-        ed->m_spent = td.m_spent;
-        ed->m_frozen = td.m_frozen;
-        ed->m_spent_height = td.m_spent_height;
-        ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
-        ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
-        ed->m_amount = td.m_amount;
-        ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol_RingCT : EnoteDetails::TxProtocol_CryptoNote;
-        ed->m_key_image_known = td.m_key_image_known;
-        ed->m_key_image_request = td.m_key_image_request;
-        ed->m_pk_index = td.m_pk_index;
-        ed->m_uses.reserve(td.m_uses.size());
-        for (auto &u : td.m_uses)
-            ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
-        ed->m_key_image_partial = td.m_key_image_partial;
-
-        enote_details.push_back(std::move(ed));
+        enotes_details.push_back(getEnoteDetails(i));
     }
+    return enotes_details;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<EnoteDetails> WalletImpl::getEnoteDetails(const std::string &enote_pub_key) const
+{
+    clearStatus();
+
+    crypto::public_key pk{};
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
+        return nullptr;
+    }
+
+    std::size_t enote_index{};
+    try { enote_index = m_wallet->get_output_index(pk); }
+    catch (const exception &e)
+    {
+        setStatusError(std::string(tr("Could not find index of enote: ")) + e.what());
+        return nullptr;
+    }
+    return getEnoteDetails(enote_index);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<EnoteDetails> WalletImpl::getEnoteDetails(const std::size_t enote_index) const
+{
+    clearStatus();
+
+    std::unique_ptr<EnoteDetails> enote_details = nullptr;
+    tools::wallet2::transfer_details td{};
+    try { td = m_wallet->get_transfer_details(enote_index); }
+    catch (const exception &e)
+    {
+        setStatusError(std::string(tr("Could not find enote details for index: ")) + std::to_string(enote_index));
+        return nullptr;
+    }
+
+    std::unique_ptr<EnoteDetailsImpl> ed(new EnoteDetailsImpl);
+    crypto::public_key enote_pub_key{};
+    cryptonote::get_output_public_key(td.m_tx.vout[td.m_internal_output_index], enote_pub_key);
+    auto view_tag = cryptonote::get_output_view_tag(td.m_tx.vout[td.m_internal_output_index]);
+
+    ed->m_onetime_address = epee::string_tools::pod_to_hex(enote_pub_key);
+    ed->m_view_tag = view_tag ? epee::string_tools::pod_to_hex(*view_tag) : "";
+    ed->m_payment_id = getPaymentIdFromExtra(td.m_tx.extra);
+    ed->m_block_height = td.m_block_height;
+    ed->m_unlock_time = td.m_tx.unlock_time;
+    ed->m_is_unlocked = m_wallet->is_transfer_unlocked(td);
+    ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
+    ed->m_internal_enote_index = td.m_internal_output_index;
+    ed->m_global_enote_index = td.m_global_output_index;
+    ed->m_spent = td.m_spent;
+    ed->m_frozen = td.m_frozen;
+    ed->m_spent_height = td.m_spent_height;
+    ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
+    ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
+    ed->m_amount = td.m_amount;
+    ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol::TxProtocol_RingCT : EnoteDetails::TxProtocol::TxProtocol_CryptoNote;
+    ed->m_key_image_known = td.m_key_image_known;
+    ed->m_key_image_request = td.m_key_image_request;
+    ed->m_pk_index = td.m_pk_index;
+    ed->m_uses.reserve(td.m_uses.size());
+    ed->m_subaddress_index_major = td.m_subaddr_index.major;
+    ed->m_subaddress_index_minor = td.m_subaddr_index.minor;
+    for (auto &u : td.m_uses)
+        ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
+    ed->m_key_image_partial = td.m_key_image_partial;
+
+    enote_details = std::move(ed);
+    return enote_details;
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::string WalletImpl::convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const
@@ -3241,46 +3509,58 @@ bool WalletImpl::saveMultisigTx(const PendingTransaction &multisig_ptx, const st
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const
+PendingTransaction* WalletImpl::parseTxFromStr(const std::string &signed_tx_str)
 {
-    PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&ptx);
+    clearStatus();
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
     std::shared_ptr<tools::wallet2::signed_tx_set> signed_tx_set_out = std::make_shared<tools::wallet2::signed_tx_set>();
-    bool r = m_wallet->parse_tx_from_str(signed_tx_str, ptx_impl->m_pending_tx, /* accept_func = */ NULL, signed_tx_set_out.get(), /* do_handle_key_images = */ false);
-    if (r)
-        ptx_impl->m_tx_key_images = signed_tx_set_out->tx_key_images;
-    return r;
+    bool r = m_wallet->parse_tx_from_str(signed_tx_str,
+                                         ptx->m_pending_tx,
+                                         /* accept_func = */ NULL,
+                                         signed_tx_set_out.get(),
+                                         /* do_handle_key_images = */ false);
+    if (!r)
+    {
+        setStatusError(tr("Failed to parse signed tx from str"));
+        ptx->m_status = PendingTransaction::Status::Status_Error;
+        ptx->m_errorString = errorString();
+        return ptx.release();
+    }
+
+    ptx->m_tx_key_images = signed_tx_set_out->tx_key_images;
+
+    // Check tx data and construct confirmation message
+    std::string extra_message;
+    ptx->checkLoadedTx([&ptx](){return ptx->txCount();}, [&ptx](size_t n)->const tools::wallet2::tx_construction_data & {return ptx->m_pending_tx[n].construction_data;}, extra_message);
+    setStatus(ptx->status(), ptx->errorString());
+
+    return ptx.release();
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::insertColdKeyImages(PendingTransaction &ptx)
-{
-    m_wallet->insert_cold_key_images(dynamic_cast<PendingTransactionImpl*>(&ptx)->m_tx_key_images);
-}
-//-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const
+PendingTransaction* WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str)
 {
     clearStatus();
 
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
     try
     {
         checkMultisigWalletReady(m_wallet);
 
-        PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&exported_txs);
         tools::wallet2::multisig_tx_set multisig_tx;
 
         if (!m_wallet->parse_multisig_tx_from_str(multisig_tx_str, multisig_tx))
             throw runtime_error(tr("Failed to parse multisig transaction from string."));
 
-        ptx_impl->m_pending_tx = multisig_tx.m_ptx;
-        ptx_impl->m_signers = multisig_tx.m_signers;
-
-        return true;
+        ptx->m_pending_tx = multisig_tx.m_ptx;
+        ptx->m_signers = multisig_tx.m_signers;
     }
     catch (const exception &e)
     {
         setStatusError(e.what());
+        return nullptr;
     }
 
-    return false;
+    return ptx.release();
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
@@ -3289,7 +3569,8 @@ std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algor
 
     try
     {
-        return m_wallet->get_fee_multiplier(priority, fee_algorithm);
+        return m_wallet->get_fee_multiplier(tools::fee_priority_utilities::from_integral(priority),
+                                            static_cast<tools::fee_algorithm>(fee_algorithm));
     }
     catch (const exception &e)
     {
@@ -3305,7 +3586,7 @@ std::uint64_t WalletImpl::getBaseFee() const
 //-------------------------------------------------------------------------------------------------------------------
 std::uint32_t WalletImpl::adjustPriority(std::uint32_t priority)
 {
-    return m_wallet->adjust_priority(priority);
+    return tools::fee_priority_utilities::as_integral(m_wallet->adjust_priority(priority));
 }
 //-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const
@@ -3520,16 +3801,6 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> WalletImpl::estimateBacklog
     return { std::make_pair(0, 0) };
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable /* = false */) const
-{
-    return m_wallet->save_to_file(path_to_file, binary, is_printable);
-}
-//-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size /* = 1000000000 */) const
-{
-    return m_wallet->load_from_file(path_to_file, target_str, max_size);
-}
-//-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::hashEnotes(std::uint64_t enote_idx, std::string &hash) const
 {
     clearStatus();
@@ -3685,11 +3956,21 @@ void WalletImpl::setAllowMismatchedDaemonVersion(bool allow_mismatch)
     m_wallet->allow_mismatched_daemon_version(allow_mismatch);
 }
 //-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getDeviceDerivationPath() const
+{
+    return m_wallet->device_derivation_path();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDeviceDerivationPath(std::string device_derivation_path)
+{
+    m_wallet->device_derivation_path(device_derivation_path);
+}
+//-------------------------------------------------------------------------------------------------------------------
 bool WalletImpl::setDaemon(const std::string &daemon_address,
         const std::string &daemon_username /* = "" */,
         const std::string &daemon_password /* = "" */,
         bool trusted_daemon /* = false */,
-        const std::string &ssl_support /* = "autodetect" */,
+        Wallet::SSLSupport ssl_support /* = Wallet::SSLSupport::SSLSupport_Autodetect */,
         const std::string &ssl_private_key_path /* = "" */,
         const std::string &ssl_certificate_path /* = "" */,
         const std::string &ssl_ca_file_path /* = "" */,
@@ -3715,13 +3996,9 @@ bool WalletImpl::setDaemon(const std::string &daemon_address,
     if (ssl_allow_any_cert)
         ssl_options.verification = epee::net_utils::ssl_verification_t::none;
     else if (!ssl_allowed_fingerprints.empty() || !ssl_ca_file_path.empty())
-        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)};
+        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), ssl_ca_file_path};
 
-    if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support))
-    {
-        setStatusError(string(tr("Invalid ssl support option (allowed options:`disabled` | `enabled` | `autodetect`), actual value: ")) + ssl_support);
-        return false;
-    }
+    ssl_options.support = static_cast<epee::net_utils::ssl_support_t>(ssl_support);
 
     ssl_options.auth = epee::net_utils::ssl_authentication_t{
         std::move(ssl_private_key_path), std::move(ssl_certificate_path)
@@ -3753,14 +4030,420 @@ bool WalletImpl::setDaemon(const std::string &daemon_address,
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::verifyPassword(const std::string_view &password)
+{
+    clearStatus();
+
+    bool r = false;
+    bool was_locked = false;
+
+    if (isKeysFileLocked())
+    {
+        was_locked = true;
+        unlockKeysFile();
+    }
+
+    try
+    {
+        bool no_spend_key = getDeviceState().protocol == DeviceState::DeviceProtocol::DeviceProtocol_Cold || watchOnly() || multisig().isMultisig || isBackgroundWallet();
+        r = tools::wallet2::verify_password(keysFilename(),
+                                            epee::wipeable_string(password.data(), password.size()),
+                                            no_spend_key,
+                                            hw::get_device("default"),
+                                            m_kdf_rounds);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to verify password: ")) + e.what());
+    }
+
+    if (was_locked)
+        lockKeysFile();
+
+    return r;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::encryptKeys(const std::string_view &password)
+{
+    m_wallet->encrypt_keys(epee::wipeable_string(password.data(), password.size()));
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::decryptKeys(const std::string_view &password)
+{
+    m_wallet->decrypt_keys(epee::wipeable_string(password.data(), password.size()));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMinRingSize() const
+{
+    try { return m_wallet->get_min_ring_size(); }
+    catch (const std::exception &e)
+    { setStatusError(std::string(tr("failed to get min ring size")) + e.what()); }
+    return 0;
+}
+std::uint64_t WalletImpl::getMaxRingSize() const
+{
+    try { return m_wallet->get_max_ring_size(); }
+    catch (const std::exception &e)
+    { setStatusError(std::string(tr("failed to get max ring size")) + e.what()); }
+    return 0;
+}
+std::uint64_t WalletImpl::adjustMixin(const std::uint64_t fake_outs_count) const
+{
+    return m_wallet->adjust_mixin(fake_outs_count);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getDaemonAdjustedTime() const
+{
+    return m_wallet->get_daemon_adjusted_time();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getLastBlockReward() const
+{
+    return m_wallet->get_last_block_reward();
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::hasUnknownKeyImages() const
+{
+    return m_wallet->has_unknown_key_images();
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getExplicitRefreshFromBlockHeight() const
+{
+    return m_wallet->explicit_refresh_from_block_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setExplicitRefreshFromBlockHeight(bool do_explicit_refresh)
+{
+    m_wallet->explicit_refresh_from_block_height(do_explicit_refresh);
+}
+//-------------------------------------------------------------------------------------------------------------------
+// Wallet Settings getter/setter
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getSeedLanguage() const
+{
+    return m_wallet->get_seed_language();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSeedLanguage(const std::string &arg)
+{
+    if (checkBackgroundSync("cannot set seed language"))
+        return;
+
+    if (crypto::ElectrumWords::is_valid_language(arg))
+        m_wallet->set_seed_language(arg);
+    else
+        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAlwaysConfirmTransfers() const
+{
+    return m_wallet->always_confirm_transfers();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAlwaysConfirmTransfers(bool do_always_confirm)
+{
+    m_wallet->always_confirm_transfers(do_always_confirm);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getPrintRingMembers() const
+{
+    return m_wallet->print_ring_members();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setPrintRingMembers(bool do_print_ring_members)
+{
+    m_wallet->print_ring_members(do_print_ring_members);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getStoreTxInfo() const
+{
+    return m_wallet->store_tx_info();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setStoreTxInfo(bool do_store_tx_info)
+{
+    m_wallet->store_tx_info(do_store_tx_info);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAutoRefresh() const
+{
+    return m_wallet->auto_refresh();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAutoRefresh(bool do_auto_refresh)
+{
+    m_wallet->auto_refresh(do_auto_refresh);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::RefreshType WalletImpl::getRefreshType() const
+{
+    return static_cast<Wallet::RefreshType>(m_wallet->get_refresh_type());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setRefreshType(Wallet::RefreshType refresh_type)
+{
+    m_wallet->set_refresh_type(static_cast<tools::wallet2::RefreshType>(refresh_type));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getDefaultPriority() const
+{
+    return tools::fee_priority_utilities::as_integral(m_wallet->get_default_priority());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDefaultPriority(std::uint32_t default_priority)
+{
+    m_wallet->set_default_priority(tools::fee_priority_utilities::from_integral(default_priority));
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::AskPasswordType WalletImpl::getAskPasswordType() const
+{
+    return static_cast<AskPasswordType>(m_wallet->ask_password());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAskPasswordType(AskPasswordType ask_password_type)
+{
+    m_wallet->ask_password(static_cast<tools::wallet2::AskPasswordType>(ask_password_type));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMaxReorgDepth() const
+{
+    return m_wallet->max_reorg_depth();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMaxReorgDepth(std::uint64_t max_reorg_depth)
+{
+    m_wallet->max_reorg_depth(max_reorg_depth);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getMinOutputCount() const
+{
+    return m_wallet->get_min_output_count();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMinOutputCount(std::uint32_t min_output_count)
+{
+    m_wallet->set_min_output_count(min_output_count);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMinOutputValue() const
+{
+    return m_wallet->get_min_output_value();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMinOutputValue(std::uint64_t min_output_value)
+{
+    m_wallet->set_min_output_value(min_output_value);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getMergeDestinations() const
+{
+    return m_wallet->merge_destinations();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMergeDestinations(bool do_merge_destinations)
+{
+    m_wallet->merge_destinations(do_merge_destinations);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getConfirmBacklog() const
+{
+    return m_wallet->confirm_backlog();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmBacklog(bool do_confirm_backlog)
+{
+    m_wallet->confirm_backlog(do_confirm_backlog);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getConfirmBacklogThreshold() const
+{
+    return m_wallet->get_confirm_backlog_threshold();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold)
+{
+    m_wallet->set_confirm_backlog_threshold(confirm_backlog_threshold);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getConfirmExportOverwrite() const
+{
+    return m_wallet->confirm_export_overwrite();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmExportOverwrite(bool do_confirm_export_overwrite)
+{
+    m_wallet->confirm_export_overwrite(do_confirm_export_overwrite);
+}
+//-------------------------------------------------------------------------------------------------------------------
+uint64_t WalletImpl::getRefreshFromBlockHeight() const
+{
+    return m_wallet->get_refresh_from_block_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
+{
+    if (checkBackgroundSync("cannot change refresh height"))
+        return;
+    m_wallet->set_refresh_from_block_height(refresh_from_block_height);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAutoLowPriority() const
+{
+    return m_wallet->auto_low_priority();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAutoLowPriority(bool use_auto_low_priority)
+{
+    m_wallet->auto_low_priority(use_auto_low_priority);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getSegregatePreForkOutputs() const
+{
+    return m_wallet->segregate_pre_fork_outputs();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSegregatePreForkOutputs(bool do_segregate)
+{
+    m_wallet->segregate_pre_fork_outputs(do_segregate);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getKeyReuseMitigation2() const
+{
+    return m_wallet->key_reuse_mitigation2();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setKeyReuseMitigation2(bool mitigation)
+{
+    m_wallet->key_reuse_mitigation2(mitigation);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressLookahead() const
+{
+    return m_wallet->get_subaddress_lookahead();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
+{
+    m_wallet->set_subaddress_lookahead(major, minor);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getSegregationHeight() const
+{
+    return m_wallet->segregation_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSegregationHeight(std::uint64_t height)
+{
+    m_wallet->segregation_height(height);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getIgnoreFractionalOutputs() const
+{
+    return m_wallet->ignore_fractional_outputs();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs)
+{
+    m_wallet->ignore_fractional_outputs(do_ignore_fractional_outputs);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getIgnoreOutputsAbove() const
+{
+    return m_wallet->ignore_outputs_above();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above)
+{
+    m_wallet->ignore_outputs_above(ignore_outputs_above);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getIgnoreOutputsBelow() const
+{
+    return m_wallet->ignore_outputs_below();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below)
+{
+    m_wallet->ignore_outputs_below(ignore_outputs_below);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getTrackUses() const
+{
+    return m_wallet->track_uses();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTrackUses(bool do_track_uses)
+{
+    m_wallet->track_uses(do_track_uses);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::BackgroundMiningSetupType WalletImpl::getSetupBackgroundMining() const
+{
+    return static_cast<Wallet::BackgroundMiningSetupType>(m_wallet->setup_background_mining());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSetupBackgroundMining(Wallet::BackgroundMiningSetupType background_mining_setup)
+{
+    m_wallet->setup_background_mining(static_cast<tools::wallet2::BackgroundMiningSetupType>(background_mining_setup));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getDeviceName() const
+{
+    return m_wallet->device_name();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDeviceName(const std::string &device_name)
+{
+    m_wallet->device_name(device_name);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::ExportFormat WalletImpl::getExportFormat() const
+{
+    return static_cast<Wallet::ExportFormat>(m_wallet->export_format());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setExportFormat(Wallet::ExportFormat export_format)
+{
+    return m_wallet->set_export_format(static_cast<tools::wallet2::ExportFormat>(export_format));
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getShowWalletNameWhenLocked() const
+{
+    return m_wallet->show_wallet_name_when_locked();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setShowWalletNameWhenLocked(bool do_show_wallet_name)
+{
+    m_wallet->show_wallet_name_when_locked(do_show_wallet_name);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getInactivityLockTimeout() const
+{
+    return m_wallet->inactivity_lock_timeout();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setInactivityLockTimeout(std::uint32_t seconds)
+{
+    m_wallet->inactivity_lock_timeout(seconds);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getEnableMultisig() const
+{
+    return m_wallet->is_multisig_enabled();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setEnableMultisig(bool do_enable_multisig)
+{
+    m_wallet->enable_multisig(do_enable_multisig);
+}
+//-------------------------------------------------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------------------------------------------------
 // PRIVATE
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
 {
-    std::vector<std::unique_ptr<EnoteDetails>> enote_details;
-    getEnoteDetails(enote_details);
+    std::vector<std::unique_ptr<EnoteDetails>> enote_details = getEnoteDetails();
     for (size_t idx = 0; idx < enote_details.size(); ++idx)
     {
         const auto &ed = dynamic_cast<EnoteDetailsImpl &>(*enote_details[idx].get());
@@ -3778,6 +4461,33 @@ std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
 
     setStatusError("Failed to get enote index by key image: Key image not found");
     return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getPaymentIdFromExtra(const std::vector<std::uint8_t> &tx_extra) const
+{
+    std::vector<tx_extra_field> tx_extra_fields;
+    parse_tx_extra(tx_extra, tx_extra_fields); // failure ok
+    tx_extra_nonce extra_nonce;
+    tx_extra_pub_key extra_pub_key;
+    crypto::hash8 payment_id8 = crypto::null_hash8;
+    crypto::hash payment_id = crypto::null_hash;
+    if (find_tx_extra_field_by_type(tx_extra_fields, extra_pub_key))
+    {
+        const crypto::public_key &tx_pub_key = extra_pub_key.pub_key;
+        if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+        {
+            if (get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+            {
+                m_wallet->get_account().get_device().decrypt_payment_id(payment_id8, tx_pub_key, m_wallet->get_account().get_keys().m_view_secret_key);
+                return epee::string_tools::pod_to_hex(payment_id8);
+            }
+            else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+            {
+                return epee::string_tools::pod_to_hex(payment_id);
+            }
+        }
+    }
+    return std::string();
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool WalletImpl::statusOk() const

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -30,7 +30,11 @@
 
 
 #include "wallet.h"
+#include "device/device.hpp"
+#include "crypto/crypto.h"
+#include "enote_details.h"
 #include "pending_transaction.h"
+#include "string_tools.h"
 #include "unsigned_transaction.h"
 #include "transaction_history.h"
 #include "address_book.h"
@@ -61,7 +65,7 @@ using namespace cryptonote;
 #define LOCK_REFRESH() \
     bool refresh_enabled = m_refreshEnabled; \
     m_refreshEnabled = false; \
-    m_wallet->stop(); \
+    stop(); \
     m_refreshCV.notify_one(); \
     boost::mutex::scoped_lock lock(m_refreshMutex); \
     boost::mutex::scoped_lock lock2(m_refreshMutex2); \
@@ -80,7 +84,7 @@ using namespace cryptonote;
         setStatusError(tr("HW wallet cannot use background sync")); \
         return false; \
     } \
-    if (m_wallet->watch_only()) \
+    if (watchOnly()) \
     { \
         setStatusError(tr("View only wallet cannot use background sync")); \
         return false; \
@@ -297,6 +301,32 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    virtual void on_reorg(std::uint64_t height, std::uint64_t blocks_detached, std::size_t transfers_detached)
+    {
+        if (m_listener) {
+            m_listener->onReorg(height, blocks_detached, transfers_detached);
+        }
+    }
+
+    virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason)
+    {
+        if (m_listener) {
+            auto password = m_listener->onGetPassword(reason);
+            if (password) {
+                return boost::optional<epee::wipeable_string>(*password);
+            }
+        }
+        return boost::none;
+    }
+
+    virtual void on_pool_tx_removed(const crypto::hash &txid)
+    {
+        std::string txid_hex = epee::string_tools::pod_to_hex(txid);
+        if (m_listener) {
+            m_listener->onPoolTxRemoved(txid_hex);
+        }
+    }
+
     WalletListener * m_listener;
     WalletImpl     * m_wallet;
 };
@@ -400,6 +430,12 @@ uint64_t Wallet::maximumAllowedAmount()
     return std::numeric_limits<uint64_t>::max();
 }
 
+bool Wallet::walletExists(const std::string &path, bool &key_file_exists, bool &wallet_file_exists)
+{
+    tools::wallet2::wallet_exists(path, key_file_exists, wallet_file_exists);
+    return (key_file_exists || wallet_file_exists);
+}
+
 void Wallet::init(const char *argv0, const char *default_log_base_name, const std::string &log_path, bool console) {
 #ifdef WIN32
     // Activate UTF-8 support for Boost filesystem classes on Windows
@@ -484,7 +520,7 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     m_recoveringFromDevice = false;
     bool keys_file_exists;
     bool wallet_file_exists;
-    tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+    Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
     LOG_PRINT_L3("wallet_path: " << path << "");
     LOG_PRINT_L3("keys_file_exists: " << std::boolalpha << keys_file_exists << std::noboolalpha
                  << "  wallet_file_exists: " << std::boolalpha << wallet_file_exists << std::noboolalpha);
@@ -497,8 +533,9 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
         setStatusCritical(error);
         return false;
     }
-    // TODO: validate language
-    m_wallet->set_seed_language(language);
+    setSeedLanguage(language);
+    if (!statusOk())
+        return false;
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, false, false);
@@ -523,7 +560,7 @@ bool WalletImpl::createWatchOnly(const std::string &path, const std::string &pas
 
     bool keys_file_exists;
     bool wallet_file_exists;
-    tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+    Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
     LOG_PRINT_L3("wallet_path: " << path << "");
     LOG_PRINT_L3("keys_file_exists: " << std::boolalpha << keys_file_exists << std::noboolalpha
                  << "  wallet_file_exists: " << std::boolalpha << wallet_file_exists << std::noboolalpha);
@@ -673,6 +710,8 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         if(has_spendkey && !has_viewkey) {
            m_wallet->generate(path, password, spendkey, true, false);
            setSeedLanguage(language);
+           if (!statusOk())
+               return false;
            LOG_PRINT_L1("Generated deterministic wallet from spend key with seed language: " + language);
         }
         
@@ -718,7 +757,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
         // Check if wallet cache exists
         bool keys_file_exists;
         bool wallet_file_exists;
-        tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+        Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
         if(!wallet_file_exists){
             // Rebuilding wallet cache, using refresh height from .keys file
             m_rebuildWalletCache = true;
@@ -731,7 +770,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
         LOG_ERROR("Error opening wallet: " << e.what());
         setStatusCritical(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 bool WalletImpl::recover(const std::string &path, const std::string &seed)
@@ -766,33 +805,35 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         old_language = Language::English().get_language_name();
 
     try {
-        m_wallet->set_seed_language(old_language);
+        setSeedLanguage(old_language);
+        if (!statusOk())
+            return false;
         m_wallet->generate(path, password, recovery_key, true, false);
         m_password = password;
 
     } catch (const std::exception &e) {
         setStatusCritical(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
-bool WalletImpl::close(bool store)
+bool WalletImpl::close(bool do_store)
 {
 
     bool result = false;
     LOG_PRINT_L1("closing wallet...");
     try {
-        if (store) {
+        if (do_store) {
             // Do not store wallet with invalid status
             // Status Critical refers to errors on opening or creating wallets.
             if (status() != Status_Critical)
-                m_wallet->store();
+                store("");
             else
                 LOG_ERROR("Status_Critical - not saving wallet");
             LOG_PRINT_L1("wallet::store done");
         }
         LOG_PRINT_L1("Calling wallet::stop...");
-        m_wallet->stop();
+        stop();
         LOG_PRINT_L1("wallet::stop done");
         m_wallet->deinit();
         result = true;
@@ -823,7 +864,11 @@ void WalletImpl::setSeedLanguage(const std::string &arg)
 {
     if (checkBackgroundSync("cannot set seed language"))
         return;
-    m_wallet->set_seed_language(arg);
+
+    if (crypto::ElectrumWords::is_valid_language(arg))
+        m_wallet->set_seed_language(arg);
+    else
+        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
 }
 
 int WalletImpl::status() const
@@ -855,7 +900,7 @@ bool WalletImpl::setPassword(const std::string &password)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 const std::string& WalletImpl::getPassword() const
@@ -871,7 +916,7 @@ bool WalletImpl::setDevicePin(const std::string &pin)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
@@ -882,7 +927,7 @@ bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 std::string WalletImpl::address(uint32_t accountIndex, uint32_t addressIndex) const
@@ -1085,7 +1130,7 @@ bool WalletImpl::refresh()
     //TODO: make doRefresh return bool to know whether the error occurred during refresh or not
     //otherwise one may try, say, to send transaction, transfer fails and this method returns false
     doRefresh();
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 void WalletImpl::refreshAsync()
@@ -1102,7 +1147,7 @@ bool WalletImpl::rescanBlockchain()
     clearStatus();
     m_refreshShouldRescan = true;
     doRefresh();
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 void WalletImpl::rescanBlockchainAsync()
@@ -1150,6 +1195,29 @@ UnsignedTransaction *WalletImpl::loadUnsignedTx(const std::string &unsigned_file
   return transaction;
 }
 
+UnsignedTransaction *WalletImpl::loadUnsignedTxFromStr(const std::string &unsigned_tx_str)
+{
+    clearStatus();
+    std::unique_ptr<UnsignedTransactionImpl> transaction(new UnsignedTransactionImpl(*this));
+    if (checkBackgroundSync("cannot load tx") || !m_wallet->parse_unsigned_tx_from_str(unsigned_tx_str, transaction->m_unsigned_tx_set))
+    {
+        setStatusError(tr("Failed to load unsigned transaction"));
+        transaction->m_status = UnsignedTransaction::Status::Status_Error;
+        transaction->m_errorString = errorString();
+
+        return transaction.release();
+    }
+
+    // Check tx data and construct confirmation message
+    std::string extra_message;
+    if (!std::get<2>(transaction->m_unsigned_tx_set.transfers).empty())
+        extra_message = (boost::format("%u outputs to import. ") % (unsigned)std::get<2>(transaction->m_unsigned_tx_set.transfers).size()).str();
+    transaction->checkLoadedTx([&transaction](){return transaction->m_unsigned_tx_set.txes.size();}, [&transaction](size_t n)->const tools::wallet2::tx_construction_data&{return transaction->m_unsigned_tx_set.txes[n];}, extra_message);
+    setStatus(transaction->status(), transaction->errorString());
+
+    return transaction.release();
+}
+
 bool WalletImpl::submitTransaction(const string &fileName) {
   clearStatus();
   if (checkBackgroundSync("cannot submit tx"))
@@ -1158,7 +1226,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
 
   bool r = m_wallet->load_tx(fileName, transaction->m_pending_tx);
   if (!r) {
-    setStatus(Status_Ok, tr("Failed to load transaction from file"));
+    setStatusError(tr("Failed to load transaction from file"));
     return false;
   }
   
@@ -1172,7 +1240,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
 
 bool WalletImpl::exportKeyImages(const string &filename, bool all) 
 {
-  if (m_wallet->watch_only())
+  if (watchOnly())
   {
     setStatusError(tr("Wallet is view only"));
     return false;
@@ -1195,6 +1263,30 @@ bool WalletImpl::exportKeyImages(const string &filename, bool all)
     return false;
   }
   return true;
+}
+
+std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
+{
+    clearStatus();
+    if (watchOnly())
+    {
+        setStatusError(tr("Wallet is view only"));
+        return "";
+    }
+    if (checkBackgroundSync("cannot export key images"))
+        return "";
+
+    try
+    {
+        return m_wallet->export_key_images_to_str(all);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error exporting key images: " << e.what());
+        setStatusError(e.what());
+        return "";
+    }
+    return "";
 }
 
 bool WalletImpl::importKeyImages(const string &filename)
@@ -1222,6 +1314,32 @@ bool WalletImpl::importKeyImages(const string &filename)
   return true;
 }
 
+bool WalletImpl::importKeyImagesFromStr(const std::string &data)
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot import key images"))
+        return false;
+    if (!trustedDaemon()) {
+        setStatusError(tr("Key images can only be imported with a trusted daemon"));
+        return false;
+    }
+    try
+    {
+        uint64_t spent = 0, unspent = 0;
+        uint64_t height = m_wallet->import_key_images_from_str(data, spent, unspent);
+        LOG_PRINT_L2("Signed key images imported to height " << height << ", "
+                << print_money(spent) << " spent, " << print_money(unspent) << " unspent");
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error importing key images: " << e.what());
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+        return false;
+    }
+
+    return true;
+}
+
 bool WalletImpl::exportOutputs(const string &filename, bool all)
 {
     if (checkBackgroundSync("cannot export outputs"))
@@ -1234,8 +1352,8 @@ bool WalletImpl::exportOutputs(const string &filename, bool all)
 
     try
     {
-        std::string data = m_wallet->export_outputs_to_str(all);
-        bool r = m_wallet->save_to_file(filename, data);
+        std::string data = exportEnotesToStr(all);
+        bool r = saveToFile(filename, data);
         if (!r)
         {
             LOG_ERROR("Failed to save file " << filename);
@@ -1265,7 +1383,7 @@ bool WalletImpl::importOutputs(const string &filename)
     }
 
     std::string data;
-    bool r = m_wallet->load_from_file(filename, data);
+    bool r = loadFromFile(filename, data);
     if (!r)
     {
         LOG_ERROR("Failed to read file: " << filename);
@@ -1275,7 +1393,9 @@ bool WalletImpl::importOutputs(const string &filename)
 
     try
     {
-        size_t n_outputs = m_wallet->import_outputs_from_str(data);
+        size_t n_outputs = importEnotesFromStr(data);
+        if (!statusOk())
+            throw runtime_error(errorString());
         LOG_PRINT_L2(std::to_string(n_outputs) << " outputs imported");
     }
     catch (const std::exception &e)
@@ -1492,7 +1612,7 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
     try {
         clearStatus();
 
-        if (m_wallet->get_multisig_status().multisig_is_active) {
+        if (multisig().isMultisig) {
             throw runtime_error("Wallet is already multisig");
         }
 
@@ -1643,6 +1763,10 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
+    uint32_t adjusted_priority = adjustPriority(static_cast<uint32_t>(priority));
+    if (!statusOk())
+        return transaction;
+
     do {
         if (checkBackgroundSync("cannot create transactions"))
             break;
@@ -1694,7 +1818,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 dsts.push_back(de);
             } else {
                 if (subaddr_indices.empty()) {
-                    for (uint32_t index = 0; index < m_wallet->get_num_subaddresses(subaddr_account); ++index)
+                    for (uint32_t index = 0; index < numSubaddresses(subaddr_account); ++index)
                         subaddr_indices.insert(index);
                 }
             }
@@ -1707,7 +1831,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
             break;
         }
         try {
-            size_t fake_outs_count = mixin_count > 0 ? mixin_count : m_wallet->default_mixin();
+            size_t fake_outs_count = mixin_count > 0 ? mixin_count : defaultMixin();
             fake_outs_count = m_wallet->adjust_mixin(mixin_count);
 
             if (amount) {
@@ -1727,7 +1851,6 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 transaction->m_signers = tx_set.m_signers;
             }
         } catch (const tools::error::daemon_busy&) {
-            // TODO: make it translatable with "tr"?
             setStatusError(tr("daemon is busy. Please try again later."));
         } catch (const tools::error::no_connection_to_daemon&) {
             setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
@@ -1821,7 +1944,6 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             pendingTxPostProcess(transaction);
 
         } catch (const tools::error::daemon_busy&) {
-            // TODO: make it translatable with "tr"?
             setStatusError(tr("daemon is busy. Please try again later."));
         } catch (const tools::error::no_connection_to_daemon&) {
             setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
@@ -1902,16 +2024,16 @@ uint64_t WalletImpl::estimateTransactionFee(const std::vector<std::pair<std::str
     const size_t extra_size = pubkey_size + encrypted_paymentid_size;
 
     return m_wallet->estimate_fee(
-        m_wallet->use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0),
-        m_wallet->use_fork_rules(4, 0),
+        useForkRules(HF_VERSION_PER_BYTE_FEE, 0),
+        useForkRules(4, 0),
         1,
         m_wallet->get_min_ring_size() - 1,
         destinations.size() + 1,
         extra_size,
-        m_wallet->use_fork_rules(8, 0),
-        m_wallet->use_fork_rules(HF_VERSION_CLSAG, 0),
-        m_wallet->use_fork_rules(HF_VERSION_BULLETPROOF_PLUS, 0),
-        m_wallet->use_fork_rules(HF_VERSION_VIEW_TAGS, 0),
+        useForkRules(8, 0),
+        useForkRules(HF_VERSION_CLSAG, 0),
+        useForkRules(HF_VERSION_BULLETPROOF_PLUS, 0),
+        useForkRules(HF_VERSION_VIEW_TAGS, 0),
         m_wallet->get_base_fee(static_cast<uint32_t>(priority)),
         m_wallet->get_fee_quantization_mask());
 }
@@ -2234,13 +2356,15 @@ bool WalletImpl::checkReserveProof(const std::string &address, const std::string
     }
 }
 
-std::string WalletImpl::signMessage(const std::string &message, const std::string &address)
+std::string WalletImpl::signMessage(const std::string &message, const std::string &address, bool sign_with_view_key)
 {
     if (checkBackgroundSync("cannot sign message"))
         return "";
 
+    tools::wallet2::message_signature_type_t sig_type = sign_with_view_key ? tools::wallet2::sign_with_view_key : tools::wallet2::sign_with_spend_key;
+
     if (address.empty()) {
-        return m_wallet->sign(message, tools::wallet2::sign_with_spend_key);
+        return m_wallet->sign(message, sig_type);
     }
 
     cryptonote::address_parse_info info;
@@ -2254,7 +2378,7 @@ std::string WalletImpl::signMessage(const std::string &message, const std::strin
         return "";
     }
 
-    return m_wallet->sign(message, tools::wallet2::sign_with_spend_key, *index);
+    return m_wallet->sign(message, sig_type, *index);
 }
 
 bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
@@ -2529,11 +2653,11 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     // If daemon isn't synced a calculated block height will be used instead
     if (isNewWallet() && daemonSynced()) {
         LOG_PRINT_L2(__FUNCTION__ << ":New Wallet - fast refresh until " << daemonBlockChainHeight());
-        m_wallet->set_refresh_from_block_height(daemonBlockChainHeight());
+        setRefreshFromBlockHeight(daemonBlockChainHeight());
     }
 
     if (m_rebuildWalletCache)
-      LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << m_wallet->get_refresh_from_block_height());
+      LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << getRefreshFromBlockHeight());
 
     if (Utils::isAddressLocal(daemon_address)) {
         this->setTrustedDaemon(true);
@@ -2614,8 +2738,19 @@ void WalletImpl::hardForkInfo(uint8_t &version, uint64_t &earliest_height) const
 
 bool WalletImpl::useForkRules(uint8_t version, int64_t early_blocks) const 
 {
-    return m_wallet->use_fork_rules(version,early_blocks);
+    clearStatus();
+
+    try
+    {
+        return m_wallet->use_fork_rules(version, early_blocks);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to check if fork rules for version `%u` with `%d` early blocks should be used: %s")) % version % early_blocks % e.what()).str());
+    }
+    return false;
 }
+//-------------------------------------------------------------------------------------------------------------------
 
 bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ring) const
 {
@@ -2751,5 +2886,906 @@ uint64_t WalletImpl::getBytesSent()
 {
     return m_wallet->get_bytes_sent();
 }
+
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getMultisigSeed(const std::string &seed_offset) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return std::string();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        epee::wipeable_string seed;
+        if (m_wallet->get_multisig_seed(seed, seed_offset))
+            return std::string(seed.data(), seed.size());
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to get multisig seed: ")) + e.what());
+    }
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressIndex(const std::string &address) const
+{
+    clearStatus();
+
+    cryptonote::address_parse_info info;
+    std::pair<std::uint32_t, std::uint32_t> indices{0, 0};
+    if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), address))
+    {
+        setStatusError(string(tr("Failed to parse address: ") + address));
+        return indices;
+    }
+
+    auto index = m_wallet->get_subaddress_index(info.address);
+    if (!index)
+        setStatusError(string(tr("Address doesn't belong to the wallet: ") + address));
+    else
+        indices = std::make_pair((*index).major, (*index).minor);
+
+    return indices;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::freeze(const std::string &key_image)
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->freeze(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to freeze enote with key image `%s`: %s")) % key_image % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::freezeByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->freeze(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % public_key % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::thaw(const std::string &key_image)
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->thaw(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to thaw enote with key image `%s`: %s")) % key_image % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::thawByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->thaw(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % public_key % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::isFrozen(const std::string &key_image) const
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return false;
+    }
+
+    try
+    {
+        return m_wallet->frozen(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to determine if enote with key image `%s` is frozen: %s")) % key_image % e.what()).str());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::isFrozenByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return false;
+    }
+
+    try
+    {
+        return m_wallet->frozen(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to determine if enote with public key `%s` is frozen: %s")) % public_key % e.what()).str());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index)
+{
+    m_wallet->create_one_off_subaddress({account_index, address_index});
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::WalletState WalletImpl::getWalletState() const
+{
+    WalletState wallet_state{};
+
+    wallet_state.is_deprecated = m_wallet->is_deprecated();
+    wallet_state.ring_size = 16;
+    wallet_state.daemon_address = m_wallet->get_daemon_address();
+
+    return wallet_state;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string &password)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->rewrite(wallet_name, epee::wipeable_string(password.data(), password.size()));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to rewrite wallet file with wallet name `%s`: %s")) % wallet_name % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->write_watch_only_wallet(m_wallet->get_wallet_file(), epee::wipeable_string(password.data(), password.size()), new_keys_file_name);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to write watch only wallet: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental /*false*/)
+{
+    clearStatus();
+
+    // Update pool state
+    std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs_pod;
+    try
+    {
+        m_wallet->update_pool_state(process_txs_pod, refreshed, try_incremental);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to update pool state: ")) + e.what());
+        return;
+    }
+
+    if (process_txs_pod.empty())
+        return;
+
+    // Process pool state
+    try
+    {
+        m_wallet->process_pool_state(process_txs_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to process pool state: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const
+{
+    tools::wallet2::transfer_container tc;
+    m_wallet->get_transfers(tc);
+    enote_details.reserve(tc.size());
+
+    for (const auto &td : tc)
+    {
+        auto ed = std::make_unique<EnoteDetailsImpl>();
+
+        cryptonote::txout_target_v txout_v = td.m_tx.vout[td.m_internal_output_index].target;
+        if (txout_v.type() == typeid(cryptonote::txout_to_key))
+            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_key>(txout_v).key);
+        else if (txout_v.type() == typeid(cryptonote::txout_to_tagged_key))
+        {
+            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).key);
+            ed->m_view_tag = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).view_tag);
+        }
+
+        ed->m_block_height = td.m_block_height;
+        ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
+        ed->m_internal_enote_index = td.m_internal_output_index;
+        ed->m_global_enote_index = td.m_global_output_index;
+        ed->m_spent = td.m_spent;
+        ed->m_frozen = td.m_frozen;
+        ed->m_spent_height = td.m_spent_height;
+        ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
+        ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
+        ed->m_amount = td.m_amount;
+        ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol_RingCT : EnoteDetails::TxProtocol_CryptoNote;
+        ed->m_key_image_known = td.m_key_image_known;
+        ed->m_key_image_request = td.m_key_image_request;
+        ed->m_pk_index = td.m_pk_index;
+        ed->m_uses.reserve(td.m_uses.size());
+        for (auto &u : td.m_uses)
+            ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
+        ed->m_key_image_partial = td.m_key_image_partial;
+
+        enote_details.push_back(std::move(ed));
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return std::string();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&multisig_ptx);
+
+        tools::wallet2::multisig_tx_set multisig_tx_set;
+        multisig_tx_set.m_ptx = ptx_impl->m_pending_tx;
+        multisig_tx_set.m_signers = ptx_impl->m_signers;
+
+        return m_wallet->save_multisig_tx(multisig_tx_set);
+    }
+    catch (const exception &e)
+    {
+        setStatusError(string(tr("Failed to convert pending multisig tx to string: ")) + e.what());
+    }
+
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return false;
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&multisig_ptx);
+
+        tools::wallet2::multisig_tx_set multisig_tx_set;
+        multisig_tx_set.m_ptx = ptx_impl->m_pending_tx;
+        multisig_tx_set.m_signers = ptx_impl->m_signers;
+
+        return m_wallet->save_multisig_tx(multisig_tx_set, filename);
+    }
+    catch (const exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to save multisig tx to file with filename `%s`: %s")) % filename % e.what()).str());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const
+{
+    PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&ptx);
+    std::shared_ptr<tools::wallet2::signed_tx_set> signed_tx_set_out = std::make_shared<tools::wallet2::signed_tx_set>();
+    bool r = m_wallet->parse_tx_from_str(signed_tx_str, ptx_impl->m_pending_tx, /* accept_func = */ NULL, signed_tx_set_out.get(), /* do_handle_key_images = */ false);
+    if (r)
+        ptx_impl->m_tx_key_images = signed_tx_set_out->tx_key_images;
+    return r;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::insertColdKeyImages(PendingTransaction &ptx)
+{
+    m_wallet->insert_cold_key_images(dynamic_cast<PendingTransactionImpl*>(&ptx)->m_tx_key_images);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const
+{
+    clearStatus();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&exported_txs);
+        tools::wallet2::multisig_tx_set multisig_tx;
+
+        if (!m_wallet->parse_multisig_tx_from_str(multisig_tx_str, multisig_tx))
+            throw runtime_error(tr("Failed to parse multisig transaction from string."));
+
+        ptx_impl->m_pending_tx = multisig_tx.m_ptx;
+        ptx_impl->m_signers = multisig_tx.m_signers;
+
+        return true;
+    }
+    catch (const exception &e)
+    {
+        setStatusError(e.what());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->get_fee_multiplier(priority, fee_algorithm);
+    }
+    catch (const exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to get fee multiplier for priority `%u` and fee algorithm `%d`: %s")) % priority % fee_algorithm % e.what()).str());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getBaseFee() const
+{
+    return m_wallet->get_base_fee();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::adjustPriority(std::uint32_t priority)
+{
+    return m_wallet->adjust_priority(priority);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const
+{
+    clearStatus();
+
+    const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&ptx);
+
+    try
+    {
+        m_wallet->cold_tx_aux_import(ptx_impl->m_pending_tx, tx_device_aux);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import cold tx aux: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const
+{
+    clearStatus();
+
+    try
+    {
+        const PendingTransactionImpl *ptx_impl_in = dynamic_cast<const PendingTransactionImpl*>(&ptx_in);
+        PendingTransactionImpl *ptx_impl_out = dynamic_cast<PendingTransactionImpl*>(&exported_txs_out);
+        tools::wallet2::signed_tx_set signed_txs;
+        std::vector<cryptonote::address_parse_info> dsts_info;
+
+        m_wallet->cold_sign_tx(ptx_impl_in->m_pending_tx, signed_txs, dsts_info, ptx_impl_out->m_tx_device_aux);
+        ptx_impl_out->m_key_images = signed_txs.key_images;
+        ptx_impl_out->m_pending_tx = signed_txs.ptx;
+        ptx_impl_out->m_tx_key_images = signed_txs.tx_key_images;
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to cold sign tx: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::discardUnmixableEnotes()
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->discard_unmixable_outputs();
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to discard unmixable enotes: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress)
+{
+    clearStatus();
+
+    crypto::hash txid_pod;
+    if (!epee::string_tools::hex_to_pod(txid, txid_pod))
+    {
+        setStatusError(string(tr("Failed to parse tx id: ")) + txid);
+        return;
+    }
+
+    crypto::secret_key tx_key_pod;
+    if (!epee::string_tools::hex_to_pod(tx_key, tx_key_pod))
+    {
+        setStatusError(tr("Failed to parse tx key"));
+        return;
+    }
+
+    std::vector<crypto::secret_key> additional_tx_keys_pod;
+    crypto::secret_key tmp_additional_tx_key_pod;
+    additional_tx_keys_pod.reserve(additional_tx_keys.size());
+    for (std::string additional_tx_key : additional_tx_keys)
+    {
+        if (!epee::string_tools::hex_to_pod(additional_tx_key, tmp_additional_tx_key_pod))
+        {
+            setStatusError(string(tr("Failed to parse additional tx key: ")) + additional_tx_key);
+            return;
+        }
+        additional_tx_keys_pod.push_back(tmp_additional_tx_key_pod);
+    }
+
+    boost::optional<cryptonote::account_public_address> single_destination_subaddress_pod = boost::none;
+    cryptonote::address_parse_info info;
+    if (!single_destination_subaddress.empty())
+    {
+        if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), single_destination_subaddress))
+        {
+            setStatusError(string(tr("Failed to get account address from string: ")) + single_destination_subaddress);
+            return;
+        }
+        single_destination_subaddress_pod = info.address;
+    }
+
+    try
+    {
+        m_wallet->set_tx_key(txid_pod, tx_key_pod, additional_tx_keys_pod, info.address);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set tx key: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& WalletImpl::getAccountTags() const
+{
+    return m_wallet->get_account_tags();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAccountTag(const std::set<uint32_t> &account_indices, const std::string &tag)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->set_account_tag(account_indices, tag);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set account tag: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAccountTagDescription(const std::string &tag, const std::string &description)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->set_account_tag_description(tag, description);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set account tag description: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::exportEnotesToStr(bool all, std::uint32_t start, std::uint32_t count) const
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot export enotes"))
+        return "";
+    if (m_wallet->key_on_device())
+    {
+        setStatusError(string(tr("Not supported on HW wallets.")));
+        return "";
+    }
+
+    try
+    {
+        return m_wallet->export_outputs_to_str(all, start, count);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to export enotes to string: ")) + e.what());
+    }
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::size_t WalletImpl::importEnotesFromStr(const std::string &enotes_str)
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot import enotes"))
+        return 0;
+    if (m_wallet->key_on_device())
+    {
+        setStatusError(string(tr("Not supported on HW wallets.")));
+        return 0;
+    }
+
+    try
+    {
+        return m_wallet->import_outputs_from_str(enotes_str);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import enotes from string: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->get_blockchain_height_by_date(year, month, day);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to get blockchain height by date: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<std::pair<std::uint64_t, std::uint64_t>> WalletImpl::estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->estimate_backlog(fee_levels);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to estimate backlog: ")) + e.what());
+    }
+    return { std::make_pair(0, 0) };
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable /* = false */) const
+{
+    return m_wallet->save_to_file(path_to_file, binary, is_printable);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size /* = 1000000000 */) const
+{
+    return m_wallet->load_from_file(path_to_file, target_str, max_size);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::hashEnotes(std::uint64_t enote_idx, std::string &hash) const
+{
+    clearStatus();
+
+    try
+    {
+        crypto::hash hash_pod;
+        boost::optional<std::uint64_t> idx = enote_idx == 0 ? boost::none : boost::optional<std::uint64_t>(enote_idx);
+        std::uint64_t current_height = m_wallet->hash_m_transfers(idx, hash_pod);
+        hash = epee::string_tools::pod_to_hex(hash_pod);
+        return current_height;
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to hash enotes: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash)
+{
+    clearStatus();
+
+    try
+    {
+        crypto::hash hash_pod;
+        if (!epee::string_tools::hex_to_pod(hash, hash_pod))
+            setStatusError(tr("Failed to parse hash"));
+        else
+            m_wallet->finish_rescan_bc_keep_key_images(enote_idx, hash_pod);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to finish rescan blockchain: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> WalletImpl::getPublicNodes(bool white_only /* = true */) const
+{
+    clearStatus();
+
+    std::vector<cryptonote::public_node> public_nodes;
+    std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> public_nodes_out;
+    try
+    {
+        public_nodes = m_wallet->get_public_nodes(white_only);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to get public nodes: ")) + e.what());
+        return std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>>{};
+    }
+
+    for (auto pub_node : public_nodes)
+        public_nodes_out.push_back(std::tuple<std::string, std::uint16_t, std::uint64_t>{pub_node.host, pub_node.rpc_port, pub_node.last_seen});
+
+    return public_nodes_out;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::size_t, std::uint64_t> WalletImpl::estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->estimate_tx_size_and_weight(use_rct, n_inputs, ring_size, n_outputs, extra_size);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to estimate transaction size and weight: ")) + e.what());
+    }
+    return std::make_pair(0, 0);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent)
+{
+    clearStatus();
+
+    std::vector<std::pair<crypto::key_image, crypto::signature>> signed_key_images_pod;
+    crypto::key_image tmp_key_image_pod;
+    crypto::signature tmp_signature_pod{};
+    size_t sig_size = sizeof(crypto::signature);
+
+    signed_key_images_pod.reserve(signed_key_images.size());
+
+    for (auto ski : signed_key_images)
+    {
+        if (!epee::string_tools::hex_to_pod(ski.first, tmp_key_image_pod))
+        {
+            setStatusError(string(tr("Failed to parse key image: ")) + ski.first);
+            return false;
+        }
+        if (!epee::string_tools::hex_to_pod(ski.second.substr(0, sig_size/2), tmp_signature_pod.c))
+        {
+            setStatusError(string(tr("Failed to parse signature.c: ")) + ski.second.substr(0, sig_size/2));
+            return false;
+        }
+        if (!epee::string_tools::hex_to_pod(ski.second.substr(sig_size/2, sig_size), tmp_signature_pod.r))
+        {
+            setStatusError(string(tr("Failed to parse signature.r: ")) + ski.second.substr(sig_size/2, sig_size));
+            return false;
+        }
+        signed_key_images_pod.push_back(std::make_pair(tmp_key_image_pod, tmp_signature_pod));
+    }
+
+    try
+    {
+        return m_wallet->import_key_images(signed_key_images_pod, offset, spent, unspent, check_spent);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::importKeyImages(const std::vector<std::string> &key_images, std::size_t offset, const std::unordered_set<std::size_t> &selected_enotes_indices)
+{
+    clearStatus();
+
+    std::vector<crypto::key_image> key_images_pod;
+    crypto::key_image tmp_key_image_pod;
+    key_images_pod.reserve(key_images.size());
+    for (std::string key_image : key_images)
+    {
+        if (!epee::string_tools::hex_to_pod(key_image, tmp_key_image_pod))
+        {
+            setStatusError(string(tr("Failed to parse key image: ")) + key_image);
+            return false;
+        }
+        key_images_pod.push_back(tmp_key_image_pod);
+    }
+
+    try
+    {
+        boost::optional<std::unordered_set<std::size_t>> optional_selected_enote_indices = selected_enotes_indices.empty() ? boost::none : boost::optional<std::unordered_set<std::size_t>>(selected_enotes_indices);
+        return m_wallet->import_key_images(key_images_pod, offset, optional_selected_enote_indices);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAllowMismatchedDaemonVersion() const
+{
+    return m_wallet->is_mismatched_daemon_version_allowed();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAllowMismatchedDaemonVersion(bool allow_mismatch)
+{
+    m_wallet->allow_mismatched_daemon_version(allow_mismatch);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::setDaemon(const std::string &daemon_address,
+        const std::string &daemon_username /* = "" */,
+        const std::string &daemon_password /* = "" */,
+        bool trusted_daemon /* = false */,
+        const std::string &ssl_support /* = "autodetect" */,
+        const std::string &ssl_private_key_path /* = "" */,
+        const std::string &ssl_certificate_path /* = "" */,
+        const std::string &ssl_ca_file_path /* = "" */,
+        const std::vector<std::string> &ssl_allowed_fingerprints_str /* = {} */,
+        bool ssl_allow_any_cert /* = false */,
+        const std::string &proxy /* = "" */)
+{
+    clearStatus();
+
+    // SSL allowed fingerprints
+    std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
+    ssl_allowed_fingerprints.reserve(ssl_allowed_fingerprints_str.size());
+    for (const std::string &fp: ssl_allowed_fingerprints_str)
+    {
+        ssl_allowed_fingerprints.push_back({});
+        std::vector<uint8_t> &v = ssl_allowed_fingerprints.back();
+        for (auto c: fp)
+            v.push_back(c);
+    }
+
+    // SSL options
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    if (ssl_allow_any_cert)
+        ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+    else if (!ssl_allowed_fingerprints.empty() || !ssl_ca_file_path.empty())
+        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)};
+
+    if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support))
+    {
+        setStatusError(string(tr("Invalid ssl support option (allowed options:`disabled` | `enabled` | `autodetect`), actual value: ")) + ssl_support);
+        return false;
+    }
+
+    ssl_options.auth = epee::net_utils::ssl_authentication_t{
+        std::move(ssl_private_key_path), std::move(ssl_certificate_path)
+    };
+
+    const bool verification_required =
+        ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+        ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+
+    if (verification_required && !ssl_options.has_strong_verification(boost::string_ref{}))
+    {
+        setStatusError(string(tr("SSL is enabled but no user certificate or fingerprints were provided")));
+        return false;
+    }
+
+    // daemon login
+    if(daemon_username != "")
+        m_daemon_login.emplace(daemon_username, daemon_password);
+
+    // set daemon
+    try
+    {
+        return m_wallet->set_daemon(daemon_address, m_daemon_login, trusted_daemon, ssl_options, proxy);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set daemon: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------------------------
+// PRIVATE
+//-------------------------------------------------------------------------------------------------------------------
+std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
+{
+    std::vector<std::unique_ptr<EnoteDetails>> enote_details;
+    getEnoteDetails(enote_details);
+    for (size_t idx = 0; idx < enote_details.size(); ++idx)
+    {
+        const auto &ed = dynamic_cast<EnoteDetailsImpl &>(*enote_details[idx].get());
+        if (ed.m_key_image == key_image)
+        {
+            if (ed.m_key_image_known)
+                return idx;
+            else if (ed.m_key_image_partial)
+            {
+                setStatusError("Failed to get enote index by key image: Enote detail lookups are not allowed for multisig partial key images");
+                return 0;
+            }
+        }
+    }
+
+    setStatusError("Failed to get enote index by key image: Key image not found");
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::statusOk() const
+{
+    boost::lock_guard<boost::mutex> l(m_statusMutex);
+    return m_status == Status_Ok;
+}
+//-------------------------------------------------------------------------------------------------------------------
+
 
 } // namespace

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -43,12 +43,14 @@
 #include "subaddress.h"
 #include "subaddress_account.h"
 #include "common_defines.h"
+#include "common/notify.h"
 #include "common/util.h"
 #include "multisig/multisig_account.h"
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
 #include "wallet/fee_priority.h"
+#include "wallet/wallet_errors.h"
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -571,6 +573,7 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
+        m_password = password;
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -661,7 +664,8 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
                                  const std::string &language,
                                  const std::string &address_string,
                                  const std::string &viewkey_string,
-                                 const std::string &spendkey_string)
+                                 const std::string &spendkey_string /* = "" */,
+                                 const bool create_address_file /* = false */)
 {
     cryptonote::address_parse_info info;
     if(!get_account_address_from_str(info, m_wallet->nettype(), address_string))
@@ -731,15 +735,15 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
     try
     {
         if (has_spendkey && has_viewkey) {
-            m_wallet->generate(path, password, info.address, spendkey, viewkey);
+            m_wallet->generate(path, password, info.address, spendkey, viewkey, create_address_file);
             LOG_PRINT_L1("Generated new wallet from spend key and view key");
         }
         if(!has_spendkey && has_viewkey) {
-            m_wallet->generate(path, password, info.address, viewkey);
+            m_wallet->generate(path, password, info.address, viewkey, create_address_file);
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         if(has_spendkey && !has_viewkey) {
-           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false);
+           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false, create_address_file);
            setSeedLanguage(language);
            if (!statusOk())
                return false;
@@ -819,14 +823,14 @@ bool WalletImpl::recoverFromMultisigSeed(const std::string &path,
     return true;
 }
 
-bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &password, const std::string &device_name)
+bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &password, const std::string &device_name, const bool create_address_file /* = false */)
 {
     clearStatus();
     m_recoveringFromSeed = false;
     m_recoveringFromDevice = true;
     try
     {
-        m_wallet->restore(path, password, device_name);
+        m_wallet->restore(path, password, device_name, create_address_file);
         LOG_PRINT_L1("Generated new wallet from device: " + device_name);
     }
     catch (const std::exception& e) {
@@ -873,7 +877,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
     return recover(path, "", seed);
 }
 
-bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/)
+bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/, const bool create_address_file /* false */)
 {
     clearStatus();
     m_errorString.clear();
@@ -903,7 +907,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         setSeedLanguage(old_language);
         if (!statusOk())
             return false;
-        m_wallet->generate(path, password, recovery_key, true, false);
+        m_wallet->generate(path, password, recovery_key, /*recover*/ true, /*non_deterministic*/ false, create_address_file);
         m_password = password;
 
     } catch (const std::exception &e) {
@@ -962,10 +966,12 @@ std::string WalletImpl::errorString() const
     return m_errorString;
 }
 
-void WalletImpl::statusWithErrorString(int& status, std::string& errorString) const {
+void WalletImpl::statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut /* = nullptr */) const {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     status = m_status;
     errorString = m_errorString;
+    if (extendedStatusOut)
+        *extendedStatusOut = m_extendedStatus;
 }
 
 bool WalletImpl::setPassword(const std::string &password)
@@ -1114,26 +1120,27 @@ void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
-uint64_t WalletImpl::balance(uint32_t accountIndex) const
+uint64_t WalletImpl::balance(uint32_t accountIndex, bool is_strict /* = false */) const
 {
-    return m_wallet->balance(accountIndex, false);
+    return m_wallet->balance(accountIndex, is_strict);
 }
 
-std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */, bool is_strict /* = false */) const
 {
-    return m_wallet->balance_per_subaddress(accountIndex, false);
+    return m_wallet->balance_per_subaddress(accountIndex, is_strict);
 }
 
 uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex /* = 0 */,
                                      uint64_t *blocks_to_unlock /* = NULL */,
-                                     uint64_t *time_to_unlock /* = NULL */) const
+                                     uint64_t *time_to_unlock /* = NULL */,
+                                     bool is_strict /* = false */) const
 {
-    return m_wallet->unlocked_balance(accountIndex, false, blocks_to_unlock, time_to_unlock);
+    return m_wallet->unlocked_balance(accountIndex, is_strict, blocks_to_unlock, time_to_unlock);
 }
 
-std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */, bool is_strict /* = false */) const
 {
-    return m_wallet->unlocked_balance_per_subaddress(accountIndex, false);
+    return m_wallet->unlocked_balance_per_subaddress(accountIndex, is_strict);
 }
 
 uint64_t WalletImpl::blockChainHeight() const
@@ -1202,12 +1209,13 @@ bool WalletImpl::refresh(std::uint64_t start_height /* = 0 */,
                          bool check_pool /* = true */,
                          bool try_incremental /* = false */,
                          std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                         bool skip_refresh_if_daemon_not_synced /* = true */,
                          std::uint64_t *blocks_fetched_out /* = nullptr */,
                          bool *received_money_out /* = nullptr */)
 {
     clearStatus();
     bool did_error_occur;
-    doRefresh(start_height, check_pool, try_incremental, max_blocks, &did_error_occur, blocks_fetched_out, received_money_out);
+    doRefresh(start_height, check_pool, try_incremental, max_blocks, skip_refresh_if_daemon_not_synced, &did_error_occur, blocks_fetched_out, received_money_out);
     return !did_error_occur;
 }
 
@@ -1370,6 +1378,35 @@ std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
         return "";
     }
     return "";
+}
+
+void WalletImpl::exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out)
+{
+    clearStatus();
+    if (watchOnly())
+    {
+        setStatusError(tr("Wallet is view only"));
+        return;
+    }
+    if (checkBackgroundSync("cannot export key images"))
+        return;
+
+    try
+    {
+        auto ski = m_wallet->export_key_images(all);
+        offset_out = ski.first;
+        key_images_and_signatures_out.resize(ski.second.size());
+        for (size_t i = 0; i < ski.second.size(); ++i)
+        {
+            key_images_and_signatures_out[i].first = epee::string_tools::pod_to_hex(ski.second[i].first);
+            key_images_and_signatures_out[i].second = epee::string_tools::pod_to_hex(ski.second[i].second);
+        }
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error exporting key images: " << e.what());
+        setStatusError(e.what());
+    }
 }
 
 bool WalletImpl::importKeyImages(const std::string &filename, std::uint64_t *spent_out /* = nullptr */, std::uint64_t *unspent_out /* = nullptr */, std::uint64_t *import_height /* = nullptr */)
@@ -1600,13 +1637,27 @@ bool WalletImpl::startBackgroundSync()
     return true;
 }
 
-bool WalletImpl::stopBackgroundSync(const std::string &wallet_password)
+bool WalletImpl::stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key /* = nullptr */)
 {
     try
     {
         PRE_VALIDATE_BACKGROUND_SYNC();
         LOCK_REFRESH();
-        m_wallet->stop_background_sync(epee::wipeable_string(wallet_password));
+        crypto::secret_key spendkey = crypto::null_skey;
+        if (spend_secret_key) {
+            cryptonote::blobdata spendkey_data;
+            std::string tmp_spend_key = std::string(spend_secret_key->data(), spend_secret_key->size());
+            const epee::scope_guard ssk_scope_exit_handler([&](){
+                memwipe(&tmp_spend_key[0], tmp_spend_key.size());
+            });
+            if(!epee::string_tools::parse_hexstr_to_binbuff(tmp_spend_key, spendkey_data) || spendkey_data.size() != sizeof(crypto::secret_key))
+            {
+                setStatusError(tr("failed to parse secret spend key"));
+                return false;
+            }
+            spendkey = *reinterpret_cast<const crypto::secret_key*>(spendkey_data.data());
+        }
+        m_wallet->stop_background_sync(epee::wipeable_string(wallet_password), spendkey);
     }
     catch (const std::exception &e)
     {
@@ -1621,7 +1672,15 @@ void WalletImpl::addSubaddressAccount(const std::string& label)
 {
     if (checkBackgroundSync("cannot add account"))
         return;
-    m_wallet->add_subaddress_account(label);
+    try
+    {
+        m_wallet->add_subaddress_account(label);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error adding subaddress account: " << e.what());
+        setStatusError(string(tr("Failed to add subaddress account: ")) + e.what());
+    }
 }
 size_t WalletImpl::numSubaddressAccounts() const
 {
@@ -1635,7 +1694,21 @@ void WalletImpl::addSubaddress(uint32_t accountIndex, const std::string& label)
 {
     if (checkBackgroundSync("cannot add subaddress"))
         return;
-    m_wallet->add_subaddress(accountIndex, label);
+    try
+    {
+        m_wallet->add_subaddress(accountIndex, label);
+    }
+    catch (const tools::error::account_index_outofbound &e)
+    {
+        LOG_ERROR("Error adding subaddress: " << e.what());
+        int extended_error = ExtendedStatus_AccountIndexOutOfBounds;
+        setStatusError(string(tr("Failed to add subaddress: ")) + e.what(), &extended_error);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error adding subaddress: " << e.what());
+        setStatusError(string(tr("Failed to add subaddress: ")) + e.what());
+    }
 }
 std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const
 {
@@ -1963,9 +2036,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 transaction->m_signers = tx_set.m_signers;
             }
         } catch (const tools::error::daemon_busy&) {
-            setStatusError(tr("daemon is busy. Please try again later."));
+            int extended_error = ExtendedStatus_DaemonIsBusy;
+            setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         } catch (const tools::error::no_connection_to_daemon&) {
-            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+            int extended_error = ExtendedStatus_NoDaemonConnection;
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         } catch (const tools::error::wallet_rpc_error& e) {
             setStatusError(tr("RPC error: ") +  e.to_string());
         } catch (const tools::error::get_outs_error &e) {
@@ -1976,14 +2051,16 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
             writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughUnlockedMoney;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::not_enough_money& e) {
             std::ostringstream writer;
 
             writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughMoney;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::tx_not_possible& e) {
             std::ostringstream writer;
 
@@ -1992,7 +2069,8 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                       print_money(e.tx_amount() + e.fee())  %
                       print_money(e.tx_amount()) %
                       print_money(e.fee());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_TxNotPossible;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::not_enough_outs_to_mix& e) {
             std::ostringstream writer;
             writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
@@ -2000,7 +2078,8 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
             }
             writer << "\n" << tr("Please sweep unmixable outputs.");
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughOutsToMix;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::tx_not_constructed&) {
             setStatusError(tr("transaction was not constructed"));
         } catch (const tools::error::tx_rejected& e) {
@@ -2010,9 +2089,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         } catch (const tools::error::tx_sum_overflow& e) {
             setStatusError(e.what());
         } catch (const tools::error::zero_amount&) {
-            setStatusError(tr("destination amount is zero"));
+            int extended_error = ExtendedStatus_ZeroAmount;
+            setStatusError(tr("destination amount is zero"), &extended_error);
         } catch (const tools::error::zero_destination&) {
-            setStatusError(tr("transaction has no destination"));
+            int extended_error = ExtendedStatus_ZeroDestination;
+            setStatusError(tr("transaction has no destination"), &extended_error);
         } catch (const tools::error::tx_too_big& e) {
             setStatusError(tr("failed to find a suitable way to split transactions"));
         } catch (const tools::error::transfer_error& e) {
@@ -2059,9 +2140,11 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             pendingTxPostProcess(transaction);
 
         } catch (const tools::error::daemon_busy&) {
-            setStatusError(tr("daemon is busy. Please try again later."));
+            int extended_error = ExtendedStatus_DaemonIsBusy;
+            setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         } catch (const tools::error::no_connection_to_daemon&) {
-            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+            int extended_error = ExtendedStatus_NoDaemonConnection;
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         } catch (const tools::error::wallet_rpc_error& e) {
             setStatusError(tr("RPC error: ") +  e.to_string());
         } catch (const tools::error::get_outs_error&) {
@@ -2506,7 +2589,8 @@ bool WalletImpl::verifySignedMessage(const std::string &message,
                                      const std::string &address,
                                      const std::string &signature,
                                      bool *is_old_out /* = nullptr */,
-                                     std::string *signature_type_out /* = nullptr */) const
+                                     std::string *signature_type_out /* = nullptr */,
+                                     unsigned *version_out /* = nullptr */) const
 {
   cryptonote::address_parse_info info;
 
@@ -2517,8 +2601,10 @@ bool WalletImpl::verifySignedMessage(const std::string &message,
       *is_old_out = result.old;
   if (signature_type_out)
       *signature_type_out = (result.type == tools::wallet2::sign_with_spend_key
-                        ? "spend key" : result.type == tools::wallet2::sign_with_view_key
-                        ? "view key" : "unknown key combination (suspicious)");
+                        ? "spend" : result.type == tools::wallet2::sign_with_view_key
+                        ? "view" : "invalid");
+  if (version_out)
+      *version_out = result.version;
   return result.valid;
 }
 
@@ -2639,11 +2725,12 @@ void WalletImpl::clearStatus() const
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     m_status = Status_Ok;
     m_errorString.clear();
+    m_extendedStatus = ExtendedStatus_Ok;
 }
 
-void WalletImpl::setStatusError(const std::string& message) const
+void WalletImpl::setStatusError(const std::string& message, const int* extended_status /* = nullptr */) const
 {
-    setStatus(Status_Error, message);
+    setStatus(Status_Error, message, extended_status);
 }
 
 void WalletImpl::setStatusCritical(const std::string& message) const
@@ -2651,11 +2738,13 @@ void WalletImpl::setStatusCritical(const std::string& message) const
     setStatus(Status_Critical, message);
 }
 
-void WalletImpl::setStatus(int status, const std::string& message) const
+void WalletImpl::setStatus(int status, const std::string& message, const int* extended_status /* = nullptr */) const
 {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     m_status = status;
     m_errorString = message;
+    if (extended_status)
+        m_extendedStatus = *extended_status;
 }
 
 void WalletImpl::refreshThreadFunc()
@@ -2693,6 +2782,7 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
                            bool check_pool /* = true */,
                            bool try_incremental /* = false */,
                            std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                           bool skip_refresh_if_daemon_not_synced /* = true */,
                            bool *error_out /* = nullptr */,
                            std::uint64_t *blocks_fetched_out /* = nullptr */,
                            bool *received_money_out /* = nullptr */)
@@ -2706,7 +2796,7 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
         LOG_PRINT_L3(__FUNCTION__ << ": doRefresh, rescan = "<<rescan);
         // Syncing daemon and refreshing wallet simultaneously is very resource intensive.
         // Disable refresh if wallet is disconnected or daemon isn't synced.
-        if (daemonSynced()) {
+        if (!skip_refresh_if_daemon_not_synced || daemonSynced()) {
             if(rescan)
                 m_wallet->rescan_blockchain(m_do_hard_rescan, /* refresh */ false, m_do_keep_key_images_on_rescan);
             std::uint64_t blocks_fetched_ignored;
@@ -2729,10 +2819,12 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
            LOG_PRINT_L3(__FUNCTION__ << ": skipping refresh - daemon is not synced");
         }
     } catch (const tools::error::daemon_busy&) {
-        setStatusError(tr("daemon is busy. Please try again later."));
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         break;
     } catch (const tools::error::no_connection_to_daemon&) {
-        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        int extended_error = ExtendedStatus_NoDaemonConnection;
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         break;
     } catch (const tools::error::deprecated_rpc_access&) {
         setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
@@ -2836,9 +2928,16 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
     // If daemon isn't synced a calculated block height will be used instead
+    // TODO : We need to do something about setting the restore height here.
+    //        Currently I witnessed two issues with this:
+    //          1. When setting a restore height on wallet creation under certain conditions this can overwrite the set restore height to a higher height which leads to missing enotes when scanning. (Discovered during debugging failing functional_test multisig.py for the wallet-rpc based on the Wallet API. The tests pass with setRefreshFromBlockHeight() below commented out.)
+    //          2. Similar, when creating a wallet offline, let's say you open it for example 3 months later, the code-block below will cause the restore height to be set to the current blockchain height at that time. So there would be 3 months worth of blocks where you could have received enotes which do not get scanned.
+    // PROPOSAL : Remove this entire block and rely on the restore height
+    //          1. provided when restoring a wallet with `recoveryWallet()`, `createWalletFromKeys()`, `createWalletFromMultisigSeed()`, `createWalletFromDevice()` (all these get the restore height by argument) and `createWalletFromJson()` (gets restore height from .json file)
+    //          2. estimated when creating a wallet with `createWallet()` (calls `wallet2::generate()` which uses `wallet2::estimate_blockchain_height()` to set the initial restore height ([src](https://github.com/monero-project/monero/blob/abe4eb60ea62f357bd71efc9037dbbc021cd6271/src/wallet/wallet2.cpp#L5732))) and let Wallet API users decide under which conditions they want to `setRrefreshFromBlockHeight()`
     if (isNewWallet() && daemonSynced()) {
         LOG_PRINT_L2(__FUNCTION__ << ":New Wallet - fast refresh until " << daemonBlockChainHeight());
-        setRefreshFromBlockHeight(daemonBlockChainHeight());
+//        setRefreshFromBlockHeight(daemonBlockChainHeight());
     }
 
     if (m_rebuildWalletCache)
@@ -2901,12 +3000,14 @@ bool WalletImpl::rescanSpent()
     }
     catch (const tools::error::daemon_busy&)
     {
-        setStatusError(tr("daemon is busy. Please try again later."));
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         return false;
     }
     catch (const tools::error::no_connection_to_daemon&)
     {
-        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        int extended_error = ExtendedStatus_NoDaemonConnection;
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         return false;
     }
     catch (const tools::error::deprecated_rpc_access&)
@@ -3288,6 +3389,7 @@ Wallet::WalletState WalletImpl::getWalletState() const
     wallet_state.is_deprecated  = m_wallet->is_deprecated();
     wallet_state.is_unattended  = m_wallet->is_unattended();
     wallet_state.daemon_address = m_wallet->get_daemon_address();
+    wallet_state.has_proxy_flag = m_wallet->has_proxy_option();
     wallet_state.ring_database  = m_wallet->get_ring_database();
     wallet_state.n_enotes       = m_wallet->get_num_transfer_details();
 
@@ -3350,6 +3452,12 @@ void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental 
     try
     {
         m_wallet->update_pool_state(process_txs_pod, refreshed, try_incremental);
+    }
+    catch (const tools::error::daemon_busy&)
+    {
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(string(tr("Failed to update pool state: daemon is busy")), &extended_error);
+        return;
     }
     catch (const std::exception &e)
     {
@@ -3561,6 +3669,26 @@ PendingTransaction* WalletImpl::parseMultisigTxFromStr(const std::string &multis
     }
 
     return ptx.release();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<PendingTransaction> WalletImpl::deserializePtxFromBlobStr(const std::string &tx_blob)
+{
+    clearStatus();
+
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
+    try
+    {
+      ptx->m_pending_tx.push_back({});
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(tx_blob)};
+      if (!::serialization::serialize(ar, ptx->m_pending_tx[0]))
+          throw runtime_error("Failed to parse tx metadata");
+        m_status = Status_Error;
+    }
+    catch(const exception &e) {
+        setStatusError(e.what());
+        return nullptr;
+    }
+    return ptx;
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
@@ -3882,7 +4010,6 @@ std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::strin
     std::vector<std::pair<crypto::key_image, crypto::signature>> signed_key_images_pod;
     crypto::key_image tmp_key_image_pod;
     crypto::signature tmp_signature_pod{};
-    size_t sig_size = sizeof(crypto::signature);
 
     signed_key_images_pod.reserve(signed_key_images.size());
 
@@ -3893,14 +4020,9 @@ std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::strin
             setStatusError(string(tr("Failed to parse key image: ")) + ski.first);
             return false;
         }
-        if (!epee::string_tools::hex_to_pod(ski.second.substr(0, sig_size/2), tmp_signature_pod.c))
+        if (!epee::string_tools::hex_to_pod(ski.second, tmp_signature_pod))
         {
-            setStatusError(string(tr("Failed to parse signature.c: ")) + ski.second.substr(0, sig_size/2));
-            return false;
-        }
-        if (!epee::string_tools::hex_to_pod(ski.second.substr(sig_size/2, sig_size), tmp_signature_pod.r))
-        {
-            setStatusError(string(tr("Failed to parse signature.r: ")) + ski.second.substr(sig_size/2, sig_size));
+            setStatusError(string(tr("Failed to parse signature: ")) + ski.second);
             return false;
         }
         signed_key_images_pod.push_back(std::make_pair(tmp_key_image_pod, tmp_signature_pod));
@@ -4117,6 +4239,11 @@ void WalletImpl::setExplicitRefreshFromBlockHeight(bool do_explicit_refresh)
     m_wallet->explicit_refresh_from_block_height(do_explicit_refresh);
 }
 //-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTxNotify(const std::string &tx_notify)
+{
+    m_wallet->set_tx_notify(std::shared_ptr<tools::Notify>(new tools::Notify(tx_notify.c_str())));
+}
+//-------------------------------------------------------------------------------------------------------------------
 // Wallet Settings getter/setter
 //-------------------------------------------------------------------------------------------------------------------
 std::string WalletImpl::getSeedLanguage() const
@@ -4129,7 +4256,7 @@ void WalletImpl::setSeedLanguage(const std::string &arg)
     if (checkBackgroundSync("cannot set seed language"))
         return;
 
-    if (crypto::ElectrumWords::is_valid_language(arg))
+    if (arg.empty() || crypto::ElectrumWords::is_valid_language(arg))
         m_wallet->set_seed_language(arg);
     else
         setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
@@ -4324,7 +4451,13 @@ std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressLookahead() con
 //-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
 {
-    m_wallet->set_subaddress_lookahead(major, minor);
+    clearStatus();
+    try {
+        m_wallet->set_subaddress_lookahead(major, minor);
+    }
+    catch (const std::exception &e) {
+        setStatusError((boost::format(tr("failed to set subaddresss lookahead: %s")) % e.what()).str());
+    }
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getSegregationHeight() const
@@ -4494,6 +4627,192 @@ bool WalletImpl::statusOk() const
 {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     return m_status == Status_Ok;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<TransactionDescription> WalletImpl::getTxDescription(const std::vector<tools::wallet2::tx_construction_data> &cds, int &error_code_out, std::string &error_msg_out) const
+{
+    error_code_out = Status_Ok;
+    error_msg_out = "";
+
+    std::unique_ptr<TransactionDescription> tx_desc{new TransactionDescription{}};
+    TxSummary &tx_sum = tx_desc->tx_summary;
+    // init summary
+    tx_sum = TxSummary{
+        /* amount_in */ 0,
+        /* amount_out */ 0,
+        /* recipients */ {},
+        /* change_amount */ 0,
+        /* change_address */ "",
+        /* fee */ 0
+    };
+
+    try
+    {
+        std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> tx_dests;
+        std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> all_dests;
+        int first_known_non_zero_change_index = -1;
+
+        // construction data per tx
+        for (size_t n = 0; n < cds.size(); ++n)
+        {
+            const tools::wallet2::tx_construction_data &cd = cds[n];
+            // init construction data entry
+            tx_desc->tx_descriptions.push_back({
+                /* amount_in */ 0,
+                /* amount_out */ 0,
+                /* ring_size */ numeric_limits<std::uint32_t>::max(),
+                /* unlock_time */ 0,
+                /* sources */ {},
+                /* recipients */ {},
+                /* payment_id */ "",
+                /* change_amount */ 0,
+                /* change_address */ "",
+                /* fee */ 0,
+                /* dummy_outputs */ 0,
+                /* extra */ ""}
+            );
+            TxDescriptionSingle &desc = tx_desc->tx_descriptions.back();
+
+            // Clear the recipients collection ready for this loop iteration
+            tx_dests.clear();
+
+            // get payment id from tx extra
+            std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+            bool has_encrypted_payment_id = false;
+            crypto::hash8 payment_id8 = crypto::null_hash8;
+            if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+            {
+                cryptonote::tx_extra_nonce extra_nonce;
+                if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+                {
+                    crypto::hash payment_id;
+                    if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                    {
+                        if (payment_id8 != crypto::null_hash8)
+                        {
+                            desc.payment_id = epee::string_tools::pod_to_hex(payment_id8);
+                            has_encrypted_payment_id = true;
+                        }
+                    }
+                    else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                    {
+                        desc.payment_id = epee::string_tools::pod_to_hex(payment_id);
+                    }
+                }
+            }
+
+            // fill sources
+            for (size_t s = 0; s < cd.sources.size(); ++s)
+            {
+                const cryptonote::tx_source_entry &src_in = cd.sources[s];
+                TxSource &src_out = desc.sources.emplace_back();
+                src_out.amount = src_in.amount;
+                src_out.global_index = src_in.outputs.at(src_in.real_output_in_tx_index).first;
+                src_out.rct = src_in.rct;
+                src_out.pubkey = epee::string_tools::pod_to_hex(src_in.outputs.at(src_in.real_output_in_tx_index).second);
+                desc.amount_in += src_in.amount;
+                size_t ring_size = src_in.outputs.size();
+                if (ring_size < desc.ring_size)
+                    desc.ring_size = ring_size;
+            }
+
+            // fill destinations
+            for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
+            {
+                const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+                std::string address = cryptonote::get_account_address_as_str(static_cast<cryptonote::network_type>(nettype()), entry.is_subaddress, entry.addr);
+                if (has_encrypted_payment_id && !entry.is_subaddress && address != entry.original)
+                    address = cryptonote::get_account_integrated_address_as_str(static_cast<cryptonote::network_type>(nettype()), entry.addr, payment_id8);
+                auto i = tx_dests.find(entry.addr);
+                if (i == tx_dests.end())
+                    tx_dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+                else
+                    i->second.second += entry.amount;
+                desc.amount_out += entry.amount;
+            }
+
+            // handle change amount
+            if (cd.change_dts.amount > 0)
+            {
+                auto it = tx_dests.find(cd.change_dts.addr);
+                if (it == tx_dests.end())
+                {
+                    error_code_out = Status_Error;
+                    error_msg_out = "Claimed change does not go to a paid address";
+                    return nullptr;
+                }
+                if (it->second.second < cd.change_dts.amount)
+                {
+                    error_code_out = Status_Error;
+                    error_msg_out = "Claimed change is larger than payment to the change address";
+                    return nullptr;
+                }
+                if (cd.change_dts.amount > 0)
+                {
+                    if (first_known_non_zero_change_index == -1)
+                        first_known_non_zero_change_index = n;
+                    const tools::wallet2::tx_construction_data &cdn = cds[first_known_non_zero_change_index];
+                    if (memcmp(&cd.change_dts.addr, &cdn.change_dts.addr, sizeof(cd.change_dts.addr)))
+                    {
+                        error_code_out = Status_Error;
+                        error_msg_out = "Change goes to more than one address";
+                        return nullptr;
+                    }
+                }
+                desc.change_amount += cd.change_dts.amount;
+                it->second.second -= cd.change_dts.amount;
+                if (it->second.second == 0)
+                    tx_dests.erase(cd.change_dts.addr);
+            }
+
+            // separate dummy outputs from real outputs
+            for (auto i = tx_dests.begin(); i != tx_dests.end(); ++i)
+            {
+                if (i->second.second > 0)
+                {
+                    desc.recipients.push_back({i->second.first, i->second.second});
+                    auto it_in_all = all_dests.find(i->first);
+                    if (it_in_all == all_dests.end())
+                        all_dests.insert(std::make_pair(i->first, i->second));
+                    else
+                        it_in_all->second.second += i->second.second;
+                }
+                else
+                    ++desc.dummy_outputs;
+            }
+
+            // set change address
+            if (desc.change_amount > 0)
+            {
+                const tools::wallet2::tx_construction_data &cd0 = cds[0];
+                desc.change_address = get_account_address_as_str(static_cast<cryptonote::network_type>(nettype()), cd0.subaddr_account > 0, cd0.change_dts.addr);
+                tx_sum.change_address = desc.change_address;
+            }
+
+            desc.fee = desc.amount_in - desc.amount_out;
+            desc.unlock_time = cd.unlock_time;
+            desc.extra = epee::to_hex::string({cd.extra.data(), cd.extra.size()});
+
+            // Update summary items
+            tx_sum.amount_in += desc.amount_in;
+            tx_sum.amount_out += desc.amount_out;
+            tx_sum.change_amount += desc.change_amount;
+            tx_sum.fee += desc.fee;
+        }
+
+        // Populate the summary recipients list
+        for (auto i = all_dests.begin(); i != all_dests.end(); ++i)
+        {
+            tx_sum.recipients.push_back({i->second.first, i->second.second});
+        }
+    }
+    catch (const std::exception &e)
+    {
+        error_code_out = Status_Error;
+        error_msg_out = "failed to describe transfer";
+        return nullptr;
+    }
+    return tx_desc;
 }
 //-------------------------------------------------------------------------------------------------------------------
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 
+#include "device/device.hpp"
 #include "wallet.h"
 #include "device/device.hpp"
 #include "crypto/crypto.h"
@@ -573,7 +574,6 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
-        m_password = password;
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -755,7 +755,6 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
-    m_password = password;
     m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
     return true;
 }
@@ -837,7 +836,6 @@ bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &p
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
-    m_password = password;
     return true;
 }
 
@@ -862,9 +860,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
             m_rebuildWalletCache = true;
         }
         m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
-        m_wallet->load(path, password);
-
-        m_password = password;
+        m_wallet->load(path, epee::wipeable_string(password));
     } catch (const std::exception &e) {
         LOG_ERROR("Error opening wallet: " << e.what());
         setStatusCritical(e.what());
@@ -908,7 +904,6 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         if (!statusOk())
             return false;
         m_wallet->generate(path, password, recovery_key, /*recover*/ true, /*non_deterministic*/ false, create_address_file);
-        m_password = password;
 
     } catch (const std::exception &e) {
         setStatusCritical(e.what());
@@ -974,23 +969,19 @@ void WalletImpl::statusWithErrorString(int& status, std::string& errorString, in
         *extendedStatusOut = m_extendedStatus;
 }
 
-bool WalletImpl::setPassword(const std::string &password)
+bool WalletImpl::setPassword(const std::string_view &old_password, const std::string_view &new_password)
 {
     if (checkBackgroundSync("cannot change password"))
         return false;
     clearStatus();
     try {
-        m_wallet->change_password(m_wallet->get_wallet_file(), m_password, password);
-        m_password = password;
+        m_wallet->change_password(m_wallet->get_wallet_file(),
+                                  epee::wipeable_string(old_password.data(), old_password.size()),
+                                  epee::wipeable_string(new_password.data(), new_password.size()));
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
     return statusOk();
-}
-
-const std::string& WalletImpl::getPassword() const
-{
-    return m_password;
 }
 
 bool WalletImpl::setDevicePin(const std::string &pin)
@@ -1069,14 +1060,18 @@ void WalletImpl::stop()
     m_wallet->stop();
 }
 
-bool WalletImpl::store(const std::string &path)
+bool WalletImpl::store(const std::string &path,
+                       const optional<std::string_view> &password /* = empty optional */)
 {
     clearStatus();
     try {
         if (path.empty()) {
             m_wallet->store();
+        } else if (password) {
+            m_wallet->store_to(path, epee::wipeable_string((*password).data(), (*password).size()));
         } else {
-            m_wallet->store_to(path, m_password);
+            setStatusError(tr("saving the wallet to a new path requires a password."));
+            return false;
         }
     } catch (const std::exception &e) {
         LOG_ERROR("Error saving wallet: " << e.what());
@@ -1770,7 +1765,7 @@ string WalletImpl::getMultisigInfo() const {
     return string();
 }
 
-string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t threshold) {
+string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t threshold, const std::string_view &password) {
     if (checkBackgroundSync("cannot make multisig"))
         return string();
     try {
@@ -1780,7 +1775,7 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
             throw runtime_error("Wallet is already multisig");
         }
 
-        return m_wallet->make_multisig(epee::wipeable_string(m_password), info, threshold);
+        return m_wallet->make_multisig(epee::wipeable_string(password.data(), password.size()), info, threshold);
     } catch (const exception& e) {
         LOG_ERROR("Error on making multisig wallet: " << e.what());
         setStatusError(string(tr("Failed to make multisig: ")) + e.what());
@@ -1789,12 +1784,12 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
     return string();
 }
 
-std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution /*= false*/) {
+std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution /*= false*/) {
     try {
         clearStatus();
         checkMultisigWalletNotReady(m_wallet);
 
-        return m_wallet->exchange_multisig_keys(epee::wipeable_string(m_password), info, force_update_use_with_caution);
+        return m_wallet->exchange_multisig_keys(epee::wipeable_string(password.data(), password.size()), info, force_update_use_with_caution);
     } catch (const exception& e) {
         LOG_ERROR("Error on exchanging multisig keys: " << e.what());
         setStatusError(string(tr("Failed to exchange multisig keys: ")) + e.what());
@@ -1805,11 +1800,12 @@ std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &inf
 
 std::string WalletImpl::getMultisigKeyExchangeBooster(const std::vector<std::string> &info,
     const std::uint32_t threshold,
-    const std::uint32_t num_signers) {
+    const std::uint32_t num_signers,
+    const std::string_view &password) {
     try {
         clearStatus();
 
-        return m_wallet->get_multisig_key_exchange_booster(epee::wipeable_string(m_password), info, threshold, num_signers);
+        return m_wallet->get_multisig_key_exchange_booster(epee::wipeable_string(password.data(), password.size()), info, threshold, num_signers);
     } catch (const exception& e) {
         LOG_ERROR("Error on boosting multisig key exchange: " << e.what());
         setStatusError(string(tr("Failed to boost multisig key exchange: ")) + e.what());

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -62,13 +62,14 @@ public:
                             const std::string &language) const override;
     bool open(const std::string &path, const std::string &password);
     bool recover(const std::string &path,const std::string &password,
-                            const std::string &seed, const std::string &seed_offset = {});
+                            const std::string &seed, const std::string &seed_offset = {}, const bool create_address_file = false);
     bool recoverFromKeysWithPassword(const std::string &path,
                             const std::string &password,
                             const std::string &language,
                             const std::string &address_string,
                             const std::string &viewkey_string,
-                            const std::string &spendkey_string = "");
+                            const std::string &spendkey_string = "",
+                            const bool create_address_file = false);
     // following two methods are deprecated since they create passwordless wallets
     // use the two equivalent methods above
     bool recover(const std::string &path, const std::string &seed);
@@ -87,13 +88,14 @@ public:
                                  const bool do_create_address_file = false);
     bool recoverFromDevice(const std::string &path,
                            const std::string &password,
-                           const std::string &device_name);
+                           const std::string &device_name,
+                           const bool create_address_file = false);
     Device getDeviceType() const override;
     bool close(bool store = true);
     std::string seed(const std::string& seed_offset = "") const override;
     int status() const override;
     std::string errorString() const override;
-    void statusWithErrorString(int& status, std::string& errorString) const override;
+    void statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut = nullptr) const override;
     bool setPassword(const std::string &password) override;
     const std::string& getPassword() const override;
     bool setDevicePin(const std::string &password) override;
@@ -117,10 +119,10 @@ public:
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     bool setProxy(const std::string &address) override;
-    uint64_t balance(uint32_t accountIndex = 0) const override;
-    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const override;
-    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL) const override;
-    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const override;
+    uint64_t balance(uint32_t accountIndex = 0, bool is_strict = false) const override;
+    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const override;
+    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL, bool is_strict = false) const override;
+    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;
@@ -128,7 +130,7 @@ public:
     uint64_t daemonBlockChainTargetHeight() const override;
     bool daemonSynced() const override;
     bool synchronized() const override;
-    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
+    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool skip_refresh_if_daemon_not_synced = true, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
     void refreshAsync() override;
     bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) override;
     void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) override;
@@ -180,6 +182,7 @@ public:
     UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
     std::string exportKeyImagesAsString(bool all = false) override;
+    void exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out) override;
     bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) override;
     bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
@@ -189,7 +192,7 @@ public:
     bool setupBackgroundSync(const BackgroundSyncType background_sync_type, const std::string &wallet_password, const optional<std::string> &background_cache_password = optional<std::string>()) override;
     BackgroundSyncType getBackgroundSyncType() const override;
     bool startBackgroundSync() override;
-    bool stopBackgroundSync(const std::string &wallet_password) override;
+    bool stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key = nullptr) override;
     bool isBackgroundSyncing() const override;
     bool isBackgroundWallet() const override;
 
@@ -221,7 +224,7 @@ public:
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
     virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const override;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr, unsigned *version_out = nullptr) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
     virtual void startRefresh() override;
@@ -265,6 +268,7 @@ public:
     bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
     PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) override;
     PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) override;
+    std::unique_ptr<PendingTransaction> deserializePtxFromBlobStr(const std::string &tx_blob) override;
     std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
     std::uint64_t getBaseFee() const override;
     std::uint32_t adjustPriority(std::uint32_t priority) override;
@@ -303,6 +307,8 @@ public:
 
     bool getExplicitRefreshFromBlockHeight() const override;
     void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) override;
+
+    void setTxNotify(const std::string &tx_notify) override;
 
     // Wallet Settings getter/setter
     std::string getSeedLanguage() const override;
@@ -370,11 +376,11 @@ public:
 
 private:
     void clearStatus() const;
-    void setStatusError(const std::string& message) const;
+    void setStatusError(const std::string& messagee, const int* extended_status = nullptr) const;
     void setStatusCritical(const std::string& message) const;
-    void setStatus(int status, const std::string& message) const;
+    void setStatus(int status, const std::string& message, const int* extended_status = nullptr) const;
     void refreshThreadFunc();
-    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
+    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool skip_refresh_if_daemon_not_synced = true, bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
     void stopRefresh();
     bool isNewWallet() const;
     void pendingTxPostProcess(PendingTransactionImpl * pending);
@@ -400,6 +406,14 @@ private:
     * return: true if status is ok, else false
     */
     bool statusOk() const;
+    /**
+    * brief: getTxDescription - helper for [Pending/Unsigned]Transaction::getTransactionDescription()
+    * param: cds - all the tx construction data
+    * param: error_code_out - [Pending/Unsigned]Transaction::m_status
+    * param: error_msg_out - [Pending/Unsigned]Transaction::m_errorString
+    * return: TransactionDescription on success, else nullptr
+    */
+    std::unique_ptr<TransactionDescription> getTxDescription(const std::vector<tools::wallet2::tx_construction_data> &cds, int &error_code_out, std::string &error_msg_out) const;
 
 private:
     friend class PendingTransactionImpl;
@@ -415,6 +429,7 @@ private:
     mutable boost::mutex m_statusMutex;
     mutable int m_status;
     mutable std::string m_errorString;
+    mutable int m_extendedStatus;
     // TODO: harden password handling in the wallet API, see relevant discussion
     // https://github.com/monero-project/monero-gui/issues/1537
     // https://github.com/feather-wallet/feather/issues/72#issuecomment-1405602142

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -42,6 +42,7 @@
 class WalletApiAccessorTest;
 
 namespace Monero {
+class EnoteDetailsImpl;
 class TransactionHistoryImpl;
 class PendingTransactionImpl;
 class UnsignedTransactionImpl;
@@ -169,8 +170,11 @@ public:
     virtual PendingTransaction * createSweepUnmixableTransaction() override;
     bool submitTransaction(const std::string &fileName) override;
     virtual UnsignedTransaction * loadUnsignedTx(const std::string &unsigned_filename) override;
+    UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
+    std::string exportKeyImagesAsString(bool all = false) override;
     bool importKeyImages(const std::string &filename) override;
+    bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
     bool importOutputs(const std::string &filename) override;
     bool scanTransactions(const std::vector<std::string> &txids) override;
@@ -209,7 +213,7 @@ public:
     virtual bool checkSpendProof(const std::string &txid, const std::string &message, const std::string &signature, bool &good) const override;
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
-    virtual std::string signMessage(const std::string &message, const std::string &address) override;
+    virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
     virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
@@ -233,6 +237,51 @@ public:
     virtual uint64_t getBytesReceived() override;
     virtual uint64_t getBytesSent() override;
 
+    std::string getMultisigSeed(const std::string &seed_offset) const override;
+    std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const override;
+    void freeze(const std::string &key_image) override;
+    void freezeByPubKey(const std::string &public_key) override;
+    void thaw(const std::string &key_image) override;
+    void thawByPubKey(const std::string &public_key) override;
+    bool isFrozen(const std::string &key_image) const override;
+    bool isFrozenByPubKey(const std::string &public_key) override;
+    void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) override;
+    WalletState getWalletState() const override;
+    void rewriteWalletFile(const std::string &wallet_name, const std::string &password) override;
+    void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) override;
+    void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) override;
+    void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const override;
+    std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const override;
+    bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
+    bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const override;
+    void insertColdKeyImages(PendingTransaction &ptx) override;
+    bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const override;
+    std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
+    std::uint64_t getBaseFee() const override;
+    std::uint32_t adjustPriority(std::uint32_t priority) override;
+    void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const override;
+    void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const override;
+    void discardUnmixableEnotes() override;
+    void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) override;
+    const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const override;
+    void setAccountTag(const std::set<uint32_t> &account_indices, const std::string &tag) override;
+    void setAccountTagDescription(const std::string &tag, const std::string &description) override;
+    std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const override;
+    std::size_t importEnotesFromStr(const std::string &enotes_str) override;
+    std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const override;
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const override;
+    bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const override;
+    bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const override;
+    std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const override;
+    void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) override;
+    std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const override;
+    std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const override;
+    std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) override;
+    bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) override;
+    bool getAllowMismatchedDaemonVersion() const override;
+    void setAllowMismatchedDaemonVersion(bool allow_mismatch) override;
+    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, const std::string &ssl_support = "autodetect", const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+
 private:
     void clearStatus() const;
     void setStatusError(const std::string& message) const;
@@ -246,6 +295,18 @@ private:
     void pendingTxPostProcess(PendingTransactionImpl * pending);
     bool doInit(const std::string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
     bool checkBackgroundSync(const std::string &message) const;
+
+    /**
+    * brief: getEnoteIndex - get the index of an enote in local enote storage
+    * param: key_image - key image to identify the enote
+    * return: enote index
+    */
+    std::size_t getEnoteIndex(const std::string &key_image) const;
+    /**
+    * brief: statusOk -
+    * return: true if status is ok, else false
+    */
+    bool statusOk() const;
 
 private:
     friend class PendingTransactionImpl;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -54,10 +54,10 @@ struct Wallet2CallbackImpl;
 class WalletImpl : public Wallet
 {
 public:
-    WalletImpl(NetworkType nettype = MAINNET, uint64_t kdf_rounds = 1);
+    WalletImpl(NetworkType nettype = MAINNET, uint64_t kdf_rounds = 1, const bool unattended = true);
     ~WalletImpl();
     bool create(const std::string &path, const std::string &password,
-                const std::string &language);
+                const std::string &language, bool create_address_file = false, bool non_deterministic = false);
     bool createWatchOnly(const std::string &path, const std::string &password,
                             const std::string &language) const override;
     bool open(const std::string &path, const std::string &password);
@@ -78,15 +78,19 @@ public:
                             const std::string &address_string, 
                             const std::string &viewkey_string,
                             const std::string &spendkey_string = "");
+    bool createFromJson(const std::string &json_file_path, std::string &pw_out);
+    bool recoverFromMultisigSeed(const std::string &path,
+                                 const std::string &password,
+                                 const std::string &language,
+                                 const std::string &multisig_seed,
+                                 const std::string seed_pass = "",
+                                 const bool do_create_address_file = false);
     bool recoverFromDevice(const std::string &path,
                            const std::string &password,
                            const std::string &device_name);
     Device getDeviceType() const override;
     bool close(bool store = true);
     std::string seed(const std::string& seed_offset = "") const override;
-    std::string getSeedLanguage() const override;
-    void setSeedLanguage(const std::string &arg) override;
-    // void setListener(Listener *) {}
     int status() const override;
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString) const override;
@@ -107,36 +111,35 @@ public:
     std::string filename() const override;
     std::string keysFilename() const override;
     bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") override;
-    void allowMismatchedDaemonVersion(bool allow_mismatch) override;
     void setRingDatabase(const std::string &path) override;
-    bool connectToDaemon() override;
+    bool connectToDaemon(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 20000, bool *wallet_is_outdated = NULL, bool *daemon_is_outdated = NULL) override;
     ConnectionStatus connected() const override;
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     bool setProxy(const std::string &address) override;
     uint64_t balance(uint32_t accountIndex = 0) const override;
-    uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
+    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const override;
+    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL) const override;
+    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;
     uint64_t daemonBlockChainHeight() const override;
     uint64_t daemonBlockChainTargetHeight() const override;
+    bool daemonSynced() const override;
     bool synchronized() const override;
-    bool refresh() override;
+    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
     void refreshAsync() override;
-    bool rescanBlockchain() override;
-    void rescanBlockchainAsync() override;    
+    bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) override;
+    void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) override;
     void setAutoRefreshInterval(int millis) override;
     int autoRefreshInterval() const override;
-    void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) override;
-    uint64_t getRefreshFromBlockHeight() const override { return m_wallet->get_refresh_from_block_height(); };
     void setRecoveringFromSeed(bool recoveringFromSeed) override;
     void setRecoveringFromDevice(bool recoveringFromDevice) override;
-    void setSubaddressLookahead(uint32_t major, uint32_t minor) override;
     bool watchOnly() const override;
     bool isDeterministic() const override;
     bool rescanSpent() override;
-    NetworkType nettype() const override {return static_cast<NetworkType>(m_wallet->nettype());}
+    NetworkType nettype() const override;
     void hardForkInfo(uint8_t &version, uint64_t &earliest_height) const override;
     bool useForkRules(uint8_t version, int64_t early_blocks) const override;
 
@@ -155,13 +158,17 @@ public:
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;
-    PendingTransaction*  restoreMultisigTransaction(const std::string& signData) override;
+    PendingTransaction* restoreMultisigTransaction(const std::string& signData, bool ask_for_confirmation = false) override;
 
     PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
                                         optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
                                         uint32_t subaddr_account = 0,
-                                        std::set<uint32_t> subaddr_indices = {}) override;
+                                        std::set<uint32_t> subaddr_indices = {},
+                                        std::set<uint32_t> subtract_fee_from_outputs = {},
+                                        const std::string key_image = "",
+                                        const size_t outputs = 1,
+                                        const std::uint64_t below = 0) override;
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                         optional<uint64_t> amount, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
@@ -173,11 +180,11 @@ public:
     UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
     std::string exportKeyImagesAsString(bool all = false) override;
-    bool importKeyImages(const std::string &filename) override;
+    bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) override;
     bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
     bool importOutputs(const std::string &filename) override;
-    bool scanTransactions(const std::vector<std::string> &txids) override;
+    bool scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon = nullptr) override;
 
     bool setupBackgroundSync(const BackgroundSyncType background_sync_type, const std::string &wallet_password, const optional<std::string> &background_cache_password = optional<std::string>()) override;
     BackgroundSyncType getBackgroundSyncType() const override;
@@ -214,7 +221,7 @@ public:
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
     virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const override;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
     virtual void startRefresh() override;
@@ -231,6 +238,7 @@ public:
     virtual bool lockKeysFile() override;
     virtual bool unlockKeysFile() override;
     virtual bool isKeysFileLocked() override;
+    std::unique_ptr<WalletKeysDecryptGuard> createKeysDecryptGuard(const std::string_view &password) override;
     virtual uint64_t coldKeyImageSync(uint64_t &spent, uint64_t &unspent) override;
     virtual void deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId) override;
     virtual bool reconnectDevice() override;
@@ -240,22 +248,23 @@ public:
     std::string getMultisigSeed(const std::string &seed_offset) const override;
     std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const override;
     void freeze(const std::string &key_image) override;
-    void freezeByPubKey(const std::string &public_key) override;
+    void freezeByPubKey(const std::string &enote_pub_key) override;
     void thaw(const std::string &key_image) override;
-    void thawByPubKey(const std::string &public_key) override;
+    void thawByPubKey(const std::string &enote_pub_key) override;
     bool isFrozen(const std::string &key_image) const override;
-    bool isFrozenByPubKey(const std::string &public_key) override;
     void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) override;
     WalletState getWalletState() const override;
-    void rewriteWalletFile(const std::string &wallet_name, const std::string &password) override;
-    void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) override;
+    DeviceState getDeviceState() const override;
+    void rewriteWalletFile(const std::string &wallet_name, const std::string_view &password) override;
+    void writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name) override;
     void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) override;
-    void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const override;
+    std::vector<std::unique_ptr<EnoteDetails>> getEnoteDetails() const override;
+    std::unique_ptr<EnoteDetails> getEnoteDetails(const std::string &enote_pub_key) const override;
+    std::unique_ptr<EnoteDetails> getEnoteDetails(const std::size_t enote_index) const override;
     std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const override;
     bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
-    bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const override;
-    void insertColdKeyImages(PendingTransaction &ptx) override;
-    bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const override;
+    PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) override;
+    PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) override;
     std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
     std::uint64_t getBaseFee() const override;
     std::uint32_t adjustPriority(std::uint32_t priority) override;
@@ -270,8 +279,6 @@ public:
     std::size_t importEnotesFromStr(const std::string &enotes_str) override;
     std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const override;
     std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const override;
-    bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const override;
-    bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const override;
     std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const override;
     void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) override;
     std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const override;
@@ -280,7 +287,86 @@ public:
     bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) override;
     bool getAllowMismatchedDaemonVersion() const override;
     void setAllowMismatchedDaemonVersion(bool allow_mismatch) override;
-    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, const std::string &ssl_support = "autodetect", const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+    std::string getDeviceDerivationPath() const override;
+    void setDeviceDerivationPath(std::string device_derivation_path) override;
+    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, Wallet::SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect, const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+    bool verifyPassword(const std::string_view &password) override;
+    void encryptKeys(const std::string_view &password) override;
+    void decryptKeys(const std::string_view &password) override;
+    std::uint64_t getMinRingSize() const override;
+    std::uint64_t getMaxRingSize() const override;
+    std::uint64_t adjustMixin(const std::uint64_t fake_outs_count) const override;
+
+    std::uint64_t getDaemonAdjustedTime() const override;
+    std::uint64_t getLastBlockReward() const override;
+    bool hasUnknownKeyImages() const override;
+
+    bool getExplicitRefreshFromBlockHeight() const override;
+    void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) override;
+
+    // Wallet Settings getter/setter
+    std::string getSeedLanguage() const override;
+    void setSeedLanguage(const std::string &arg) override;
+    bool getAlwaysConfirmTransfers() const override;
+    void setAlwaysConfirmTransfers(bool do_always_confirm) override;
+    bool getPrintRingMembers() const override;
+    void setPrintRingMembers(bool do_print_ring_members) override;
+    bool getStoreTxInfo() const override;
+    void setStoreTxInfo(bool do_store_tx_info) override;
+    bool getAutoRefresh() const override;
+    void setAutoRefresh(bool do_auto_refresh) override;
+    RefreshType getRefreshType() const override;
+    void setRefreshType(RefreshType refresh_type) override;
+    std::uint32_t getDefaultPriority() const override;
+    void setDefaultPriority(std::uint32_t default_priority) override;
+    AskPasswordType getAskPasswordType() const override;
+    void setAskPasswordType(AskPasswordType ask_password_type) override;
+    std::uint64_t getMaxReorgDepth() const override;
+    void setMaxReorgDepth(std::uint64_t max_reorg_depth) override;
+    std::uint32_t getMinOutputCount() const override;
+    void setMinOutputCount(std::uint32_t min_output_count) override;
+    std::uint64_t getMinOutputValue() const override;
+    void setMinOutputValue(std::uint64_t min_output_value) override;
+    bool getMergeDestinations() const override;
+    void setMergeDestinations(bool do_merge_destinations) override;
+    std::uint32_t getConfirmBacklogThreshold() const override;
+    bool getConfirmBacklog() const override;
+    void setConfirmBacklog(bool do_confirm_backlog) override;
+    void setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold) override;
+    bool getConfirmExportOverwrite() const override;
+    void setConfirmExportOverwrite(bool do_confirm_export_overwrite) override;
+    uint64_t getRefreshFromBlockHeight() const override;
+    void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) override;
+    bool getAutoLowPriority() const override;
+    void setAutoLowPriority(bool use_auto_low_priority) override;
+    bool getSegregatePreForkOutputs() const override;
+    void setSegregatePreForkOutputs(bool do_segregate) override;
+    bool getKeyReuseMitigation2() const override;
+    void setKeyReuseMitigation2(bool mitigation) override;
+    std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const override;
+    void setSubaddressLookahead(uint32_t major, uint32_t minor) override;
+    std::uint64_t getSegregationHeight() const override;
+    void setSegregationHeight(std::uint64_t height) override;
+    bool getIgnoreFractionalOutputs() const override;
+    void setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs) override;
+    std::uint64_t getIgnoreOutputsAbove() const override;
+    void setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above) override;
+    std::uint64_t getIgnoreOutputsBelow() const override;
+    void setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below) override;
+    bool getTrackUses() const override;
+    void setTrackUses(bool do_track_uses) override;
+    BackgroundMiningSetupType getSetupBackgroundMining() const override;
+    void setSetupBackgroundMining(BackgroundMiningSetupType background_mining_setup) override;
+    std::string getDeviceName() const override;
+    void setDeviceName(const std::string &device_name) override;
+    ExportFormat getExportFormat() const override;
+    void setExportFormat(ExportFormat export_format) override;
+    bool getShowWalletNameWhenLocked() const override;
+    void setShowWalletNameWhenLocked(bool do_show_wallet_name) override;
+    std::uint32_t getInactivityLockTimeout() const override;
+    void setInactivityLockTimeout(std::uint32_t seconds) override;
+    bool getEnableMultisig() const override;
+    void setEnableMultisig(bool do_enable_multisig) override;
 
 private:
     void clearStatus() const;
@@ -288,8 +374,7 @@ private:
     void setStatusCritical(const std::string& message) const;
     void setStatus(int status, const std::string& message) const;
     void refreshThreadFunc();
-    void doRefresh();
-    bool daemonSynced() const;
+    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
     void stopRefresh();
     bool isNewWallet() const;
     void pendingTxPostProcess(PendingTransactionImpl * pending);
@@ -302,6 +387,14 @@ private:
     * return: enote index
     */
     std::size_t getEnoteIndex(const std::string &key_image) const;
+    /**
+    * brief: getPaymentIdFromExtra -
+    * param: tx_extra - as raw bytes
+    * return: payment_id if succeeded, else empty string
+    *         (size is either A) 16 for 8 byte short encrypted payment IDs,
+    *                         B) 64 for obsolete 32 byte long unencrypted payment IDs)
+    */
+    std::string getPaymentIdFromExtra(const std::vector<std::uint8_t> &tx_extra) const;
     /**
     * brief: statusOk -
     * return: true if status is ok, else false
@@ -338,6 +431,8 @@ private:
     std::atomic<bool> m_refreshThreadDone;
     std::atomic<int>  m_refreshIntervalMillis;
     std::atomic<bool> m_refreshShouldRescan;
+    std::atomic<bool> m_do_hard_rescan;
+    std::atomic<bool> m_do_keep_key_images_on_rescan;
     // synchronizing  refresh loop;
     boost::mutex        m_refreshMutex;
 
@@ -355,6 +450,8 @@ private:
     // cache connection status to avoid unnecessary RPC calls
     mutable std::atomic<bool>   m_is_connected;
     boost::optional<epee::net_utils::http::login> m_daemon_login{};
+    // number of rounds for key derivation function for wallet password
+    std::uint64_t m_kdf_rounds;
 };
 
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -33,11 +33,13 @@
 
 #include "wallet/api/wallet2_api.h"
 #include "wallet/wallet2.h"
+#include "wipeable_string.h"
 
 #include <string>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <string_view>
 
 class WalletApiAccessorTest;
 
@@ -96,8 +98,7 @@ public:
     int status() const override;
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut = nullptr) const override;
-    bool setPassword(const std::string &password) override;
-    const std::string& getPassword() const override;
+    bool setPassword(const std::string_view &old_password, const std::string_view &new_password) override;
     bool setDevicePin(const std::string &password) override;
     bool setDevicePassphrase(const std::string &password) override;
     std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const override;
@@ -109,7 +110,7 @@ public:
     std::string publicMultisigSignerKey() const override;
     std::string path() const override;
     void stop() override;
-    bool store(const std::string &path) override;
+    bool store(const std::string &path, const optional<std::string_view> &password = optional<std::string_view>()) override;
     std::string filename() const override;
     std::string keysFilename() const override;
     bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") override;
@@ -154,9 +155,9 @@ public:
 
     MultisigState multisig() const override;
     std::string getMultisigInfo() const override;
-    std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) override;
-    std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution = false) override;
-    std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) override;
+    std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold, const std::string_view &password) override;
+    std::string exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution = false) override;
+    std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers, const std::string_view &password) override;
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;
@@ -430,11 +431,6 @@ private:
     mutable int m_status;
     mutable std::string m_errorString;
     mutable int m_extendedStatus;
-    // TODO: harden password handling in the wallet API, see relevant discussion
-    // https://github.com/monero-project/monero-gui/issues/1537
-    // https://github.com/feather-wallet/feather/issues/72#issuecomment-1405602142
-    // https://github.com/monero-project/monero/pull/8619#issuecomment-1632951461
-    std::string m_password;
     std::unique_ptr<TransactionHistoryImpl> m_history;
     std::unique_ptr<Wallet2CallbackImpl> m_wallet2Callback;
     std::unique_ptr<AddressBookImpl>  m_addressBook;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -134,6 +134,74 @@ struct EnoteDetails
 };
 
 /**
+ * @brief TxSource -
+ */
+struct TxSource
+{
+    // enote amount
+    std::uint64_t amount;
+    // part of amount-global output index pair {rct ? 0 : amount, global_index}
+    std::uint64_t global_index;
+    // true if enote was created in RingCT, else false
+    bool rct;
+    // enote pubkey
+    std::string pubkey;
+};
+/**
+ * @brief TxRecipient -
+ */
+struct TxRecipient
+{
+    std::string address;
+    std::uint64_t amount;
+};
+/**
+ * @brief TxDesctiptionSingle - description of a single tx in PendingTransaction/UnsignedTransaction
+ */
+struct TxDescriptionSingle
+{
+    std::uint64_t amount_in;
+    std::uint64_t amount_out;
+    std::uint32_t ring_size;
+    std::uint64_t unlock_time;
+    std::list<TxSource> sources;
+    std::list<TxRecipient> recipients;
+    std::string payment_id;
+    std::uint64_t change_amount;
+    std::string change_address;
+    std::uint64_t fee;
+    std::uint32_t dummy_outputs;
+    std::string extra;
+};
+/**
+ * @brief TxSummary - summary for all txs in a PendingTransaction/UnsignedTransaction
+ */
+struct TxSummary
+{
+    // Sum of amounts for all enotes that were used to create the tx
+    std::uint64_t amount_in;
+    // Sum of amounts for all enotes that were created by this tx
+    std::uint64_t amount_out;
+    // All recipients, excluding change
+    std::list<TxRecipient> recipients;
+    // Sum of all change amounts created by this tx
+    std::uint64_t change_amount;
+    // Address receiving change
+    std::string change_address;
+    // Total fee
+    std::uint64_t fee;
+};
+/**
+ * @brief TransactionDescription - description of each tx in a PendingTransaction/UnsignedTransaction
+ *                                 and a summary for the entire PendingTransaction/UnsignedTransaction
+ */
+struct TransactionDescription
+{
+    std::list<TxDescriptionSingle> tx_descriptions;
+    TxSummary tx_summary;
+};
+
+/**
  * @brief Transaction-like interface for sending money
  */
 struct PendingTransaction
@@ -156,13 +224,25 @@ struct PendingTransaction
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
+    virtual int extendedStatus() const = 0;
     virtual std::string confirmationMessage() const = 0;
     // commit transaction or save to file if filename is provided.
+    // note: be careful, after calling this method other methods in this class may not work as expected anymore
+    //       if you want to get any info about the ptx, you should fetch it before calling commit()
+    // note: this method sets extendedStatus if it catches one of the following exceptions:
+    //          `no_connection_to_daemon`, `daemon_busy`, `not_enough_unlocked_money`, `not_enough_money`,
+    //          `tx_not_possible`, `not_enough_outs_to_mix`, `zero_amount`, `zero_destination`
     virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
+    // summed up total amount for all txs and destinations, excluding change and fee
     virtual uint64_t amount() const = 0;
+    // amount for each destination per tx
+    virtual std::vector<std::vector<uint64_t>> amountsPerDestination() const = 0;
     virtual uint64_t dust() const = 0;
     virtual uint64_t dustInFee() const = 0;
+    // summed up total fee for all txs
     virtual uint64_t fee() const = 0;
+    // fee amount per tx
+    virtual std::vector<uint64_t> fees() const = 0;
     virtual uint64_t change() const = 0;
     virtual std::vector<std::string> txid() const = 0;
     /*!
@@ -194,6 +274,20 @@ struct PendingTransaction
     */
     virtual std::vector<std::string> convertTxToRawBlobStr() = 0;
     /**
+    * brief: asHexStr - create hex string for each tx in `PendingTransaction`
+    *                   which can be used as arguments for `tx_as_hex`
+    *                   for daemon RPC `/send_raw_transaction`
+    * return: serialized ptx objects as hex strings if succeeded, else empty vector
+    * note: sets status error on failure
+    */
+    virtual std::vector<std::string> asHexStr() = 0;
+    /**
+    * brief: txWeights -
+    * return: weight per tx
+    * note: sets status error on failure
+    */
+    virtual std::vector<std::uint64_t> txWeights() = 0;
+    /**
     * brief: getWorstFeePerByte - needed when checking for backlog
     * return: worst fee per bytes
     */
@@ -220,6 +314,11 @@ struct PendingTransaction
     */
     virtual std::vector<std::vector<std::uint64_t>> vinAmounts() const = 0;
     /**
+    * brief: getTxKeys - tx_key + optional additional_tx_keys concatenated to a single string per tx
+    * return: secret tx keys
+    */
+    virtual std::vector<std::string> getTxKeys() const = 0;
+    /**
     * brief: getEnoteDetailsIn -
     * return: enote details for all enotes that are used as inputs per tx
     *         [ tx_idx : [ enote_idx : EnoteDetails, ... ], ... ]
@@ -233,6 +332,12 @@ struct PendingTransaction
     * return: true on success
     */
     virtual bool finishParsingTx() = 0;
+    /**
+    * brief: getTransactionDescription - details for each tx
+    * return: TransactionDescription on success, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<TransactionDescription> getTransactionDescription() = 0;
 
     /**
      * @brief multisigSignData
@@ -314,6 +419,12 @@ struct UnsignedTransaction
     * note: sets status error on failure
     */
     virtual std::string signAsString() = 0;
+    /**
+    * brief: getTransactionDescription - details for each tx
+    * return: TransactionDescription on success, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<TransactionDescription> getTransactionDescription() = 0;
 };
 
 /**
@@ -376,7 +487,9 @@ struct TransactionHistory
     virtual int count() const = 0;
     virtual TransactionInfo * transaction(int index)  const = 0;
     virtual TransactionInfo * transaction(const std::string &id) const = 0;
-    virtual std::vector<TransactionInfo*> getAll() const = 0;
+    // note: usually you would call tx_history->refresh() on the wallets moneyReceived/moneySpent callbacks
+    //       though there are no callbacks if the wallet is unattended
+    virtual std::vector<TransactionInfo*> getAll(bool do_refresh = false) = 0;
     virtual void refresh() = 0;
     virtual void setTxNote(const std::string &txid, const std::string &note) = 0;
 };
@@ -422,6 +535,7 @@ struct AddressBook
     virtual bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) = 0;  
     virtual bool deleteRow(std::size_t rowId) = 0;
     virtual bool setDescription(std::size_t index, const std::string &description) = 0;
+    virtual bool setAddress(std::size_t index, const std::string &address) = 0;
     virtual void refresh() = 0;  
     virtual std::string errorString() const = 0;
     virtual int errorCode() const = 0;
@@ -634,6 +748,25 @@ struct Wallet
         Status_Critical
     };
 
+    enum ExtendedStatus {
+        ExtendedStatus_Ok,
+        ExtendedStatus_WalletInternalError,     // generic error, if none of the ones below
+        ExtendedStatus_WalletAlreadyExists,
+        ExtendedStatus_InvalidPassword,
+        ExtendedStatus_NoDaemonConnection,
+        ExtendedStatus_DaemonIsBusy,
+        ExtendedStatus_AccountIndexOutOfBounds,
+        ExtendedStatus_AddressIndexOutOfBounds,
+        ExtendedStatus_NotEnoughMoney,
+        ExtendedStatus_NotEnoughUnlockedMoney,
+        ExtendedStatus_NotEnoughOutsToMix,
+        ExtendedStatus_ZeroAmount,
+        ExtendedStatus_ZeroDestination,
+        ExtendedStatus_TxNotPossible,
+        ExtendedStatus_WrongSignature,
+        ExtendedStatus_NonZeroUnlockTime,
+    };
+
     enum ConnectionStatus {
         ConnectionStatus_Disconnected,
         ConnectionStatus_Connected,
@@ -702,6 +835,7 @@ struct Wallet
         // is wallet file format deprecated
         bool is_deprecated;
         bool is_unattended;
+        bool has_proxy_flag;
         std::string daemon_address;
         std::string ring_database;
         std::uint64_t n_enotes;
@@ -709,12 +843,12 @@ struct Wallet
 
     virtual ~Wallet() = 0;
     virtual std::string seed(const std::string& seed_offset = "") const = 0;
-    //! returns wallet status (Status_Ok | Status_Error)
+    //! returns wallet status (Status_Ok | Status_Error | Status_Critical)
     virtual int status() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! in case error status, returns error string
     virtual std::string errorString() const = 0; //deprecated: use safe alternative statusWithErrorString
-    //! returns both error and error string atomically. suggested to use in instead of status() and errorString()
-    virtual void statusWithErrorString(int& status, std::string& errorString) const = 0;
+    //! returns both error and error string atomically. suggested to use in instead of status() and errorString(), optionally gives ExtendedStatus code if any
+    virtual void statusWithErrorString(int& status, std::string& errorString, int* extendedStatus = nullptr) const = 0;
     virtual bool setPassword(const std::string &password) = 0;
     virtual const std::string& getPassword() const = 0;
     virtual bool setDevicePin(const std::string &pin) { (void)pin; return false; };
@@ -807,7 +941,6 @@ struct Wallet
      * \return  - true on success
      */
     virtual bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") = 0;
-    virtual void allowMismatchedDaemonVersion(bool allow_mismatch) = 0;
     virtual void setRingDatabase(const std::string &path) = 0;
 
    /*!
@@ -852,20 +985,36 @@ struct Wallet
     virtual void setTrustedDaemon(bool arg) = 0;
     virtual bool trustedDaemon() const = 0;
     virtual bool setProxy(const std::string &address) = 0;
-    virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
-    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const = 0;
-    uint64_t balanceAll() const {
+    virtual uint64_t balance(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    /**
+     * @brief balanceAll - sum of balances for all accounts and subaddresses
+     * @param is_strict - true = only consider blockchain state, false = also consider pool state (Default: false)
+     * @return - balance
+     */
+    uint64_t balanceAll(bool is_strict = false) const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += balance(i);
+            result += balance(i, is_strict);
         return result;
     }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL) const = 0;
-    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const = 0;
-    uint64_t unlockedBalanceAll() const {
+    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL, bool is_strict = false) const = 0;
+    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    uint64_t unlockedBalanceAll(uint64_t *blocks_to_unlock = nullptr, uint64_t *time_to_unlock = nullptr, bool is_strict = false) const {
         uint64_t result = 0;
+        if (blocks_to_unlock)
+            *blocks_to_unlock = 0;
+        if (time_to_unlock)
+            *time_to_unlock = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += unlockedBalance(i);
+        {
+            uint64_t local_blocks_to_unlock, local_time_to_unlock;
+            result += unlockedBalance(i, blocks_to_unlock ? &local_blocks_to_unlock : nullptr,  time_to_unlock ? &local_time_to_unlock : nullptr, is_strict);
+            if (blocks_to_unlock)
+                *blocks_to_unlock = std::max(*blocks_to_unlock, local_blocks_to_unlock);
+            if (time_to_unlock)
+                *time_to_unlock = std::max(*time_to_unlock, local_time_to_unlock);
+        }
         return result;
     }
 
@@ -975,6 +1124,7 @@ struct Wallet
      * @param check_pool            - wether to also scan tx pool (Default: true)
      * @param try_incremental       - if daemon supports it, only get txs from the pool which the wallet hasn't seen before (Default: false)
      * @param max_blocks            - refresh returns when blocks fetched reaches max_blocks (Default: std::numeric_limits<std::uint64_t>::max())
+     * @param skip_refresh_if_daemon_not_synced - (Default: true)
      * @outparam blocks_fetched_out - number of blocks fetched during refresh (Default: nullptr)
      * @outparam received_money_out - true if the wallet received money in the blocks fetched during refresh (Default: nullptr)
      * @return - true if refreshed successfully;
@@ -983,6 +1133,7 @@ struct Wallet
                          bool check_pool = true,
                          bool try_incremental = false,
                          std::uint64_t max_blocks = std::numeric_limits<std::uint64_t>::max(),
+                         bool skip_refresh_if_daemon_not_synced = true,
                          std::uint64_t *blocks_fetched_out = nullptr,
                          bool *received_money_out = nullptr) = 0;
 
@@ -1028,6 +1179,7 @@ struct Wallet
     /**
      * @brief addSubaddressAccount - appends a new subaddress account at the end of the last major index of existing subaddress accounts
      * @param label - the label for the new account (which is the as the label of the primary address (accountIndex,0))
+     * @note - sets status error on failure
      */
     virtual void addSubaddressAccount(const std::string& label) = 0;
     /**
@@ -1043,6 +1195,7 @@ struct Wallet
      * @brief addSubaddress - appends a new subaddress at the end of the last minor index of the specified subaddress account
      * @param accountIndex - the major index specifying the subaddress account
      * @param label - the label for the new subaddress
+     * @note - sets status error on failure
      */
     virtual void addSubaddress(uint32_t accountIndex, const std::string& label) = 0;
     /**
@@ -1135,6 +1288,10 @@ struct Wallet
      * \param below                     threshold for sweep_below, only used if `amount` is not set (Default: 0)
      * \return                          PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                                  after object returned
+     * \note: sets status error on failure
+     * \note: this method sets `extendedStatus` if it catches one of the following exceptions:
+     *           `no_connection_to_daemon`, `daemon_busy`, `not_enough_unlocked_money`, `not_enough_money`,
+     *           `tx_not_possible`, `not_enough_outs_to_mix`, `zero_amount`, `zero_destination`
      */
 
     virtual PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
@@ -1229,6 +1386,14 @@ struct Wallet
     * note: sets status error on failure
     */
     virtual std::string exportKeyImagesAsString(bool all = false) = 0;
+    /**
+    * brief: exportKeyImages - export key images
+    * param: all - export all key images or only those that have not yet been exported
+    * outparam: offset_out - number of skipped key images, 0 if `all = true`
+    * outparam: key_images_and_signatures_out - pairs of key_image + signature both as hex string
+    * note: sets status error on failure
+    */
+    virtual void exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out) = 0;
    
    /*!
     * \brief importKeyImages  - imports key images from file
@@ -1292,8 +1457,9 @@ struct Wallet
     /**
      * @brief stopBackgroundSync  - bring back spend key and process background synced txs
      * \param wallet_password
+     * \param spend_secret_key (optional)
      */
-    virtual bool stopBackgroundSync(const std::string &wallet_password) = 0;
+    virtual bool stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key = nullptr) = 0;
 
     /**
      * @brief isBackgroundSyncing - returns true if the wallet is background syncing
@@ -1375,10 +1541,11 @@ struct Wallet
      * \param address - the address the signature claims to be made with
      * \param signature - the signature
      * \outparam is_old_out - true if signature uses old format (optional)
-     * \outparam signature_type_out - either signed by: spendkey | viewkey | unkown (suspicious); (optional)
+     * \outparam signature_type_out - signed by which key: [ "spend" | "view" | "invalid" (suspicious) ] (optional)
+     * \outparam version_out - currently supported signature versions: [ 1 = "SigV1", 2 = "SigV2" ] (optional)
      * \return true if the signature verified, false otherwise
      */
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const = 0;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr, unsigned *version_out = nullptr) const = 0;
 
     /*!
      * \brief signMultisigParticipant   signs given message with the multisig public signer key
@@ -1540,6 +1707,8 @@ struct Wallet
     * param: refreshed - (default: false)
     * param: try_incremental - (default: false)
     * note: sets status error on failure
+    * note: this method sets `extendedStatus` if it catches one of the following exceptions:
+    *          `no_connection_to_daemon`, `daemon_busy`
     */
     virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
     /**
@@ -1592,6 +1761,13 @@ struct Wallet
     * note: sets status error on failure
     */
     virtual PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) = 0;
+    /**
+    * brief: deserializePtxFromBlobStr - get pending transaction from unencrypted BLOB string
+    * param: tx_blob - also known as `tx_metadata` returned by wallet-rpc transfer/sweep methods
+    * return: ptx if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<PendingTransaction> deserializePtxFromBlobStr(const std::string &tx_blob) = 0;
     /**
     * brief: getFeeMultiplier -
     * param: priority -
@@ -1853,6 +2029,9 @@ struct Wallet
     virtual bool getExplicitRefreshFromBlockHeight() const = 0;
     virtual void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) = 0;
 
+    // "Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash" (Default: disabled)
+    virtual void setTxNotify(const std::string &tx_notify) = 0;
+
     // Wallet Settings getter/setter
     virtual std::string getSeedLanguage() const = 0;
     // note: sets status error on failure
@@ -1895,6 +2074,7 @@ struct Wallet
     virtual bool getKeyReuseMitigation2() const = 0;
     virtual void setKeyReuseMitigation2(bool do_key_reuse_mitigation) = 0;
     virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const = 0;
+    // note: sets status error on failure
     virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
     virtual std::uint64_t getSegregationHeight() const = 0;
     virtual void setSegregationHeight(std::uint64_t segregation_height) = 0;
@@ -1933,14 +2113,17 @@ struct WalletManager
      * \param  language       Language to be used to generate electrum seed mnemonic
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
-     * \param  create_address_file - Create <wallet_name>.address.txt file (Default: false)
-     *                               NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
-     * \param  non_determinisitc - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
-     *                             NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
-     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+     * \param  create_address_file  - Create <wallet_name>.address.txt file (Default: false)
+     *                                NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
+     * \param  non_determinisitc    - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
+     *                                NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
+     * \param  unattended           - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+     * \param  extra_entropy_file   - "File containing extra entropy to initialize the PRNG
+     *                                 (any data, aim for 256 bits of entropy to be useful, which typically means more than 256 bits of data)"
+     *                                (Default: empty string)
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
-    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true) = 0;
+    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true, const std::string extra_entropy_file = "") = 0;
     Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false)      // deprecated
     {
         return createWallet(path, password, language, testnet ? TESTNET : MAINNET);
@@ -1971,12 +2154,13 @@ struct WalletManager
      * \param  restoreHeight  restore from start height
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  seed_offset    Seed offset passphrase (optional)
+     * \param  create_address_file Create <wallet_name>.address.txt file (Default: false)
      * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     NetworkType nettype = MAINNET, uint64_t restoreHeight = 0, uint64_t kdf_rounds = 1,
-                                    const std::string &seed_offset = {}, const bool unattended = true) = 0;
+                                    const std::string &seed_offset = {}, const bool create_address_file = false, const bool unattended = true) = 0;
     Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     bool testnet = false, uint64_t restoreHeight = 0)           // deprecated
     {
@@ -2202,8 +2386,8 @@ struct WalletManager
     //! returns verbose error string regarding last error;
     virtual std::string errorString() const = 0;
 
-    //! set the daemon address (hostname and port)
-    virtual void setDaemonAddress(const std::string &address) = 0;
+    //! set the daemon address (hostname and port) and, if necessary, daemon login
+    virtual void setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password = nullptr) = 0;
 
     //! returns whether the daemon can be reached, and its version number
     virtual bool connected(uint32_t *version = NULL) = 0;
@@ -2222,9 +2406,6 @@ struct WalletManager
 
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
-
-    //! returns true if bootstrap mode was used by daemon or if bootstrap daemon address is set
-    virtual bool wasBootstrapEverUsed() = 0;
 
     //! returns true iff backgound mining is enabled
     virtual bool isBackgroundMiningEnabled() = 0;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -849,8 +849,7 @@ struct Wallet
     virtual std::string errorString() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! returns both error and error string atomically. suggested to use in instead of status() and errorString(), optionally gives ExtendedStatus code if any
     virtual void statusWithErrorString(int& status, std::string& errorString, int* extendedStatus = nullptr) const = 0;
-    virtual bool setPassword(const std::string &password) = 0;
-    virtual const std::string& getPassword() const = 0;
+    virtual bool setPassword(const std::string_view &old_password, const std::string_view &new_password) = 0;
     virtual bool setDevicePin(const std::string &pin) { (void)pin; return false; };
     virtual bool setDevicePassphrase(const std::string &passphrase) { (void)passphrase; return false; };
     virtual std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const = 0;
@@ -914,9 +913,10 @@ struct Wallet
      * \brief store - stores wallet to file.
      * \param path - main filename to store wallet to. additionally stores address file and keys file.
      *               to store to the same file - just pass empty string;
+     * \param password - only needed if path is not empty (default: empty optional)
      * \return
      */
-    virtual bool store(const std::string &path) = 0;
+    virtual bool store(const std::string &path, const optional<std::string_view> &password = optional<std::string_view>()) = 0;
     /*!
      * \brief filename - returns wallet filename
      * \return
@@ -1226,25 +1226,28 @@ struct Wallet
      * @brief makeMultisig - switches wallet in multisig state. The one and only creation phase for N / N wallets
      * @param info - vector of multisig infos from other participants obtained with getMulitisInfo call
      * @param threshold - number of required signers to make valid transaction. Must be <= number of participants
+     * @param password - wallet password
      * @return in case of N / N wallets returns empty string since no more key exchanges needed. For N - 1 / N wallets returns base58 encoded extra multisig info
      */
-    virtual std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) = 0;
+    virtual std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold, const std::string_view &password) = 0;
     /**
      * @brief exchange_multisig_keys - provides additional key exchange round for arbitrary multisig schemes (like N-1/N, M/N)
      * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
+     * @param password - wallet password
      * @param force_update_use_with_caution - force multisig account to update even if not all signers contribute round messages
      * @return new info string if more rounds required or an empty string if wallet creation is done
      */
-    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution) = 0;
+    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution) = 0;
     /**
      * @brief getMultisigKeyExchangeBooster - obtain partial information for the key exchange round after the in-progress round,
      *                                        to speed up another signer's key exchange process
      * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
      * @param threshold - number of required signers to make valid transaction. Must be <= number of participants.
      * @param num_signers - total number of multisig participants.
+     * @param password - wallet password
      * @return new info string if more rounds required or exception if no more rounds (i.e. no rounds to boost)
      */
-    virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) = 0;
+    virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers, const std::string_view &password) = 0;
     /**
      * @brief exportMultisigImages - exports transfers' key images
      * @param images - output parameter for hex encoded array of images

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -35,11 +35,15 @@
 #include <ctime>
 #include <iostream>
 #include <list>
+#include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
+
 
 //  Public interface for libwallet library
 namespace Monero {
@@ -58,6 +62,39 @@ enum NetworkType : uint8_t {
     // backwards compatible shim for old declaration of handmade optional<> struct
     template<typename T>
     using optional = std::optional<T>;
+
+/**
+* brief: EnoteDetails - Container for all the necessary information that belongs to an enote
+*/
+struct EnoteDetails
+{
+    enum TxProtocol {
+        TxProtocol_CryptoNote,
+        TxProtocol_RingCT
+    };
+
+    virtual ~EnoteDetails() = 0;
+    virtual std::string onetimeAddress() const = 0;
+    virtual std::string viewTag() const = 0;
+    virtual std::uint64_t blockHeight() const = 0;
+    virtual std::string txId() const = 0;
+    virtual std::uint64_t internalEnoteIndex() const = 0;
+    virtual std::uint64_t globalEnoteIndex() const = 0;
+    virtual bool isSpent() const = 0;
+    virtual bool isFrozen() const = 0;
+    virtual std::uint64_t spentHeight() const = 0;
+    virtual std::string keyImage() const = 0;
+    virtual std::string mask() const = 0;
+    virtual std::uint64_t amount() const = 0;
+    virtual TxProtocol protocolVersion() const = 0;
+    virtual bool isKeyImageKnown() const = 0;
+    virtual bool isKeyImageRequest() const = 0;
+    virtual std::uint64_t pkIndex() const = 0;
+    virtual std::vector<std::pair<std::uint64_t, std::string>> uses() const = 0;
+
+    // Multisig
+    virtual bool isKeyImagePartial() const = 0;
+};
 
 /**
  * @brief Transaction-like interface for sending money
@@ -118,6 +155,12 @@ struct PendingTransaction
      * @return vector of base58-encoded signers' public keys
      */
     virtual std::vector<std::string> signersKeys() const = 0;
+    /**
+    * brief: convertTxToStr - convert PendingTransaction to hex string (same content which would be saved to file with commit(filename))
+    * return: unsigned tx data as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string convertTxToStr() = 0;
 };
 
 /**
@@ -154,6 +197,12 @@ struct UnsignedTransaction
     * return - true on success
     */
     virtual bool sign(const std::string &signedFileName) = 0;
+    /**
+    * brief: signAsString - convert UnsignedTransaction to hex string (same content which would be saved to file with sign(filename))
+    * return: signed tx data as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string signAsString() = 0;
 };
 
 /**
@@ -166,6 +215,13 @@ struct TransactionInfo
         Direction_Out
     };
 
+    enum TxState {
+       TxState_Pending,
+       TxState_PendingInPool,
+       TxState_Failed,
+       TxState_Confirmed
+    };
+
     struct Transfer {
         Transfer(uint64_t _amount, const std::string &address);
         const uint64_t amount;
@@ -174,7 +230,9 @@ struct TransactionInfo
 
     virtual ~TransactionInfo() = 0;
     virtual int  direction() const = 0;
+    // legacy : use txState() instead
     virtual bool isPending() const = 0;
+    // legacy : use txState() instead
     virtual bool isFailed() const = 0;
     virtual bool isCoinbase() const = 0;
     virtual uint64_t amount() const = 0;
@@ -192,6 +250,10 @@ struct TransactionInfo
     virtual std::string paymentId() const = 0;
     //! only applicable for output transactions
     virtual const std::vector<Transfer> & transfers() const = 0;
+
+    virtual std::uint64_t receivedChangeAmount() const = 0;
+    virtual TxState txState() const = 0;
+    virtual bool isDoubleSpendSeen() const = 0;
 };
 /**
  * @brief The TransactionHistory - interface for displaying transaction history
@@ -297,7 +359,6 @@ private:
     std::string m_balance;
     std::string m_unlockedBalance;
 public:
-    std::string extra;
     std::string getAddress() const {return m_address;}
     std::string getLabel() const {return m_label;}
     std::string getBalance() const {return m_balance;}
@@ -413,6 +474,18 @@ struct WalletListener
      * @brief If the listener is created before the wallet this enables to set created wallet object
      */
     virtual void onSetWallet(Wallet * wallet) { (void)wallet; };
+    /**
+    * brief: onReorg - called on blockchain reorg
+    */
+    virtual void onReorg(std::uint64_t height, std::uint64_t blocks_detached, std::size_t transfers_detached) = 0;
+    /**
+    * brief: onGetPassword - called by scan_output() to decrypt keys
+    */
+    virtual optional<std::string> onGetPassword(const char *reason) = 0;
+    /**
+    * brief: onPoolTxRemoved - when obsolete pool transactions get removed
+    */
+    virtual void onPoolTxRemoved(const std::string &txid) = 0;
 };
 
 
@@ -443,6 +516,13 @@ struct Wallet
         BackgroundSync_Off = 0,
         BackgroundSync_ReusePassword = 1,
         BackgroundSync_CustomPassword = 2
+    };
+
+    struct WalletState {
+        // is wallet file format deprecated
+        bool is_deprecated;
+        std::uint64_t ring_size;
+        std::string daemon_address;
     };
 
     virtual ~Wallet() = 0;
@@ -694,6 +774,14 @@ struct Wallet
         return paymentIdFromAddress(str, testnet ? TESTNET : MAINNET);
     }
     static uint64_t maximumAllowedAmount();
+    /**
+    * brief: walletExists - check if wallet file and .keys file exist for given path
+    * param: path - filename
+    * outparam: keys_file_exists -
+    * outparam: wallet_file_exists -
+    * return: true if (key_file_exists || wallet_file_exists)
+    */
+    static bool walletExists(const std::string &path, bool &key_file_exists, bool &wallet_file_exists);
     // Easylogger wrapper
     static void init(const char *argv0, const char *default_log_base_name) { init(argv0, default_log_base_name, "", true); }
     static void init(const char *argv0, const char *default_log_base_name, const std::string &log_path, bool console);
@@ -889,6 +977,13 @@ struct Wallet
     *                          after object returned
     */
     virtual UnsignedTransaction * loadUnsignedTx(const std::string &unsigned_filename) = 0;
+    /**
+    * brief: loadUnsignedTxFromStr - create UnsignedTransaction from unsigned tx string
+    * param: unsigned_tx_str - encrypted unsigned tx hex string
+    * return: UnsignedTransaction object. caller is responsible to check UnsignedTransaction::status() after object returned
+    * note: sets status error on fail
+    */
+    virtual UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) = 0;
     
    /*!
     * \brief submitTransaction - submits transaction in signed tx file
@@ -918,6 +1013,13 @@ struct Wallet
     * \return                  - true on success
     */
     virtual bool exportKeyImages(const std::string &filename, bool all = false) = 0;
+    /**
+    * brief: exportKeyImagesAsString - export key images as string
+    * param: all - export all key images or only those that have not yet been exported
+    * return: exported key images as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string exportKeyImagesAsString(bool all = false) = 0;
    
    /*!
     * \brief importKeyImages - imports key images from file
@@ -925,6 +1027,13 @@ struct Wallet
     * \return                  - true on success
     */
     virtual bool importKeyImages(const std::string &filename) = 0;
+    /**
+    * brief: importKeyImagesFromStr - import key images from string
+    * param: data - exported key images as encrypted hex string
+    * return: true if succeeded, else false
+    * note: sets status error on fail
+    */
+    virtual bool importKeyImagesFromStr(const std::string &data) = 0;
 
     /*!
      * \brief importOutputs - exports outputs to file
@@ -1038,12 +1147,15 @@ struct Wallet
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const = 0;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const = 0;
 
-    /*
-     * \brief signMessage - sign a message with the spend private key
-     * \param message - the message to sign (arbitrary byte data)
-     * \return the signature
-     */
-    virtual std::string signMessage(const std::string &message, const std::string &address = "") = 0;
+    /**
+    * brief: signMessage - sign a message with your private key (SigV2)
+    * param: message - message to sign (arbitrary byte data)
+    * param: address - address used to sign the message (use main address if empty)
+    * param: sign_with_view_key - (default: false, use spend key to sign)
+    * return: proof type prefix + base58 encoded signature, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string signMessage(const std::string &message, const std::string &address = "", bool sign_with_view_key = false) = 0;
     /*!
      * \brief verifySignedMessage - verify a signature matches a given message
      * \param message - the message (arbitrary byte data)
@@ -1130,6 +1242,328 @@ struct Wallet
 
     //! get bytes sent
     virtual uint64_t getBytesSent() = 0;
+
+    /**
+    * brief: getMultisigSeed - get seed for multisig wallet
+    * param: seed_offset - passphrase
+    * return: seed if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string getMultisigSeed(const std::string &seed_offset) const = 0;
+    /**
+    * brief: getSubaddressIndex - get major and minor index of provided subaddress
+    * param: address - main- or sub-address to get the index from
+    * return: [major_index, minor_index] if succeeded
+    * note: sets status error on fail
+    */
+    virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const = 0;
+    /**
+    * brief: freeze - freeze enote "so they don't appear in balance, nor are considered when creating a transaction, etc." (https://github.com/monero-project/monero/pull/5333)
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * note: sets status error on fail
+    */
+    virtual void freeze(const std::string &key_image) = 0;
+    virtual void freezeByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: thaw - thaw enote that is frozen, so it appears in balance and can be spent in a transaction
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * note: sets status error on fail
+    */
+    virtual void thaw(const std::string &key_image) = 0;
+    virtual void thawByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: isFrozen - check if enote is frozen
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * return : true if enote is frozen, else false
+    * note: sets status error on fail
+    */
+    virtual bool isFrozen(const std::string &key_image) const = 0;
+    virtual bool isFrozenByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: createOneOffSubaddress - create a subaddress for given index
+    * param: account_index - major index
+    * param: address_index - minor index
+    */
+    virtual void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) = 0;
+    /**
+    * brief: getWalletState - get information about the wallet
+    * return: WalletState object
+    */
+    virtual WalletState getWalletState() const = 0;
+    /**
+    * brief: rewriteWalletFile - rewrite the wallet file for wallet update
+    * param: wallet_name - name of the wallet file (should exist)
+    * param: password - wallet password
+    * note: sets status error on fail
+    */
+    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string &password) = 0;
+    /**
+    * brief: writeWatchOnlyWallet -  create a new watch-only wallet file with view keys from current wallet
+    * param: password - password for new watch-only wallet
+    * outparam: new_keys_file_name - wallet_name + "-watchonly.keys"
+    * note: sets status error on fail
+    */
+    virtual void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) = 0;
+    /**
+    * brief: refreshPoolOnly - calls wallet2 update_pool_state and process_pool_state
+    * param: refreshed - (default: false)
+    * param: try_incremental - (default: false)
+    * note: sets status error on fail
+    */
+    virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
+    /**
+    * brief: getEnoteDetails - get information about all enotes
+    * outparam: enote_details -
+    */
+    virtual void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const = 0;
+    /**
+    * brief: convertMultisigTxToString - get the encrypted unsigned multisig transaction as hex string from a multisig pending transaction
+    * param: multisig_ptx - multisig pending transaction
+    * return: encrypted tx data as hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const = 0;
+    /**
+    * brief: saveMultisigTx - save a multisig pending transaction to file
+    * param: multisig_ptx - multisig pending transaction
+    * param: filename -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const = 0;
+    /**
+    * brief: parseTxFromStr - get transactions from encrypted signed transaction as hex string
+    * param: signed_tx_str -
+    * outparam: ptx -
+    * return: true if succeeded
+    */
+    virtual bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const = 0;
+    /**
+    * brief: insertColdKeyImages - remember cold key images for parsed tx, for when we get those txes from the blockchain
+    *                              Call:
+    *                               - parseTxFromStr()
+    *                               - accept_func() (optional)
+    *                               - importKeyImages()
+    *                               - insertColdKeyImages()
+    * param: ptx - PendingTransaction obtained from parseTxFromStr() outparam ptx
+    */
+    virtual void insertColdKeyImages(PendingTransaction &ptx) = 0;
+    /**
+    * brief: parseMultisigTxFromStr - get pending multisig transaction from encrypted unsigned multisig transaction as hex string
+    * param: multisig_tx_str -
+    * outparam: exported_txs -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const = 0;
+    /**
+    * brief: getFeeMultiplier -
+    * param: priority -
+    * param: fee_algorithm -
+    * return: fee multiplier
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const = 0;
+    /**
+    * brief: getBaseFee -
+    * return: dynamic base fee estimate if using dynamic fee, else FEE_PER_KB
+    */
+    virtual std::uint64_t getBaseFee() const = 0;
+    /**
+    * brief: adjustPriority - adjust priority depending on how "full" last N blocks are
+    * param: priority -
+    * return: adjusted priority
+    * warning: doesn't tell if it failed
+    */
+    virtual std::uint32_t adjustPriority(std::uint32_t priority) = 0;
+    /**
+    * brief: coldTxAuxImport -
+    * param: ptx -
+    * param: tx_device_aux -
+    * note: sets status error on fail
+    */
+    virtual void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const = 0;
+    /**
+    * brief: coldSignTx -
+    * param: ptx_in -
+    * outparam: exported_txs_out -
+    */
+    virtual void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const = 0;
+    /**
+    * brief: discardUnmixableEnotes - freeze all unmixable enotes
+    * note: sets status error on fail
+    */
+    virtual void discardUnmixableEnotes() = 0;
+    /**
+    * brief: setTxKey - set the transaction key (r) for a given <txid> in case the tx was made by some other device or 3rd party wallet
+    * param: txid -
+    * param: tx_key - secret transaction key r
+    * param: additional_tx_keys -
+    * param: single_destination_subaddress -
+    * note: sets status error on fail
+    */
+    virtual void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) = 0;
+    /**
+    * brief: getAccountTags - get the list of registered account tags
+    * return: first.Key=(tag's name), first.Value=(tag's label), second[i]=(i-th account's tag)
+    */
+    virtual const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const = 0;
+    /**
+    * brief: setAccountTag - set a tag to a set of subaddress accounts by index
+    * param: account_index - major index
+    * param: tag -
+    * note: sets status error on fail
+    */
+    virtual void setAccountTag(const std::set<std::uint32_t> &account_indices, const std::string &tag) = 0;
+    /**
+    * brief: setAccountTagDescription - set a description for a tag, tag must already exist
+    * param: tag -
+    * param: description -
+    * note: sets status error on fail
+    */
+    virtual void setAccountTagDescription(const std::string &tag, const std::string &description) = 0;
+    /**
+    * brief: exportEnotesToStr - export enotes and return encrypted data
+    *                            (comparable with legacy exportOutputs(), with the difference that this returns a string, the other one saves to file)
+    * param: all   - go from `start` for `count` enotes if true, else go incremental from last exported enote for `count` enotes (default: false)
+    * param: start - offset index in enote storage, needs to be 0 for incremental mode (default: 0)
+    * param: count - try to export this quantity of enotes (default: 0xffffffff)
+    * return: encrypted data of exported enotes as hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const = 0;
+    /**
+    * brief: importEnotesFromStr - import enotes from encrypted hex string
+    * param: enotes_str - enotes data as encrypted hex string
+    * return: total size of enote storage
+    * note: sets status error on fail
+    */
+    virtual std::size_t importEnotesFromStr(const std::string &enotes_str) = 0;
+    /**
+    * brief: getBlockchainHeightByDate -
+    * param: year  -
+    * param: month - in range 1-12
+    * param: day   - in range 1-31
+    * return: blockchain height
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const = 0;
+    /**
+    * brief: estimateBacklog -
+    * param: fee_levels - [ [fee per byte min, fee per byte max], ... ]
+    * return: [ [number of blocks min, number of blocks max], ... ]
+    * note: sets status error on fail
+    */
+    virtual std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const = 0;
+    /**
+    * brief: saveToFile   - save hex string to file
+    * param: path_to_file - file name
+    * param: binary       - hex string data
+    * param: is_printable - (default: false)
+    * return: true if succeeded
+    */
+    virtual bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const = 0;
+    /**
+    * brief: loadFromFile  - load hex string from file
+    * param: path_to_file  - file name
+    * outparam: target_str - hex string data
+    * param: max_size      - maximum size in bytes (default: 1000000000)
+    * return: true if succeeded
+    */
+    virtual bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const = 0;
+    /**
+    * brief: hashEnotes - get hash of all enotes in local enote store up until `enote_idx`
+    *                     (formerly in wallet2: `uint64_t wallet2::hash_m_transfers(boost::optional<uint64_t> transfer_height, crypto::hash &hash)`)
+    * param: enote_idx - include all enotes below this index
+    * outparam: hash - hash as hex string
+    * return: number of hashed enotes
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const = 0;
+    /**
+    * brief: finishRescanBcKeepKeyImages  -
+    * param: enote_idx -
+    * param: hash -
+    * note: sets status error on fail
+    */
+    virtual void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) = 0;
+    /**
+    * brief: getPublicNodes - get a list of public notes with information when they were last seen
+    * param: white_only - include gray nodes if false (default: true)
+    * return: [ [ host_ip, host_rpc_port, last_seen ], ... ]
+    * note: sets status error on fail
+    */
+    virtual std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const = 0;
+    /**
+    * brief: estimateTxSizeAndWeight -
+    * param: use_rct    -
+    * param: n_inputs   - number of input enotes
+    * param: ring_size  -
+    * param: n_outputs  - number of output enotes
+    * param: extra_size - size of tx_extra
+    * return: [estimated tx size, estimated tx weight]
+    * note: sets status error on fail
+    */
+    virtual std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const = 0;
+    /**
+    * brief: importKeyImages -
+    * param: signed_key_images - [ [key_image, signature c || signature r], ... ]
+    * param: offset      - offset in local enote storage
+    * outparam: spent    - total spent amount of the wallet
+    * outparam: unspent  - total unspent amount of the wallet
+    * param: check_spent -
+    * return: blockchain height of last signed key image, can be 0 if height unknown
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) = 0;
+    /**
+    * brief: importKeyImages -
+    * param: key_images -
+    * param: offset     - offset in local enote storage
+    * param: selected_enotes_indices -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) = 0;
+    /**
+    * brief: getAllowMismatchedDaemonVersion -
+    */
+    virtual bool getAllowMismatchedDaemonVersion() const = 0;
+    /**
+    * brief: setAllowMismatchedDaemonVersion -
+    * param: allow_mismatch -
+    */
+    virtual void setAllowMismatchedDaemonVersion(bool allow_mismatch) = 0;
+    /**
+    * brief: setDaemon -
+    * param: daemon_address       -
+    * param: daemon_username      - for daemon login (default: empty string)
+    * param: daemon_password      - for daemon login (default: empty string)
+    * param: trusted_daemon       - (default: false)
+    * param: ssl_support          - "disabled" | "enabled" | "autodetect" (default: "autodetect")
+    * param: ssl_private_key_path - (default: empty string)
+    * param: ssl_certificate_path - (default: empty string)
+    * param: ssl_ca_file_path     - (default: empty string)
+    * param: ssl_allowed_fingerprints_str - (default: empty vector)
+    * param: ssl_allow_any_cert   - (default: false)
+    * param: proxy                - (default: empty string)
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool setDaemon(const std::string &daemon_address,
+        const std::string &daemon_username = "",
+        const std::string &daemon_password = "",
+        bool trusted_daemon = false,
+        const std::string &ssl_support = "autodetect",
+        const std::string &ssl_private_key_path = "",
+        const std::string &ssl_certificate_path = "",
+        const std::string &ssl_ca_file_path = "",
+        const std::vector<std::string> &ssl_allowed_fingerprints_str = {},
+        bool ssl_allow_any_cert = false,
+        const std::string &proxy = "") = 0;
 };
 
 /**

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -35,12 +35,14 @@
 #include <ctime>
 #include <iostream>
 #include <list>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -68,29 +70,64 @@ enum NetworkType : uint8_t {
 */
 struct EnoteDetails
 {
-    enum TxProtocol {
+    enum class TxProtocol {
         TxProtocol_CryptoNote,
         TxProtocol_RingCT
     };
 
     virtual ~EnoteDetails() = 0;
+    //! enote public key (Ko), as hex string
     virtual std::string onetimeAddress() const = 0;
+    //! view tag, as hex string
     virtual std::string viewTag() const = 0;
+    //! payment id, as 16 char (8 bytes, short encrypted) or 64 char (32 bytes, long unencrypted [DEPRECATED]) hex string
+    virtual std::string paymentId() const = 0;
+    //! blockchain height at which this enote was received
     virtual std::uint64_t blockHeight() const = 0;
+    //! when enote will become spendable
+    // NOTE: there was a change in tx relay rule that prevents to make txs with arbitrary lock times: https://github.com/monero-project/monero/pull/9151
+    // txs that were created before the new rule can still be locked, unlockTime() is represented either as block index if unlockTime() < CRYPTONOTE_MAX_BLOCK_NUMBER or else as time
+    // now with the new rule, txs will have this set to either 0 for normal txs
+    //                        or blockHeight() + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW for coinbase txs
+    // NOTE: if unlockTime() == 0, the blockchain still has to reach blockHeight() + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE before this enote is actually unlocked
+    virtual std::uint64_t unlockTime() const = 0;
+    //! return true if enote is unlocked
+    virtual bool isUnlocked() const = 0;
+    //! tx id, as hex string
     virtual std::string txId() const = 0;
+    //! index in tx
     virtual std::uint64_t internalEnoteIndex() const = 0;
+    //! index in db
     virtual std::uint64_t globalEnoteIndex() const = 0;
+    //! return true if enote is spent
     virtual bool isSpent() const = 0;
+    //! return true if enote is frozen
     virtual bool isFrozen() const = 0;
+    //! blockchain height at which enote was spent, set to 0 if enote hasn't been spent yet
     virtual std::uint64_t spentHeight() const = 0;
+    //! key image, as hex string
     virtual std::string keyImage() const = 0;
+    //! x, blinding factor in amount commitment C = x G + a H, as hex string
     virtual std::string mask() const = 0;
+    //! amount in piconero
     virtual std::uint64_t amount() const = 0;
+    //! protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
     virtual TxProtocol protocolVersion() const = 0;
+    //! return true if key image is known
     virtual bool isKeyImageKnown() const = 0;
+    //! return true if:
+    //      a) for view wallets: we want to request the key image for this enote
+    //      b) for cold wallets: the key image for this enote was requested
     virtual bool isKeyImageRequest() const = 0;
+    //! public key index in tx_extra
     virtual std::uint64_t pkIndex() const = 0;
+    //! show uses of this enote as decoy in the blockchain in the format [ [block_height, tx_id], ... ]
+    // Note: tracking this is disabled by default, use `Wallet::setTrackUses(true)` to enable tracking
     virtual std::vector<std::pair<std::uint64_t, std::string>> uses() const = 0;
+    //! account index
+    virtual std::uint32_t subaddressIndexMajor() const = 0;
+    //! subaddress index
+    virtual std::uint32_t subaddressIndexMinor() const = 0;
 
     // Multisig
     virtual bool isKeyImagePartial() const = 0;
@@ -108,21 +145,25 @@ struct PendingTransaction
     };
 
     enum Priority {
-        Priority_Default = 0,
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
+        Priority_Default  = 0,
+        Priority_Low      = 1,  // unimportant
+        Priority_Medium   = 2,  // normal
+        Priority_High     = 3,  // elevated
+        Priority_VeryHigh = 4,  // priority
         Priority_Last
     };
 
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
+    virtual std::string confirmationMessage() const = 0;
     // commit transaction or save to file if filename is provided.
     virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t dust() const = 0;
+    virtual uint64_t dustInFee() const = 0;
     virtual uint64_t fee() const = 0;
+    virtual uint64_t change() const = 0;
     virtual std::vector<std::string> txid() const = 0;
     /*!
      * \brief txCount - number of transactions current transaction will be split into
@@ -131,6 +172,67 @@ struct PendingTransaction
     virtual uint64_t txCount() const = 0;
     virtual std::vector<uint32_t> subaddrAccount() const = 0;
     virtual std::vector<std::set<uint32_t>> subaddrIndices() const = 0;
+    /**
+    * brief: convertTxToStr - convert `PendingTransaction` to octal escape sequence string of `UnsignedTransaction`
+    *                         encrypted with the wallet's secret view key
+    *                         (same content which would be saved to file with `ptx->commit(filename)`)
+    *                         which then can be read with `loadUnsignedTxFromStr()`
+    * return: unsigned tx data as encrypted octal escape sequence string if succeeded, else empty string
+    * note: sets status error on failure
+    *       - to get a hex string call:
+    *           `epee::string_tools::buff_to_hex_nodelimer(ptx->convertTxToStr())`
+    */
+    virtual std::string convertTxToStr() = 0;
+    /**
+    * brief: convertTxToRawBlobStr - convert each tx in `PendingTransaction` to octal escape sequence string
+    *                                which can be turned into hex string and used as arguments for `tx_as_hex`
+    *                                for daemon RPC `/send_raw_transaction`
+    * return: serialized tx data as octal escape sequence strings if succeeded, else empty vector
+    * note: sets status error on failure
+    *       - to get a hex string call:
+    *           `epee::string_tools::buff_to_hex_nodelimer(ptx->convertTxToRawBlobStr())`
+    */
+    virtual std::vector<std::string> convertTxToRawBlobStr() = 0;
+    /**
+    * brief: getWorstFeePerByte - needed when checking for backlog
+    * return: worst fee per bytes
+    */
+    virtual double getWorstFeePerByte() const = 0;
+    /**
+    * brief: vinOffsets - relative indices + offsets for all real inputs and decoys for each ring and each tx
+    * return: enote indices
+              [ tx_idx : [ ring_idx : [ enote_idx_0 : global_idx, ..., enote_idx_<n_ring_members> : offset  ], ... ], ... ]
+    * note: - there is one ring for each input enote
+    *         enote_idx_0 is the global enote index in the db, every following enote_idx_<n> is the offset from enote_idx_0
+    *       - these indices (after being converted to absolute indices) are used by RPC /get_outs.bin
+    *       - to get the real inputs indices use constructionDataRealOutputIndices()
+    */
+    virtual std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const = 0;
+    /**
+    * brief: constructionDataRealOutputIndices -
+    * return: indices of real input enotes in ring per tx
+    *         [ tx_idx : [ ring_idx : real_input_idx_in_ring , ... ], ... ]
+    */
+    virtual std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const = 0;
+    /**
+    * brief: vinAmounts -
+    * return: enote amounts
+    */
+    virtual std::vector<std::vector<std::uint64_t>> vinAmounts() const = 0;
+    /**
+    * brief: getEnoteDetailsIn -
+    * return: enote details for all enotes that are used as inputs per tx
+    *         [ tx_idx : [ enote_idx : EnoteDetails, ... ], ... ]
+    */
+    virtual std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const =0;
+    /**
+    * brief: finishParsingTx - remember cold key images for parsed tx, for when we get those txes from the blockchain
+    *                           call this after both:
+    *                            1.) this ptx was created with Wallet::parseTxFromStr()
+    *                            2.) user accepted the ptx->confirmationMessage()
+    * return: true on success
+    */
+    virtual bool finishParsingTx() = 0;
 
     /**
      * @brief multisigSignData
@@ -149,18 +251,23 @@ struct PendingTransaction
      *              pendingTransaction->commit();
      */
     virtual std::string multisigSignData() = 0;
-    virtual void signMultisigTx() = 0;
+    /**
+     * @brief signMultisigTx
+     * @outparam txids - only gets set if multisig tx is fully signed, else empty if partially signed
+     */
+    virtual void signMultisigTx(std::vector<std::string> *txids = nullptr) = 0;
     /**
      * @brief signersKeys
      * @return vector of base58-encoded signers' public keys
      */
     virtual std::vector<std::string> signersKeys() const = 0;
     /**
-    * brief: convertTxToStr - convert PendingTransaction to hex string (same content which would be saved to file with commit(filename))
-    * return: unsigned tx data as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
-    */
-    virtual std::string convertTxToStr() = 0;
+     * @brief finishRestoringMultisigTransaction - call this if:
+     *                                               1.) this ptx was created with Wallet::restoreMultisigTransaction(..., ask_for_confirmation = true)
+     *                                             and then
+     *                                               2.) user accepted the ptx->confirmationMessage()
+     */
+    virtual void finishRestoringMultisigTransaction() = 0;
 };
 
 /**
@@ -194,13 +301,17 @@ struct UnsignedTransaction
    /*!
     * @brief sign - Sign txs and saves to file
     * @param signedFileName
+    * @param do_export_raw - export signed transaction as raw unencrypted hex
+    *                        along normal <signedFileName>
+    *                        as "<signedFileName>_raw[_<n_txs>]" (Default: false)
+    * @param tx_ids_out
     * return - true on success
     */
-    virtual bool sign(const std::string &signedFileName) = 0;
+    virtual bool sign(const std::string &signedFileName, bool do_export_raw = false, std::vector<std::string> *tx_ids_out = nullptr) = 0;
     /**
     * brief: signAsString - convert UnsignedTransaction to hex string (same content which would be saved to file with sign(filename))
     * return: signed tx data as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string signAsString() = 0;
 };
@@ -215,7 +326,7 @@ struct TransactionInfo
         Direction_Out
     };
 
-    enum TxState {
+    enum class TxState {
        TxState_Pending,
        TxState_PendingInPool,
        TxState_Failed,
@@ -235,6 +346,7 @@ struct TransactionInfo
     // legacy : use txState() instead
     virtual bool isFailed() const = 0;
     virtual bool isCoinbase() const = 0;
+    virtual bool isUnlocked() const = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t fee() const = 0;
     virtual uint64_t blockHeight() const = 0;
@@ -406,15 +518,21 @@ struct WalletListener
      * @brief moneySpent - called when money spent
      * @param txId       - transaction id
      * @param amount     - amount
+     * @param enote_pub_key - enote public key
+     * @param subaddr_index - accounnt index (major) and subaddress index (minor)
      */
-    virtual void moneySpent(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneySpent(const std::string &txId, uint64_t amount, const std::string &enote_pub_key, std::pair<uint32_t, uint32_t> subaddr_index = {}) = 0;
 
     /**
      * @brief moneyReceived - called when money received
      * @param txId          - transaction id
-     * @param amount        - amount
+     * @param amount        - amount (after subtracting burnt amount)
+     * @param burnt         - amount burnt
+     * @param enote_pub_key - enote public key
+     * @param is_change     - whether output is change
+     * @param is_coinbase   - whether output is coinbase
      */
-    virtual void moneyReceived(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneyReceived(const std::string &txId, uint64_t amount, const uint64_t burnt, const std::string &enote_pub_key, const bool is_change = false, const bool is_coinbase = false) = 0;
     
    /**
     * @brief unconfirmedMoneyReceived - called when payment arrived in tx pool
@@ -488,6 +606,16 @@ struct WalletListener
     virtual void onPoolTxRemoved(const std::string &txid) = 0;
 };
 
+/**
+ * @brief RAII interface for decrypting in-memory wallet spend-keys
+ */
+struct WalletKeysDecryptGuard
+{
+    /**
+     * @brief Re-encrypt spend-keys on destruct unless other WalletKeysDecryptGuard is in scope for same wallet
+     */
+    virtual ~WalletKeysDecryptGuard() = 0;
+};
 
 /**
  * @brief Interface for wallet operations.
@@ -518,17 +646,69 @@ struct Wallet
         BackgroundSync_CustomPassword = 2
     };
 
+    enum class AskPasswordType {
+      AskPassword_Never = 0,
+      AskPassword_OnAction = 1,
+      AskPassword_ToDecrypt = 2,
+    };
+
+    enum class RefreshType {
+      Refresh_Full = 0,
+      Refresh_OptimizeCoinbase = 1,
+      Refresh_NoCoinbase = 2,
+      Refresh_Default = Refresh_OptimizeCoinbase,
+    };
+
+    enum class BackgroundMiningSetupType {
+      BackgroundMining_Maybe = 0,
+      BackgroundMining_Yes = 1,
+      BackgroundMining_No = 2,
+    };
+
+    enum class ExportFormat {
+      ExportFormat_Binary = 0,
+      ExportFormat_Ascii = 1,
+    };
+
+    enum class SSLSupport {
+        SSLSupport_Disabled = 0,
+        SSLSupport_Enabled = 1,
+        SSLSupport_Autodetect = 2,
+    };
+
+    struct DeviceState {
+        enum class DeviceProtocol {
+          DeviceProtocol_Default = 0,
+          DeviceProtocol_Proxy = 1,
+          DeviceProtocol_Cold = 2,
+        };
+        enum class DeviceType {
+          DeviceType_Software = 0,
+          DeviceType_Ledger = 1,
+          DeviceType_Trezor = 2,
+        };
+
+        bool key_on_device;
+        std::string device_name;
+        bool has_tx_cold_sign;
+        bool has_ki_live_refresh;
+        bool has_ki_cold_sync;
+        std::uint64_t last_ki_sync;
+        DeviceProtocol protocol;
+        DeviceType device_type;
+    };
+
     struct WalletState {
         // is wallet file format deprecated
         bool is_deprecated;
-        std::uint64_t ring_size;
+        bool is_unattended;
         std::string daemon_address;
+        std::string ring_database;
+        std::uint64_t n_enotes;
     };
 
     virtual ~Wallet() = 0;
     virtual std::string seed(const std::string& seed_offset = "") const = 0;
-    virtual std::string getSeedLanguage() const = 0;
-    virtual void setSeedLanguage(const std::string &arg) = 0;
     //! returns wallet status (Status_Ok | Status_Error)
     virtual int status() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! in case error status, returns error string
@@ -640,19 +820,6 @@ struct Wallet
     virtual bool createWatchOnly(const std::string &path, const std::string &password, const std::string &language) const = 0;
 
    /*!
-    * \brief setRefreshFromBlockHeight - start refresh from block height on recover
-    *
-    * \param refresh_from_block_height - blockchain start height
-    */
-    virtual void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) = 0;
-
-   /*!
-    * \brief getRestoreHeight - get wallet creation height
-    *
-    */
-    virtual uint64_t getRefreshFromBlockHeight() const = 0;
-
-   /*!
     * \brief setRecoveringFromSeed - set state recover form seed
     *
     * \param recoveringFromSeed - true/false
@@ -666,19 +833,16 @@ struct Wallet
     */
     virtual void setRecoveringFromDevice(bool recoveringFromDevice) = 0;
 
-    /*!
-     * \brief setSubaddressLookahead - set size of subaddress lookahead
-     *
-     * \param major - size for the major index
-     * \param minor - size for the minor index
-     */
-    virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
-
     /**
-     * @brief connectToDaemon - connects to the daemon. TODO: check if it can be removed
-     * @return
+     * @brief connectToDaemon - connects to the daemon.
+     * outparam: version -
+     * outparam: ssl -
+     * param: timeout -
+     * outparam: wallet_is_outdated -
+     * outparam: daemon_is_outdated -
+     * @return true if connected to daemon
      */
-    virtual bool connectToDaemon() = 0;
+    virtual bool connectToDaemon(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 20000, bool *wallet_is_outdated = NULL, bool *daemon_is_outdated = NULL) = 0;
 
     /**
      * @brief connected - checks if the wallet connected to the daemon
@@ -689,13 +853,15 @@ struct Wallet
     virtual bool trustedDaemon() const = 0;
     virtual bool setProxy(const std::string &address) = 0;
     virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
+    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const = 0;
     uint64_t balanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
             result += balance(i);
         return result;
     }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0) const = 0;
+    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL) const = 0;
+    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const = 0;
     uint64_t unlockedBalanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
@@ -746,6 +912,8 @@ struct Wallet
      *             status() will return Status_Error and errorString() will return verbose error description
      */
     virtual uint64_t daemonBlockChainTargetHeight() const = 0;
+    //! return: true if daemon is synced
+    virtual bool daemonSynced() const = 0;
 
     /**
      * @brief synchronized - checks if wallet was ever synchronized
@@ -758,6 +926,8 @@ struct Wallet
     static uint64_t amountFromDouble(double amount);
     static std::string genPaymentId();
     static bool paymentIdValid(const std::string &paiment_id);
+    static bool isSubaddress(const std::string &address, NetworkType nettype);
+    static std::string getAddressFromIntegrated(const std::string &address, NetworkType nettype);
     static bool addressValid(const std::string &str, NetworkType nettype);
     static bool addressValid(const std::string &str, bool testnet)          // deprecated
     {
@@ -801,9 +971,20 @@ struct Wallet
 
     /**
      * @brief refresh - refreshes the wallet, updating transactions from daemon
+     * @param start_height          - (Default: 0)
+     * @param check_pool            - wether to also scan tx pool (Default: true)
+     * @param try_incremental       - if daemon supports it, only get txs from the pool which the wallet hasn't seen before (Default: false)
+     * @param max_blocks            - refresh returns when blocks fetched reaches max_blocks (Default: std::numeric_limits<std::uint64_t>::max())
+     * @outparam blocks_fetched_out - number of blocks fetched during refresh (Default: nullptr)
+     * @outparam received_money_out - true if the wallet received money in the blocks fetched during refresh (Default: nullptr)
      * @return - true if refreshed successfully;
      */
-    virtual bool refresh() = 0;
+    virtual bool refresh(std::uint64_t start_height = 0,
+                         bool check_pool = true,
+                         bool try_incremental = false,
+                         std::uint64_t max_blocks = std::numeric_limits<std::uint64_t>::max(),
+                         std::uint64_t *blocks_fetched_out = nullptr,
+                         bool *received_money_out = nullptr) = 0;
 
     /**
      * @brief refreshAsync - refreshes wallet asynchronously.
@@ -812,14 +993,25 @@ struct Wallet
 
     /**
      * @brief rescanBlockchain - rescans the wallet, updating transactions from daemon
+     * @param do_hard_rescan     - if true you will lose any information which can not be recovered from the blockchain itself (Default: true)
+     * @param do_keep_key_images - keep key images, only works with soft rescan,
+     *                             if set `true` you may want to check `hashEnotes()` and `finishRescanBcKeepKeyImages()` for manual control,
+     *                             else set `do_skip_refresh = false` and the two methods get handled automatically by the backend (Default: false)
+     * @param do_skip_refresh    - if true this functions does not call `refresh()` itself,
+     *                             so you have to call it manually and therefore can make use of the outparams (Default: false)
      * @return - true if refreshed successfully;
+     * @note -  do_hard_rescan   do_keep_key_images
+     *          false            false                  soft rescan
+     *          false            true                   soft rescan, keep key images
+     *          true             false                  hard rescan
+     *          true             true                   ERROR: cannot preserve key images on hard rescan
      */
-    virtual bool rescanBlockchain() = 0;
+    virtual bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) = 0;
 
     /**
      * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesis
      */
-    virtual void rescanBlockchainAsync() = 0;
+    virtual void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) = 0;
 
     /**
      * @brief setAutoRefreshInterval - setup interval for automatic refresh.
@@ -921,9 +1113,12 @@ struct Wallet
     /**
      * @brief restoreMultisigTransaction creates PendingTransaction from signData
      * @param signData encrypted unsigned transaction. Obtained with PendingTransaction::multisigSignData
+     * @param ask_for_confirmation - if set true the transaction doesn't get fully loaded,
+     *                               in case you want to get a confirmation text from ptx->confirmationMessage()
+     *                               and then, if the user accepts the message, call ptx->finishRestoringMultisigTransaction() to complete loading the tx (Default: false)
      * @return PendingTransaction
      */
-    virtual PendingTransaction*  restoreMultisigTransaction(const std::string& signData) = 0;
+    virtual PendingTransaction*  restoreMultisigTransaction(const std::string& signData, bool ask_for_confirmation = false) = 0;
 
     /*!
      * \brief createTransactionMultDest creates transaction with multiple destinations. if dst_addr is an integrated address, payment_id is ignored
@@ -931,9 +1126,13 @@ struct Wallet
      * \param payment_id                optional payment_id, can be empty string
      * \param amount                    vector of amounts
      * \param mixin_count               mixin count. if 0 passed, wallet will use default value
+     * \param priority                  fee priority, Priority_[Low|Medium|High|VeryHigh] (Default: Priority_Low)
      * \param subaddr_account           subaddress account from which the input funds are taken
      * \param subaddr_indices           set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
+     * \param subtract_fee_from_outputs transfer amount with fee included #8861
+     * \param key_image                 only used for sweep_single (Default: empty string)
+     * \param outputs                   number of outputs to create, only used for sweeping, for normal transactions `outputs` get determined by `dst_addr` (Default: 1)
+     * \param below                     threshold for sweep_below, only used if `amount` is not set (Default: 0)
      * \return                          PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                                  after object returned
      */
@@ -942,7 +1141,11 @@ struct Wallet
                                                    optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
                                                    PendingTransaction::Priority = PendingTransaction::Priority_Low,
                                                    uint32_t subaddr_account = 0,
-                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
+                                                   std::set<uint32_t> subaddr_indices = {},
+                                                   std::set<uint32_t> subtract_fee_from_outputs = {},
+                                                   const std::string key_image = "",
+                                                   const size_t outputs = 1,
+                                                   const std::uint64_t below = 0) = 0;
 
     /*!
      * \brief createTransaction creates transaction. if dst_addr is an integrated address, payment_id is ignored
@@ -950,9 +1153,9 @@ struct Wallet
      * \param payment_id        optional payment_id, can be empty string
      * \param amount            amount
      * \param mixin_count       mixin count. if 0 passed, wallet will use default value
+     * \param priority          fee priority, Priority_[Low|Medium|High|VeryHigh] (Default: Priority_Low)
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
@@ -981,13 +1184,19 @@ struct Wallet
     * brief: loadUnsignedTxFromStr - create UnsignedTransaction from unsigned tx string
     * param: unsigned_tx_str - encrypted unsigned tx hex string
     * return: UnsignedTransaction object. caller is responsible to check UnsignedTransaction::status() after object returned
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) = 0;
-    
    /*!
     * \brief submitTransaction - submits transaction in signed tx file
     * \return                  - true on success
+    * \note                    - this submits the transaction without checking the file content and asking for confirmation
+    *                            if you want to get a confirmationMessage before commiting, use:
+    *                               1. loadFromFile(signed_tx_file, signed_tx_str);
+    *                               2. ptx = parseTxFromStr(signed_tx_str);
+    *                               3. if there are no errors and user accepts ptx->confirmationMessage()
+    *                                  ptx->finishParsingTx()
+    *                               4. ptx->commit()
     */
     virtual bool submitTransaction(const std::string &fileName) = 0;
     
@@ -1017,21 +1226,24 @@ struct Wallet
     * brief: exportKeyImagesAsString - export key images as string
     * param: all - export all key images or only those that have not yet been exported
     * return: exported key images as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string exportKeyImagesAsString(bool all = false) = 0;
    
    /*!
-    * \brief importKeyImages - imports key images from file
+    * \brief importKeyImages  - imports key images from file
     * \param filename
-    * \return                  - true on success
+    * \outparam spent_out     - spent amount in imported key images
+    * \outparam unspent_out   - unspent amount in imported key images
+    * \outparam import_height - height of most recent imported key image
+    * \return                 - true on success
     */
-    virtual bool importKeyImages(const std::string &filename) = 0;
+    virtual bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) = 0;
     /**
     * brief: importKeyImagesFromStr - import key images from string
     * param: data - exported key images as encrypted hex string
     * return: true if succeeded, else false
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool importKeyImagesFromStr(const std::string &data) = 0;
 
@@ -1052,9 +1264,10 @@ struct Wallet
     /*!
      * \brief scanTransactions - scan a list of transaction ids, this operation may reveal the txids to the remote node and affect your privacy
      * \param txids            - list of transaction ids
+     * \param wont_reprocess_recent_txs_via_untrusted_daemon - allows you to catch the wallet error with the same name (used by CLI to show certain error message)
      * \return                 - true on success
      */
-    virtual bool scanTransactions(const std::vector<std::string> &txids) = 0;
+    virtual bool scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon = nullptr) = 0;
 
     /*!
      * \brief setupBackgroundSync       - setup background sync mode with just a view key
@@ -1153,7 +1366,7 @@ struct Wallet
     * param: address - address used to sign the message (use main address if empty)
     * param: sign_with_view_key - (default: false, use spend key to sign)
     * return: proof type prefix + base58 encoded signature, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string signMessage(const std::string &message, const std::string &address = "", bool sign_with_view_key = false) = 0;
     /*!
@@ -1161,9 +1374,11 @@ struct Wallet
      * \param message - the message (arbitrary byte data)
      * \param address - the address the signature claims to be made with
      * \param signature - the signature
+     * \outparam is_old_out - true if signature uses old format (optional)
+     * \outparam signature_type_out - either signed by: spendkey | viewkey | unkown (suspicious); (optional)
      * \return true if the signature verified, false otherwise
      */
-    virtual bool verifySignedMessage(const std::string &message, const std::string &addres, const std::string &signature) const = 0;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const = 0;
 
     /*!
      * \brief signMultisigParticipant   signs given message with the multisig public signer key
@@ -1208,12 +1423,15 @@ struct Wallet
     virtual bool setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative) = 0;
 
     //! sets whether pre-fork outs are to be segregated
+    // DEPRECATED, use setSegregatePreForkOutputs()
     virtual void segregatePreForkOutputs(bool segregate) = 0;
 
     //! sets the height where segregation should occur
+    // DEPRECATED, use setSegregationHeight()
     virtual void segregationHeight(uint64_t height) = 0;
 
     //! secondary key reuse mitigation
+    // DEPRECATED, use setKeyReuseMitigation2()
     virtual void keyReuseMitigation2(bool mitigation) = 0;
 
     //! locks/unlocks the keys file; returns true on success
@@ -1222,13 +1440,20 @@ struct Wallet
     //! returns true if the keys file is locked
     virtual bool isKeysFileLocked() = 0;
 
+    /**
+     * \brief Decrypt spend-keys if not already decrypted and create a keys decryption guard
+     * \param password password to decrypt in-memory spend-keys
+     * \return Keys decryption guard
+     */
+    virtual std::unique_ptr<WalletKeysDecryptGuard> createKeysDecryptGuard(const std::string_view &password) = 0;
+
     /*!
      * \brief Queries backing device for wallet keys
      * \return Device they are on
      */
     virtual Device getDeviceType() const = 0;
 
-    //! cold-device protocol key image sync
+    //! cold-device protocol key image sync, Note: this can throw
     virtual uint64_t coldKeyImageSync(uint64_t &spent, uint64_t &unspent) = 0;
 
     //! shows address on device display
@@ -1247,41 +1472,39 @@ struct Wallet
     * brief: getMultisigSeed - get seed for multisig wallet
     * param: seed_offset - passphrase
     * return: seed if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string getMultisigSeed(const std::string &seed_offset) const = 0;
     /**
     * brief: getSubaddressIndex - get major and minor index of provided subaddress
     * param: address - main- or sub-address to get the index from
     * return: [major_index, minor_index] if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const = 0;
     /**
     * brief: freeze - freeze enote "so they don't appear in balance, nor are considered when creating a transaction, etc." (https://github.com/monero-project/monero/pull/5333)
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
-    * note: sets status error on fail
+    * param: enote_pub_key - public key of enote
+    * note: sets status error on failure
     */
     virtual void freeze(const std::string &key_image) = 0;
-    virtual void freezeByPubKey(const std::string &public_key) = 0;
+    virtual void freezeByPubKey(const std::string &enote_pub_key) = 0;
     /**
     * brief: thaw - thaw enote that is frozen, so it appears in balance and can be spent in a transaction
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
-    * note: sets status error on fail
+    * param: enote_pub_key - public key of enote
+    * note: sets status error on failure
     */
     virtual void thaw(const std::string &key_image) = 0;
-    virtual void thawByPubKey(const std::string &public_key) = 0;
+    virtual void thawByPubKey(const std::string &enote_pub_key) = 0;
     /**
     * brief: isFrozen - check if enote is frozen
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
     * return : true if enote is frozen, else false
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool isFrozen(const std::string &key_image) const = 0;
-    virtual bool isFrozenByPubKey(const std::string &public_key) = 0;
     /**
     * brief: createOneOffSubaddress - create a subaddress for given index
     * param: account_index - major index
@@ -1294,36 +1517,55 @@ struct Wallet
     */
     virtual WalletState getWalletState() const = 0;
     /**
+    * brief: getDeviceState - get information about the HW device
+    * return: DeviceState object
+    */
+    virtual DeviceState getDeviceState() const = 0;
+    /**
     * brief: rewriteWalletFile - rewrite the wallet file for wallet update
     * param: wallet_name - name of the wallet file (should exist)
     * param: password - wallet password
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
-    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string &password) = 0;
+    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string_view &password) = 0;
     /**
     * brief: writeWatchOnlyWallet -  create a new watch-only wallet file with view keys from current wallet
     * param: password - password for new watch-only wallet
     * outparam: new_keys_file_name - wallet_name + "-watchonly.keys"
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
-    virtual void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) = 0;
+    virtual void writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name) = 0;
     /**
     * brief: refreshPoolOnly - calls wallet2 update_pool_state and process_pool_state
     * param: refreshed - (default: false)
     * param: try_incremental - (default: false)
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
     /**
     * brief: getEnoteDetails - get information about all enotes
-    * outparam: enote_details -
+    * return: vector of enotes details
     */
-    virtual void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const = 0;
+    virtual std::vector<std::unique_ptr<EnoteDetails>> getEnoteDetails() const = 0;
+    /**
+    * brief: getEnoteDetails - get information about a single enote
+    * param: enote_pub_key - ephemeral public key
+    * return: enote details if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<EnoteDetails> getEnoteDetails(const std::string &enote_pub_key) const = 0;
+    /**
+    * brief: getEnoteDetails - get information about a single enote
+    * param: enote_index - index of enote in internal storage
+    * return: enote details if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<EnoteDetails> getEnoteDetails(const std::size_t enote_index) const = 0;
     /**
     * brief: convertMultisigTxToString - get the encrypted unsigned multisig transaction as hex string from a multisig pending transaction
     * param: multisig_ptx - multisig pending transaction
     * return: encrypted tx data as hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const = 0;
     /**
@@ -1331,40 +1573,31 @@ struct Wallet
     * param: multisig_ptx - multisig pending transaction
     * param: filename -
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const = 0;
     /**
     * brief: parseTxFromStr - get transactions from encrypted signed transaction as hex string
     * param: signed_tx_str -
-    * outparam: ptx -
-    * return: true if succeeded
+    * return: PendingTransaction object. caller is responsible to check ptx->status()
+    *         and ptx->confirmationMessage() after object returned, and then ptx->finishParsingTx()
+    *         if user accepts confirmationMessage
+    * note: sets status error on failure
     */
-    virtual bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const = 0;
-    /**
-    * brief: insertColdKeyImages - remember cold key images for parsed tx, for when we get those txes from the blockchain
-    *                              Call:
-    *                               - parseTxFromStr()
-    *                               - accept_func() (optional)
-    *                               - importKeyImages()
-    *                               - insertColdKeyImages()
-    * param: ptx - PendingTransaction obtained from parseTxFromStr() outparam ptx
-    */
-    virtual void insertColdKeyImages(PendingTransaction &ptx) = 0;
+    virtual PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) = 0;
     /**
     * brief: parseMultisigTxFromStr - get pending multisig transaction from encrypted unsigned multisig transaction as hex string
     * param: multisig_tx_str -
-    * outparam: exported_txs -
-    * return: true if succeeded
-    * note: sets status error on fail
+    * return: ptx if succeeded, else nullptr
+    * note: sets status error on failure
     */
-    virtual bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const = 0;
+    virtual PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) = 0;
     /**
     * brief: getFeeMultiplier -
     * param: priority -
     * param: fee_algorithm -
     * return: fee multiplier
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const = 0;
     /**
@@ -1383,7 +1616,7 @@ struct Wallet
     * brief: coldTxAuxImport -
     * param: ptx -
     * param: tx_device_aux -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const = 0;
     /**
@@ -1394,7 +1627,7 @@ struct Wallet
     virtual void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const = 0;
     /**
     * brief: discardUnmixableEnotes - freeze all unmixable enotes
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void discardUnmixableEnotes() = 0;
     /**
@@ -1403,26 +1636,28 @@ struct Wallet
     * param: tx_key - secret transaction key r
     * param: additional_tx_keys -
     * param: single_destination_subaddress -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) = 0;
     /**
-    * brief: getAccountTags - get the list of registered account tags
+    * brief: getAccountTags - get tag description for each tag and tag for each account
+    *                         as map of [tag : tag_description] and list of tag per account
     * return: first.Key=(tag's name), first.Value=(tag's label), second[i]=(i-th account's tag)
     */
     virtual const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const = 0;
     /**
-    * brief: setAccountTag - set a tag to a set of subaddress accounts by index
+    * brief: setAccountTag - set a tag to a set of accounts by index
+    *                        one account can have one tag, but one tag can be shared by many accounts
     * param: account_index - major index
     * param: tag -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setAccountTag(const std::set<std::uint32_t> &account_indices, const std::string &tag) = 0;
     /**
     * brief: setAccountTagDescription - set a description for a tag, tag must already exist
     * param: tag -
     * param: description -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setAccountTagDescription(const std::string &tag, const std::string &description) = 0;
     /**
@@ -1432,14 +1667,14 @@ struct Wallet
     * param: start - offset index in enote storage, needs to be 0 for incremental mode (default: 0)
     * param: count - try to export this quantity of enotes (default: 0xffffffff)
     * return: encrypted data of exported enotes as hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const = 0;
     /**
     * brief: importEnotesFromStr - import enotes from encrypted hex string
     * param: enotes_str - enotes data as encrypted hex string
     * return: total size of enote storage
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::size_t importEnotesFromStr(const std::string &enotes_str) = 0;
     /**
@@ -1448,53 +1683,46 @@ struct Wallet
     * param: month - in range 1-12
     * param: day   - in range 1-31
     * return: blockchain height
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const = 0;
     /**
     * brief: estimateBacklog -
     * param: fee_levels - [ [fee per byte min, fee per byte max], ... ]
     * return: [ [number of blocks min, number of blocks max], ... ]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const = 0;
     /**
-    * brief: saveToFile   - save hex string to file
-    * param: path_to_file - file name
-    * param: binary       - hex string data
-    * param: is_printable - (default: false)
-    * return: true if succeeded
-    */
-    virtual bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const = 0;
-    /**
-    * brief: loadFromFile  - load hex string from file
-    * param: path_to_file  - file name
-    * outparam: target_str - hex string data
-    * param: max_size      - maximum size in bytes (default: 1000000000)
-    * return: true if succeeded
-    */
-    virtual bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const = 0;
-    /**
-    * brief: hashEnotes - get hash of all enotes in local enote store up until `enote_idx`
+    * brief: hashEnotes - only needed before calling `rescanBlockChain(do_hard_rescan=false, do_keep_key_images=true, do_skip_refresh=true)`
+    *                     (with the exact settings from above, or in other words: rescan soft keep key images, skip refresh)
+    *                     get hash of all enotes in local enote store up until, but excluding, `enote_idx`
+    *                     with the information returned by this method, `finishRescanBcKeepKeyImages()` can determine if a BC reorg happened during rescan
+    *                       1. `n_hashed_enotes_pre = hashEnotes(0, hash_pre)`
+    *                       2. `rescanBlockChain(false, true, true)`
+    *                       3. `refresh(start_height, check_pool, try_incremental, max_blocks, fetched_blocks_out, received_money_out)`
+    *                       4. `finishRescanBcKeepKeyImages(n_hashed_enotes_pre, hash_pre)`
     *                     (formerly in wallet2: `uint64_t wallet2::hash_m_transfers(boost::optional<uint64_t> transfer_height, crypto::hash &hash)`)
-    * param: enote_idx - include all enotes below this index
+    * param: enote_idx - include all enotes below this index, if set to 0 it will hash all known enotes, similiar to using `getWalletState().n_enotes`
     * outparam: hash - hash as hex string
     * return: number of hashed enotes
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const = 0;
     /**
-    * brief: finishRescanBcKeepKeyImages  -
-    * param: enote_idx -
-    * param: hash -
-    * note: sets status error on fail
+    * brief: finishRescanBcKeepKeyImages - only needed after calling `rescanBlockChain()` with `do_keep_key_images = true`
+    *                                      restores key images in m_transfers from m_key_images if no BC reorg happpened during rescan
+    *                                      more information in comment for `hashEnotes()`
+    * param: enote_idx - number of hashed enotes returned by `hashEnotes()` before rescan
+    * param: hash - hash returned as outparam by `hashEnotes()` before rescan
+    * note: sets status error on failure
     */
     virtual void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) = 0;
     /**
     * brief: getPublicNodes - get a list of public notes with information when they were last seen
     * param: white_only - include gray nodes if false (default: true)
     * return: [ [ host_ip, host_rpc_port, last_seen ], ... ]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const = 0;
     /**
@@ -1505,7 +1733,7 @@ struct Wallet
     * param: n_outputs  - number of output enotes
     * param: extra_size - size of tx_extra
     * return: [estimated tx size, estimated tx weight]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const = 0;
     /**
@@ -1516,7 +1744,7 @@ struct Wallet
     * outparam: unspent  - total unspent amount of the wallet
     * param: check_spent -
     * return: blockchain height of last signed key image, can be 0 if height unknown
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) = 0;
     /**
@@ -1525,7 +1753,7 @@ struct Wallet
     * param: offset     - offset in local enote storage
     * param: selected_enotes_indices -
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) = 0;
     /**
@@ -1538,12 +1766,21 @@ struct Wallet
     */
     virtual void setAllowMismatchedDaemonVersion(bool allow_mismatch) = 0;
     /**
+    * brief: getDeviceDerivationPath -
+    */
+    virtual std::string getDeviceDerivationPath() const = 0;
+    /**
+    * brief: setDeviceDerivationPath -
+    * param: device_derivation_path -
+    */
+    virtual void setDeviceDerivationPath(std::string device_derivation_path) = 0;
+    /**
     * brief: setDaemon -
     * param: daemon_address       -
     * param: daemon_username      - for daemon login (default: empty string)
     * param: daemon_password      - for daemon login (default: empty string)
     * param: trusted_daemon       - (default: false)
-    * param: ssl_support          - "disabled" | "enabled" | "autodetect" (default: "autodetect")
+    * param: ssl_support          - SSLSupport_Disabled | SSLSupport_Enabled | SSLSupport_Autodetect (default: SSLSupport_Autodetect)
     * param: ssl_private_key_path - (default: empty string)
     * param: ssl_certificate_path - (default: empty string)
     * param: ssl_ca_file_path     - (default: empty string)
@@ -1551,19 +1788,136 @@ struct Wallet
     * param: ssl_allow_any_cert   - (default: false)
     * param: proxy                - (default: empty string)
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool setDaemon(const std::string &daemon_address,
         const std::string &daemon_username = "",
         const std::string &daemon_password = "",
         bool trusted_daemon = false,
-        const std::string &ssl_support = "autodetect",
+        const SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect,
         const std::string &ssl_private_key_path = "",
         const std::string &ssl_certificate_path = "",
         const std::string &ssl_ca_file_path = "",
         const std::vector<std::string> &ssl_allowed_fingerprints_str = {},
         bool ssl_allow_any_cert = false,
         const std::string &proxy = "") = 0;
+    /**
+    * brief: verifyPassword -
+    * param: password   - password to verify
+    * return: true if succeeded
+    * note: sets status error on failure
+    *       This function automatically locks/unlocks the keys file as needed.
+    *       When possible use this instead of WalletManager::verifyWalletPassword()
+    */
+    virtual bool verifyPassword(const std::string_view &password) = 0;
+    /**
+    * brief: encryptKeys - encrypt cached secret keys
+    * param: password    - wallet password
+    */
+    virtual void encryptKeys(const std::string_view &password) = 0;
+    /**
+    * brief: decryptKeys - decrypt cached secret keys
+    * param: password    - wallet password
+    */
+    virtual void decryptKeys(const std::string_view &password) = 0;
+    /**
+    * brief: getMinRingSize -
+    * return: minimal ring size
+    */
+    virtual std::uint64_t getMinRingSize() const = 0;
+    /**
+    * brief: getMaxRingSize -
+    * return: maximal ring size
+    */
+    virtual std::uint64_t getMaxRingSize() const = 0;
+    /**
+    * brief: adjustMixin - clamps fake_outs_count to be in range [min_ring_size, max_ring_size]
+    * param: fake_outs_count - number of decoys to be used in ring
+    * return: adjusted fake_outs_count
+    */
+    virtual std::uint64_t adjustMixin(const std::uint64_t fake_outs_count) const = 0;
+
+    /**
+    * brief: getDaemonAdjustedTime - (see comment in src/cryptonote_core/blockchain.h for get_adjusted_time() for more details about daemon adjusted time)
+    * return: daemon adjusted time
+    * note: sets status error on failure
+    */
+    virtual std::uint64_t getDaemonAdjustedTime() const = 0;
+    // return: last block reward the wallet has whitnessed
+    virtual std::uint64_t getLastBlockReward() const = 0;
+    // return: true if wallet owns enotes with unknown key images
+    virtual bool hasUnknownKeyImages() const = 0;
+
+
+    //! return: true if block height was explicitly set to 0
+    virtual bool getExplicitRefreshFromBlockHeight() const = 0;
+    virtual void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) = 0;
+
+    // Wallet Settings getter/setter
+    virtual std::string getSeedLanguage() const = 0;
+    // note: sets status error on failure
+    virtual void setSeedLanguage(const std::string &arg) = 0;
+    virtual bool getAlwaysConfirmTransfers() const = 0;
+    virtual void setAlwaysConfirmTransfers(bool do_always_confirm) = 0;
+    virtual bool getPrintRingMembers() const = 0;
+    virtual void setPrintRingMembers(bool do_print_ring_members) = 0;
+    virtual bool getStoreTxInfo() const = 0;
+    virtual void setStoreTxInfo(bool do_store_tx_info) = 0;
+    virtual bool getAutoRefresh() const = 0;
+    virtual void setAutoRefresh(bool do_auto_refresh) = 0;
+    virtual RefreshType getRefreshType() const = 0;
+    virtual void setRefreshType(RefreshType refresh_type) = 0;
+    virtual std::uint32_t getDefaultPriority() const = 0;
+    virtual void setDefaultPriority(std::uint32_t default_priority) = 0;
+    virtual AskPasswordType getAskPasswordType() const = 0;
+    virtual void setAskPasswordType(AskPasswordType ask_password_type) = 0;
+    virtual std::uint64_t getMaxReorgDepth() const = 0;
+    virtual void setMaxReorgDepth(std::uint64_t max_reorg_depth) = 0;
+    virtual std::uint32_t getMinOutputCount() const = 0;
+    virtual void setMinOutputCount(std::uint32_t min_output_count) = 0;
+    virtual std::uint64_t getMinOutputValue() const = 0;
+    virtual void setMinOutputValue(std::uint64_t min_output_value) = 0;
+    virtual bool getMergeDestinations() const = 0;
+    virtual void setMergeDestinations(bool do_merge_destinations) = 0;
+    virtual bool getConfirmBacklog() const = 0;
+    virtual void setConfirmBacklog(bool do_confirm_backlog) = 0;
+    virtual std::uint32_t getConfirmBacklogThreshold() const = 0;
+    virtual void setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold) = 0;
+    virtual bool getConfirmExportOverwrite() const = 0;
+    virtual void setConfirmExportOverwrite(bool do_confirm_export_overwrite) = 0;
+    virtual std::uint64_t getRefreshFromBlockHeight() const = 0;
+    // note: sets status error on failure
+    virtual void setRefreshFromBlockHeight(std::uint64_t refresh_from_block_height) = 0;
+    virtual bool getAutoLowPriority() const = 0;
+    virtual void setAutoLowPriority(bool use_auto_low_priority) = 0;
+    virtual bool getSegregatePreForkOutputs() const = 0;
+    virtual void setSegregatePreForkOutputs(bool do_segregate_pre_fork_outputs) = 0;
+    virtual bool getKeyReuseMitigation2() const = 0;
+    virtual void setKeyReuseMitigation2(bool do_key_reuse_mitigation) = 0;
+    virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const = 0;
+    virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
+    virtual std::uint64_t getSegregationHeight() const = 0;
+    virtual void setSegregationHeight(std::uint64_t segregation_height) = 0;
+    virtual bool getIgnoreFractionalOutputs() const = 0;
+    virtual void setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs) = 0;
+    virtual std::uint64_t getIgnoreOutputsAbove() const = 0;
+    virtual void setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above) = 0;
+    virtual std::uint64_t getIgnoreOutputsBelow() const = 0;
+    virtual void setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below) = 0;
+    virtual bool getTrackUses() const = 0;
+    virtual void setTrackUses(bool do_track_uses) = 0;
+    virtual BackgroundMiningSetupType getSetupBackgroundMining() const = 0;
+    virtual void setSetupBackgroundMining(BackgroundMiningSetupType background_mining_setup) = 0;
+    virtual std::string getDeviceName() const = 0;
+    virtual void setDeviceName(const std::string &device_name) = 0;
+    virtual ExportFormat getExportFormat() const = 0;
+    virtual void setExportFormat(ExportFormat export_format) = 0;
+    virtual bool getShowWalletNameWhenLocked() const = 0;
+    virtual void setShowWalletNameWhenLocked(bool do_show_wallet_name) = 0;
+    virtual std::uint32_t getInactivityLockTimeout() const = 0;
+    virtual void setInactivityLockTimeout(std::uint32_t seconds) = 0;
+    virtual bool getEnableMultisig() const = 0;
+    virtual void setEnableMultisig(bool do_enable_multisig) = 0;
 };
 
 /**
@@ -1579,9 +1933,14 @@ struct WalletManager
      * \param  language       Language to be used to generate electrum seed mnemonic
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
+     * \param  create_address_file - Create <wallet_name>.address.txt file (Default: false)
+     *                               NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
+     * \param  non_determinisitc - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
+     *                             NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
-    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) = 0;
+    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true) = 0;
     Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false)      // deprecated
     {
         return createWallet(path, password, language, testnet ? TESTNET : MAINNET);
@@ -1594,9 +1953,10 @@ struct WalletManager
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  listener       Wallet listener to set to the wallet after creation
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if opened successfully)
      */
-    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr) = 0;
+    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, const bool unattended = true) = 0;
     Wallet * openWallet(const std::string &path, const std::string &password, bool testnet = false)     // deprecated
     {
         return openWallet(path, password, testnet ? TESTNET : MAINNET);
@@ -1611,11 +1971,12 @@ struct WalletManager
      * \param  restoreHeight  restore from start height
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  seed_offset    Seed offset passphrase (optional)
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     NetworkType nettype = MAINNET, uint64_t restoreHeight = 0, uint64_t kdf_rounds = 1,
-                                    const std::string &seed_offset = {}) = 0;
+                                    const std::string &seed_offset = {}, const bool unattended = true) = 0;
     Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     bool testnet = false, uint64_t restoreHeight = 0)           // deprecated
     {
@@ -1648,6 +2009,8 @@ struct WalletManager
      * \param  viewKeyString  view key
      * \param  spendKeyString spend key (optional)
      * \param  kdf_rounds     Number of rounds for key derivation function
+     * \param  create_address_file Whether to create an address file
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromKeys(const std::string &path,
@@ -1658,7 +2021,9 @@ struct WalletManager
                                                     const std::string &addressString,
                                                     const std::string &viewKeyString,
                                                     const std::string &spendKeyString = "",
-                                                    uint64_t kdf_rounds = 1) = 0;
+                                                    uint64_t kdf_rounds = 1,
+                                                    const bool create_address_file = false,
+                                                    const bool unattended = true) = 0;
     Wallet * createWalletFromKeys(const std::string &path,
                                   const std::string &password,
                                   const std::string &language,
@@ -1700,6 +2065,61 @@ struct WalletManager
     {
         return createWalletFromKeys(path, language, testnet ? TESTNET : MAINNET, restoreHeight, addressString, viewKeyString, spendKeyString);
     }
+    /**
+    * brief: createWalletFromJson - create a deterministic, non-deterministic or watch-only wallet from a json file
+    * json file fields:
+    *     "version"             :  <json_file_version>,       // [mandatory]    (1 (=current version at time of writing))
+    *     "filename"            : "<wallet_file_name>",       // [mandatory]
+    *     "scan_from_height"    :  <restore_height>,          // [optional]
+    *     "password"            : "<wallet_password>",        // [optional]
+    *     "viewkey"             : "<private_viewkey>",        // [optional]
+    *     "spendkey"            : "<private_spendkey>",       // [optional]
+    *     "seed"                : "<mnemonic_seed_phrase>",   // [optional]
+    *     "seed_passphrase"     : "<seed_offset_passphrase>", // [optional]
+    *     "address"             : "<wallet_main_address>",    // [optional]
+    *     "create_address_file" :  <do_create_address_file>,  // [optional]     (0 (=false) | 1 (=true))
+    *
+    * depending on what type of wallet you want to create you need to specify different combinations of fields:
+    *   "normal" (determ.)  : either `spendkey` or `seed`
+    *   non-deterministic   : `spendkey` and `viewkey`
+    *   watch-only          : `viewkey` and `address`
+    *
+    * param: json_file_path       - path to json file
+    * param: nettype              - network type
+    * outparam: pw_out            - password given by json file, this method sets an empty wallet password if no password is given
+    * param: kdf_rounds           - Number of rounds for key derivation function (Default: 1)
+    * param: unattended           - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+    * return:                       Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+    */
+    virtual Wallet * createWalletFromJson(const std::string &json_file_path,
+                                          NetworkType nettype,
+                                          std::string &pw_out,
+                                          uint64_t kdf_rounds = 1,
+                                          const bool unattended = true) = 0;
+    /**
+    * \brief: createWalletFromMultisigSeed - recovers existing multisig wallet from a multisig seed and optional seed offset passphrase
+    * \param: path                - name of wallet file to be created
+    * \param: password            - password of wallet file
+    * \param: language            - mnemonic seed language
+    * \param: nettype             - network type
+    * \param: restore_height      - restore from start height
+    * \param: multisig_seed       - multisig seed
+    * \param: seed_pass           - seed offset passphrase (Default: "")
+    * \param: kdf_rounds          - Number of rounds for key derivation function (Default: 1)
+    * \param: create_address_file - Whether to create an address file (Default: false)
+    * \param: unattended          - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+    * \return:                      Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+    */
+    virtual Wallet * createWalletFromMultisigSeed(const std::string &path,
+                                                  const std::string &password,
+                                                  const std::string &language,
+                                                  NetworkType nettype,
+                                                  uint64_t restore_height,
+                                                  const std::string &multisig_seed,
+                                                  const std::string seed_pass = "",
+                                                  uint64_t kdf_rounds = 1,
+                                                  const bool create_address_file = false,
+                                                  const bool unattended = true) = 0;
 
     /*!
      * \brief  creates wallet using hardware device.
@@ -1711,6 +2131,9 @@ struct WalletManager
      * \param  subaddressLookahead  Size of subaddress lookahead (empty sets to some default low value)
      * \param  kdf_rounds           Number of rounds for key derivation function
      * \param  listener             Wallet listener to set to the wallet after creation
+     * \param  device_derivation_path
+     * \param  create_address_file  Whether to create an address file
+     * \param  unattended           Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                      Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromDevice(const std::string &path,
@@ -1720,14 +2143,17 @@ struct WalletManager
                                             uint64_t restoreHeight = 0,
                                             const std::string &subaddressLookahead = "",
                                             uint64_t kdf_rounds = 1,
-                                            WalletListener * listener = nullptr) = 0;
+                                            WalletListener * listener = nullptr,
+                                            const std::string device_derivation_path = "",
+                                            const bool create_address_file = false,
+                                            const bool unattended = true) = 0;
 
     /*!
      * \brief Closes wallet. In case operation succeeded, wallet object deleted. in case operation failed, wallet object not deleted
      * \param wallet        previously opened / created wallet instance
      * \return              None
      */
-    virtual bool closeWallet(Wallet *wallet, bool store = true) = 0;
+    virtual bool closeWallet(Wallet *wallet, bool store = true, bool do_delete_pointer = true) = 0;
 
     /*
      * ! checks if wallet with the given name already exists
@@ -1797,6 +2223,12 @@ struct WalletManager
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
 
+    //! returns true if bootstrap mode was used by daemon or if bootstrap daemon address is set
+    virtual bool wasBootstrapEverUsed() = 0;
+
+    //! returns true iff backgound mining is enabled
+    virtual bool isBackgroundMiningEnabled() = 0;
+
     //! returns true iff mining
     virtual bool isMining() = 0;
 
@@ -1805,6 +2237,12 @@ struct WalletManager
 
     //! stops mining
     virtual bool stopMining() = 0;
+
+    //! saves the blockchain
+    virtual bool saveBlockchain() = 0;
+
+    //! daemon RPC /get_outs
+    virtual bool getOutsBin(const std::vector<std::pair<std::uint64_t, std::uint64_t>> &output_amount_index, const bool do_get_txid, std::vector<std::string> &enote_public_key_out, std::vector<std::string> &rct_key_mask_out, std::vector<bool> &unlocked_out, std::vector<std::uint64_t> &height_out, std::vector<std::string> &tx_id_out) = 0;
 
     //! resolves an OpenAlias address to a monero address
     virtual std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const = 0;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -37,6 +37,7 @@
 #include "common/dns_utils.h"
 #include "common/util.h"
 #include "common/updates.h"
+#include "crypto/crypto.h"
 #include "version.h"
 #include "net/http_client.h"
 #include <boost/filesystem.hpp>
@@ -73,9 +74,18 @@ Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::stri
                                     const std::string &language, NetworkType nettype, uint64_t kdf_rounds,
                                     const bool create_address_file /* = false */,
                                     const bool non_deterministic /* = false */,
-                                    const bool unattended /* = true */)
+                                    const bool unattended /* = true */,
+                                    const std::string extra_entropy_file /* = "" */)
 {
     WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds, unattended);
+    if (!extra_entropy_file.empty())
+    {
+        std::string data;
+        THROW_WALLET_EXCEPTION_IF(!epee::file_io_utils::load_file_to_string(extra_entropy_file, data),
+                                  tools::error::wallet_internal_error, "Failed to load extra entropy from " + extra_entropy_file);
+        crypto::add_extra_entropy_thread_safe(data.data(), data.size());
+    }
+
     wallet->create(path, password, language, create_address_file, non_deterministic);
     return wallet;
 }
@@ -118,13 +128,14 @@ Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
                                                 uint64_t restoreHeight,
                                                 uint64_t kdf_rounds,
                                                 const std::string &seed_offset/* = {}*/,
+                                                const bool create_address_file /* = false */,
                                                 const bool unattended /* = true */)
 {
     WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds, unattended);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recover(path, password, mnemonic, seed_offset);
+    wallet->recover(path, password, mnemonic, seed_offset, create_address_file);
     return wallet;
 }
 
@@ -144,7 +155,7 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recoverFromKeysWithPassword(path, password, language, addressString, viewKeyString, spendKeyString);
+    wallet->recoverFromKeysWithPassword(path, password, language, addressString, viewKeyString, spendKeyString, create_address_file);
     return wallet;
 }
 
@@ -208,7 +219,7 @@ Wallet *WalletManagerImpl::createWalletFromDevice(const std::string &path,
     {
         wallet->setSubaddressLookahead(lookahead->first, lookahead->second);
     }
-    wallet->recoverFromDevice(path, password, deviceName);
+    wallet->recoverFromDevice(path, password, deviceName, create_address_file);
     return wallet;
 }
 
@@ -287,9 +298,12 @@ std::string WalletManagerImpl::errorString() const
     return m_errorString;
 }
 
-void WalletManagerImpl::setDaemonAddress(const std::string &address)
+void WalletManagerImpl::setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password /* = nullptr */)
 {
-    m_http_client.set_server(address, boost::none);
+    boost::optional<epee::net_utils::http::login> daemon_login{boost::none};
+    if (daemon_username_password)
+        daemon_login.emplace(daemon_username_password->first, daemon_username_password->second);
+    m_http_client.set_server(address, daemon_login);
 }
 
 bool WalletManagerImpl::connected(uint32_t *version)
@@ -367,18 +381,6 @@ uint64_t WalletManagerImpl::blockTarget()
     if (!r)
         return 0;
     return ires.target;
-}
-
-bool WalletManagerImpl::wasBootstrapEverUsed()
-{
-    cryptonote::COMMAND_RPC_GET_INFO::request mreq;
-    cryptonote::COMMAND_RPC_GET_INFO::response mres;
-
-    bool r = epee::net_utils::invoke_http_json("/getinfo", mreq, mres, m_http_client);
-    m_errorString = interpret_rpc_response(r, mres.status);
-    if (!r)
-        return false;
-    return (mres.was_bootstrap_ever_used || !mres.bootstrap_daemon_address.empty());
 }
 
 bool WalletManagerImpl::isBackgroundMiningEnabled()

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -39,15 +39,16 @@ class WalletManagerImpl : public WalletManager
 {
 public:
     Wallet * createWallet(const std::string &path, const std::string &password,
-                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) override;
-    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr) override;
+                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true) override;
+    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, bool unattended = true) override;
     virtual Wallet * recoveryWallet(const std::string &path,
                                        const std::string &password,
                                        const std::string &mnemonic,
                                        NetworkType nettype,
                                        uint64_t restoreHeight,
                                        uint64_t kdf_rounds = 1,
-                                       const std::string &seed_offset = {}) override;
+                                       const std::string &seed_offset = {},
+                                       const bool unattended = true) override;
     virtual Wallet * createWalletFromKeys(const std::string &path,
                                              const std::string &password,
                                              const std::string &language,
@@ -56,7 +57,24 @@ public:
                                              const std::string &addressString,
                                              const std::string &viewKeyString,
                                              const std::string &spendKeyString = "",
-                                             uint64_t kdf_rounds = 1) override;
+                                             uint64_t kdf_rounds = 1,
+                                             const bool create_address_file = false,
+                                             const bool unattended = true) override;
+    Wallet * createWalletFromJson(const std::string &json_file_path,
+                                  NetworkType nettype,
+                                  std::string &pw_out,
+                                  uint64_t kdf_rounds = 1,
+                                  const bool unattended = true) override;
+    Wallet * createWalletFromMultisigSeed(const std::string &path,
+                                          const std::string &password,
+                                          const std::string &language,
+                                          NetworkType nettype,
+                                          uint64_t restoreHeight,
+                                          const std::string &multisig_seed,
+                                          const std::string seed_pass = "",
+                                          uint64_t kdf_rounds = 1,
+                                          const bool create_address_file = false,
+                                          const bool unattended = true) override;
     // next two methods are deprecated - use the above version which allow setting of a password
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &mnemonic, NetworkType nettype, uint64_t restoreHeight) override;
     // deprecated: use createWalletFromKeys(..., password, ...) instead
@@ -74,8 +92,11 @@ public:
                                             uint64_t restoreHeight = 0,
                                             const std::string &subaddressLookahead = "",
                                             uint64_t kdf_rounds = 1,
-                                            WalletListener * listener = nullptr) override;
-    virtual bool closeWallet(Wallet *wallet, bool store = true) override;
+                                            WalletListener * listener = nullptr,
+                                            const std::string device_derivation_path = "",
+                                            const bool create_address_file = false,
+                                            const bool unattended = true) override;
+    virtual bool closeWallet(Wallet *wallet, bool store = true, bool do_delete_pointer = true) override;
     bool walletExists(const std::string &path) override;
     bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const override;
     bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const override;
@@ -88,9 +109,13 @@ public:
     uint64_t networkDifficulty() override;
     double miningHashRate() override;
     uint64_t blockTarget() override;
+    bool wasBootstrapEverUsed() override;
+    bool isBackgroundMiningEnabled() override;
     bool isMining() override;
     bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) override;
     bool stopMining() override;
+    bool saveBlockchain() override;
+    bool getOutsBin(const std::vector<std::pair<std::uint64_t, std::uint64_t>> &output_amount_index, const bool do_get_txid, std::vector<std::string> &enote_public_key_out, std::vector<std::string> &rct_key_mask_out, std::vector<bool> &unlocked_out, std::vector<std::uint64_t> &height_out, std::vector<std::string> &tx_id_out) override;
     std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const override;
     bool setProxy(const std::string &address) override;
 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -39,7 +39,7 @@ class WalletManagerImpl : public WalletManager
 {
 public:
     Wallet * createWallet(const std::string &path, const std::string &password,
-                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true) override;
+                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true, const std::string extra_entropy = "") override;
     Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, bool unattended = true) override;
     virtual Wallet * recoveryWallet(const std::string &path,
                                        const std::string &password,
@@ -48,6 +48,7 @@ public:
                                        uint64_t restoreHeight,
                                        uint64_t kdf_rounds = 1,
                                        const std::string &seed_offset = {},
+                                       const bool create_address_file = false,
                                        const bool unattended = true) override;
     virtual Wallet * createWalletFromKeys(const std::string &path,
                                              const std::string &password,
@@ -102,14 +103,13 @@ public:
     bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const override;
     std::vector<std::string> findWallets(const std::string &path) override;
     std::string errorString() const override;
-    void setDaemonAddress(const std::string &address) override;
+    void setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password = nullptr) override;
     bool connected(uint32_t *version = NULL) override;
     uint64_t blockchainHeight() override;
     uint64_t blockchainTargetHeight() override;
     uint64_t networkDifficulty() override;
     double miningHashRate() override;
     uint64_t blockTarget() override;
-    bool wasBootstrapEverUsed() override;
     bool isBackgroundMiningEnabled() override;
     bool isMining() override;
     bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) override;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2123,6 +2123,13 @@ size_t wallet2::get_transfer_details(const crypto::key_image &ki) const
   CHECK_AND_ASSERT_THROW_MES(false, "Key image not found");
 }
 //----------------------------------------------------------------------------------------------------
+size_t wallet2::get_output_index(const crypto::public_key &pk) const
+{
+  auto search = m_pub_keys.find(pk);
+  CHECK_AND_ASSERT_THROW_MES(search != m_pub_keys.end(), "Public key not found in owned outputs");
+  return search->second;
+}
+//----------------------------------------------------------------------------------------------------
 bool wallet2::frozen(const transfer_details &td) const
 {
   return td.m_frozen;
@@ -8005,7 +8012,7 @@ bool wallet2::load_tx(const std::string &signed_filename, std::vector<tools::wal
   return parse_tx_from_str(s, ptx, accept_func);
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func)
+bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func, tools::wallet2::signed_tx_set *signed_txs_out /* = nullptr */, bool do_handle_key_images /* = true */)
 {
   std::string s = signed_tx_st;
   signed_tx_set signed_txs;
@@ -8062,17 +8069,29 @@ bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<too
     return false;
   }
 
-  // import key images
-  bool r = import_key_images(signed_txs.key_images);
-  if (!r) return false;
+  // `do_handle_key_images = true` was (and is) the default behavior, but for more flexibility in the Wallet API it can be turned off now
+  if (do_handle_key_images)
+  {
+    // import key images
+    bool r = import_key_images(signed_txs.key_images);
+    if (!r) return false;
 
-  // remember key images for this tx, for when we get those txes from the blockchain
-  for (const auto &e: signed_txs.tx_key_images)
-    m_cold_key_images.insert(e);
-
+    // remember key images for this tx, for when we get those txes from the blockchain
+    insert_cold_key_images(signed_txs.tx_key_images);
+  }
   ptx = signed_txs.ptx;
 
+  // Make signed_tx_set available to caller
+  if (signed_txs_out)
+      *signed_txs_out = std::move(signed_txs);
+
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+void wallet2::insert_cold_key_images(std::unordered_map<crypto::public_key, crypto::key_image> &cold_key_images)
+{
+    for (const auto &ki: cold_key_images)
+      m_cold_key_images.insert(ki);
 }
 //----------------------------------------------------------------------------------------------------
 std::string wallet2::save_multisig_tx(multisig_tx_set txs)
@@ -13075,6 +13094,11 @@ crypto::public_key wallet2::get_tx_pub_key_from_received_outs(const tools::walle
 bool wallet2::export_key_images(const std::string &filename, bool all) const
 {
   PERF_TIMER(export_key_images);
+  return save_to_file(filename, export_key_images_to_str(all));
+}
+
+std::string wallet2::export_key_images_to_str(bool all /* = false */) const
+{
   std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> ski = export_key_images(all);
   std::string magic(KEY_IMAGE_EXPORT_FILE_MAGIC, strlen(KEY_IMAGE_EXPORT_FILE_MAGIC));
   const cryptonote::account_public_address &keys = get_account().get_keys().m_account_address;
@@ -13098,7 +13122,7 @@ bool wallet2::export_key_images(const std::string &filename, bool all) const
   // encrypt data, keep magic plaintext
   PERF_TIMER(export_key_images_encrypt);
   std::string ciphertext = encrypt_with_view_secret_key(data);
-  return save_to_file(filename, magic + ciphertext);
+  return magic + ciphertext;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -13163,10 +13187,16 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
 
   THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, std::string(tr("failed to read file ")) + filename);
 
+  return import_key_images_from_str(data, spent, unspent);
+}
+
+std::uint64_t wallet2::import_key_images_from_str(const std::string &key_images_str, std::uint64_t &spent, std::uint64_t &unspent)
+{
+  std::string data = key_images_str;
   const size_t magiclen = strlen(KEY_IMAGE_EXPORT_FILE_MAGIC);
   if (data.size() < magiclen || memcmp(data.data(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen))
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Bad key image export file magic in ") + filename);
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Bad key image export file magic"));
   }
 
   try
@@ -13176,11 +13206,11 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
   }
   catch (const std::exception &e)
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to decrypt ") + filename + ": " + e.what());
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to decrypt: ") + e.what());
   }
 
   const size_t headerlen = 4 + 2 * sizeof(crypto::public_key);
-  THROW_WALLET_EXCEPTION_IF(data.size() < headerlen, error::wallet_internal_error, std::string("Bad data size from file ") + filename);
+  THROW_WALLET_EXCEPTION_IF(data.size() < headerlen, error::wallet_internal_error, std::string("Bad data size from file "));
   const uint32_t offset = (uint8_t)data[0] | (((uint8_t)data[1]) << 8) | (((uint8_t)data[2]) << 16) | (((uint8_t)data[3]) << 24);
   crypto::public_key public_spend_key, public_view_key;
   memcpy(&public_spend_key, &data[4], sizeof(public_spend_key));
@@ -13188,13 +13218,13 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
   const cryptonote::account_public_address &keys = get_account().get_keys().m_account_address;
   if (public_spend_key != keys.m_spend_public_key || public_view_key != keys.m_view_public_key)
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string( "Key images from ") + filename + " are for a different account");
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Key images are for a different account"));
   }
   THROW_WALLET_EXCEPTION_IF(offset > m_transfers.size(), error::wallet_internal_error, "Offset larger than known outputs");
 
   const size_t record_size = sizeof(crypto::key_image) + sizeof(crypto::signature);
   THROW_WALLET_EXCEPTION_IF((data.size() - headerlen) % record_size,
-      error::wallet_internal_error, std::string("Bad data size from file ") + filename);
+      error::wallet_internal_error, std::string("Bad data size "));
   size_t nki = (data.size() - headerlen) / record_size;
 
   std::vector<std::pair<crypto::key_image, crypto::signature>> ski;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1157,6 +1157,7 @@ wallet_keys_unlocker::~wallet_keys_unlocker()
     if (--lockers_per_wallet[w_ptr] > 0)
       return; // there are other unlock-ers for this wallet, do nothing for now
     lockers_per_wallet.erase(w_ptr);
+
     w.encrypt_keys(key);
   }
   catch (...)
@@ -2636,7 +2637,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
             }
 	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid);
 	    if (!ignore_callbacks && 0 != m_callback)
-	      m_callback->on_money_received(height, txid, tx, td.m_amount, 0, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time);
+	      m_callback->on_money_received(height, txid, tx, td.m_amount, 0, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time, td.get_public_key());
           }
           total_received_1 += amount;
           notify = true;
@@ -2714,7 +2715,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
 	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid);
 	    if (!ignore_callbacks && 0 != m_callback)
-	      m_callback->on_money_received(height, txid, tx, td.m_amount, burnt, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time);
+	      m_callback->on_money_received(height, txid, tx, td.m_amount, burnt, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time, td.get_public_key());
           }
           total_received_1 += extra_amount;
           notify = true;
@@ -2771,7 +2772,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       if (!pool)
       {
         if (!ignore_callbacks && 0 != m_callback)
-          m_callback->on_money_spent(height, txid, tx, amount, tx, td.m_subaddr_index);
+          m_callback->on_money_spent(height, txid, tx, amount, tx, td.m_subaddr_index, td.get_public_key());
 
         if (m_background_syncing && m_background_sync_data.txs.find(txid) == m_background_sync_data.txs.end())
         {
@@ -6137,7 +6138,7 @@ std::string wallet2::get_multisig_key_exchange_booster(const epee::wipeable_stri
   CHECK_AND_ASSERT_THROW_MES(kex_messages.size() > 0, "No key exchange messages passed in.");
 
   // decrypt account keys
-  wallet_keys_unlocker unlocker(*this, &password);
+  std::optional<wallet_keys_unlocker> unlocker(std::in_place, *this, &password);
 
   // prepare multisig account
   multisig::multisig_account multisig_account;
@@ -8219,7 +8220,7 @@ bool wallet2::parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func)
+bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func, bool skip_callback /* = false */)
 {
   if(!parse_multisig_tx_from_str(s, exported_txs))
   {
@@ -8230,30 +8231,18 @@ bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported
   LOG_PRINT_L1("Loaded multisig tx unsigned data from binary: " << exported_txs.m_ptx.size() << " transactions");
   for (auto &ptx: exported_txs.m_ptx) LOG_PRINT_L0(cryptonote::obj_to_json_str(ptx.tx));
 
+  if (skip_callback) return true;
+
   if (accept_func && !accept_func(exported_txs))
   {
     LOG_PRINT_L1("Transactions rejected by callback");
     return false;
   }
-
-  const bool is_signed = exported_txs.m_signers.size() >= m_multisig_threshold;
-  if (is_signed)
-  {
-    for (const auto &ptx: exported_txs.m_ptx)
-    {
-      const crypto::hash txid = get_transaction_hash(ptx.tx);
-      if (store_tx_info())
-      {
-        m_tx_keys[txid] = ptx.tx_key;
-        m_additional_tx_keys[txid] = ptx.additional_tx_keys;
-      }
-    }
-  }
-
+  finish_loading_accepted_multisig_tx(exported_txs);
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func)
+bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func, bool skip_callback /* = false */)
 {
   std::string s;
   boost::system::error_code errcode;
@@ -8269,12 +8258,29 @@ bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_t
     return false;
   }
 
-  if (!load_multisig_tx(s, exported_txs, accept_func))
+  if (!load_multisig_tx(s, exported_txs, accept_func, skip_callback))
   {
     LOG_PRINT_L0("Failed to parse multisig tx data from " << filename);
     return false;
   }
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+void wallet2::finish_loading_accepted_multisig_tx(multisig_tx_set &exported_txs)
+{
+  const bool is_signed = exported_txs.m_signers.size() >= m_multisig_threshold;
+  if (is_signed)
+  {
+    for (const auto &ptx: exported_txs.m_ptx)
+    {
+      const crypto::hash txid = get_transaction_hash(ptx.tx);
+      if (store_tx_info())
+      {
+        m_tx_keys[txid] = ptx.tx_key;
+        m_additional_tx_keys[txid] = ptx.additional_tx_keys;
+      }
+    }
+  }
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs_inout, std::vector<crypto::hash> &txids)
@@ -13475,7 +13481,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
           LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << *spent_txid);
           set_spent(it->second, e.block_height);
           if (m_callback)
-            m_callback->on_money_spent(e.block_height, *spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index);
+            m_callback->on_money_spent(e.block_height, *spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index, td.get_public_key());
           if (subaddr_account != (uint32_t)-1 && subaddr_account != td.m_subaddr_index.major)
             LOG_PRINT_L0("WARNING: This tx spends outputs received by different subaddress accounts, which isn't supposed to happen");
           subaddr_account = td.m_subaddr_index.major;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -113,7 +113,7 @@ private:
     wallet_keys_unlocker(wallet2 &w, const epee::wipeable_string *password);
     ~wallet_keys_unlocker();
   private:
-    wallet2 &w;
+    tools::wallet2 &w;
     bool should_relock;
     crypto::chacha_key key;
     static boost::mutex lockers_lock;
@@ -126,9 +126,9 @@ private:
     // Full wallet callbacks
     virtual void on_new_block(uint64_t height, const cryptonote::block& block) {}
     virtual void on_reorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) {}
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time) {}
+    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time, const crypto::public_key& enote_pub_key) {}
     virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index) {}
-    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index) {}
+    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index, const crypto::public_key& enote_pub_key) {}
     virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx) {}
     virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason) { return boost::none; }
     // Device callbacks
@@ -904,7 +904,8 @@ private:
     bool load_unsigned_tx(const std::string &unsigned_filename, unsigned_tx_set &exported_txs) const;
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
-    bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
+    bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func, tools::wallet2::signed_tx_set *signed_txs_out = nullptr, bool do_handle_key_images = true );
+    void insert_cold_key_images(std::unordered_map<crypto::public_key, crypto::key_image> &cold_key_images);
     std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
     std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
     std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
@@ -915,8 +916,11 @@ private:
     uint64_t cold_key_image_sync(uint64_t &spent, uint64_t &unspent);
     void device_show_address(uint32_t account_index, uint32_t address_index, const boost::optional<crypto::hash8> &payment_id);
     bool parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx_set &exported_txs) const;
-    bool load_multisig_tx(cryptonote::blobdata blob, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL);
-    bool load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL);
+    // skip_callback = true allows the Wallet API to use it's own confirmation mechanism
+    bool load_multisig_tx(cryptonote::blobdata blob, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL, bool skip_callback = false);
+    bool load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL, bool skip_callback = false);
+    // call this after load_multisig_tx*(..., skip_callback = true), when loading the tx was accepted
+    void finish_loading_accepted_multisig_tx(multisig_tx_set &exported_txs);
     bool sign_multisig_tx_from_file(const std::string &filename, std::vector<crypto::hash> &txids, std::function<bool(const multisig_tx_set&)> accept_func);
     bool sign_multisig_tx(multisig_tx_set &exported_txs_inout, std::vector<crypto::hash> &txids);
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1248,6 +1248,8 @@ private:
     uint64_t get_num_rct_outputs();
     size_t get_num_transfer_details() const { return m_transfers.size(); }
     const transfer_details &get_transfer_details(size_t idx) const;
+    // similar to get_transfer_details(ki) below, but uses outputs pubkey instead of key image and this method is public
+    size_t get_output_index(const crypto::public_key &pk) const;
 
     uint8_t get_current_hard_fork();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
@@ -1336,8 +1338,10 @@ private:
     std::tuple<size_t, crypto::hash, std::vector<crypto::hash>> export_blockchain() const;
     void import_blockchain(const std::tuple<size_t, crypto::hash, std::vector<crypto::hash>> &bc);
     bool export_key_images(const std::string &filename, bool all = false) const;
+    std::string export_key_images_to_str(bool all = false) const;
     std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> export_key_images(bool all = false) const;
     uint64_t import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, size_t offset, uint64_t &spent, uint64_t &unspent, bool check_spent = true);
+    std::uint64_t import_key_images_from_str(const std::string &key_images_str, std::uint64_t &spent, std::uint64_t &unspent);
     uint64_t import_key_images(const std::string &filename, uint64_t &spent, uint64_t &unspent);
     bool import_key_images(std::vector<crypto::key_image> key_images, size_t offset=0, boost::optional<std::unordered_set<size_t>> selected_transfers=boost::none);
     bool import_key_images(signed_tx_set & signed_tx, size_t offset=0, bool only_selected_transfers=false);

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -102,7 +102,7 @@ static void configure_wallet(Monero::Wallet *wallet)
 {
     if (!wallet)
         return;
-    wallet->allowMismatchedDaemonVersion(true);
+    wallet->setAllowMismatchedDaemonVersion(true);
     wallet->setRefreshFromBlockHeight(1);
     if (!RING_DATABASE_DIR.empty())
         wallet->setRingDatabase(RING_DATABASE_DIR);

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -1033,7 +1033,7 @@ struct MyWalletListener : public Monero::WalletListener
         send_triggered = receive_triggered = newblock_triggered = update_triggered = refresh_triggered = false;
     }
 
-    virtual void moneySpent(const string &txId, uint64_t amount)
+    virtual void moneySpent(const string &txId, uint64_t amount, const string &enote_pub_key, std::pair<uint32_t, uint32_t> subaddr_index /* = {} */)
     {
         std::cerr << "wallet: " << wallet->mainAddress() << "**** just spent money ("
                   << txId  << ", " << wallet->displayAmount(amount) << ")" << std::endl;
@@ -1042,7 +1042,7 @@ struct MyWalletListener : public Monero::WalletListener
         cv_send.notify_one();
     }
 
-    virtual void moneyReceived(const string &txId, uint64_t amount)
+    virtual void moneyReceived(const string &txId, uint64_t amount, const uint64_t burnt, const string &enote_pub_key, const bool is_change /* = false */, const bool is_coinbase /* = false */)
     {
         std::cout << "wallet: " << wallet->mainAddress() << "**** just received money ("
                   << txId  << ", " << wallet->displayAmount(amount) << ")" << std::endl;
@@ -1087,6 +1087,11 @@ struct MyWalletListener : public Monero::WalletListener
         cv_refresh.notify_one();
     }
 
+    void onReorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) override {}
+
+    optional<std::string> onGetPassword(const char *reason) override { return {}; }
+
+    void onPoolTxRemoved(const string &txid) override {}
 };
 
 

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -397,7 +397,7 @@ TEST_F(WalletManagerTest, WalletManagerMovesWallet)
             (boost::filesystem::temp_directory_path() / (std::string(WALLET_NAME) + ".moved")).string();
     Utils::deleteWallet(WALLET_NAME_MOVED);
     std::string seed1 = wallet1->seed();
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_MOVED));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_MOVED, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_MOVED, WALLET_PASS, WALLET_NETWORK_TYPE);
@@ -413,7 +413,7 @@ TEST_F(WalletManagerTest, WalletManagerChangesPassword)
 {
     Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, WALLET_NETWORK_TYPE);
     std::string seed1 = wallet1->seed();
-    ASSERT_TRUE(wallet1->setPassword(WALLET_PASS2));
+    ASSERT_TRUE(wallet1->setPassword(WALLET_PASS, WALLET_PASS2));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS2, WALLET_NETWORK_TYPE);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
@@ -451,7 +451,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromSeed)
     Monero::Wallet * wallet2 = wmgr->recoveryWallet(WALLET_NAME, WALLET_PASS, seed1, Monero::NetworkType::MAINNET, 0);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->mainAddress() == address1);
-    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
     Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
     ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
@@ -470,7 +470,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromKeys)
     Monero::Wallet * wallet2 = wmgr->createWalletFromKeys(WALLET_NAME, WALLET_PASS, WALLET_LANG, Monero::NetworkType::MAINNET, 0, address1, viewkey1, spendkey1);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->mainAddress() == address1);
-    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
     Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
     ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
@@ -486,7 +486,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet1)
     std::string address1 = wallet1->mainAddress();
 
     ASSERT_TRUE(wallet1->store(""));
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, WALLET_NETWORK_TYPE);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
@@ -502,7 +502,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->mainAddress();
 
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_WITH_DIR));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_WITH_DIR, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME_WITH_DIR, WALLET_PASS, WALLET_NETWORK_TYPE);


### PR DESCRIPTION
For some context, this change was proposed a while ago by @j-berman in Step 2 [here](https://github.com/seraphis-migration/wallet3/issues/64).

This PR is based on https://github.com/monero-project/monero/pull/10232 which is based on https://github.com/monero-project/monero/pull/9464

## Possible improvements:

Instead of implementing every idea, which would delay this PR even more, I added this list of things, so we can decide together what should be
a) added to this PR
b) a separate PR
c) not worth to get PRed

- Add option to change the description of an address book entry ([context](https://libera.monerologs.net/monero-dev/20250917#c589017-c589019)), so the new usage message would look something like this:
    ```
    address_book [(add (<address>|<integrated address>) [<description possibly with whitespaces>])|(delete <index>)|(change <address> <description>)]
    ```
- `get_tx_proof`, `check_tx_proof`, `get_spend_proof`, `check_spend_proof`, `get_reserve_proof`, `check_reserve_proof` all fail if <message> is more than one word [src](https://github.com/monero-project/monero/blob/bba6aa518ba4533859766672cf996f6427b8f1a4/src/simplewallet/simplewallet.cpp#L222-L227). We could read them like we do for `<description>` in `address_book` ([src](https://github.com/monero-project/monero/blob/bba6aa518ba4533859766672cf996f6427b8f1a4/src/simplewallet/simplewallet.cpp#L9659-L9664)).

## Behavior changes:

Some behavior changes or new/removed features I could not resist to add to this PR.

- In Monero Tech Meeting [#140](https://github.com/monero-project/meta/issues/1277) we discussed how to show the `amount` & `fee` in the confirmation message when creating a transaction. Then I changed it from "before" to "now". After further consideration I came up with the "new proposal", which I will implement if others agree on it.
  (The `simple_wallet::transfer_main()` method captured the `change` amount [here](https://github.com/monero-project/monero/blob/8e9ab9677f90492bca3c7555a246f2a8677bd570/src/simplewallet/simplewallet.cpp#L6692C18-L6699) but never used/printed it. Imo it's nice to directly see the change you'll receive, so I added it to the confirmation prompt.)
  - `transfer`
    - before:
      ```
      Sending <amount>.  The transaction fee is <fee>
      ```
    - now (`total` = `amount` + `fee`):
      ```
      Sending <amount>.  The transaction fee is <fee>. The overall total is <total>. The change is <change>.
      ```
    - new proposal (`total` = `amount` + `fee` + `change`):
      ```
      Sending overall total <total> = <amount_sent> (amount sent) + <fee> (fee) + <change> (change).
      ```
  - `sweep_*`
    - before:
      ```
      Sweeping <total> for a total fee of <fee>.  Is this okay?  (Y/Yes/N/No):
      ```
    - now (`total` = `amount` + `fee`):
      ```
      Sweeping <amount> for a total fee of <fee>, overall total <total>.  Is this okay?  (Y/Yes/N/No):
      ```
    - new proposal (`total` = `amount` + `fee`):
      ```
      Sweeping overall total <total> = <amount_sent> (amount sent) + <fee> (fee).
      ```

- DataHoarder [reported some issues](https://libera.monerologs.net/monero-dev/20250921#c591956-c591963) with `check_tx_proof`
    TLDR:
        1. can't read a proof directly from string, have to use signature file
        2. signature file content may not end with new line or white spaces, or else verification fails
  With this PR both issues are solved.

- add: Options to set daemon login (username:password) and proxy in `set_daemon` command

- remove: The `payment_id` argument is already not working for `transfer` command (see below) and it's marked "obsolete" for other commands [here](https://github.com/monero-project/monero/blob/bba6aa518ba4533859766672cf996f6427b8f1a4/src/simplewallet/simplewallet.cpp#L200-L205), so I removed the argument from all transfer/sweep commands and from the USAGE messages, and added error messages in case someone still passes a valid payment_id
  - before:
    ```
    [wallet xxxxxx]: transfer <address> <amount> <short_payment_id>
    Error: Invalid last argument: <short_payment_id>
    [wallet xxxxxx]: transfer <address> <amount> <long_payment_id>
    Error: Error: Long payment IDs are obsolete.
    Error: Long payment IDs were not encrypted on the blockchain and would harm your privacy.
    Error: If the party you're sending to still requires a long payment ID, please notify them.
    ```
  - now:
    ```
    [wallet xxxxxx]: transfer <address> <amount> <short_payment_id>
    Error: Short payment IDs are supposed to be used with integrated addresses.
    Error: If you want to make a payment with a certain payment_id, the receiver has to generate an address with `integrated_address <payment_id>`
    ```

- add: `freeze` & `thaw` by enote public key (match [this usage message](https://github.com/monero-project/monero/blob/bba6aa518ba4533859766672cf996f6427b8f1a4/src/simplewallet/simplewallet.cpp#L2160))

- `transfer <address> <amount>` from `watch-only` wallet writes tx to file `unsigned_monero_tx`.  If that file already exists
  - before: overwrite file
    ```
    Unsigned transaction(s) successfully written to file: unsigned_monero_tx
    ```
  - now: warn and don't overwrite 
    ```
    Error: Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:unsigned_monero_tx
    ```
 
## Bugs

- `refresh_progress_reporter_t` prints `Height x / y` when it shouldn't, e.g. in a confirmation prompt
  - Edit: the problem in the confirmation prompt is fixed, but there are other places where it messes up the output, because it doesn't print on a new line 
- Edit: these should be fixed now: `show_transfers` does not show:
    - outgoing "pending" txs
    - incoming "pool" txs

## Testers welcome

Help to make sure everything works the same as before (or better).
Special attention to hardware devices. I don't have access to any hw wallet, so they're completely untested.
