### PR TITLE
rpc: return error gracefully on cryptonight v1 check

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1622,7 +1622,9 @@ namespace cryptonote
     }
     else // CryptoNight
     {
-      const int pow_variant = major_version >= 7 ? major_version - 6 : 0;
+      static_assert(HF_VERSION_CRYPTONIGHT_VARIANT_1 >= 1);
+      const int pow_variant = major_version >= HF_VERSION_CRYPTONIGHT_VARIANT_1
+        ? major_version - (HF_VERSION_CRYPTONIGHT_VARIANT_1 - 1) : 0;
       crypto::cn_slow_hash(block_hashing_blob.data(), block_hashing_blob.size(), res, pow_variant, height);
     }
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -174,6 +174,7 @@
 #define HF_VERSION_DYNAMIC_FEE                  4
 #define HF_VERSION_MIN_MIXIN_4                  6
 #define HF_VERSION_MIN_MIXIN_6                  7
+#define HF_VERSION_CRYPTONIGHT_VARIANT_1        7
 #define HF_VERSION_MIN_MIXIN_10                 8
 #define HF_VERSION_MIN_MIXIN_15                 15
 #define HF_VERSION_ENFORCE_RCT                  6


### PR DESCRIPTION
A continuation of #9985: RPC endpoint `calc_pow` will return an error code and message instead of failing when using CryptoNight v1 on a block blob of size < 43. Fixes https://issues.oss-fuzz.com/issues/446998347.

Depends on #10039.