### PR TITLE
multisig: add flag to skip refresh after multisig import

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14631,7 +14631,7 @@ void wallet2::update_multisig_rescan_info(const std::vector<std::vector<rct::key
   m_key_images[td.m_key_image] = n;
 }
 //----------------------------------------------------------------------------------------------------
-size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
+size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs, bool refresh_after_import)
 {
   CHECK_AND_ASSERT_THROW_MES(m_multisig, "Wallet is not multisig");
 
@@ -14749,8 +14749,8 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
     update_multisig_rescan_info(m_multisig_rescan_k, m_multisig_rescan_info, n);
   }
 
-
-  refresh(false);
+  if (refresh_after_import)
+    refresh(false);
 
   return n_outputs;
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -999,9 +999,11 @@ private:
     cryptonote::blobdata export_multisig();
     /*!
      * Import a set of multisig info from multisig partners
+     * \param info Multisig info from other participants
+     * \param refresh_after_import Whether to refresh the wallet and rescan spent outputs after importing
      * \return the number of inputs which were imported
      */
-    size_t import_multisig(std::vector<cryptonote::blobdata> info);
+    size_t import_multisig(std::vector<cryptonote::blobdata> info, bool refresh_after_import = true);
     /*!
      * \brief Rewrites to the wallet file for wallet upgrade (doesn't generate key, assumes it's already there)
      * \param wallet_name Name of wallet file (should exist)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4472,7 +4472,7 @@ namespace tools
 
     try
     {
-      res.n_outputs = m_wallet->import_multisig(info);
+      res.n_outputs = m_wallet->import_multisig(info, req.refresh_after_import);
     }
     catch (const std::exception &e)
     {
@@ -4481,20 +4481,23 @@ namespace tools
       return false;
     }
 
-    if (m_wallet->is_trusted_daemon())
+    if (req.refresh_after_import)
     {
-      try
+      if (m_wallet->is_trusted_daemon())
       {
-        m_wallet->rescan_spent();
+        try
+        {
+          m_wallet->rescan_spent();
+        }
+        catch (const std::exception &e)
+        {
+          er.message = std::string("Success, but failed to update spent status after import multisig info: ") + e.what();
+        }
       }
-      catch (const std::exception &e)
+      else
       {
-        er.message = std::string("Success, but failed to update spent status after import multisig info: ") + e.what();
+        er.message = "Success, but cannot update spent status after import multisig info as daemon is untrusted";
       }
-    }
-    else
-    {
-      er.message = "Success, but cannot update spent status after import multisig info as daemon is untrusted";
     }
 
     return true;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2456,9 +2456,11 @@ namespace wallet_rpc
     struct request_t
     {
       std::vector<std::string> info;
+      bool refresh_after_import;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(info)
+        KV_SERIALIZE_OPT(refresh_after_import, true)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
Currently, `import_multisig` triggers an immediate, blocking `refresh` and `rescan_spent` after import.

On high-latency connections (e.g., Tor), this often causes the RPC call to hang or timeout while waiting for the scan to complete.

Furthermore, it prevents clients from using their own sync routines to report progress or sync in the background so the wallet is not blocked.

This PR adds an optional flag to `import_multisig` to decouple the data import from post-processing. This allows callers to ingest multisig data immediately and manage the subsequent resync on their own, providing a more responsive and transparent user experience.

Release PR: https://github.com/monero-project/monero/pull/10402