### PR TITLE
Remove invalid constexpr

### DIFF
--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -71,7 +71,7 @@ namespace crypto {
     return h;
   }
 
-  static constexpr void cn_variant1_check(const std::size_t length, const int variant)
+  static void cn_variant1_check(const std::size_t length, const int variant)
   {
     // see VARIANT1_CHECK in slow-hash.c
     if (variant == 1 && length < 43)


### PR DESCRIPTION
`constexpr` implies a return value. Some compilers generate hard errors on this.