### PR TITLE
crypto: derive key image generator & separate {un}biased hash to ec

### DIFF
--- a/src/crypto/blake2b.c
+++ b/src/crypto/blake2b.c
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "memwipe.h"
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
@@ -280,9 +281,12 @@ int blake2b_init_key(blake2b_state *S, size_t outlen, const void *key, size_t ke
 		uint8_t block[BLAKE2B_BLOCKBYTES];
 		memset(block, 0, BLAKE2B_BLOCKBYTES);
 		memcpy(block, key, keylen);
-		blake2b_update(S, block, BLAKE2B_BLOCKBYTES);
+		int r = blake2b_update(S, block, BLAKE2B_BLOCKBYTES);
 		/* Burn the key from stack */
 		clear_internal_memory(block, BLAKE2B_BLOCKBYTES);
+		if (r < 0) {
+			return -1;
+		}
 	}
 	return 0;
 }
@@ -514,5 +518,74 @@ fail:
 #undef TRY
 }
 /* Argon2 Team - End Code */
+
+int blake2b_monero(void *out, size_t outlen, const void *in, size_t inlen,
+	const void *key, size_t keylen) {
+	// At this time, we expect all Monero-based callers to use a keylen=32
+	// if a key is included. If a caller wants to use a key and keylen != 32,
+	// just remove this assert (and #include <assert.h>).
+	assert(keylen == 0 || keylen == 32);
+
+	static const uint8_t PERSONAL[BLAKE2B_PERSONALBYTES] = {'M', 'o', 'n', 'e', 'r', 'o'};
+
+	blake2b_param P;
+	blake2b_state S;
+	int ret = -1;
+
+	/* Verify parameters */
+	if (NULL == in && inlen > 0) {
+		goto fail;
+	}
+
+	if (NULL == out || outlen == 0 || outlen > BLAKE2B_OUTBYTES) {
+		goto fail;
+	}
+
+	if ((NULL == key && keylen > 0) || keylen > BLAKE2B_KEYBYTES) {
+		goto fail;
+	}
+
+	if (NULL != key && keylen == 0) {
+		goto fail;
+	}
+
+	/* Setup Parameter Block */
+	P.digest_length = (uint8_t)outlen;
+	P.key_length = (uint8_t)keylen;
+	P.fanout = 1;
+	P.depth = 1;
+	P.leaf_length = 0;
+	P.node_offset = 0;
+	P.node_depth = 0;
+	P.inner_length = 0;
+	memset(P.reserved, 0, sizeof(P.reserved));
+	memset(P.salt, 0, sizeof(P.salt));
+	memcpy(P.personal, PERSONAL, sizeof(PERSONAL));
+
+	if (blake2b_init_param(&S, &P) < 0) {
+		goto fail;
+	}
+
+	if (NULL != key) {
+		uint8_t block[BLAKE2B_BLOCKBYTES];
+		memset(block, 0, BLAKE2B_BLOCKBYTES);
+		memcpy(block, key, keylen);
+		int r = blake2b_update(&S, block, BLAKE2B_BLOCKBYTES);
+		/* Burn the key from stack */
+		clear_internal_memory(block, BLAKE2B_BLOCKBYTES);
+		if (r < 0) {
+			goto fail;
+		}
+	}
+
+	if (blake2b_update(&S, in, inlen) < 0) {
+		goto fail;
+	}
+	ret = blake2b_final(&S, out, outlen);
+
+fail:
+	clear_internal_memory(&S, sizeof(S));
+	return ret;
+}
 
 /// END: blake2b.c

--- a/src/crypto/blake2b.h
+++ b/src/crypto/blake2b.h
@@ -111,6 +111,9 @@ extern "C" {
 	int blake2b_long(void *out, size_t outlen, const void *in, size_t inlen);
 	/* Argon2 Team - End Code */
 
+	int blake2b_monero(void *out, size_t outlen, const void *in, size_t inlen,
+		const void *key, size_t keylen);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -42,6 +42,7 @@
 #include "warnings.h"
 #include "crypto.h"
 #include "hash.h"
+#include "blake2b.h"
 
 #include "cryptonote_config.h"
 
@@ -608,7 +609,7 @@ namespace crypto {
     return sc_isnonzero(&c2) == 0;
   }
 
-  static void hash_to_ec(const public_key &key, ge_p3 &res) {
+  static void biased_hash_to_ec(const public_key &key, ge_p3 &res) {
     hash h;
     ge_p2 point;
     ge_p1p1 point2;
@@ -618,11 +619,58 @@ namespace crypto {
     ge_p1p1_to_p3(&res, &point2);
   }
 
+  void crypto_ops::unbiased_hash_to_ec(const unsigned char *preimage, const std::size_t length, ec_point &res) {
+    unsigned char hash[64];
+    if (blake2b_monero(std::addressof(hash), 64, preimage, length, NULL, 0) != 0)
+      throw std::runtime_error("Failed blake2b");
+
+    ge_p2 first;
+    ge_fromfe_frombytes_vartime(&first, hash);
+    ge_p1p1 first_p1p1;
+    ge_mul8(&first_p1p1, &first);
+    ge_p3 first_p3;
+    ge_p1p1_to_p3(&first_p3, &first_p1p1);
+
+    ge_p2 second;
+    ge_fromfe_frombytes_vartime(&second, hash + 32);
+    ge_p1p1 second_p1p1;
+    ge_mul8(&second_p1p1, &second);
+    ge_p3 second_p3;
+    ge_p1p1_to_p3(&second_p3, &second_p1p1);
+    ge_cached second_cached;
+    ge_p3_to_cached(&second_cached, &second_p3);
+
+    ge_p1p1 point;
+    ge_add(&point, &first_p3, &second_cached);
+
+    ge_p3 res_ge_p3;
+    ge_p1p1_to_p3(&res_ge_p3, &point);
+    ge_p3_tobytes(&res, &res_ge_p3);
+  }
+
+  static void biased_derive_key_image_generator(const public_key &pub, ec_point &ki_gen) {
+    ge_p3 point;
+    biased_hash_to_ec(pub, point);
+    ge_p3_tobytes(&ki_gen, &point);
+  }
+
+  static void unbiased_derive_key_image_generator(const public_key &pub, ec_point &ki_gen) {
+    unbiased_hash_to_ec(&pub, sizeof(public_key), ki_gen);
+  }
+
+  void crypto_ops::derive_key_image_generator(const public_key &pub, const bool biased, ec_point &ki_gen) {
+    if (biased)
+      biased_derive_key_image_generator(pub, ki_gen);
+    else
+      unbiased_derive_key_image_generator(pub, ki_gen);
+  }
+
+  // key image derivation used before FCMP++/Carrot
   void crypto_ops::generate_key_image(const public_key &pub, const secret_key &sec, key_image &image) {
     ge_p3 point;
     ge_p2 point2;
     assert(sc_check(&sec) == 0);
-    hash_to_ec(pub, point);
+    biased_hash_to_ec(pub, point);
     ge_scalarmult(&point2, &unwrap(sec), &point);
     ge_tobytes(&image, &point2);
   }
@@ -683,7 +731,7 @@ POP_WARNINGS
         random_scalar(k);
         ge_scalarmult_base(&tmp3, &k);
         ge_p3_tobytes(&buf->ab[i].a, &tmp3);
-        hash_to_ec(*pubs[i], tmp3);
+        biased_hash_to_ec(*pubs[i], tmp3);
         ge_scalarmult(&tmp2, &k, &tmp3);
         ge_tobytes(&buf->ab[i].b, &tmp2);
       } else {
@@ -695,7 +743,7 @@ POP_WARNINGS
         }
         ge_double_scalarmult_base_vartime(&tmp2, &sig[i].c, &tmp3, &sig[i].r);
         ge_tobytes(&buf->ab[i].a, &tmp2);
-        hash_to_ec(*pubs[i], tmp3);
+        biased_hash_to_ec(*pubs[i], tmp3);
         ge_double_scalarmult_precomp_vartime(&tmp2, &sig[i].r, &tmp3, &sig[i].c, image_pre);
         ge_tobytes(&buf->ab[i].b, &tmp2);
         sc_add(&sum, &sum, &sig[i].c);
@@ -740,7 +788,7 @@ POP_WARNINGS
       }
       ge_double_scalarmult_base_vartime(&tmp2, &sig[i].c, &tmp3, &sig[i].r);
       ge_tobytes(&buf->ab[i].a, &tmp2);
-      hash_to_ec(*pubs[i], tmp3);
+      biased_hash_to_ec(*pubs[i], tmp3);
       ge_double_scalarmult_precomp_vartime(&tmp2, &sig[i].r, &tmp3, &sig[i].c, image_pre);
       ge_tobytes(&buf->ab[i].b, &tmp2);
       sc_add(&sum, &sum, &sig[i].c);

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -133,6 +133,10 @@ namespace crypto {
     friend void generate_tx_proof_v1(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const secret_key &, signature &);
     static bool check_tx_proof(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const signature &, const int);
     friend bool check_tx_proof(const hash &, const public_key &, const public_key &, const boost::optional<public_key> &, const public_key &, const signature &, const int);
+    static void unbiased_hash_to_ec(const unsigned char *, const std::size_t, ec_point &);
+    friend void unbiased_hash_to_ec(const unsigned char *, const std::size_t, ec_point &);
+    static void derive_key_image_generator(const public_key &, const bool biased, ec_point &);
+    friend void derive_key_image_generator(const public_key &, const bool biased, ec_point &);
     static void generate_key_image(const public_key &, const secret_key &, key_image &);
     friend void generate_key_image(const public_key &, const secret_key &, key_image &);
     static void generate_ring_signature(const hash &, const key_image &,
@@ -258,6 +262,10 @@ namespace crypto {
     return crypto_ops::check_tx_proof(prefix_hash, R, A, B, D, sig, version);
   }
 
+  inline void derive_key_image_generator(const public_key &pub, const bool biased, ec_point &ki_gen) {
+    crypto_ops::derive_key_image_generator(pub, biased, ki_gen);
+  }
+
   /* To send money to a key:
    * * The sender generates an ephemeral key and includes it in transaction output.
    * * To spend the money, the receiver generates a key image from it.
@@ -299,6 +307,10 @@ namespace crypto {
    */
   inline void derive_view_tag(const key_derivation &derivation, std::size_t output_index, view_tag &vt) {
     crypto_ops::derive_view_tag(derivation, output_index, vt);
+  }
+
+  inline void unbiased_hash_to_ec(const unsigned char *preimage, const std::size_t length, ec_point &res) {
+    crypto_ops::unbiased_hash_to_ec(preimage, length, res);
   }
 
   inline std::ostream &operator <<(std::ostream &o, const crypto::public_key &v) {

--- a/tests/crypto/crypto-tests.h
+++ b/tests/crypto/crypto-tests.h
@@ -45,7 +45,7 @@ bool check_scalar(const crypto::ec_scalar &scalar);
 void random_scalar(crypto::ec_scalar &res);
 void hash_to_scalar(const void *data, std::size_t length, crypto::ec_scalar &res);
 void hash_to_point(const crypto::hash &h, crypto::ec_point &res);
-void hash_to_ec(const crypto::public_key &key, crypto::ec_point &res);
+void biased_hash_to_ec(const crypto::public_key &key, crypto::ec_point &res);
 bool check_ge_p3_identity_failure(const crypto::public_key &point);
 bool check_ge_p3_identity_success(const crypto::public_key &point);
 #endif

--- a/tests/crypto/crypto.cpp
+++ b/tests/crypto/crypto.cpp
@@ -80,9 +80,9 @@ void hash_to_point(const crypto::hash &h, crypto::ec_point &res) {
   crypto::ge_tobytes(crypto::operator &(res), &point);
 }
 
-void hash_to_ec(const crypto::public_key &key, crypto::ec_point &res) {
+void biased_hash_to_ec(const crypto::public_key &key, crypto::ec_point &res) {
   crypto::ge_p3 tmp;
-  crypto::hash_to_ec(key, tmp);
+  crypto::biased_hash_to_ec(key, tmp);
   crypto::ge_p3_tobytes(crypto::operator &(res), &tmp);
 }
 

--- a/tests/crypto/main.cpp
+++ b/tests/crypto/main.cpp
@@ -194,11 +194,11 @@ int main(int argc, char *argv[]) {
       if (expected != actual) {
         goto error;
       }
-    } else if (cmd == "hash_to_ec") {
+    } else if (cmd == "biased_hash_to_ec") {
       public_key key;
       ec_point expected, actual;
       get(input, key, expected);
-      hash_to_ec(key, actual);
+      biased_hash_to_ec(key, actual);
       if (expected != actual) {
         goto error;
       }
@@ -285,6 +285,15 @@ int main(int argc, char *argv[]) {
         goto error;
       }
       if (expected_wei_x != actual_wei_x || expected_wei_y != actual_wei_y) {
+        goto error;
+      }
+    } else if (cmd == "derive_key_image_generator") {
+      public_key point;
+      bool biased;
+      ec_point expected_result, actual_result;
+      get(input, point, biased, expected_result);
+      crypto::derive_key_image_generator(point, biased, actual_result);
+      if (expected_result != actual_result) {
         goto error;
       }
     } else {


### PR DESCRIPTION
In https://github.com/monero-project/research-lab/issues/142 , @kayabaNerve noted the potential bias in Monero's hash-to-point function, and proposed introducing a cleaner *unbiased* hash-to-point function with the FCMP++ upgrade to maximize bit security. This proposal was discussed further in [this MRL meeting](https://github.com/monero-project/meta/issues/1261), where @kayabaNerve provided [additional context](https://github.com/monero-project/research-lab/issues/142#issuecomment-3956284024) for why this property is even more desirable with FCMP++/Carrot to avoid the ["burning bug"](https://web.getmonero.org/2018/09/25/a-post-mortum-of-the-burning-bug.html) in potential circumstances specific to FCMP++/Carrot and not RingCT.

With that general context in mind, this PR introduces 3 new core crypto functions:

- `biased_hash_to_ec` (previously `hash_to_ec`)
  - This change makes it clear that legacy code uses the "biased" implementation, which should help clearly separate it from the upgraded "unbiased" implementation and help avoid accidental usage for new code. 
- `unbiased_hash_to_ec`
  - Used to generate key images in FCMP++ / Carrot code (current iteration needs [this PR](https://github.com/monero-oxide/monero-oxide/pull/182) also UPDATE: that PR was merged).
- `derive_key_image_generator`
  - This new helper function is used in FCMP++ code for generating `I`, which is a member of a leaf that enters the FCMP++ "curve tree," and is used to derive the key image (key images are `x * I`, where x is the one-time priv key used to spend an output). See references to `I` in [the FCMP++ paper](https://github.com/kayabaNerve/fcmp-plus-plus-paper/blob/develop/fcmp%2B%2B.pdf) ([specific commit](https://github.com/kayabaNerve/fcmp-plus-plus-paper/blob/6f01fd3296b17f90b5c97c738cc3320e3369ad49/fcmp%2B%2B.pdf)).
  ______

Cypher Stack and Trail of bits audited an earlier state of this PR.

Cypher Stack recommended using a domain-separating tag for our hash to point in [Section 9.3.3](https://github.com/cypherstack/fcmp-impl-audit/blob/d7de33d08c48a3c249629e47f71ea72c938a3404/FCMP_Code_Implementation_Audit.pdf). Thus, I implemented and used the same `blake2_monero` used for SAL from [this PR](https://github.com/monero-oxide/monero-oxide/pull/176) by @UkoeHB. The Rust side needs [this PR](https://github.com/monero-oxide/monero-oxide/pull/182) to match, which also implements the same tests as this current PR (@UkoeHB suggested to include hard-coded tests consistent on the C++ side and Rust side).

Both Cypher Stack and Trail of Bits affirmed the rationale for this PR, and the implementation of the unbiased hash-to-point (neither reviewed the code that includes the DST from `blake2_monero`). I will share the Trail of Bits audit once public.
