### PR TITLE
Fix ZMQ-PUB reporting of mempool txes that were initially in stem phase

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1138,7 +1138,7 @@ namespace cryptonote
     const bool res = m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, tx_relay, relayed, version);
 
     // If new incoming tx passed verification and entered the pool, notify ZMQ
-    if (!tvc.m_verifivation_failed && tvc.m_added_to_pool && matches_category(tx_relay, relay_category::legacy))
+    if (!tvc.m_verifivation_failed && res && matches_category(tx_relay, relay_category::legacy))
     {
       m_blockchain_storage.notify_txpool_event({txpool_event{
         .tx = tx,

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -116,6 +116,8 @@ namespace cryptonote
      * @tx_relay how the transaction was received
      * @param tx_weight the transaction's weight
      * @param valid_input_verification_id a previously valid verID if non-null
+     * @return True if tx passes verification checks AND is first observation
+     *   of tx in `broadcasted` relay method.
      */
     bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob,
       size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed,
@@ -144,7 +146,8 @@ namespace cryptonote
      * passes the non-input consensus tests (e.g. for newly received relayed txs), then leave
      * "nic_verified_hf_version" as its default value of 0 (there is no v0 fork).
      *
-     * @return true if the transaction passes validations, otherwise false
+     * @return True if tx passes verification checks AND is first observation
+     *   of tx in `broadcasted` relay method.
      */
     bool add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed,
       uint8_t version, uint8_t nic_verified_hf_version = 0,


### PR DESCRIPTION
An update by @jeffro256 changed how the txpool set `m_added_to_pool` - it only set the value on first observation as opposed to first fluff/block observation. Unfortunately, the ZMQ-PUB code was designed to only report txes observed during block/fluff (suppressing "knowledge" of the tx during stem phase).

This means a node taking part in the stem phase of a tx never reports the tx over ZMQ currently. This reverts back to the prior behavior by using the return code from `txpool::add_tx`.

Watching the CI, and then pushing a 0.18 patch too.