### PR TITLE
Misc clang 21 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ endif()
 if(WIN32 OR ARM OR PPC64LE OR PPC64 OR PPC)
   set(OPT_FLAGS_RELEASE "-O2")
 else()
-  set(OPT_FLAGS_RELEASE "-Ofast")
+  set(OPT_FLAGS_RELEASE "-O3 -ffast-math -fno-semantic-interposition") # not present: -fallow-store-data-races
 endif()
 
 # BUILD_TAG is used to select the build type to check for a new version
@@ -508,7 +508,7 @@ if (APPLE OR NETBSD)
 elseif (DEPENDS AND NOT LINUX)
   set(DEFAULT_STACK_TRACE OFF)
   set(LIBUNWIND_LIBRARIES "")
-elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
   set(DEFAULT_STACK_TRACE ON)
   set(STACK_TRACE_LIB "easylogging++") # for diag output only
   set(LIBUNWIND_LIBRARIES "")

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -35,6 +35,7 @@
 
 #include <stdexcept>
 #include <iomanip>
+#include <sstream>
 #ifdef USE_UNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
@@ -54,7 +55,9 @@
   do { \
     auto elpp = ELPP; \
     if (elpp) { \
-      CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x; \
+      std::stringstream ss; \
+      ss << x; \
+      CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << ss.str(); \
     } \
     else { \
       std::cout << x << std::endl; \
@@ -105,18 +108,8 @@ void CXA_THROW(void *ex, CXA_THROW_INFO_T *info, void (*dest)(void*))
   __real___cxa_throw(ex, info, dest);
 }
 
-namespace
-{
-  std::string stack_trace_log;
-}
-
 namespace tools
 {
-
-void set_stack_trace_log(const std::string &log)
-{
-  stack_trace_log = log;
-}
 
 void log_stack_trace(const char *msg)
 {
@@ -127,7 +120,6 @@ void log_stack_trace(const char *msg)
   unsigned level;
   char sym[512], *dsym;
   int status;
-  const char *log = stack_trace_log.empty() ? NULL : stack_trace_log.c_str();
 #endif
 
   if (msg)

--- a/src/common/stack_trace.h
+++ b/src/common/stack_trace.h
@@ -29,12 +29,9 @@
 #ifndef MONERO_EXCEPTION_H
 #define MONERO_EXCEPTION_H
 
-#include <string>
-
 namespace tools
 {
 
-void set_stack_trace_log(const std::string &log);
 void log_stack_trace(const char *msg);
 
 }  // namespace tools

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -227,15 +227,15 @@ namespace cryptonote
       *
       * @return true if the block was added to the main chain, otherwise false
       */
-     virtual bool handle_block_found(block& b, block_verification_context &bvc) override;
+     bool handle_block_found(block& b, block_verification_context &bvc) final;
 
      /**
       * @copydoc Blockchain::create_block_template
       *
       * @note see Blockchain::create_block_template
       */
-     virtual bool get_block_template(block& b, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, uint64_t &cumulative_weight, const blobdata& ex_nonce, uint64_t &seed_height, crypto::hash &seed_hash) override;
-     virtual bool get_block_template(block& b, const crypto::hash *prev_block, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, uint64_t &cumulative_weight, const blobdata& ex_nonce, uint64_t &seed_height, crypto::hash &seed_hash);
+     bool get_block_template(block& b, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, uint64_t &cumulative_weight, const blobdata& ex_nonce, uint64_t &seed_height, crypto::hash &seed_hash) final;
+     bool get_block_template(block& b, const crypto::hash *prev_block, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, uint64_t &cumulative_weight, const blobdata& ex_nonce, uint64_t &seed_height, crypto::hash &seed_hash);
 
      /**
       * @copydoc Blockchain::get_miner_data
@@ -248,7 +248,7 @@ namespace cryptonote
       * @brief called when a transaction is relayed.
       * @note Should only be invoked from `levin_notify`.
       */
-     virtual void on_transactions_relayed(epee::span<const cryptonote::blobdata> tx_blobs, relay_method tx_relay) final;
+     void on_transactions_relayed(epee::span<const cryptonote::blobdata> tx_blobs, relay_method tx_relay) final;
 
 
      /**
@@ -340,7 +340,7 @@ namespace cryptonote
       *
       * @note see Blockchain::get_current_blockchain_height()
       */
-     virtual uint64_t get_current_blockchain_height() const final;
+     uint64_t get_current_blockchain_height() const final;
 
      /**
       * @brief get the hash and height of the most recent block
@@ -671,7 +671,7 @@ namespace cryptonote
       *
       * @return core synchronization status
       */
-     virtual bool is_synchronized() const final;
+     bool is_synchronized() const final;
 
      /**
       * @copydoc miner::on_synchronized

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2645,7 +2645,7 @@ skip:
   {
     // sort peers between fluffy ones and others
     std::vector<std::pair<epee::net_utils::zone, boost::uuids::uuid>> fluffyConnections;
-    m_p2p->for_each_connection([this, &exclude_context, &fluffyConnections](connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)
+    m_p2p->for_each_connection([&exclude_context, &fluffyConnections](connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)
     {
       // peer_id also filters out connections before handshake
       if (peer_id && exclude_context.m_connection_id != context.m_connection_id && context.m_remote_address.get_zone() == epee::net_utils::zone::public_)

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -291,10 +291,6 @@ int main(int argc, char const * argv[])
     // after logs initialized
     tools::create_directories_if_necessary(data_dir.string());
 
-#ifdef STACK_TRACE
-    tools::set_stack_trace_log(log_file_path.filename().string());
-#endif // STACK_TRACE
-
     if (!command_line::is_arg_defaulted(vm, daemon_args::arg_max_concurrency))
       tools::set_max_concurrency(command_line::get_arg(vm, daemon_args::arg_max_concurrency));
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2153,7 +2153,7 @@ namespace nodetool
     if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))
       return true;
 
-    unsigned good = 0, bad = 0;
+    unsigned good = 0;
     for (const auto& record : records)
     {
       std::vector<std::string> ips;
@@ -2177,7 +2177,6 @@ namespace nodetool
           continue;
         }
         MWARNING("Invalid IP address or subnet from DNS blocklist: " << ip << " - " << parsed_addr.error());
-        ++bad;
       }
     }
     if (good > 0)

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -36,8 +36,10 @@
 #include <cassert>
 #include <iostream>
 #include <iterator>
+#include <type_traits>
+
 #include <boost/endian/conversion.hpp>
-#include <boost/type_traits/make_unsigned.hpp>
+#include <boost/mpl/bool.hpp>
 
 #include "common/varint.h"
 #include "span.h"
@@ -106,7 +108,7 @@ struct binary_archive<false> : public binary_archive_base<false>
   template <class T>
   void serialize_int(T &v)
   {
-    serialize_uint(*(typename boost::make_unsigned<T>::type *)&v);
+    serialize_uint(*(typename std::make_unsigned<T>::type *)&v);
   }
 
   /*! \fn serialize_uint
@@ -137,7 +139,7 @@ struct binary_archive<false> : public binary_archive_base<false>
   template <class T>
   void serialize_varint(T &v)
   {
-    serialize_uvarint(*(typename boost::make_unsigned<T>::type *)(&v));
+    serialize_uvarint(*(typename std::make_unsigned<T>::type *)(&v));
   }
 
   template <class T>
@@ -190,7 +192,7 @@ struct binary_archive<true> : public binary_archive_base<true>
   template <class T>
   void serialize_int(T v)
   {
-    serialize_uint(static_cast<typename boost::make_unsigned<T>::type>(v));
+    serialize_uint(static_cast<typename std::make_unsigned<T>::type>(v));
   }
   template <class T>
   void serialize_uint(T v)
@@ -209,7 +211,7 @@ struct binary_archive<true> : public binary_archive_base<true>
   template <class T>
   void serialize_varint(T &v)
   {
-    serialize_uvarint(*(typename boost::make_unsigned<T>::type *)(&v));
+    serialize_uvarint(*(typename std::make_unsigned<T>::type *)(&v));
   }
 
   template <class T>

--- a/src/serialization/pair.h
+++ b/src/serialization/pair.h
@@ -29,8 +29,9 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
-#include <memory>
-#include <boost/type_traits/make_unsigned.hpp>
+
+#include <cstdint>
+
 #include "serialization.h"
 
 namespace serialization


### PR DESCRIPTION
* Use -O3 and other flags instead of -Ofast
  - https://discourse.llvm.org/t/rfc-deprecate-ofast/78687
  - https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
* Find libunwind library based on C++ compiler type, not C compiler type
* In stack_trace.cpp, pass stream modifiers to `std::stringstream` first, then send string to log
* In stack_trace.cpp, remove dead code related to `stack_trace_log` path
* Remove `virtual` method attributues from `final` class `cryptonote::core`
* Remove unused `this` capture in cryptonote protocol handler
* Remove unused variable `bad` in net node
* Use `std::make_unsigned` instead of `boost::make_unsigned`
  - https://github.com/boostorg/type_traits/issues/171
  - https://github.com/boostorg/type_traits/issues/202
  - https://github.com/boostorg/type_traits/pull/199
* Cleanup `include`s in pair serialization
* Test convergence b/t `std::make_unsigned` and `boost::make_unsigned`

Fixes compilation and silences warnings on:
clang version 21.1.6
Linux 6.18.8-3-cachyos