### PR TITLE
FCMP++: tower cycle Curve class + hash_grow implementation + tests

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -275,7 +275,7 @@ mkdir -p "$LOGDIR_BASE"
 # RUST_DEPS_HASH with the hash reported below, and update
 # contrib/guix/rust/config.toml if the set of git sources changed
 RUST_DEPS_VERSION=0
-RUST_DEPS_HASH="gg5izydrra2b1ywgskvlrfrh983gf6b4"
+RUST_DEPS_HASH="xcxpbdn8wv1gqy1iwgj3x8ddl7hz595s"
 RUST_DEPS_ARCHIVE="rust_deps-${RUST_DEPS_VERSION}.tar.gz"
 RUST_DEPS_STORE_ITEM="/gnu/store/${RUST_DEPS_HASH}-${RUST_DEPS_ARCHIVE}"
 if [ ! -f "${RUST_DEPS_STORE_ITEM}" ]; then

--- a/contrib/guix/rust/config.toml
+++ b/contrib/guix/rust/config.toml
@@ -6,9 +6,9 @@ git = "https://github.com/kayabaNerve/crypto-bigint"
 branch = "c-repr"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/monero-oxide/monero-oxide?rev=71da8f03a87f596db674258cda74553068a57bcd"]
+[source."git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93"]
 git = "https://github.com/monero-oxide/monero-oxide"
-rev = "71da8f03a87f596db674258cda74553068a57bcd"
+rev = "31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -120,6 +120,20 @@ OutputTuple output_to_tuple(const OutputPair &output_pair)
     return output_tuple_from_bytes(O, I, C);
 }
 //----------------------------------------------------------------------------------------------------------------------
+std::shared_ptr<CurveTreesV1> curve_trees_v1(const std::size_t selene_chunk_width, const std::size_t helios_chunk_width)
+{
+    std::unique_ptr<Selene> selene(new Selene());
+    std::unique_ptr<Helios> helios(new Helios());
+    return std::shared_ptr<CurveTreesV1>(
+            new CurveTreesV1(
+                std::move(selene),
+                std::move(helios),
+                selene_chunk_width,
+                helios_chunk_width
+            )
+        );
+};
+//----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // Static functions
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -116,6 +116,18 @@ public:
     const std::size_t m_c2_width;
 };
 //----------------------------------------------------------------------------------------------------------------------
+using Selene       = tower_cycle::Selene;
+using Helios       = tower_cycle::Helios;
+using CurveTreesV1 = CurveTrees<Selene, Helios>;
+
+// https://github.com/monero-oxide/monero-oxide/blob/31c26d96eaadbba910ffe3613ad8b4cf9c598a93/crypto/fcmps/src/lib.rs#L54-L59
+const std::size_t SELENE_CHUNK_WIDTH = 38;
+const std::size_t HELIOS_CHUNK_WIDTH = 18;
+
+std::shared_ptr<CurveTreesV1> curve_trees_v1(
+    const std::size_t selene_chunk_width = SELENE_CHUNK_WIDTH,
+    const std::size_t helios_chunk_width = HELIOS_CHUNK_WIDTH);
+//----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 } //namespace curve_trees
 } //namespace fcmp_pp

--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,15 +206,18 @@ dependencies = [
 [[package]]
 name = "ec-divisors"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=71da8f03a87f596db674258cda74553068a57bcd#71da8f03a87f596db674258cda74553068a57bcd"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
 dependencies = [
+ "crypto-bigint",
  "dalek-ff-group 0.5.0",
  "ff",
  "group",
  "rand_core",
  "std-shims",
  "subtle",
+ "tap",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -267,7 +258,10 @@ version = "0.0.0"
 dependencies = [
  "ciphersuite",
  "dalek-ff-group 0.5.0",
+ "full-chain-membership-proofs",
  "helioselene",
+ "monero-fcmp-plus-plus",
+ "monero-fcmp-plus-plus-generators",
 ]
 
 [[package]]
@@ -302,10 +296,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "full-chain-membership-proofs"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "blake2",
+ "ciphersuite",
+ "ec-divisors",
+ "generalized-bulletproofs",
+ "generalized-bulletproofs-circuit-abstraction",
+ "generalized-bulletproofs-ec-gadgets",
+ "generic-array 1.1.1",
+ "multiexp",
+ "rand_core",
+ "std-shims",
+ "subtle",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "generalized-bulletproofs"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "blake2",
+ "ciphersuite",
+ "ff",
+ "flexible-transcript",
+ "multiexp",
+ "rand_core",
+ "std-shims",
+ "subtle",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "generalized-bulletproofs-circuit-abstraction"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "ciphersuite",
+ "generalized-bulletproofs",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
+name = "generalized-bulletproofs-ec-gadgets"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "ciphersuite",
+ "generalized-bulletproofs-circuit-abstraction",
+ "generic-array 1.1.1",
+ "std-shims",
+]
 
 [[package]]
 name = "generic-array"
@@ -351,17 +410,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
 name = "helioselene"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=71da8f03a87f596db674258cda74553068a57bcd#71da8f03a87f596db674258cda74553068a57bcd"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -373,6 +432,7 @@ dependencies = [
  "rand_core",
  "std-shims",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -432,6 +492,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "monero-ed25519"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "blake2",
+ "crypto-bigint",
+ "curve25519-dalek",
+ "monero-io",
+ "monero-primitives",
+ "rand_core",
+ "sha3",
+ "std-shims",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-fcmp-plus-plus"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "blake2",
+ "ciphersuite",
+ "dalek-ff-group 0.5.0",
+ "ec-divisors",
+ "flexible-transcript",
+ "full-chain-membership-proofs",
+ "generalized-bulletproofs",
+ "generalized-bulletproofs-ec-gadgets",
+ "generic-array 1.1.1",
+ "helioselene",
+ "monero-ed25519",
+ "monero-fcmp-plus-plus-generators",
+ "monero-io",
+ "monero-primitives",
+ "multiexp",
+ "rand_chacha",
+ "rand_core",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
+name = "monero-fcmp-plus-plus-generators"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "ciphersuite",
+ "full-chain-membership-proofs",
+ "generalized-bulletproofs",
+ "group",
+ "helioselene",
+ "monero-ed25519",
+ "monero-primitives",
+ "std-shims",
+]
+
+[[package]]
+name = "monero-io"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "std-shims",
+]
+
+[[package]]
+name = "monero-primitives"
+version = "0.1.0"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=31c26d96eaadbba910ffe3613ad8b4cf9c598a93#31c26d96eaadbba910ffe3613ad8b4cf9c598a93"
+dependencies = [
+ "blake2",
+ "crypto-bigint",
+ "dalek-ff-group 0.5.0",
+ "sha3",
+ "tap",
+]
+
+[[package]]
+name = "multiexp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b18c2faf6b61e10dcf2e69836e8620e184df56064622bc94db9d4f74394e21"
+dependencies = [
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
+ "tap",
+ "zeroize",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +608,15 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -490,6 +651,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -583,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "std-shims"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbb9ed849fede2765386134c64bc8984081e8c8408bc9201b99c6e3143ec5e7"
+checksum = "227c4f8561598188d0df96dbe749824576174bba278b5b6bb2eacff1066067d0"
 dependencies = [
  "hashbrown",
  "rustversion",

--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
@@ -10,7 +10,12 @@ crate-type = ["staticlib"]
 [dependencies]
 ciphersuite = { version = "0.4.2", features = ["ed25519"] }
 dalek-ff-group = "0.5.0"
-helioselene = { git = "https://github.com/monero-oxide/monero-oxide", rev = "71da8f03a87f596db674258cda74553068a57bcd" }
+helioselene = { git = "https://github.com/monero-oxide/monero-oxide", rev = "31c26d96eaadbba910ffe3613ad8b4cf9c598a93" }
+
+full-chain-membership-proofs = { git = "https://github.com/monero-oxide/monero-oxide", rev = "31c26d96eaadbba910ffe3613ad8b4cf9c598a93" }
+
+monero-fcmp-plus-plus-generators = { git = "https://github.com/monero-oxide/monero-oxide", rev = "31c26d96eaadbba910ffe3613ad8b4cf9c598a93" }
+monero-fcmp-plus-plus = { git = "https://github.com/monero-oxide/monero-oxide", rev = "31c26d96eaadbba910ffe3613ad8b4cf9c598a93" }
 
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/kayabaNerve/crypto-bigint", branch = "c-repr" }

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -52,6 +52,32 @@ struct SeleneScalar {
 FFI_STATIC_ASSERT(sizeof(struct SeleneScalar) == 32, "SeleneScalar FFI type unexpected size");
 FFI_STATIC_ASSERT(alignof(struct SeleneScalar) == sizeof(uintptr_t), "SeleneScalar FFI type unexpected alignment");
 
+/// The field novel to Helios/Selene.
+/// This type is expected to be opaque to the C/C++ side, meaning only the Rust side should read/write
+/// its internal represenation. We're using a modified crypto-bigint crate for this type so that we
+/// can work with points and scalars across the FFI without tons of byte repr conversions.
+struct HeliosScalar {
+  uintptr_t _0[32 / sizeof(uintptr_t)];
+};
+FFI_STATIC_ASSERT(sizeof(struct HeliosScalar) == 32, "HeliosScalar FFI type unexpected size");
+FFI_STATIC_ASSERT(alignof(struct HeliosScalar) == sizeof(uintptr_t), "HeliosScalar FFI type unexpected alignment");
+
+struct HeliosPoint {
+  struct SeleneScalar x;
+  struct SeleneScalar y;
+  struct SeleneScalar z;
+};
+FFI_STATIC_ASSERT(sizeof(struct HeliosPoint) == 32*3, "HeliosPoint FFI type unexpected size");
+FFI_STATIC_ASSERT(alignof(struct HeliosPoint) == sizeof(uintptr_t), "HeliosPoint FFI type unexpected alignment");
+
+struct SelenePoint {
+  struct HeliosScalar x;
+  struct HeliosScalar y;
+  struct HeliosScalar z;
+};
+FFI_STATIC_ASSERT(sizeof(struct SelenePoint) == 32*3, "SelenePoint FFI type unexpected size");
+FFI_STATIC_ASSERT(alignof(struct SelenePoint) == sizeof(uintptr_t), "SelenePoint FFI type unexpected alignment");
+
 struct OutputTuple
 {
   uint8_t O[32];
@@ -61,6 +87,26 @@ struct OutputTuple
 FFI_STATIC_ASSERT(sizeof(struct OutputTuple) == 32*3, "OutputTuple FFI type unexpected size");
 FFI_STATIC_ASSERT(alignof(struct OutputTuple) == 1, "OutputTuple FFI type unexpected alignment");
 
+struct HeliosScalarSlice
+{
+  const struct HeliosScalar *buf;
+  uintptr_t len;
+};
+FFI_STATIC_ASSERT(sizeof(struct HeliosScalarSlice) == sizeof(struct HeliosScalar*)+sizeof(uintptr_t),
+    "HeliosScalarSlice FFI type unexpected size");
+FFI_STATIC_ASSERT(alignof(struct HeliosScalarSlice) == sizeof(uintptr_t),
+    "HeliosScalarSlice FFI type unexpected alignment");
+
+struct SeleneScalarSlice
+{
+  const struct SeleneScalar *buf;
+  uintptr_t len;
+};
+FFI_STATIC_ASSERT(sizeof(struct SeleneScalarSlice) == sizeof(struct SeleneScalar*)+sizeof(uintptr_t),
+    "SeleneScalarSlice FFI type unexpected size");
+FFI_STATIC_ASSERT(alignof(struct SeleneScalarSlice) == sizeof(uintptr_t),
+    "SeleneScalarSlice FFI type unexpected alignment");
+
 // ----- End deps C bindings -----
 
 #ifdef __cplusplus
@@ -68,6 +114,34 @@ extern "C" {
 #endif
 
 int selene_scalar_from_bytes(const uint8_t *selene_scalar_bytes, struct SeleneScalar *selene_scalar_out);
+
+struct HeliosPoint helios_hash_init_point(void);
+
+struct SelenePoint selene_hash_init_point(void);
+
+struct HeliosScalar helios_zero_scalar(void);
+
+struct SeleneScalar selene_zero_scalar(void);
+
+void helios_scalar_to_bytes(const struct HeliosScalar *helios_scalar, uint8_t bytes_out[32]);
+
+void selene_scalar_to_bytes(const struct SeleneScalar *selene_scalar, uint8_t bytes_out[32]);
+
+void helios_point_to_bytes(const struct HeliosPoint *helios_point, uint8_t bytes_out[32]);
+
+void selene_point_to_bytes(const struct SelenePoint *selene_point, uint8_t bytes_out[32]);
+
+int hash_grow_helios(struct HeliosPoint existing_hash,
+                                             uintptr_t offset,
+                                             struct HeliosScalar existing_child_at_offset,
+                                             struct HeliosScalarSlice new_children,
+                                             struct HeliosPoint *hash_out);
+
+int hash_grow_selene(struct SelenePoint existing_hash,
+                                             uintptr_t offset,
+                                             struct SeleneScalar existing_child_at_offset,
+                                             struct SeleneScalarSlice new_children,
+                                             struct SelenePoint *hash_out);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -1,6 +1,23 @@
-use ciphersuite::Ciphersuite;
+use ciphersuite::{
+    group::{
+        ff::{Field, PrimeField},
+        GroupEncoding,
+    },
+    Ciphersuite,
+};
 
-use helioselene::{Field25519 as SeleneScalar, Selene};
+use full_chain_membership_proofs::tree::hash_grow;
+use helioselene::{
+    Field25519 as SeleneScalar, HeliosPoint, HelioseleneField as HeliosScalar, Selene,
+    SelenePoint,
+};
+
+use monero_fcmp_plus_plus::{
+    HELIOS_FCMP_GENERATORS, SELENE_FCMP_GENERATORS,
+};
+use monero_fcmp_plus_plus_generators::{
+    HELIOS_HASH_INIT, SELENE_HASH_INIT,
+};
 
 use std::{mem::{align_of, size_of}, os::raw::c_int};
 
@@ -29,8 +46,43 @@ macro_rules! static_assert_alignment {
 static_assert_size_eq!(SeleneScalar, 32);
 static_assert_alignment!(SeleneScalar, size_of::<usize>());
 
+static_assert_size_eq!(HeliosScalar, 32);
+static_assert_alignment!(HeliosScalar, size_of::<usize>());
+
+static_assert_size_eq!(HeliosPoint, 32*3);
+static_assert_alignment!(HeliosPoint, size_of::<usize>());
+
+static_assert_size_eq!(SelenePoint, 32*3);
+static_assert_alignment!(SelenePoint, size_of::<usize>());
+
 static_assert_size_eq!(OutputTuple, 32*3);
 static_assert_alignment!(OutputTuple, 1);
+
+//-------------------------------------------------------------------------------------- Curve points
+
+#[no_mangle]
+pub extern "C" fn helios_hash_init_point() -> HeliosPoint {
+    *HELIOS_HASH_INIT
+}
+
+#[no_mangle]
+pub extern "C" fn selene_hash_init_point() -> SelenePoint {
+    *SELENE_HASH_INIT
+}
+
+macro_rules! ec_elem_to_bytes {
+    ($fn_name:ident, $Type:ty, $to_bytes:ident) => {
+        /// # Safety
+        ///
+        /// This function assumes a raw pointer to expected obj type, and to have
+        /// 32 bytes already allocated for bytes_out.
+        #[no_mangle]
+        pub unsafe extern "C" fn $fn_name(obj: *const $Type, bytes_out: *mut u8) {
+            let bytes_out = core::slice::from_raw_parts_mut(bytes_out, 32);
+            bytes_out.clone_from_slice(&(*obj).$to_bytes());
+        }
+    };
+}
 
 macro_rules! ec_elem_from_bytes {
     ($fn_name:ident, $Type:ty, $Curve:ty, $from_bytes:ident) => {
@@ -56,7 +108,119 @@ macro_rules! ec_elem_from_bytes {
     };
 }
 
+ec_elem_to_bytes!(helios_scalar_to_bytes, HeliosScalar, to_repr);
+ec_elem_to_bytes!(selene_scalar_to_bytes, SeleneScalar, to_repr);
+ec_elem_to_bytes!(helios_point_to_bytes, HeliosPoint, to_bytes);
+ec_elem_to_bytes!(selene_point_to_bytes, SelenePoint, to_bytes);
+
 ec_elem_from_bytes!(selene_scalar_from_bytes, SeleneScalar, Selene, read_F);
+
+// Undefined behavior occurs when the data pointer passed to core::slice::from_raw_parts is null,
+// even when len is 0. slice_from_raw_parts_0able() lets you pass p as null, as long as len is 0
+const unsafe fn slice_from_raw_parts_0able<'a, T>(p: *const T, len: usize) -> &'a [T] {
+    if len == 0 {
+        &[]
+    } else {
+        core::slice::from_raw_parts(p, len)
+    }
+}
+
+#[repr(C)]
+pub struct Slice<T> {
+    buf: *const T,
+    len: usize,
+}
+
+pub type HeliosScalarSlice = Slice<HeliosScalar>;
+static_assert_size_eq!(HeliosScalarSlice, size_of::<*const HeliosScalar>() + size_of::<usize>());
+static_assert_alignment!(HeliosScalarSlice, size_of::<usize>());
+
+pub type SeleneScalarSlice = Slice<SeleneScalar>;
+static_assert_size_eq!(SeleneScalarSlice, size_of::<*const SeleneScalar>() + size_of::<usize>());
+static_assert_alignment!(SeleneScalarSlice, size_of::<usize>());
+
+impl<T> From<Slice<T>> for &[T] {
+    fn from(slice: Slice<T>) -> Self {
+        unsafe { slice_from_raw_parts_0able(slice.buf, slice.len) }
+    }
+}
+impl<T> From<&Slice<T>> for &[T] {
+    fn from(slice: &Slice<T>) -> Self {
+        unsafe { slice_from_raw_parts_0able(slice.buf, slice.len) }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn helios_zero_scalar() -> HeliosScalar {
+    HeliosScalar::ZERO
+}
+
+#[no_mangle]
+pub extern "C" fn selene_zero_scalar() -> SeleneScalar {
+    SeleneScalar::ZERO
+}
+
+/// # Safety
+///
+/// This function expects a valid pointer to a HeliosPoint passed in hash_out.
+#[no_mangle]
+pub unsafe extern "C" fn hash_grow_helios(
+    existing_hash: HeliosPoint,
+    offset: usize,
+    existing_child_at_offset: HeliosScalar,
+    new_children: HeliosScalarSlice,
+    hash_out: *mut HeliosPoint,
+) -> c_int {
+    if hash_out.is_null() {
+        return -1;
+    }
+
+    let hash = hash_grow(
+        &HELIOS_FCMP_GENERATORS.generators,
+        existing_hash,
+        offset,
+        existing_child_at_offset,
+        new_children.into(),
+    );
+
+    let Some(hash) = hash else {
+        return -2;
+    };
+
+    *hash_out = hash;
+    0
+}
+
+/// # Safety
+///
+/// This function expects a valid pointer to a SelenePoint passed in hash_out.
+#[no_mangle]
+pub unsafe extern "C" fn hash_grow_selene(
+    existing_hash: SelenePoint,
+    offset: usize,
+    existing_child_at_offset: SeleneScalar,
+    new_children: SeleneScalarSlice,
+    hash_out: *mut SelenePoint,
+) -> c_int {
+    if hash_out.is_null() {
+        return -1;
+    }
+
+    let hash = hash_grow(
+        &SELENE_FCMP_GENERATORS.generators,
+        existing_hash,
+        offset,
+        existing_child_at_offset,
+        new_children.into(),
+    );
+
+    let Some(hash) = hash else {
+        return -2;
+    };
+
+    *hash_out = hash;
+    0
+}
 
 // https://github.com/rust-lang/rust/issues/79609
 #[cfg(all(target_os = "windows", target_arch = "x86"))]

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -42,6 +42,27 @@ namespace fcmp_pp
 //----------------------------------------------------------------------------------------------------------------------
 // Rust types
 //----------------------------------------------------------------------------------------------------------------------
+using SeleneScalar = ::SeleneScalar;
+static_assert(sizeof(SeleneScalar) == 32, "unexpected size of selene scalar");
+using HeliosScalar = ::HeliosScalar;
+static_assert(sizeof(HeliosScalar) == 32, "unexpected size of helios scalar");
+//----------------------------------------------------------------------------------------------------------------------
+struct SeleneT final
+{
+    using Scalar       = SeleneScalar;
+    using Point        = ::SelenePoint;
+    using Chunk        = ::SeleneScalarSlice;
+    using CycleScalar  = HeliosScalar;
+};
+//----------------------------------------------------------------------------------------------------------------------
+struct HeliosT final
+{
+    using Scalar       = HeliosScalar;
+    using Point        = ::HeliosPoint;
+    using Chunk        = ::HeliosScalarSlice;
+    using CycleScalar  = SeleneScalar;
+};
+//----------------------------------------------------------------------------------------------------------------------
 using OutputTuple = ::OutputTuple;
 //----------------------------------------------------------------------------------------------------------------------
 OutputTuple output_tuple_from_bytes(const crypto::ec_point &O, const crypto::ec_point &I, const crypto::ec_point &C);

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -29,6 +29,7 @@
 #include "tower_cycle.h"
 
 #include "misc_log_ex.h"
+#include "string_tools.h"
 
 namespace fcmp_pp
 {
@@ -48,6 +49,108 @@ SeleneScalar selene_scalar_from_bytes(const crypto::ec_coord &bytes)
     int r = ::selene_scalar_from_bytes(to_bytes(bytes), &selene_scalar);
     CHECK_FFI_RES;
     return selene_scalar;
+}
+//----------------------------------------------------------------------------------------------------------------------
+Selene::Point Selene::hash_init_point() const
+{
+    return ::selene_hash_init_point();
+}
+//----------------------------------------------------------------------------------------------------------------------
+Helios::Point Helios::hash_init_point() const
+{
+    return ::helios_hash_init_point();
+}
+//----------------------------------------------------------------------------------------------------------------------
+Selene::Scalar Selene::zero_scalar() const
+{
+    return ::selene_zero_scalar();
+}
+//----------------------------------------------------------------------------------------------------------------------
+Helios::Scalar Helios::zero_scalar() const
+{
+    return ::helios_zero_scalar();
+}
+//----------------------------------------------------------------------------------------------------------------------
+Selene::Point Selene::hash_grow(
+    const Selene::Point &existing_hash,
+    const std::size_t offset,
+    const Selene::Scalar &existing_child_at_offset,
+    const Selene::Chunk &new_children) const
+{
+    Selene::Point hash;
+    int r = ::hash_grow_selene(
+        existing_hash,
+        offset,
+        existing_child_at_offset,
+        new_children,
+        &hash);
+    CHECK_FFI_RES;
+    return hash;
+}
+//----------------------------------------------------------------------------------------------------------------------
+Helios::Point Helios::hash_grow(
+    const Helios::Point &existing_hash,
+    const std::size_t offset,
+    const Helios::Scalar &existing_child_at_offset,
+    const Helios::Chunk &new_children) const
+{
+    Helios::Point hash;
+    int r = ::hash_grow_helios(
+        existing_hash,
+        offset,
+        existing_child_at_offset,
+        new_children,
+        &hash);
+    CHECK_FFI_RES;
+    return hash;
+}
+//----------------------------------------------------------------------------------------------------------------------
+crypto::ec_scalar Selene::to_bytes(const Selene::Scalar &scalar) const
+{
+    crypto::ec_scalar res;
+    ::selene_scalar_to_bytes(&scalar, ::to_bytes(res));
+    return res;
+}
+//----------------------------------------------------------------------------------------------------------------------
+crypto::ec_scalar Helios::to_bytes(const Helios::Scalar &scalar) const
+{
+    crypto::ec_scalar res;
+    ::helios_scalar_to_bytes(&scalar, ::to_bytes(res));
+    return res;
+}
+//----------------------------------------------------------------------------------------------------------------------
+crypto::ec_point Selene::to_bytes(const Selene::Point &point) const
+{
+    crypto::ec_point res;
+    ::selene_point_to_bytes(&point, ::to_bytes(res));
+    return res;
+}
+//----------------------------------------------------------------------------------------------------------------------
+crypto::ec_point Helios::to_bytes(const Helios::Point &point) const
+{
+    crypto::ec_point res;
+    ::helios_point_to_bytes(&point, ::to_bytes(res));
+    return res;
+}
+//----------------------------------------------------------------------------------------------------------------------
+std::string Selene::to_string(const typename Selene::Scalar &scalar) const
+{
+    return epee::string_tools::pod_to_hex(this->to_bytes(scalar));
+}
+//----------------------------------------------------------------------------------------------------------------------
+std::string Helios::to_string(const typename Helios::Scalar &scalar) const
+{
+    return epee::string_tools::pod_to_hex(this->to_bytes(scalar));
+}
+//----------------------------------------------------------------------------------------------------------------------
+std::string Selene::to_string(const typename Selene::Point &point) const
+{
+    return epee::string_tools::pod_to_hex(this->to_bytes(point));
+}
+//----------------------------------------------------------------------------------------------------------------------
+std::string Helios::to_string(const typename Helios::Point &point) const
+{
+    return epee::string_tools::pod_to_hex(this->to_bytes(point));
 }
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/tower_cycle.h
+++ b/src/fcmp_pp/tower_cycle.h
@@ -30,12 +30,94 @@
 
 #include "crypto/crypto.h"
 #include "fcmp_pp_rust/fcmp++.h"
+#include "fcmp_pp_types.h"
 
+#include <string>
 
 namespace fcmp_pp
 {
 namespace tower_cycle
 {
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+// Abstract parent curve class that curves in a cycle must implement
+template<typename C>
+class Curve
+{
+//member functions
+public:
+    virtual typename C::Point hash_init_point() const = 0;
+
+    virtual typename C::Point hash_grow(
+        const typename C::Point &existing_hash,
+        const std::size_t offset,
+        const typename C::Scalar &existing_child_at_offset,
+        const typename C::Chunk &new_children) const = 0;
+
+    virtual typename C::Scalar zero_scalar() const = 0;
+
+    virtual crypto::ec_scalar to_bytes(const typename C::Scalar &scalar) const = 0;
+    virtual crypto::ec_point to_bytes(const typename C::Point &point) const = 0;
+
+    virtual std::string to_string(const typename C::Scalar &scalar) const = 0;
+    virtual std::string to_string(const typename C::Point &point) const = 0;
+};
+//----------------------------------------------------------------------------------------------------------------------
+class Selene final : public Curve<SeleneT>
+{
+//typedefs
+public:
+    using Scalar       = SeleneT::Scalar;
+    using Point        = SeleneT::Point;
+    using Chunk        = SeleneT::Chunk;
+    using CycleScalar  = SeleneT::CycleScalar;
+
+//member functions
+public:
+    Point hash_init_point() const override;
+
+    Point hash_grow(
+        const Point &existing_hash,
+        const std::size_t offset,
+        const Scalar &existing_child_at_offset,
+        const Chunk &new_children) const override;
+
+    Scalar zero_scalar() const override;
+
+    crypto::ec_scalar to_bytes(const Scalar &scalar) const override;
+    crypto::ec_point to_bytes(const Point &point) const override;
+
+    std::string to_string(const Scalar &scalar) const override;
+    std::string to_string(const Point &point) const override;
+};
+//----------------------------------------------------------------------------------------------------------------------
+class Helios final : public Curve<HeliosT>
+{
+//typedefs
+public:
+    using Scalar       = HeliosT::Scalar;
+    using Point        = HeliosT::Point;
+    using Chunk        = HeliosT::Chunk;
+    using CycleScalar  = HeliosT::CycleScalar;
+
+//member functions
+public:
+    Point hash_init_point() const override;
+
+    Point hash_grow(
+        const Point &existing_hash,
+        const std::size_t offset,
+        const Scalar &existing_child_at_offset,
+        const Chunk &new_children) const override;
+
+    Scalar zero_scalar() const override;
+
+    crypto::ec_scalar to_bytes(const Scalar &scalar) const override;
+    crypto::ec_point to_bytes(const Point &point) const override;
+
+    std::string to_string(const Scalar &scalar) const override;
+    std::string to_string(const Point &point) const override;
+};
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 SeleneScalar selene_scalar_from_bytes(const crypto::ec_coord &bytes);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(unit_tests_sources
   command_line.cpp
   crypto.cpp
   cryptonote_format_utils.cpp
+  curve_trees.cpp
   decompose_amount_into_digits.cpp
   device.cpp
   difficulty.cpp

--- a/tests/unit_tests/curve_trees.cpp
+++ b/tests/unit_tests/curve_trees.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "curve_trees.h"
+
+#include "fcmp_pp/fcmp_pp_crypto.h"
+#include "misc_log_ex.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+// Test helpers
+//----------------------------------------------------------------------------------------------------------------------
+static const Selene::Scalar generate_random_selene_scalar()
+{
+    crypto::secret_key s;
+    crypto::public_key S;
+
+    crypto::generate_keys(S, s, s, false);
+
+    crypto::ec_coord S_x, S_y;
+    CHECK_AND_ASSERT_THROW_MES(fcmp_pp::point_to_wei_x_y((crypto::ec_point&)S, S_x, S_y), "failed to convert to wei x");
+    return fcmp_pp::tower_cycle::selene_scalar_from_bytes(S_x);
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+// Test
+//----------------------------------------------------------------------------------------------------------------------
+TEST(curve_trees, hash_grow)
+{
+    const auto curve_trees = fcmp_pp::curve_trees::curve_trees_v1();
+
+    // Start by hashing: {selene_scalar_0, selene_scalar_1}
+    // Then grow 1:      {selene_scalar_0, selene_scalar_1, selene_scalar_2}
+    // Then grow 1:      {selene_scalar_0, selene_scalar_1, selene_scalar_2, selene_scalar_3}
+    const auto selene_scalar_0 = generate_random_selene_scalar();
+    const auto selene_scalar_1 = generate_random_selene_scalar();
+
+    // Get the initial hash of the 2 selene scalars
+    std::vector<Selene::Scalar> all_children{selene_scalar_0, selene_scalar_1};
+    const auto init_hash = curve_trees->m_c1->hash_grow(
+        /*existing_hash*/            curve_trees->m_c1->hash_init_point(),
+        /*offset*/                   0,
+        /*existing_child_at_offset*/ curve_trees->m_c1->zero_scalar(),
+        /*children*/                 Selene::Chunk{all_children.data(), all_children.size()});
+
+    // Extend with a new child
+    const auto selene_scalar_2 = generate_random_selene_scalar();
+    std::vector<Selene::Scalar> new_children{selene_scalar_2};
+    const auto ext_hash = curve_trees->m_c1->hash_grow(
+        init_hash,
+        all_children.size(),
+        curve_trees->m_c1->zero_scalar(),
+        Selene::Chunk{new_children.data(), new_children.size()});
+    const auto ext_hash_str = curve_trees->m_c1->to_string(ext_hash);
+
+    // Now compare to calling hash_grow{selene_scalar_0, selene_scalar_1, selene_scalar_2}
+    all_children.push_back(selene_scalar_2);
+    const auto grow_res = curve_trees->m_c1->hash_grow(
+        /*existing_hash*/            curve_trees->m_c1->hash_init_point(),
+        /*offset*/                   0,
+        /*existing_child_at_offset*/ curve_trees->m_c1->zero_scalar(),
+        /*children*/                 Selene::Chunk{all_children.data(), all_children.size()});
+    const auto grow_res_str = curve_trees->m_c1->to_string(grow_res);
+
+    ASSERT_EQ(ext_hash_str, grow_res_str);
+
+    // Replace selene_scalar_2 with selene_scalar_3
+    const auto selene_scalar_3 = generate_random_selene_scalar();
+    new_children.clear();
+    new_children = {selene_scalar_3};
+    const auto ext_hash2 = curve_trees->m_c1->hash_grow(
+        ext_hash,
+        all_children.size() - 1,
+        selene_scalar_2,
+        Selene::Chunk{new_children.data(), new_children.size()});
+    const auto ext_hash_str2 = curve_trees->m_c1->to_string(ext_hash2);
+
+    // Now compare to calling hash_grow{selene_scalar_0, selene_scalar_1, selene_scalar_3}
+    all_children.clear();
+    all_children = {selene_scalar_0, selene_scalar_1, selene_scalar_3};
+    const auto grow_res2 = curve_trees->m_c1->hash_grow(
+        /*existing_hash*/            curve_trees->m_c1->hash_init_point(),
+        /*offset*/                   0,
+        /*existing_child_at_offset*/ curve_trees->m_c1->zero_scalar(),
+        /*children*/                 Selene::Chunk{all_children.data(), all_children.size()});
+    const auto grow_res_str2 = curve_trees->m_c1->to_string(grow_res2);
+
+    ASSERT_EQ(ext_hash_str2, grow_res_str2);
+}
+//----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/curve_trees.h
+++ b/tests/unit_tests/curve_trees.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "fcmp_pp/curve_trees.h"
+
+using Selene       = fcmp_pp::curve_trees::Selene;
+using Helios       = fcmp_pp::curve_trees::Helios;
+using CurveTreesV1 = fcmp_pp::curve_trees::CurveTreesV1;


### PR DESCRIPTION
Builds on top of:
- #10360

The Curve class is an abstract interface for curves that form a cycle with another curve. This commit implements the [Helios and Selene](https://gist.github.com/tevador/4524c2092178df08996487d4e272b096) classes inherited from the Curve parent class.

This commit tests the `hash_grow` flow under circumstances that occur when the curve trees merkle tree grows.

It implements all the necessary functions on the Helios and Selene classes:
- `hash_init_point`
- `hash_grow`
- `zero_scalar`
- `to_bytes(Scalar)`
- `to_bytes(Point)`
- `to_string(Scalar)`
- `to_string(Point)`

It introduces new Rust FFI compatible C structs:
- `HeliosScalar` compatible with [`HelioseleneField`](https://github.com/monero-oxide/monero-oxide/blob/92af05e0d44bd1ec1fed6028a8d2aade615f805a/crypto/helioselene/src/field.rs#L20)
- `HeliosPoint` compatible with this [`HeliosPoint`](https://github.com/monero-oxide/monero-oxide/blob/92af05e0d44bd1ec1fed6028a8d2aade615f805a/crypto/helioselene/src/point.rs#L448)
- `SelenePoint` compatible with this [`SelenePoint`](https://github.com/monero-oxide/monero-oxide/blob/92af05e0d44bd1ec1fed6028a8d2aade615f805a/crypto/helioselene/src/point.rs#L486)
- Slices compatible with respective slices.

And introduces new Rust FFI functions:
- `helios_hash_init_point`
- `selene_hash_init_point`
- `helios_zero_scalar`
- `selene_zero_scalar`
- `helios_scalar_to_bytes`
- `selene_scalar_to_bytes`
- `helios_point_to_bytes`
- `selene_point_to_bytes`
- `hash_grow_helios`
- `hash_grow_selene`

Notably we also instantiate the `CurveTreesV1` object with expected production widths in order to use it in tests.