### PR TITLE
logging: Generalize terminal color detection

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -1244,11 +1244,19 @@ std::string OS::currentHost(void) {
 #endif  // ELPP_OS_UNIX && !ELPP_OS_ANDROID
 }
 
+static bool endswith(const std::string &s, const std::string &ending)
+{
+    return s.size() >= ending.size() && s.substr(s.size() - ending.size()) == ending;
+}
+
+bool OS::termSupportsColor(std::string& term) {
+  return term == "xterm" || term == "screen" || term == "linux" || term == "cygwin"
+        || endswith(term, "-color") || endswith(term, "-256color");
+}
+
 bool OS::termSupportsColor(void) {
   std::string term = getEnvironmentVariable("TERM", "");
-  return term == "xterm" || term == "xterm-color" || term == "xterm-256color"
-         || term == "screen" || term == "linux" || term == "cygwin"
-         || term == "screen-256color" || term == "screen.xterm-256color";
+  return termSupportsColor(term);
 }
 
 // DateTime

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -1210,7 +1210,9 @@ class OS : base::StaticClass {
   ///
   /// @detail For android systems this is device name with its manufacturer and model seperated by hyphen
   static std::string currentHost(void);
-  /// @brief Whether or not terminal supports colors
+  /// @brief Whether or not the named terminal supports colors
+  static bool termSupportsColor(std::string& term);
+  /// @brief Whether or not the process's current terminal supports colors
   static bool termSupportsColor(void);
 };
 /// @brief Contains utilities for cross-platform date/time. This class make use of el::base::utils::Str


### PR DESCRIPTION
> Assume the terminal supports color codes if TERM ends with `-color` or `-256color`, rather than special-casing a handful of such terminals.
> 
> Add tests for terminal color detection.

backport of #9808 (~~no changes~~ removed tests as they caused compilation failure)