### PR TITLE
wallet: make change output address index configurable

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3051,6 +3051,22 @@ bool simple_wallet::set_enable_multisig(const std::vector<std::string> &args/* =
   return true;
 }
 
+bool simple_wallet::set_change_output_index(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  const auto pwd_container = get_and_verify_password();
+  if (pwd_container)
+  {
+    uint32_t index;
+    if (!epee::string_tools::get_xtype_from_string(index, args[1]))
+    {
+      fail_msg_writer() << tr("Invalid index");
+      return true;
+    }
+    m_wallet->set_change_output_address_index(index);
+    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+  }
+  return true;
+}
 bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   if(args.empty())
@@ -3351,6 +3367,8 @@ simple_wallet::simple_wallet()
                                   "  Device name for hardware wallet.\n "
                                   "export-format <\"binary\"|\"ascii\">\n "
                                   "  Save all exported files as binary (cannot be copied and pasted) or ascii (can be).\n "
+                                  "change-output-index <n>\n "
+                                  "  the destination address index for generating the change output if needed.\n "
                                   "load-deprecated-formats <1|0>\n "
                                   "  Whether to enable importing data in deprecated formats.\n "
                                   "show-wallet-name-when-locked <1|0>\n "
@@ -3751,6 +3769,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "setup-background-mining = " << setup_background_mining_string;
     success_msg_writer() << "device-name = " << m_wallet->device_name();
     success_msg_writer() << "export-format = " << (m_wallet->export_format() == tools::wallet2::ExportFormat::Ascii ? "ascii" : "binary");
+    success_msg_writer() << "change-output-index = " << m_wallet->change_output_address_index();
     success_msg_writer() << "show-wallet-name-when-locked = " << m_wallet->show_wallet_name_when_locked();
     success_msg_writer() << "inactivity-lock-timeout = " << m_wallet->inactivity_lock_timeout()
 #ifdef _WIN32
@@ -3824,6 +3843,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     CHECK_SIMPLE_VARIABLE("export-format", set_export_format, tr("\"binary\" or \"ascii\""));
     CHECK_SIMPLE_VARIABLE("load-deprecated-formats", set_load_deprecated_formats, tr("0 or 1"));
     CHECK_SIMPLE_VARIABLE("enable-multisig-experimental", set_enable_multisig, tr("0 or 1"));
+    CHECK_SIMPLE_VARIABLE("change-output-index", set_change_output_index, tr("unsigned integer"));
   }
   fail_msg_writer() << tr("set: unrecognized argument(s)");
   return true;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -155,6 +155,7 @@ namespace cryptonote
     bool set_export_format(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_load_deprecated_formats(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_enable_multisig(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_change_output_index(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
     bool apropos(const std::vector<std::string> &args);
     bool scan_tx(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1485,6 +1485,8 @@ private:
     void device_derivation_path(const std::string &device_derivation_path) { m_device_derivation_path = device_derivation_path; }
     const ExportFormat & export_format() const { return m_export_format; }
     inline void set_export_format(const ExportFormat& export_format) { m_export_format = export_format; }
+    uint32_t change_output_address_index() const { return m_change_output_address_index; }
+    void set_change_output_address_index(uint32_t value) { m_change_output_address_index = value; }
     bool is_multisig_enabled() const { return m_enable_multisig; }
     void enable_multisig(bool enable) { m_enable_multisig = enable; }
     bool is_mismatched_daemon_version_allowed() const { return m_allow_mismatched_daemon_version; }
@@ -2044,6 +2046,8 @@ private:
     std::unique_ptr<wallet_device_callback> m_device_callback;
 
     ExportFormat m_export_format;
+
+    uint32_t m_change_output_address_index;
 
     bool m_has_ever_refreshed_from_node;
 


### PR DESCRIPTION
Current wallet software always send the change output to address index 0, but sometimes it is desirable to use a subaddress to receive changes. This patch adds a wallet option `change-output-index <n>`, which configures the change output index.

Test output:
```
[wallet A2Sbbz]: balance detail
Currently selected account: [0] Primary account
Tag: (No tag assigned)
Balance: 0.002070760000, unlocked balance: 0.002070760000
Balance per address:
        Address               Balance      Unlocked balance Outputs                 Label
       0 A2Sbbz        0.000300000000        0.000300000000       2       Primary account
       3 Bb1UtR        0.001770760000        0.001770760000       3                      
[wallet A2Sbbz]: set change-output-index 2
Wallet password: 
[wallet A2Sbbz]: donate 0.00011
Donating 0.00011 monero to Bds1fhmD9yxJsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDb4ZMHB.
Wallet password: 

Transaction 1/1:
Spending from address index 3
Sending 0.000110000000.  The transaction fee is 0.000043920000

Is this okay?  (Y/Yes/N/No): yes
Transaction successfully submitted, transaction <edada2fdd759290ad0c399c7c235fe9b11e5ac235d7ab67e1b30f0e1600d6174>
You can check its status by using the `show_transfers` command.
[wallet A2Sbbz]: refresh
Starting refresh...
Enter password (output received): 
Height 2902501, txid <edada2fdd759290ad0c399c7c235fe9b11e5ac235d7ab67e1b30f0e1600d6174>, 0.000816840000, idx 0/2
Height 2902501, txid <edada2fdd759290ad0c399c7c235fe9b11e5ac235d7ab67e1b30f0e1600d6174>, spent 0.000706100000, idx 0/3
Height 2902501, txid <edada2fdd759290ad0c399c7c235fe9b11e5ac235d7ab67e1b30f0e1600d6174>, spent 0.000264660000, idx 0/3
Refresh done, blocks received: 3                                
Currently selected account: [0] Primary account
Tag: (No tag assigned)
Balance: 0.001916840000, unlocked balance: 0.001100000000 (7 block(s) to unlock)
[wallet A2Sbbz]: balance detail
Currently selected account: [0] Primary account
Tag: (No tag assigned)
Balance: 0.001916840000, unlocked balance: 0.001100000000 (7 block(s) to unlock)
Balance per address:
        Address               Balance      Unlocked balance Outputs                 Label
       0 A2Sbbz        0.000300000000        0.000300000000       2       Primary account
       2 Ba8YcK        0.000816840000        0.000000000000       1                      
       3 Bb1UtR        0.000800000000        0.000800000000       1                      
```
