### PR TITLE
Add unit tests for common utility modules

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -40,8 +40,11 @@ set(unit_tests_sources
   canonical_amounts.cpp
   chacha.cpp
   checkpoints.cpp
+  combinator.cpp
   command_line.cpp
+  container_helpers.cpp
   crypto.cpp
+  data_cache.cpp
   decompose_amount_into_digits.cpp
   device.cpp
   difficulty.cpp
@@ -74,6 +77,7 @@ set(unit_tests_sources
   notify.cpp
   output_distribution.cpp
   parse_amount.cpp
+  powerof.cpp
   pruning.cpp
   random.cpp
   rolling_median.cpp

--- a/tests/unit_tests/combinator.cpp
+++ b/tests/unit_tests/combinator.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2014-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "common/combinator.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+
+TEST(combinator, combinations_count_basic)
+{
+  // C(5,2) = 10
+  EXPECT_EQ(10u, tools::combinations_count(2, 5));
+  // C(4,4) = 1
+  EXPECT_EQ(1u, tools::combinations_count(4, 4));
+  // C(1,10) = 10
+  EXPECT_EQ(10u, tools::combinations_count(1, 10));
+  // C(0,5) = 1
+  EXPECT_EQ(1u, tools::combinations_count(0, 5));
+  // C(0,0) = 1
+  EXPECT_EQ(1u, tools::combinations_count(0, 0));
+  // C(6,6) = 1
+  EXPECT_EQ(1u, tools::combinations_count(6, 6));
+  // C(3,7) = 35
+  EXPECT_EQ(35u, tools::combinations_count(3, 7));
+}
+
+TEST(combinator, combinations_count_k_greater_than_n_throws)
+{
+  EXPECT_THROW(tools::combinations_count(5, 3), std::runtime_error);
+}
+
+TEST(combinator, combine_choose_1_from_3)
+{
+  std::vector<int> v = {10, 20, 30};
+  tools::Combinator<int> comb(v);
+  auto result = comb.combine(1);
+  EXPECT_EQ(3u, result.size());
+  // Each combination should have exactly 1 element
+  for (const auto &c : result)
+    EXPECT_EQ(1u, c.size());
+}
+
+TEST(combinator, combine_choose_2_from_4)
+{
+  std::vector<int> v = {1, 2, 3, 4};
+  tools::Combinator<int> comb(v);
+  auto result = comb.combine(2);
+  // C(4,2) = 6
+  EXPECT_EQ(6u, result.size());
+  // Verify all combinations are unique
+  std::set<std::vector<int>> unique_combos(result.begin(), result.end());
+  EXPECT_EQ(6u, unique_combos.size());
+  // Each should have 2 elements
+  for (const auto &c : result)
+    EXPECT_EQ(2u, c.size());
+}
+
+TEST(combinator, combine_choose_all)
+{
+  std::vector<int> v = {1, 2, 3};
+  tools::Combinator<int> comb(v);
+  auto result = comb.combine(3);
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ(v, result[0]);
+}
+
+TEST(combinator, combine_k_zero_throws)
+{
+  std::vector<int> v = {1, 2};
+  tools::Combinator<int> comb(v);
+  EXPECT_THROW(comb.combine(0), std::runtime_error);
+}
+
+TEST(combinator, combine_k_too_large_throws)
+{
+  std::vector<int> v = {1, 2};
+  tools::Combinator<int> comb(v);
+  EXPECT_THROW(comb.combine(3), std::runtime_error);
+}
+
+TEST(combinator, combine_preserves_element_order)
+{
+  std::vector<std::string> v = {"a", "b", "c", "d"};
+  tools::Combinator<std::string> comb(v);
+  auto result = comb.combine(2);
+  // Each combination should have elements in their original relative order
+  for (const auto &c : result)
+  {
+    ASSERT_EQ(2u, c.size());
+    auto it1 = std::find(v.begin(), v.end(), c[0]);
+    auto it2 = std::find(v.begin(), v.end(), c[1]);
+    EXPECT_LT(it1, it2);
+  }
+}
+
+TEST(combinator, combine_count_matches_combinations_count)
+{
+  std::vector<int> v = {1, 2, 3, 4, 5, 6};
+  tools::Combinator<int> comb(v);
+  for (size_t k = 1; k <= v.size(); ++k)
+  {
+    auto result = comb.combine(k);
+    EXPECT_EQ(tools::combinations_count(k, v.size()), result.size());
+  }
+}
+
+TEST(combinator, combine_single_element_vector)
+{
+  std::vector<int> v = {42};
+  tools::Combinator<int> comb(v);
+  auto result = comb.combine(1);
+  ASSERT_EQ(1u, result.size());
+  ASSERT_EQ(1u, result[0].size());
+  EXPECT_EQ(42, result[0][0]);
+}

--- a/tests/unit_tests/container_helpers.cpp
+++ b/tests/unit_tests/container_helpers.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2022-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "common/container_helpers.h"
+
+#include <string>
+#include <vector>
+
+// -- is_sorted_and_unique tests --
+
+TEST(container_helpers, is_sorted_and_unique_empty)
+{
+  std::vector<int> v;
+  EXPECT_TRUE(tools::is_sorted_and_unique(v));
+}
+
+TEST(container_helpers, is_sorted_and_unique_single)
+{
+  std::vector<int> v = {42};
+  EXPECT_TRUE(tools::is_sorted_and_unique(v));
+}
+
+TEST(container_helpers, is_sorted_and_unique_sorted_unique)
+{
+  std::vector<int> v = {1, 2, 3, 4, 5};
+  EXPECT_TRUE(tools::is_sorted_and_unique(v));
+}
+
+TEST(container_helpers, is_sorted_and_unique_unsorted)
+{
+  std::vector<int> v = {1, 3, 2};
+  EXPECT_FALSE(tools::is_sorted_and_unique(v));
+}
+
+TEST(container_helpers, is_sorted_and_unique_duplicates)
+{
+  std::vector<int> v = {1, 2, 2, 3};
+  EXPECT_FALSE(tools::is_sorted_and_unique(v));
+}
+
+TEST(container_helpers, is_sorted_and_unique_custom_comparator)
+{
+  // Descending order
+  std::vector<int> v = {5, 4, 3, 2, 1};
+  EXPECT_TRUE(tools::is_sorted_and_unique(v, std::greater<int>{}));
+}
+
+TEST(container_helpers, is_sorted_and_unique_custom_comparator_with_dups)
+{
+  std::vector<int> v = {5, 4, 4, 2, 1};
+  EXPECT_FALSE(tools::is_sorted_and_unique(v, std::greater<int>{}));
+}
+
+TEST(container_helpers, is_sorted_and_unique_strings)
+{
+  std::vector<std::string> v = {"apple", "banana", "cherry"};
+  EXPECT_TRUE(tools::is_sorted_and_unique(v));
+
+  std::vector<std::string> v2 = {"apple", "apple", "cherry"};
+  EXPECT_FALSE(tools::is_sorted_and_unique(v2));
+}
+
+// -- keys_match_internal_values tests --
+
+TEST(container_helpers, keys_match_internal_values_all_match)
+{
+  std::unordered_map<int, int> m = {{1, 2}, {3, 6}, {5, 10}};
+  // Check that value == key * 2
+  EXPECT_TRUE(tools::keys_match_internal_values(m,
+    [](const int &key, const int &val) { return val == key * 2; }));
+}
+
+TEST(container_helpers, keys_match_internal_values_mismatch)
+{
+  std::unordered_map<int, int> m = {{1, 2}, {3, 7}, {5, 10}};
+  EXPECT_FALSE(tools::keys_match_internal_values(m,
+    [](const int &key, const int &val) { return val == key * 2; }));
+}
+
+TEST(container_helpers, keys_match_internal_values_empty)
+{
+  std::unordered_map<int, int> m;
+  EXPECT_TRUE(tools::keys_match_internal_values(m,
+    [](const int &key, const int &val) { return false; }));
+}
+
+// -- for_all_in_map_erase_if tests --
+
+TEST(container_helpers, for_all_in_map_erase_if_remove_evens)
+{
+  std::unordered_map<int, std::string> m = {
+    {1, "a"}, {2, "b"}, {3, "c"}, {4, "d"}
+  };
+  tools::for_all_in_map_erase_if(m,
+    [](const std::pair<const int, std::string> &entry) { return entry.first % 2 == 0; });
+  EXPECT_EQ(2u, m.size());
+  EXPECT_TRUE(m.count(1));
+  EXPECT_TRUE(m.count(3));
+  EXPECT_FALSE(m.count(2));
+  EXPECT_FALSE(m.count(4));
+}
+
+TEST(container_helpers, for_all_in_map_erase_if_remove_none)
+{
+  std::unordered_map<int, int> m = {{1, 1}, {2, 2}};
+  tools::for_all_in_map_erase_if(m,
+    [](const std::pair<const int, int> &) { return false; });
+  EXPECT_EQ(2u, m.size());
+}
+
+TEST(container_helpers, for_all_in_map_erase_if_remove_all)
+{
+  std::unordered_map<int, int> m = {{1, 1}, {2, 2}};
+  tools::for_all_in_map_erase_if(m,
+    [](const std::pair<const int, int> &) { return true; });
+  EXPECT_TRUE(m.empty());
+}
+
+TEST(container_helpers, for_all_in_map_erase_if_empty_map)
+{
+  std::unordered_map<int, int> m;
+  tools::for_all_in_map_erase_if(m,
+    [](const std::pair<const int, int> &) { return true; });
+  EXPECT_TRUE(m.empty());
+}
+
+// -- compare_func / as_functor tests --
+
+TEST(container_helpers, compare_func_basic)
+{
+  auto cmp = tools::compare_func<int>(std::less<int>{});
+  EXPECT_TRUE(cmp(1, 2));
+  EXPECT_FALSE(cmp(2, 1));
+  EXPECT_FALSE(cmp(1, 1));
+}
+
+TEST(container_helpers, is_sorted_and_unique_with_function_pointer)
+{
+  std::vector<int> v = {1, 2, 3, 4};
+  // Use the function pointer overload
+  EXPECT_TRUE(tools::is_sorted_and_unique(v,
+    [](const int &a, const int &b) -> bool { return a < b; }));
+}

--- a/tests/unit_tests/data_cache.cpp
+++ b/tests/unit_tests/data_cache.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2014-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "common/data_cache.h"
+
+#include <string>
+#include <thread>
+#include <vector>
+
+TEST(data_cache, empty_cache_has_nothing)
+{
+  tools::data_cache<uint64_t, 4> cache;
+  EXPECT_FALSE(cache.has(0));
+  EXPECT_FALSE(cache.has(1));
+  EXPECT_FALSE(cache.has(UINT64_MAX));
+}
+
+TEST(data_cache, add_and_find)
+{
+  tools::data_cache<uint64_t, 4> cache;
+  cache.add(42);
+  EXPECT_TRUE(cache.has(42));
+  EXPECT_FALSE(cache.has(43));
+}
+
+TEST(data_cache, add_multiple_within_capacity)
+{
+  tools::data_cache<uint64_t, 4> cache;
+  cache.add(1);
+  cache.add(2);
+  cache.add(3);
+  cache.add(4);
+  EXPECT_TRUE(cache.has(1));
+  EXPECT_TRUE(cache.has(2));
+  EXPECT_TRUE(cache.has(3));
+  EXPECT_TRUE(cache.has(4));
+}
+
+TEST(data_cache, eviction_on_overflow)
+{
+  tools::data_cache<uint64_t, 4> cache;
+  // Fill cache
+  cache.add(1);
+  cache.add(2);
+  cache.add(3);
+  cache.add(4);
+  // Adding a 5th element should evict the oldest (1)
+  cache.add(5);
+  EXPECT_FALSE(cache.has(1));
+  EXPECT_TRUE(cache.has(2));
+  EXPECT_TRUE(cache.has(3));
+  EXPECT_TRUE(cache.has(4));
+  EXPECT_TRUE(cache.has(5));
+}
+
+TEST(data_cache, eviction_wraps_around)
+{
+  tools::data_cache<uint64_t, 3> cache;
+  // Fill: slots [0]=1, [1]=2, [2]=3
+  cache.add(1);
+  cache.add(2);
+  cache.add(3);
+  // Overflow: slot [0] overwritten with 4, evicts 1
+  cache.add(4);
+  EXPECT_FALSE(cache.has(1));
+  EXPECT_TRUE(cache.has(4));
+  // Overflow again: slot [1] overwritten with 5, evicts 2
+  cache.add(5);
+  EXPECT_FALSE(cache.has(2));
+  EXPECT_TRUE(cache.has(5));
+  // Overflow again: slot [2] overwritten with 6, evicts 3
+  cache.add(6);
+  EXPECT_FALSE(cache.has(3));
+  EXPECT_TRUE(cache.has(4));
+  EXPECT_TRUE(cache.has(5));
+  EXPECT_TRUE(cache.has(6));
+}
+
+TEST(data_cache, duplicate_add_is_noop)
+{
+  tools::data_cache<uint64_t, 4> cache;
+  cache.add(1);
+  cache.add(2);
+  cache.add(3);
+  // Re-adding 1 should not advance the counter or evict anything
+  cache.add(1);
+  cache.add(4);
+  // All should still be present since duplicate didn't consume a slot
+  EXPECT_TRUE(cache.has(1));
+  EXPECT_TRUE(cache.has(2));
+  EXPECT_TRUE(cache.has(3));
+  EXPECT_TRUE(cache.has(4));
+}
+
+TEST(data_cache, string_keys)
+{
+  tools::data_cache<std::string, 2> cache;
+  cache.add("hello");
+  cache.add("world");
+  EXPECT_TRUE(cache.has("hello"));
+  EXPECT_TRUE(cache.has("world"));
+  cache.add("foo");
+  EXPECT_FALSE(cache.has("hello"));
+  EXPECT_TRUE(cache.has("world"));
+  EXPECT_TRUE(cache.has("foo"));
+}
+
+TEST(data_cache, size_one_cache)
+{
+  tools::data_cache<int, 1> cache;
+  cache.add(10);
+  EXPECT_TRUE(cache.has(10));
+  cache.add(20);
+  EXPECT_FALSE(cache.has(10));
+  EXPECT_TRUE(cache.has(20));
+}
+
+TEST(data_cache, concurrent_access)
+{
+  tools::data_cache<uint64_t, 128> cache;
+  constexpr int num_threads = 4;
+  constexpr int items_per_thread = 100;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < num_threads; ++t)
+  {
+    threads.emplace_back([&cache, t]() {
+      for (int i = 0; i < items_per_thread; ++i)
+      {
+        uint64_t val = t * items_per_thread + i;
+        cache.add(val);
+        // Just exercise has() concurrently; result may vary due to eviction
+        cache.has(val);
+      }
+    });
+  }
+  for (auto &th : threads)
+    th.join();
+
+  // No crash or deadlock is the primary assertion; also verify cache still works
+  cache.add(999999);
+  EXPECT_TRUE(cache.has(999999));
+}

--- a/tests/unit_tests/powerof.cpp
+++ b/tests/unit_tests/powerof.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2014-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "common/powerof.h"
+
+TEST(powerof, base_cases)
+{
+  // Anything to the power of 0 is 1
+  EXPECT_EQ(1u, (tools::PowerOf<2, 0>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<10, 0>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<1, 0>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<100, 0>::Value));
+}
+
+TEST(powerof, powers_of_two)
+{
+  EXPECT_EQ(2u, (tools::PowerOf<2, 1>::Value));
+  EXPECT_EQ(4u, (tools::PowerOf<2, 2>::Value));
+  EXPECT_EQ(8u, (tools::PowerOf<2, 3>::Value));
+  EXPECT_EQ(16u, (tools::PowerOf<2, 4>::Value));
+  EXPECT_EQ(1024u, (tools::PowerOf<2, 10>::Value));
+  EXPECT_EQ(1048576u, (tools::PowerOf<2, 20>::Value));
+}
+
+TEST(powerof, powers_of_ten)
+{
+  EXPECT_EQ(10u, (tools::PowerOf<10, 1>::Value));
+  EXPECT_EQ(100u, (tools::PowerOf<10, 2>::Value));
+  EXPECT_EQ(1000u, (tools::PowerOf<10, 3>::Value));
+  EXPECT_EQ(1000000u, (tools::PowerOf<10, 6>::Value));
+  EXPECT_EQ(1000000000000u, (tools::PowerOf<10, 12>::Value));
+}
+
+TEST(powerof, one_to_any_power)
+{
+  EXPECT_EQ(1u, (tools::PowerOf<1, 0>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<1, 1>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<1, 10>::Value));
+  EXPECT_EQ(1u, (tools::PowerOf<1, 50>::Value));
+}
+
+TEST(powerof, miscellaneous)
+{
+  EXPECT_EQ(27u, (tools::PowerOf<3, 3>::Value));
+  EXPECT_EQ(625u, (tools::PowerOf<5, 4>::Value));
+  EXPECT_EQ(7776u, (tools::PowerOf<6, 5>::Value));
+  EXPECT_EQ(256u, (tools::PowerOf<4, 4>::Value));
+}
+
+TEST(powerof, compile_time_constexpr)
+{
+  // Verify these are usable as compile-time constants
+  static_assert(tools::PowerOf<2, 8>::Value == 256, "2^8 should be 256");
+  static_assert(tools::PowerOf<10, 3>::Value == 1000, "10^3 should be 1000");
+  static_assert(tools::PowerOf<3, 0>::Value == 1, "3^0 should be 1");
+}


### PR DESCRIPTION
39 new C++ tests for data_cache, combinator, container_helpers, and powerof. 566 lines.