### PR TITLE
blockchain_db: remove `{add/get}_max_block_size()`

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1615,20 +1615,6 @@ public:
   virtual bool check_pruning() = 0;
 
   /**
-   * @brief get the max block size
-   */
-  virtual uint64_t get_max_block_size() = 0;
-
-  /**
-   * @brief add a new max block size
-   *
-   * The max block size will be the maximum of sz and the current block size
-   *
-   * @param: sz the block size
-   */
-  virtual void add_max_block_size(uint64_t sz) = 0;
-
-  /**
    * @brief add a new alternative block
    *
    * @param: blkid the block hash

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2690,58 +2690,6 @@ std::vector<uint64_t> BlockchainLMDB::get_block_info_64bit_fields(uint64_t start
   return ret;
 }
 
-uint64_t BlockchainLMDB::get_max_block_size()
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  check_open();
-
-  TXN_PREFIX_RDONLY();
-  RCURSOR(properties)
-  MDB_val_str(k, "max_block_size");
-  MDB_val v;
-  int result = mdb_cursor_get(m_cur_properties, &k, &v, MDB_SET);
-  if (result == MDB_NOTFOUND)
-    return std::numeric_limits<uint64_t>::max();
-  if (result)
-    throw0(DB_ERROR(lmdb_error("Failed to retrieve max block size: ", result).c_str()));
-  if (v.mv_size != sizeof(uint64_t))
-    throw0(DB_ERROR("Failed to retrieve or create max block size: unexpected value size"));
-  uint64_t max_block_size;
-  memcpy(&max_block_size, v.mv_data, sizeof(max_block_size));
-  TXN_POSTFIX_RDONLY();
-  return max_block_size;
-}
-
-void BlockchainLMDB::add_max_block_size(uint64_t sz)
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  check_open();
-  mdb_txn_cursors *m_cursors = &m_wcursors;
-
-  CURSOR(properties)
-
-  MDB_val_str(k, "max_block_size");
-  MDB_val v;
-  int result = mdb_cursor_get(m_cur_properties, &k, &v, MDB_SET);
-  if (result && result != MDB_NOTFOUND)
-    throw0(DB_ERROR(lmdb_error("Failed to retrieve max block size: ", result).c_str()));
-  uint64_t max_block_size = 0;
-  if (result == 0)
-  {
-    if (v.mv_size != sizeof(uint64_t))
-      throw0(DB_ERROR("Failed to retrieve or create max block size: unexpected value size"));
-    memcpy(&max_block_size, v.mv_data, sizeof(max_block_size));
-  }
-  if (sz > max_block_size)
-    max_block_size = sz;
-  v.mv_data = (void*)&max_block_size;
-  v.mv_size = sizeof(max_block_size);
-  result = mdb_cursor_put(m_cur_properties, &k, &v, 0);
-  if (result)
-    throw0(DB_ERROR(lmdb_error("Failed to set max_block_size: ", result).c_str()));
-}
-
-
 std::vector<uint64_t> BlockchainLMDB::get_block_weights(uint64_t start_height, size_t count) const
 {
   return get_block_info_64bit_fields(start_height, count, offsetof(mdb_block_info, bi_weight));

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -417,9 +417,6 @@ private:
 
   std::vector<uint64_t> get_block_info_64bit_fields(uint64_t start_height, size_t count, off_t offset) const;
 
-  uint64_t get_max_block_size() override;
-  void add_max_block_size(uint64_t sz) override;
-
   // fix up anything that may be wrong due to past bugs
   void fixup() override;
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -158,9 +158,6 @@ public:
   virtual bool check_pruning() override { return true; }
   virtual void prune_outputs(uint64_t amount) override {}
 
-  virtual uint64_t get_max_block_size() override { return 100000000; }
-  virtual void add_max_block_size(uint64_t sz) override { }
-
   virtual void add_alt_block(const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata_ref &blob) override {}
   virtual bool get_alt_block(const crypto::hash &blkid, alt_block_data_t *data, cryptonote::blobdata *blob) override { return false; }
   virtual void remove_alt_block(const crypto::hash &blkid) override {}

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4480,9 +4480,6 @@ bool Blockchain::update_next_cumulative_weight_limit(uint64_t *long_term_effecti
   if (long_term_effective_median_block_weight)
     *long_term_effective_median_block_weight = m_long_term_effective_median_block_weight;
 
-  if (!m_db->is_read_only())
-    m_db->add_max_block_size(m_current_block_cumul_weight_limit);
-
   return true;
 }
 //------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/446735539. The max block size property field was not actually used in current code.