### PR TITLE
Transition asio::deadline_timer to asio::steady_timer

### DIFF
--- a/contrib/epee/include/net/levin_base.h
+++ b/contrib/epee/include/net/levin_base.h
@@ -29,6 +29,7 @@
 #ifndef _LEVIN_BASE_H_
 #define _LEVIN_BASE_H_
 
+#include <chrono>
 #include <cstdint>
 
 #include "byte_stream.h"
@@ -72,7 +73,7 @@ namespace levin
 #pragma pack(pop)
 
 
-#define LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED 0
+constexpr const std::chrono::milliseconds LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED{0};
 #define LEVIN_INITIAL_MAX_PACKET_SIZE  256*1024      // 256 KiB before handshake
 #define LEVIN_DEFAULT_MAX_PACKET_SIZE 100000000      //100MB by default after handshake
 

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -56,7 +56,6 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/chrono.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "misc_language.h"
 #include <sstream>

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -57,7 +57,7 @@ namespace epee
   namespace net_utils
   {
     template<class t_result, class t_arg, class callback_t, class t_transport>
-    bool async_invoke_remote_command2(const epee::net_utils::connection_context_base &context, int command, const t_arg& out_struct, t_transport& transport, const callback_t &cb, size_t inv_timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
+    bool async_invoke_remote_command2(const epee::net_utils::connection_context_base &context, int command, const t_arg& out_struct, t_transport& transport, const callback_t &cb, const std::chrono::milliseconds inv_timeout = levin::LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
     {
       const boost::uuids::uuid &conn_id = context.m_connection_id;
       typename serialization::portable_storage stg;

--- a/src/debug_utilities/object_sizes.cpp
+++ b/src/debug_utilities/object_sizes.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
   SL(boost::thread);
   SL(boost::asio::io_context);
   SL(boost::asio::executor_work_guard<boost::asio::io_context::executor_type>);
-  SL(boost::asio::deadline_timer);
+  SL(boost::asio::steady_timer);
 
   SL(cryptonote::DB_ERROR);
   SL(cryptonote::mdb_txn_safe);

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -571,7 +571,7 @@ namespace trezor{
     return ping_int();
   }
 
-  bool UdpTransport::ping_int(boost::posix_time::time_duration timeout){
+  bool UdpTransport::ping_int(boost::asio::steady_timer::duration timeout){
     require_socket();
     try {
       std::string req = "PINGPING";
@@ -619,7 +619,7 @@ namespace trezor{
     m_socket.reset(new udp::socket(m_io_service));
     m_socket->open(udp::v4());
 
-    m_deadline.expires_at(boost::posix_time::pos_infin);
+    m_deadline.expires_after(boost::asio::steady_timer::duration::max());
     check_deadline();
 
     m_proto->session_begin(*this);
@@ -701,14 +701,14 @@ namespace trezor{
     return static_cast<size_t>(len);
   }
 
-  ssize_t UdpTransport::receive(void * buff, size_t size, boost::system::error_code * error_code, bool no_throw, boost::posix_time::time_duration timeout){
+  ssize_t UdpTransport::receive(void * buff, size_t size, boost::system::error_code * error_code, bool no_throw, const boost::asio::steady_timer::duration timeout){
     boost::system::error_code ec;
     boost::asio::mutable_buffer buffer = boost::asio::buffer(buff, size);
 
     require_socket();
 
     // Set a deadline for the asynchronous operation.
-    m_deadline.expires_from_now(timeout);
+    m_deadline.expires_after(timeout);
 
     // Set up the variables that receive the result of the asynchronous
     // operation. The error code is set to would_block to signal that the
@@ -766,7 +766,7 @@ namespace trezor{
     // Check whether the deadline has passed. We compare the deadline against
     // the current time since a new asynchronous operation may have moved the
     // deadline before this actor had a chance to run.
-    if (m_deadline.expires_at() <= boost::asio::deadline_timer::traits_type::now())
+    if (m_deadline.expiry() <= boost::asio::steady_timer::clock_type::now())
     {
       // The deadline has passed. The outstanding asynchronous operation needs
       // to be cancelled so that the blocked receive() function will return.
@@ -778,7 +778,7 @@ namespace trezor{
 
       // There is no longer an active deadline. The expiry is set to positive
       // infinity so that the actor takes no action until a new deadline is set.
-      m_deadline.expires_at(boost::posix_time::pos_infin);
+      m_deadline.expires_after(boost::asio::steady_timer::duration::max());
     }
 
     // Put the actor back to sleep.

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -32,7 +32,7 @@
 
 
 #include <boost/asio.hpp>
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/array.hpp>
 #include <boost/utility/string_ref.hpp>
 
@@ -233,11 +233,11 @@ namespace trezor {
 
   private:
     void require_socket();
-    ssize_t receive(void * buff, size_t size, boost::system::error_code * error_code=nullptr, bool no_throw=false, boost::posix_time::time_duration timeout=boost::posix_time::seconds(10));
+    ssize_t receive(void * buff, size_t size, boost::system::error_code * error_code=nullptr, bool no_throw=false, boost::asio::steady_timer::duration timeout = std::chrono::seconds(10));
     void check_deadline();
     static void handle_receive(const boost::system::error_code& ec, std::size_t length,
                                boost::system::error_code* out_ec, std::size_t* out_length);
-    bool ping_int(boost::posix_time::time_duration timeout=boost::posix_time::milliseconds(1500));
+    bool ping_int(boost::asio::steady_timer::duration = std::chrono::milliseconds(1500));
 
     std::shared_ptr<Protocol> m_proto;
     std::string m_device_host;
@@ -245,7 +245,7 @@ namespace trezor {
 
     std::unique_ptr<udp::socket> m_socket;
     boost::asio::io_context m_io_service;
-    boost::asio::deadline_timer m_deadline;
+    boost::asio::steady_timer m_deadline;
     udp::endpoint m_endpoint;
   };
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -230,7 +230,7 @@ namespace nodetool
         m_config.m_net_config.packet_max_size = P2P_DEFAULT_PACKET_MAX_SIZE;
         m_config.m_net_config.config_id = 0;
         m_config.m_net_config.connection_timeout = P2P_DEFAULT_CONNECTION_TIMEOUT;
-        m_config.m_net_config.ping_connection_timeout = P2P_DEFAULT_PING_CONNECTION_TIMEOUT;
+        m_config.m_net_config.ping_connection_timeout = std::chrono::milliseconds{P2P_DEFAULT_PING_CONNECTION_TIMEOUT};
         m_config.m_net_config.send_peerlist_sz = P2P_DEFAULT_PEERS_IN_HANDSHAKE;
         m_config.m_support_flags = 0; // only set in public zone
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -988,7 +988,7 @@ namespace nodetool
     for (auto& zone : m_network_zones)
     {
       zone.second.m_net_server.get_config_object().set_handler(this);
-      zone.second.m_net_server.get_config_object().m_invoke_timeout = P2P_DEFAULT_INVOKE_TIMEOUT;
+      zone.second.m_net_server.get_config_object().m_invoke_timeout = std::chrono::milliseconds{P2P_DEFAULT_INVOKE_TIMEOUT};
 
       if (!zone.second.m_bind_ip.empty())
       {
@@ -1073,8 +1073,8 @@ namespace nodetool
     })); // lambda
 
     network_zone& public_zone = m_network_zones.at(epee::net_utils::zone::public_);
-    public_zone.m_net_server.add_idle_handler(boost::bind(&node_server<t_payload_net_handler>::idle_worker, this), 1000);
-    public_zone.m_net_server.add_idle_handler(boost::bind(&t_payload_net_handler::on_idle, &m_payload_handler), 1000);
+    public_zone.m_net_server.add_idle_handler(boost::bind(&node_server<t_payload_net_handler>::idle_worker, this), std::chrono::seconds{1});
+    public_zone.m_net_server.add_idle_handler(boost::bind(&t_payload_net_handler::on_idle, &m_payload_handler), std::chrono::seconds{1});
 
     //here you can set worker threads count
     int thrds_count = 10;
@@ -1234,7 +1234,7 @@ namespace nodetool
         LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE(AND CLOSE) INVOKED OK");
       }
       context_ = context;
-    }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
+    }, std::chrono::milliseconds{P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT});
 
     if(r)
     {
@@ -2564,7 +2564,7 @@ namespace nodetool
         
         f(context_, rsp.support_flags);
       },
-      P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT
+      std::chrono::milliseconds{P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT}
     );
 
     return r;

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -136,10 +136,10 @@ namespace nodetool
       KV_SERIALIZE(config_id)
     END_KV_SERIALIZE_MAP()
 
+    std::chrono::milliseconds ping_connection_timeout;
     uint32_t max_out_connection_count;
     uint32_t max_in_connection_count;
     uint32_t connection_timeout;
-    uint32_t ping_connection_timeout;
     uint32_t handshake_interval;
     uint32_t packet_max_size;
     uint32_t config_id;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -350,7 +350,7 @@ namespace cryptonote
       http_login.emplace(std::move(rpc_config->login->username), std::move(rpc_config->login->password).password());
 
     if (m_rpc_payment)
-      m_net_server.add_idle_handler([this](){ return m_rpc_payment->on_idle(); }, 60 * 1000);
+      m_net_server.add_idle_handler([this](){ return m_rpc_payment->on_idle(); }, std::chrono::minutes{1});
 
     bool store_ssl_key = !restricted && rpc_config->ssl_options && rpc_config->ssl_options.auth.certificate_path.empty();
     const auto ssl_base_path = (boost::filesystem::path{data_dir} / "rpc_ssl").string();

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -267,7 +267,7 @@ namespace tools
         }
       }
       return true;
-    }, auto_refresh_evaluation_ms.count());
+    }, auto_refresh_evaluation_ms);
     m_net_server.add_idle_handler([this](){
       if (m_stop.load(std::memory_order_relaxed))
       {
@@ -275,7 +275,7 @@ namespace tools
         return false;
       }
       return true;
-    }, 500);
+    }, std::chrono::milliseconds{500});
 
     //DO NOT START THIS SERVER IN MORE THEN 1 THREADS WITHOUT REFACTORING
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::run(1, true);

--- a/tests/net_load_tests/clt.cpp
+++ b/tests/net_load_tests/clt.cpp
@@ -50,7 +50,7 @@ using namespace net_load_tests;
 namespace
 {
   const size_t CONNECTION_COUNT = 100000;
-  const size_t CONNECTION_TIMEOUT = 10000;
+  constexpr const std::chrono::seconds CONNECTION_TIMEOUT{10};
   const size_t DEFAULT_OPERATION_TIMEOUT = 30000;
   const size_t RESERVED_CONN_CNT = 1;
 

--- a/tests/net_load_tests/srv.cpp
+++ b/tests/net_load_tests/srv.cpp
@@ -28,6 +28,7 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include <boost/asio/steady_timer.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
@@ -189,10 +190,10 @@ namespace
       if (0 < count)
       {
         // Perhaps not all connections were closed, try to close it after 7 seconds
-        boost::shared_ptr<boost::asio::deadline_timer> sh_deadline(new boost::asio::deadline_timer(m_tcp_server.get_io_context(), boost::posix_time::seconds(7)));
+        std::shared_ptr<boost::asio::steady_timer> sh_deadline(std::make_shared<boost::asio::steady_timer>(m_tcp_server.get_io_context(), std::chrono::seconds(7)));
         sh_deadline->async_wait([=](const boost::system::error_code& ec)
         {
-          boost::shared_ptr<boost::asio::deadline_timer> t = sh_deadline; // Capture sh_deadline
+          std::shared_ptr<boost::asio::steady_timer> t = sh_deadline; // Capture sh_deadline
           if (!ec)
           {
             close_connections(cmd_conn_id);
@@ -229,7 +230,7 @@ int main(int argc, char** argv)
 
   srv_levin_commands_handler *commands_handler = new srv_levin_commands_handler(tcp_server);
   tcp_server.get_config_object().set_handler(commands_handler, [](epee::levin::levin_commands_handler<test_connection_context> *handler) { delete handler; });
-  tcp_server.get_config_object().m_invoke_timeout = 10000;
+  tcp_server.get_config_object().m_invoke_timeout = std::chrono::seconds{10};
   //tcp_server.get_config_object().m_max_packet_size = max_packet_size;
 
   if (!tcp_server.run_server(thread_count, true))

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -282,7 +282,7 @@ TEST(test_epee_connection, test_lifetime)
     while (shared_state->sock_count);
     ASSERT_TRUE(shared_state->get_connections_count() == 0);
     constexpr auto DELAY = 30;
-    constexpr auto TIMEOUT = 1;
+    constexpr std::chrono::milliseconds TIMEOUT{1};
     while (server.get_connections_count()) {
       server.get_config_shared()->del_in_connections(
         server.get_config_shared()->get_in_connections_count()

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -185,7 +185,7 @@ namespace
   class async_protocol_handler_test : public ::testing::Test
   {
   public:
-    const static uint64_t invoke_timeout = 5 * 1000;
+    constexpr const static std::chrono::seconds invoke_timeout{5};
     const static size_t max_packet_size = 10 * 1024 * 1024;
 
     typedef std::unique_ptr<test_connection> test_connection_ptr;

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -690,7 +690,7 @@ TEST(cryptonote_protocol_handler, race_condition)
             net_node.core_protocol->process_payload_sync_data(msg.payload_data, context, true);
             handshaked.raise();
           },
-          P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT
+          std::chrono::milliseconds{P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT}
         );
         return true;
       }
@@ -1202,7 +1202,7 @@ TEST(node_server, race_condition)
         EXPECT_TRUE(code >= 0);
         handshaked.raise();
       },
-      P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT
+      std::chrono::milliseconds{P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT}
     );
     handshaked.wait();
     boost::asio::post(conn->strand_, [conn]{


### PR DESCRIPTION
As of Boost 1.77, `asio::deadline_timer` has been deprecated. The build log gets spammed with warnings about it. The deprecating timer will likely be around for a while, so this isn't a high priority PR right now.

The transition to `asio::steady_timer` pushes more usage of `std::chrono` to help with type-checking. Usages of `boost::shared_ptr` are updated to `std::shared_ptr` too, when the line is already being touched to update the timer type.