### PR TITLE
guix: bump time-machine to 4a507aa8c0a579d150267d81ab4013189a7ec505

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -58,7 +58,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://codeberg.org/guix/guix.git \
-                      --commit=3cd1c8769c618cab07181c6a4807792a371f0b2e \
+                      --commit=4a507aa8c0a579d150267d81ab4013189a7ec505 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
Previous bump: #10005

To ensure reproducibility, reviewers are requested to perform a build and share their hashes.

#### Notable changes

- Update Rust to 1.93.0 (up from 1.85.1)
