### PR TITLE
epee: optimize uri conversion functions

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -34,27 +34,8 @@ namespace epee
 {
 namespace net_utils
 {
-  inline const char* get_hex_vals()
-  {
-    static constexpr const char hexVals[16] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
-    return hexVals;
-  }
-
-  inline const char* get_unsave_chars()
-  {
-    //static constexpr char unsave_chars[] = "\"<>%\\^[]`+$,@:;/!#?=&";
-    static constexpr const char unsave_chars[] = "\"<>%\\^[]`+$,@:;!#&";
-    return unsave_chars;
-  }
-
-  bool is_unsafe(unsigned char compare_char);
-  std::string dec_to_hex(char num, int radix);
-  int get_index(const char *s, char c);
-  std::string hex_to_dec_2bytes(const char *s);
-  std::string convert(char val);
-  std::string conver_to_url_format(const std::string& uri);
-  std::string convert_from_url_format(const std::string& uri);
-
+  std::string convert_to_url_format(std::string_view uri);
+  std::string convert_from_url_format(std::string_view uri);
 namespace http
 {
   class abstract_http_client

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14850,12 +14850,12 @@ std::string wallet2::make_uri(const std::string &address, const std::string &pay
 
   if (!recipient_name.empty())
   {
-    uri += (n_fields++ ? "&" : "?") + std::string("recipient_name=") + epee::net_utils::conver_to_url_format(recipient_name);
+    uri += (n_fields++ ? "&" : "?") + std::string("recipient_name=") + epee::net_utils::convert_to_url_format(recipient_name);
   }
 
   if (!tx_description.empty())
   {
-    uri += (n_fields++ ? "&" : "?") + std::string("tx_description=") + epee::net_utils::conver_to_url_format(tx_description);
+    uri += (n_fields++ ? "&" : "?") + std::string("tx_description=") + epee::net_utils::convert_to_url_format(tx_description);
   }
 
   return uri;


### PR DESCRIPTION
- greatly reduced # of string allocations (only 1 per function)
- fixed typo in function name (conver -> convert)
- used more standard library functions to simplify manual logic and remove pointer arithmetic
- removed all functions in header that were only used by these 2 functions
- replaced const std::string& with std::string_view

Tested changes with unit tests and functional tests (especially uri.py)