### PR TITLE
Remove .no moneropulse domain from codebase

### DIFF
--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -50,7 +50,7 @@ namespace tools
         "updates.moneropulse.net",
         "updates.moneropulse.fr",
         "updates.moneropulse.de",
-        "updates.moneropulse.no",
+        "updates.moneropulse.co",
         "updates.moneropulse.ch",
         "updates.moneropulse.se"
     };

--- a/src/debug_utilities/dns_checks.cpp
+++ b/src/debug_utilities/dns_checks.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
 
   lookup(LOOKUP_A, {"seeds.moneroseeds.se", "seeds.moneroseeds.ae.org", "seeds.moneroseeds.ch", "seeds.moneroseeds.li"});
 
-  lookup(LOOKUP_TXT, {"updates.moneropulse.org", "updates.moneropulse.net", "updates.moneropulse.co", "updates.moneropulse.se", "updates.moneropulse.fr", "updates.moneropulse.de", "updates.moneropulse.no", "updates.moneropulse.ch"});
+  lookup(LOOKUP_TXT, {"updates.moneropulse.org", "updates.moneropulse.net", "updates.moneropulse.co", "updates.moneropulse.se", "updates.moneropulse.fr", "updates.moneropulse.de", "updates.moneropulse.ch"});
 
   lookup(LOOKUP_TXT, {"checkpoints.moneropulse.org", "checkpoints.moneropulse.net", "checkpoints.moneropulse.co", "checkpoints.moneropulse.se"});
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2143,7 +2143,7 @@ namespace nodetool
       "blocklist.moneropulse.se"
     , "blocklist.moneropulse.org"
     , "blocklist.moneropulse.net"
-    , "blocklist.moneropulse.no"
+    , "blocklist.moneropulse.co"
     , "blocklist.moneropulse.fr"
     , "blocklist.moneropulse.de"
     , "blocklist.moneropulse.ch"


### PR DESCRIPTION
The core team doesn't own this domain anymore (due to new stricter restrictions on who can own or not a domain from Norway).