### PR TITLE
`export_transfers` command in wallet didn't check for output file writing error

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8768,6 +8768,10 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
   }
 
   std::ofstream file(filename);
+  if(file.fail()) {
+    fail_msg_writer() << boost::format(tr("Failed to open %s for writing")) % filename;
+    return true;
+  }
 
   // header
   file <<
@@ -8837,7 +8841,11 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
   }
   file.close();
 
-  success_msg_writer() << tr("CSV exported to ") << filename;
+  if(file.fail()) {
+    fail_msg_writer() << tr("Failed to export CSV to ") << filename;
+  } else {
+    success_msg_writer() << tr("CSV exported to ") << filename;
+  }
 
   return true;
 }


### PR DESCRIPTION
The **export_transfers** command in **monero-wallet-cli** does not have any error handling logic for writing the output file; it will happily report the CSV data as 'exported', even the output file could not be opened.

For example, the following 2 operations are expected to fail with errors `EISDIR` and `EACCES`, **monero-wallet-cli** however incorrectly reports that the CSV files are exported successfully:
```
[wallet A2Sbbz]: export_transfers output=/
CSV exported to /
[wallet A2Sbbz]: export_transfers output=/no-creation-permission
CSV exported to /no-creation-permission
```

After the fix:
```
[wallet A2Sbbz]: export_transfers output=/
Error: Failed to export CSV to /
[wallet A2Sbbz]: export_transfers output=/no-creation-permission
Error: Failed to export CSV to /no-creation-permission
[wallet A2Sbbz]: export_transfers output=/tmp/write-accessible-path
CSV exported to /tmp/write-accessible-path
```

