### PR TITLE
Correct help messages' default number of daemon out peers

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -158,7 +158,7 @@ namespace nodetool
     const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "delayed"};
     const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
     const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4  = {"p2p-ignore-ipv4", "Ignore unsuccessful IPv4 bind for p2p", false};
-    const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
+    const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", P2P_DEFAULT_CONNECTIONS_COUNT};
     const command_line::arg_descriptor<int64_t>     arg_in_peers = {"in-peers", "set max number of in peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};
 

--- a/utils/fish/monerod.fish
+++ b/utils/fish/monerod.fish
@@ -74,7 +74,7 @@ complete -c monerod -l no-sync -d "Don't synchronize the blockchain with other p
 complete -c monerod -l enable-dns-blocklist -d "Apply realtime blocklist from DNS"
 complete -c monerod -l no-igd -d "Disable UPnP port mapping"
 complete -c monerod -l igd -r -a "Enabled disabled enabled" -d "UPnP port mapping. Default: delayed"
-complete -c monerod -l out-peers -r -d "Set max number of out peers. Default: -1"
+complete -c monerod -l out-peers -r -d "Set max number of out peers. Default: 12"
 complete -c monerod -l in-peers -r -d "Set max number of in peers. Default: -1"
 complete -c monerod -l tos-flag -r -d "Set TOS flag. Default: -1"
 complete -c monerod -l limit-rate-up -r -d "Set limit-rate-up [kB/s]. Default: 8192"


### PR DESCRIPTION
On daemon [initialization](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/p2p/net_node.inl#L2852) the number is of out peers is set to 12 when the `--out-peers` option is not specified, or specified as -1 by running `monerod --out-peers -1`.

This implies the [default](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/cryptonote_config.h#L139) is 12, not unlimited, which is what -1 means in other cases. For example, sending `out_peers -1` in the daemon console sets the number of out peers to unlimited.

Another set of limits are rate limits. Like the number of peers, [it](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/p2p/net_node.inl#L2927) [isn't](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/p2p/net_node.inl#L2940) [possible](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/p2p/net_node.inl#L2954) to set these to unlimited with options, yet the help messages specify [the](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/src/p2p/net_node.cpp#L165-L166) [practical](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/utils/fish/monerod.fish#L80) [defaults](https://github.com/monero-project/monero/blob/f65b2864552f855af1ef58c031dafffa58aae90c/utils/fish/monerod.fish#L81), not the number used internally (except for `--limit-rate`, but this option and command has unconventional behavior, setting a symmetric limit as opposed to limiting the total bandwidth).

Below is the current output of `monerod --help`:
```
  --out-peers arg (=-1)                 set max number of out peers
  --in-peers arg (=-1)                  set max number of in peers
  --tos-flag arg (=-1)                  set TOS flag
  --limit-rate-up arg (=8192)           set limit-rate-up [kB/s]
  --limit-rate-down arg (=32768)        set limit-rate-down [kB/s]
  --limit-rate arg (=-1)                set limit-rate [kB/s]
```

Addresses the remark made in #9275.

The inability to have an unlimited number of peers and bandwidth using daemon options could be purposeful. If so, it would be worth documenting this, and if not, further modifications could be made to allow this.

Commits formatted as requested per #10291.