### PR TITLE
tx_pool: notify txpool event when stem bumps to fluff

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1146,7 +1146,7 @@ namespace cryptonote
     const bool res = m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, tx_relay, relayed, version);
 
     // If new incoming tx passed verification and entered the pool, notify ZMQ
-    if (!tvc.m_verifivation_failed && res && matches_category(tx_relay, relay_category::legacy))
+    if (!tvc.m_verifivation_failed && res && matches_category(tvc.m_relay, relay_category::legacy))
     {
       m_blockchain_storage.notify_txpool_event({txpool_event{
         .tx = tx,

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -339,15 +339,15 @@ namespace cryptonote
         MERROR("internal error: error adding transaction to txpool: " << e.what());
         return false;
       }
-
-      static_assert(unsigned(relay_method::none) == 0, "expected relay_method::none value to be zero");
-      if(meta.fee > 0 && tx_relay != relay_method::forward)
-        tvc.m_relay = tx_relay;
     }
 
     tvc.m_verifivation_failed = false;
     if (tvc.m_added_to_pool)
       m_txpool_weight += tx_weight;
+
+    static_assert(unsigned(relay_method::none) == 0, "expected relay_method::none value to be zero");
+    if (meta.fee > 0 && tx_relay != relay_method::forward)
+      tvc.m_relay = tx_relay;
 
     ++m_cookie;
 


### PR DESCRIPTION
Issue identified by @vtnerd [here](https://github.com/monero-project/monero/pull/10352#issuecomment-4017717899) (and further explained to me in DM's).

This PR builds on top of #10352.

My explanation: if a tx exists in the db as a stem tx, and then is received again as a stem tx from another node, then it will be upgraded to a fluff tx [here](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/cryptonote_core/tx_pool.cpp#L295-L296). Without this change, the tx won't ever get published over zmq. This change ensures such a tx gets published in L1151 of `cryptonote_core.cpp`.

### Why I moved the bit of code that sets `m_relay`

Assume a totally distinct scenario where `tx_relay=block` and the tx fails `ch_inp_res` [here](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/cryptonote_core/tx_pool.cpp#L229-L231) and the tx is then added to the pool. Without this PR's change, the tx would still get published over zmq in L1151 of `cryptonote_core.cpp`. With this PR's change, to maintain that behavior and ensure the tx still gets published over zmq in L1151, I make sure to set `m_relay` even for txs with `tx_relay=block` that fail `ch_inp_res` and make it into the pool.

### Why setting `tvc.m_relay` for txs with `tx_relay=block` does not modify other behavior

Here are the 3 other callers that read `tvc.m_relay`:

1) [`handle_notify_new_transactions`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L964)

This can never call `m_core.handle_incoming_tx` with `tx_relay=block` (it only ever calls it with [`stem` or `forward`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L941-L942)). Thus, it's impossible for `tvc.m_relay` to get set to `block` via that call, because `tvc.m_relay` is set with the `tx_relay` set in `handle_incoming_tx`.

2) [`on_send_raw_tx`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/rpc/core_rpc_server.cpp#L1432)

This too can never call `m_core.handle_incoming_tx` with `tx_relay=block` (only [`none` or `local`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/rpc/core_rpc_server.cpp#L1396)). Thus, impossible for `tvc.m_relay` to get set to `block` there.

3) [`handleTxBlob`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/rpc/daemon_handler.cpp#L376)

This too can never call `m_core.handle_incoming_tx` with `tx_relay=block` (only [`none` or `local`](https://github.com/monero-project/monero/blob/4fc4d1e2e54c178678fffad5ef5963838d9b3b7e/src/rpc/daemon_handler.cpp#L376)). Thus, impossible for `tvc.m_relay` to get set to `block` there.