### PR TITLE
crypto: wipe AES key material before free

### DIFF
--- a/src/crypto/oaes_lib.c
+++ b/src/crypto/oaes_lib.c
@@ -55,6 +55,7 @@
 #endif
 
 #include "oaes_lib.h"
+#include <memwipe.h>
 
 #define OAES_RKEY_LEN 4
 #define OAES_COL_LEN 4
@@ -120,12 +121,14 @@ static OAES_RET oaes_key_destroy( oaes_key ** key )
 	
 	if( (*key)->data )
 	{
+		memwipe( (*key)->data, (*key)->data_len );
 		free( (*key)->data );
 		(*key)->data = NULL;
 	}
 	
 	if( (*key)->exp_data )
 	{
+		memwipe( (*key)->exp_data, (*key)->exp_data_len );
 		free( (*key)->exp_data );
 		(*key)->exp_data = NULL;
 	}


### PR DESCRIPTION
`oaes_key_destroy()` frees the AES key and expanded key buffers without clearing them first. This leaves key material in memory until the allocator reuses the blocks. This change wipes both buffers with `memwipe()` before calling `free()`, using the same pattern as elsewhere in the codebase.

OpenAES is used by `cn_slow_hash()`, including for wallet passphrase-derived key derivation; clearing this data reduces exposure of passphrase-derived material in freed heap.

Note: #9508 proposes replacing the alloc-based OAES path with a buffer-based expansion; if that is merged, this change would be superseded. Until then, this wipes key material in the current implementation.