### PR TITLE
epee: show error-level log messages at the default log level

### DIFF
--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -100,7 +100,7 @@ static const char *get_default_categories(int level)
   switch (level)
   {
     case 0:
-      categories = "*:WARNING,net:FATAL,net.http:FATAL,net.ssl:FATAL,net.p2p:FATAL,net.cn:FATAL,daemon.rpc:FATAL,global:INFO,verify:FATAL,serialization:FATAL,daemon.rpc.payment:ERROR,stacktrace:INFO,logging:INFO,msgwriter:INFO";
+      categories = "*:WARNING,net:ERROR,net.http:ERROR,net.ssl:ERROR,net.p2p:ERROR,net.cn:ERROR,daemon.rpc:ERROR,global:INFO,verify:ERROR,serialization:ERROR,daemon.rpc.payment:ERROR,stacktrace:INFO,logging:INFO,msgwriter:INFO";
       break;
     case 1:
       categories = "*:INFO,global:INFO,stacktrace:INFO,logging:INFO,msgwriter:INFO,perf.*:DEBUG";


### PR DESCRIPTION
At the default log level (0), eight log categories (`net, net.http, net.ssl, net.p2p, net.cn, daemon.rpc, verify, serialization`) were set to FATAL-only, which silenced all ERROR-level messages from these components. This meant that when something went wrong — like a port already in use — the user only saw a generic message like "`Exception in main! Failed to initialize p2p server`." with the actual error hidden unless they set `log-level=1`. This change promotes those categories from FATAL to ERROR so that error details are always visible.