### PR TITLE
ringct: remove dead multisig_out type

### DIFF
--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -294,15 +294,6 @@ namespace boost
   }
 
   template <class Archive>
-  inline void serialize(Archive &a, rct::multisig_out &x, const boost::serialization::version_type ver)
-  {
-    a & x.c;
-    if (ver < 1)
-      return;
-    a & x.mu_p;
-  }
-
-  template <class Archive>
   inline typename std::enable_if<Archive::is_loading::value, void>::type serializeOutPk(Archive &a, rct::ctkeyV &outPk_, const boost::serialization::version_type ver)
   {
     rct::keyV outPk;
@@ -427,4 +418,3 @@ namespace boost
 
 BOOST_CLASS_VERSION(rct::rctSigPrunable, 2)
 BOOST_CLASS_VERSION(rct::rctSig, 2)
-BOOST_CLASS_VERSION(rct::multisig_out, 1)

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -120,19 +120,6 @@ namespace rct {
         ~multisig_kLRki() { memwipe(&k, sizeof(k)); }
     };
 
-    struct multisig_out {
-        std::vector<key> c; // for all inputs
-        std::vector<key> mu_p; // for all inputs
-        std::vector<key> c0; // for all inputs
-
-        BEGIN_SERIALIZE_OBJECT()
-          FIELD(c)
-          FIELD(mu_p)
-          if (!mu_p.empty() && mu_p.size() != c.size())
-            return false;
-        END_SERIALIZE()
-    };
-
     //data for passing the amount to the receiver secretly
     // If the pedersen commitment to an amount is C = aG + bH,
     // "mask" contains a 32 byte key a
@@ -789,7 +776,6 @@ VARIANT_TAG(debug_archive, rct::boroSig, "rct::boroSig");
 VARIANT_TAG(debug_archive, rct::rctSig, "rct::rctSig");
 VARIANT_TAG(debug_archive, rct::Bulletproof, "rct::bulletproof");
 VARIANT_TAG(debug_archive, rct::multisig_kLRki, "rct::multisig_kLRki");
-VARIANT_TAG(debug_archive, rct::multisig_out, "rct::multisig_out");
 VARIANT_TAG(debug_archive, rct::clsag, "rct::clsag");
 VARIANT_TAG(debug_archive, rct::BulletproofPlus, "rct::bulletproof_plus");
 
@@ -807,7 +793,6 @@ VARIANT_TAG(binary_archive, rct::boroSig, 0x9a);
 VARIANT_TAG(binary_archive, rct::rctSig, 0x9b);
 VARIANT_TAG(binary_archive, rct::Bulletproof, 0x9c);
 VARIANT_TAG(binary_archive, rct::multisig_kLRki, 0x9d);
-VARIANT_TAG(binary_archive, rct::multisig_out, 0x9e);
 VARIANT_TAG(binary_archive, rct::clsag, 0x9f);
 VARIANT_TAG(binary_archive, rct::BulletproofPlus, 0xa0);
 
@@ -825,7 +810,6 @@ VARIANT_TAG(json_archive, rct::boroSig, "rct_boroSig");
 VARIANT_TAG(json_archive, rct::rctSig, "rct_rctSig");
 VARIANT_TAG(json_archive, rct::Bulletproof, "rct_bulletproof");
 VARIANT_TAG(json_archive, rct::multisig_kLRki, "rct_multisig_kLR");
-VARIANT_TAG(json_archive, rct::multisig_out, "rct_multisig_out");
 VARIANT_TAG(json_archive, rct::clsag, "rct_clsag");
 VARIANT_TAG(json_archive, rct::BulletproofPlus, "rct_bulletproof_plus");
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -612,7 +612,6 @@ private:
       std::unordered_set<crypto::public_key> ignore;
       std::unordered_set<rct::key> used_L;
       std::unordered_set<crypto::public_key> signing_keys;
-      rct::multisig_out msout;
 
       rct::keyM total_alpha_G;
       rct::keyM total_alpha_H;
@@ -620,14 +619,20 @@ private:
       rct::keyV s;
 
       BEGIN_SERIALIZE_OBJECT()
-        VERSION_FIELD(1)
+        VERSION_FIELD(2)
         if (version < 1)
           return false;
         FIELD(sigs)
         FIELD(ignore)
         FIELD(used_L)
         FIELD(signing_keys)
-        FIELD(msout)
+        if (version < 2 && !W)
+        {
+          // read 2 empty key vectors inside defunct `multisig_out`
+          rct::keyV dummy;
+          FIELDS(dummy)
+          FIELDS(dummy)
+        }
         FIELD(total_alpha_G)
         FIELD(total_alpha_H)
         FIELD(c_0)


### PR DESCRIPTION
Bumps the wallet cache version. Alternatively, wallet cache format could stay the same, with the two empty vectors serialized on write.