### PR TITLE
Tweak command_line::add_arg for clang 21

### DIFF
--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -207,8 +207,7 @@ namespace command_line
     description.add_options()(arg.name, make_semantic(arg, def), arg.description);
   }
 
-  template<>
-  inline void add_arg(boost::program_options::options_description& description, const arg_descriptor<bool, false>& arg, bool unique)
+  inline void add_arg(boost::program_options::options_description& description, const arg_descriptor<bool, false>& arg, bool unique = true)
   {
     if (0 != description.find_nothrow(arg.name, false))
     {


### PR DESCRIPTION
Clang 21 spits out an error claiming this function has a duplicated mangled name from a function slightly above this. This change changes the function from a partial template overload to a full overload. In both cases, this function is the preferred candidate when multiple are possible.

Arguably this is a clang 21 bug, as the original code should be valid C++. I leave it to the remainder of the team whether it's worth merging this, or leaving it purely for people hacking at Monero to use.

Also, this doesn't appear to trigger for `master`, and I don't fully understand why (perhaps the function is inlined)?