### PR TITLE
device: enable support for Ledger Speculos

### DIFF
--- a/src/device/device_io_hid.hpp
+++ b/src/device/device_io_hid.hpp
@@ -58,7 +58,7 @@ namespace hw {
     };
     
 
-    class device_io_hid: device_io {
+    class device_io_hid: public device_io {
       
 
     private:

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//paired header
+#include "device_io_tcp.hpp"
+
+//local headers
+#include "int-util.h"
+#include "misc_log_ex.h"
+#include "net/net_helper.h"
+
+//third party headers
+#include <array>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <chrono>
+
+//standard headers
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "device.io"
+
+namespace hw {
+namespace io {
+//-------------------------------------------------------------------------------------------------------------------
+device_io_tcp::device_io_tcp(boost::asio::io_context &io_context):
+    m_io_context(io_context),
+    m_socket(m_io_context),
+    m_timeout(DEFAULT_TIMEOUT)
+{}
+//-------------------------------------------------------------------------------------------------------------------
+device_io_tcp::~device_io_tcp()
+{}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::init()
+{
+    // no global setup
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::connect(void *params)
+{
+    static const conn_params_t conn_params{}; // default params
+    const conn_params_t &params_cref = params ? reinterpret_cast<const conn_params_t &>(params) : conn_params;
+    this->connect(params_cref);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool device_io_tcp::connected() const
+{
+    return this->m_socket.is_open();
+}
+//-------------------------------------------------------------------------------------------------------------------
+int  device_io_tcp::exchange(
+    unsigned char * const command,
+    unsigned int cmd_len,
+    unsigned char *response,
+    unsigned int max_resp_len,
+    const bool user_input)
+{
+    boost::asio::steady_timer deadline(this->m_io_context);
+    boost::system::error_code ec = boost::asio::error::would_block;
+    std::size_t bytes_transfered = 0;
+    const auto io_cb = [&](const boost::system::error_code ec_, const std::size_t bytes_transfered_)
+    {
+        ec = ec_;
+        bytes_transfered = bytes_transfered_;
+    };
+    const auto block_io = [&ec, this]()
+    {
+        while (ec == boost::asio::error::would_block)
+        {
+            this->m_io_context.restart();
+            this->m_io_context.run_one();
+        }
+    };
+    const auto set_deadline = [&ec, &deadline, this]()
+    {
+        deadline.expires_after(std::chrono::seconds(this->m_timeout));
+        deadline.async_wait([&ec](const boost::system::error_code ec_){
+            if (ec_ != boost::asio::error::operation_aborted) ec = boost::asio::error::operation_aborted;
+        });
+    };
+
+    // if command to send, then send...
+    if (nullptr != command && 0 != cmd_len)
+    {
+        set_deadline();
+
+        // write [payload length as big-endian 32-bit int, payload bytes...]
+        const std::uint32_t cmd_len_be = SWAP32BE(static_cast<std::uint32_t>(cmd_len));
+        const std::array<boost::asio::const_buffer, 2> send_buffers{{
+            {&cmd_len_be, sizeof(cmd_len_be)},
+            {command, cmd_len}
+        }};
+        boost::asio::async_write(this->m_socket, send_buffers, io_cb);
+        block_io();
+
+        // check failure
+        CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while writing ADPU to TCP: " << ec);
+        CHECK_AND_ASSERT_MES(bytes_transfered == cmd_len + sizeof(uint32_t),
+            -1, "Transferred the wrong number of bytes to ADPU TCP: " << bytes_transfered
+                << " vs " << (cmd_len + sizeof(uint32_t)));
+    }
+
+    // do first read, waiting indefinitely if user_input=true
+    std::uint32_t n_read_bytes = -1;
+    {
+        ec = boost::asio::error::would_block;
+        bytes_transfered = 0;
+        if (!user_input)
+            set_deadline();
+
+        // read in [response payload length as big-endian 32-bit int, beginnig of payload...]
+        const std::array<boost::asio::mutable_buffer, 2> read_buffers{{
+            {&n_read_bytes, sizeof(n_read_bytes)},
+            {response, max_resp_len}
+        }};
+        boost::asio::async_read(this->m_socket, read_buffers, boost::asio::transfer_at_least(4), io_cb);
+        block_io();
+
+        // check I/O failure
+        CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while performing TCP read: " << ec);
+
+        MDEBUG("Read " << bytes_transfered << " bytes from the TCP APDU device from first read");
+
+        // get payload length and check against buffer length...
+        CHECK_AND_ASSERT_MES(bytes_transfered >= sizeof(n_read_bytes),
+            -1, "Did not read enough bytes to get ADPU payload length");
+
+        // recv length is encoded as a 32-bit big-endian int, minus 2 for some reason
+        n_read_bytes = SWAP32BE(n_read_bytes);
+        n_read_bytes += 2;
+        MDEBUG("ADPU payload length will be " << n_read_bytes << " bytes");
+
+        CHECK_AND_ASSERT_MES(n_read_bytes <= max_resp_len, -1, "Not enough space in buffer for APDU payload");
+
+        // buffer length is shrunk to payload length
+        max_resp_len = n_read_bytes;
+        bytes_transfered -= 4;
+    }
+
+    do
+    {
+        CHECK_AND_ASSERT_MES(bytes_transfered <= max_resp_len, -1, "Buffer overflow occurred on APDU TCP read ;(");
+        response += bytes_transfered;
+        max_resp_len -= bytes_transfered;
+
+        // if ended a read on payload length line, then we are done
+        if (!max_resp_len)
+            break;
+
+        ec = boost::asio::error::would_block;
+        bytes_transfered = 0;
+        set_deadline();
+
+        // read in [rest of payload bytes...]
+        boost::asio::async_read(this->m_socket, boost::asio::mutable_buffer(response, max_resp_len), io_cb);
+        block_io();
+
+        // check I/O failure
+        CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while performing TCP read: " << ec);
+    }
+    while (true);
+
+    return n_read_bytes;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::disconnect()
+{
+    if (this->m_socket.is_open())
+    {
+        this->m_socket.shutdown(boost::asio::socket_base::shutdown_both);
+        this->m_socket.close();
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::release()
+{
+    // no global resources to release
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::connect(const char *address, unsigned int port)
+{
+    // set timeout timer
+    boost::asio::steady_timer deadline(this->m_io_context);
+    deadline.expires_after(std::chrono::seconds(this->m_timeout));
+
+    // blocking wait for DNS resolution and connection
+    auto socket_future = epee::net_utils::direct_connect()(address, std::to_string(port), deadline);
+    for (;;)
+    {
+        this->m_io_context.restart();
+        this->m_io_context.run_one();
+
+        if (socket_future.is_ready())
+            break;
+    }
+
+    this->m_socket = socket_future.get();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::connect(const conn_params_t &conn_params)
+{
+    this->connect(conn_params.address, conn_params.port);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void device_io_tcp::set_timeout(unsigned int timeout)
+{
+    this->m_timeout = timeout;
+}
+//-------------------------------------------------------------------------------------------------------------------
+}  //namespace io
+}  //namespace hw

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -121,7 +121,7 @@ int  device_io_tcp::exchange(
         block_io();
 
         // check failure
-        CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while writing ADPU to TCP: " << ec);
+        CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while writing APDU to TCP: " << ec);
         CHECK_AND_ASSERT_MES(bytes_transfered == cmd_len + sizeof(uint32_t),
             -1, "Transferred the wrong number of bytes to ADPU TCP: " << bytes_transfered
                 << " vs " << (cmd_len + sizeof(uint32_t)));

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -66,7 +66,7 @@ void device_io_tcp::init()
 void device_io_tcp::connect(void *params)
 {
     static const conn_params_t conn_params{}; // default params
-    const conn_params_t &params_cref = params ? reinterpret_cast<const conn_params_t &>(params) : conn_params;
+    const conn_params_t &params_cref = params ? *static_cast<const conn_params_t *>(params) : conn_params;
     this->connect(params_cref);
 }
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -135,7 +135,7 @@ int  device_io_tcp::exchange(
         if (!user_input)
             set_deadline();
 
-        // read in [response payload length as big-endian 32-bit int, beginnig of payload...]
+        // read in [response payload length as big-endian 32-bit int, beginning of payload...]
         const std::array<boost::asio::mutable_buffer, 2> read_buffers{{
             {&n_read_bytes, sizeof(n_read_bytes)},
             {response, max_resp_len}

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -84,7 +84,7 @@ int  device_io_tcp::exchange(
 {
     boost::asio::steady_timer deadline(this->m_io_context);
     boost::system::error_code ec = boost::asio::error::would_block;
-    std::size_t bytes_transfered = 0;
+    std::size_t bytes_transferred = 0;
     const auto io_cb = [&](const boost::system::error_code ec_, const std::size_t bytes_transfered_)
     {
         ec = ec_;

--- a/src/device/device_io_tcp.cpp
+++ b/src/device/device_io_tcp.cpp
@@ -123,7 +123,7 @@ int  device_io_tcp::exchange(
         // check failure
         CHECK_AND_ASSERT_MES(!ec, -1, "Got error code while writing APDU to TCP: " << ec);
         CHECK_AND_ASSERT_MES(bytes_transfered == cmd_len + sizeof(uint32_t),
-            -1, "Transferred the wrong number of bytes to ADPU TCP: " << bytes_transfered
+            -1, "Transferred the wrong number of bytes to APDU TCP: " << bytes_transfered
                 << " vs " << (cmd_len + sizeof(uint32_t)));
     }
 

--- a/src/device/device_io_tcp.hpp
+++ b/src/device/device_io_tcp.hpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Ledger APDU I/O interface for TCP, typically used by Speculos
+
+#pragma once
+
+//local headers
+#include "device_io.hpp"
+
+//third party headers
+#include <boost/asio/ip/tcp.hpp>
+
+//standard headers
+
+//forward declarations
+
+namespace hw {
+namespace io {
+/** Speculos TCP commands are formatted as follows:
+ *
+ * |----------------------------------------------|
+ * |           4 bytes               |  len bytes |
+ * |---------------------------------|------------|
+ * |  len of payload as big-endian,  |  payload   |
+ * |         minus 2 on receive      |            |
+ * |----------------------------------------------|
+ */
+
+class device_io_tcp final: public device_io
+{
+public:
+    static constexpr const char DEFAULT_ADDRESS[] = "127.0.0.1";
+    static constexpr unsigned int DEFAULT_PORT = 9999;
+    static constexpr unsigned int DEFAULT_TIMEOUT = 60; // seconds
+
+    struct conn_params_t
+    {
+        const char *address = DEFAULT_ADDRESS;
+        unsigned int port = DEFAULT_PORT;
+    };
+
+    device_io_tcp(boost::asio::io_context &io_context);
+    ~device_io_tcp();
+
+    void init() final;
+    void connect(void *params) final;
+    bool connected() const final;
+    int  exchange(unsigned char *command,
+        unsigned int cmd_len,
+        unsigned char *response,
+        unsigned int max_resp_len,
+        bool user_input) final;
+    void disconnect() final;
+    void release() final;
+
+    void connect(const char *address, unsigned int port);
+    void connect(const conn_params_t &conn_params);
+    void set_timeout(unsigned int timeout);
+
+private:
+    boost::asio::io_context &m_io_context;
+    boost::asio::ip::tcp::socket m_socket;
+    unsigned int m_timeout;
+}; //class device_io_tcp
+}  //namespace io
+}  //namespace hw

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -27,12 +27,14 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include "version.h"
 #include "device_ledger.hpp"
-#include "ringct/rctOps.h"
+
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/subaddress_index.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
+#include "device/device_io_hid.hpp"
+#include "log.hpp"
+#include "version.h"
 
 namespace hw {
 
@@ -41,8 +43,29 @@ namespace hw {
   #ifdef WITH_DEVICE_LEDGER
 
     namespace {
-        bool apdu_verbose =true;
-    }
+      bool apdu_verbose =true;
+
+      static const std::vector<hw::io::hid_conn_params> known_devices {
+        {0x2c97, 0x0001, 0, 0xffa0},
+        {0x2c97, 0x0004, 0, 0xffa0},
+        {0x2c97, 0x0005, 0, 0xffa0},
+        {0x2c97, 0x0006, 0, 0xffa0},
+        {0x2c97, 0x0007, 0, 0xffa0},
+        {0x2c97, 0x0008, 0, 0xffa0},
+      };
+
+      class default_device_io_hid: public io::device_io_hid {
+      public:
+        default_device_io_hid():
+          io::device_io_hid(0x0101, 0x05, 64, 2000)
+        {}
+
+        void connect(void *parms) final {
+          assert(nullptr == parms);
+          io::device_io_hid::connect(known_devices);
+        }
+      };
+    } //anonymous namespace
 
     #undef MONERO_DEFAULT_LOG_CATEGORY
     #define MONERO_DEFAULT_LOG_CATEGORY "device.ledger"
@@ -298,7 +321,11 @@ namespace hw {
     #define INS_GET_RESPONSE                    0xc0
 
 
-    device_ledger::device_ledger(): hw_device(0x0101, 0x05, 64, 2000) {
+    device_ledger::device_ledger():
+      device_ledger(std::make_unique<default_device_io_hid>())
+    {}
+
+    device_ledger::device_ledger(std::unique_ptr<io::device_io> &&device_io) : hw_device_io(std::move(device_io)) {
       this->id = device_id++;
       this->reset_buffer();      
       this->mode = NONE;
@@ -479,7 +506,7 @@ namespace hw {
     unsigned int device_ledger::exchange(unsigned int ok, unsigned int mask) {
       logCMD();
 
-      this->length_recv =  hw_device.exchange(this->buffer_send, this->length_send, this->buffer_recv, BUFFER_SEND_SIZE, false);
+      this->length_recv =  hw_device_io->exchange(this->buffer_send, this->length_send, this->buffer_recv, BUFFER_SEND_SIZE, false);
       ASSERT_X(this->length_recv>=2, "Communication error, less than two bytes received");
 
       this->length_recv -= 2;
@@ -496,7 +523,7 @@ namespace hw {
     unsigned int device_ledger::exchange_wait_on_input(unsigned int ok, unsigned int mask) {
       logCMD();
       unsigned int deny = 0;
-      this->length_recv =  hw_device.exchange(this->buffer_send, this->length_send, this->buffer_recv, BUFFER_SEND_SIZE, true);
+      this->length_recv =  hw_device_io->exchange(this->buffer_send, this->length_send, this->buffer_recv, BUFFER_SEND_SIZE, true);
       ASSERT_X(this->length_recv>=2, "Communication error, less than two bytes received");
 
       this->length_recv -= 2;
@@ -538,23 +565,13 @@ namespace hw {
     bool device_ledger::init(void) {
       this->controle_device = &hw::get_device("default");
       this->release();
-      hw_device.init();      
-      MDEBUG( "Device "<<this->id <<" HIDUSB initiated");
+      hw_device_io->init();
       return true;
     }
-    
-    static const std::vector<hw::io::hid_conn_params> known_devices {
-        {0x2c97, 0x0001, 0, 0xffa0}, 
-        {0x2c97, 0x0004, 0, 0xffa0},       
-        {0x2c97, 0x0005, 0, 0xffa0},
-        {0x2c97, 0x0006, 0, 0xffa0},
-        {0x2c97, 0x0007, 0, 0xffa0},
-        {0x2c97, 0x0008, 0, 0xffa0},
-    };
 
     bool device_ledger::connect(void) {
       this->disconnect();
-      hw_device.connect(known_devices);
+      this->hw_device_io->connect(nullptr);
       this->reset();
       #ifdef DEBUG_HWDEVICE
       cryptonote::account_public_address pubkey;
@@ -565,20 +582,21 @@ namespace hw {
     }
 
     bool device_ledger::connected(void) const {
-      return hw_device.connected();
+      return hw_device_io->connected();
     }
 
     bool device_ledger::disconnect() {
-      hw_device.disconnect();
+      hw_device_io->disconnect();
       this->viewkey.scrub();
       this->has_view_key = false;
       this->requested_view_key = false;
+
       return true;
     }
 
     bool device_ledger::release() {
       this->disconnect();
-      hw_device.release();
+      hw_device_io->release();
       return true;
     }
 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -30,11 +30,12 @@
 
 #pragma once
 
-#include <cstddef>
-#include <string>
 #include "device.hpp"
-#include "log.hpp"
-#include "device_io_hid.hpp"
+#include "device_io.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
 #include <mutex>
 
 namespace hw {
@@ -143,7 +144,7 @@ namespace hw {
         mutable std::mutex   command_locker;
 
         //IO
-        hw::io::device_io_hid hw_device;
+        std::unique_ptr<io::device_io> hw_device_io;
         unsigned int  length_send;
         unsigned char buffer_send[BUFFER_SEND_SIZE];
         unsigned int  length_recv;
@@ -185,7 +186,11 @@ namespace hw {
         device *controle_device;
 
     public:
+        // assumes default HID transport for device I/O
         device_ledger();
+        // explicit transport for device I/O
+        device_ledger(std::unique_ptr<io::device_io> &&device_io);
+
         ~device_ledger();
 
         device_ledger(const device_ledger &device) = delete ;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,11 @@ if (BUILD_GUI_DEPS)
   add_subdirectory(libwallet_api_tests)
 endif()
 
+option(LEDGER_DEBUG "Ledger debugging enabled" OFF)
+if (LEDGER_DEBUG)
+  add_subdirectory(ledger)
+endif()
+
 if (TREZOR_DEBUG)
   add_subdirectory(trezor)
 endif()

--- a/tests/ledger/CMakeLists.txt
+++ b/tests/ledger/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2016, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,58 +26,27 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(device_sources
-  device.cpp
-  device_default.cpp
-  device_io_tcp.cpp
-  log.cpp
-  )
+set(ledger_tests_sources
+  basic_signing.cpp
+  ledger_tests_utils.cpp
+  main.cpp)
 
-if(HIDAPI_FOUND)
-  set(device_sources 
-    ${device_sources} 
-    device_ledger.cpp
-    device_io_hid.cpp
-    )
-endif()
+set(unit_tests_headers
+  ledger_tests_utils.h)
 
-set(device_headers
-  device.hpp
-  device_io.hpp
-  device_default.hpp
-  device_cold.hpp
-  log.hpp
- )
-
-if(HIDAPI_FOUND)
-  set(device_headers 
-    ${device_headers} 
-    device_ledger.hpp
-    device_io_hid.hpp
-    )
-endif()
-
-set(device_private_headers)
-
-
-monero_private_headers(device
-  ${device_private_headers})
-
-monero_add_library(device
-  ${device_sources}
-  ${device_headers}
-  ${device_private_headers})
-
-target_link_libraries(device
-  PUBLIC
-    ${HIDAPI_LIBRARIES}
-    cncrypto
-    cryptonote_format_utils_basic
-    epee
-    ringct_basic
-    wallet-crypto
-    ${OPENSSL_CRYPTO_LIBRARIES}
-    ${Boost_SERIALIZATION_LIBRARY}
+monero_add_minimal_executable(ledger_tests
+  ${ledger_tests_sources}
+  ${ledger_tests_headers})
+target_link_libraries(ledger_tests
   PRIVATE
-    version
-    ${EXTRA_LIBRARIES})
+    cryptonote_core
+    device
+    epee
+    ${GTEST_LIBRARIES})
+set_property(TARGET ledger_tests
+  PROPERTY
+    FOLDER "tests")
+
+add_test(
+  NAME    ledger_tests
+  COMMAND ledger_tests)

--- a/tests/ledger/basic_signing.cpp
+++ b/tests/ledger/basic_signing.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "crypto/crypto.h"
+#include "cryptonote_basic/account.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/subaddress_index.h"
+#include "cryptonote_basic/verification_context.h"
+#include "cryptonote_config.h"
+#include "cryptonote_core/cryptonote_tx_utils.h"
+#include "cryptonote_core/tx_verification_utils.h"
+#include "device/device.hpp"
+#include "ledger_tests_utils.h"
+#include "ringct/rctTypes.h"
+
+#include <boost/asio/io_context.hpp>
+#include <unordered_map>
+
+//----------------------------------------------------------------------------------------------------------------------
+TEST(ledger, sign_ringct_to_ringct_bpp_tx)
+{
+    const cryptonote::account_keys &alice = mock::get_global_ledger_account();
+    const cryptonote::account_public_address &alice_addr = alice.m_account_address;
+
+    cryptonote::account_base bob;
+    bob.generate();
+
+    const rct::xmr_amount input_amount = 10 * COIN;
+    const rct::xmr_amount bob_amount = 6 * COIN;
+    const rct::xmr_amount fee = COIN / 10;
+    const rct::xmr_amount change_amount = input_amount - bob_amount - fee;
+
+    // destinations
+    std::vector<cryptonote::tx_destination_entry> dests{
+        cryptonote::tx_destination_entry(bob_amount, bob.get_keys().m_account_address, false), // bob
+        cryptonote::tx_destination_entry(change_amount, alice_addr, false), // change
+    };
+
+    // generate fake RingCT transaction input data to Alice
+    ASSERT_TRUE(alice.get_device().set_mode(hw::device::TRANSACTION_PARSE));
+    std::vector<cryptonote::tx_source_entry> srcs{
+        mock::gen_ringed_tx_source_entry(input_amount, alice_addr , false)};
+
+    // subaddress map for Alice
+    std::unordered_map<crypto::public_key, cryptonote::subaddress_index> alice_subaddresses;
+    alice_subaddresses[alice_addr.m_spend_public_key];
+
+    // make tx from Alice to Bob
+    cryptonote::transaction tx;
+    crypto::secret_key tx_key;
+    std::vector<crypto::secret_key> additional_tx_keys;
+    ASSERT_TRUE(alice.get_device().set_mode(hw::device::TRANSACTION_CREATE_REAL));
+    ASSERT_TRUE(cryptonote::construct_tx_and_get_tx_key(alice, alice_subaddresses, srcs, dests,
+        alice_addr, {}, tx, tx_key, additional_tx_keys, true, {rct::RangeProofPaddedBulletproof, 0}, true));
+    ASSERT_EQ(2, tx.version);
+    ASSERT_EQ(1, tx.vin.size());
+    ASSERT_EQ(2, tx.vout.size());
+    ASSERT_EQ(rct::RCTTypeBulletproofPlus, tx.rct_signatures.type);
+    ASSERT_EQ(fee, tx.rct_signatures.txnFee);
+    cryptonote::tx_verification_context tvc{};
+    ASSERT_TRUE(cryptonote::ver_non_input_consensus(tx, tvc, HF_VERSION_BULLETPROOF_PLUS));
+}
+//----------------------------------------------------------------------------------------------------------------------

--- a/tests/ledger/ledger_tests_utils.cpp
+++ b/tests/ledger/ledger_tests_utils.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//paired header
+#include "ledger_tests_utils.h"
+
+//local headers
+#include "crypto/generators.h"
+#include "cryptonote_basic/account.h"
+#include "device/device.hpp"
+#include "device/device_io_tcp.hpp"
+#include "device/device_ledger.hpp"
+#include "net/net_parse_helpers.h"
+#include "ringct/rctOps.h"
+#include "ringct/rctTypes.h"
+
+//third party headers
+#include <boost/asio/io_context.hpp>
+
+//standard headers
+#include <memory>
+#include <string>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "mock"
+
+namespace
+{
+boost::asio::io_context global_io_context;
+std::optional<hw::ledger::device_ledger> global_ledger_device;
+std::optional<cryptonote::account_base> global_ledger_account;
+} //anonymous namespace
+
+namespace mock
+{
+//----------------------------------------------------------------------------------------------------------------------
+void init_global_ledger_account(const bool speculos, const std::string &speculos_address)
+{
+    assert(speculos_address.empty() || speculos);
+    if (speculos)
+    {
+        std::string speculos_host = hw::io::device_io_tcp::DEFAULT_ADDRESS;
+        unsigned int speculos_port = hw::io::device_io_tcp::DEFAULT_PORT;
+        if (speculos_address.size())
+        {
+            epee::net_utils::http::url_content url_content;
+            if (!epee::net_utils::parse_url(speculos_address, url_content))
+                throw std::runtime_error("Could not parse Speculos URL: " + speculos_address);
+            speculos_host = url_content.host;
+            if (url_content.port)
+                speculos_port = url_content.port;
+        }
+
+        std::unique_ptr<hw::io::device_io_tcp> device_io = std::make_unique<hw::io::device_io_tcp>(global_io_context);
+        device_io->connect(speculos_host.c_str(), speculos_port);
+        global_ledger_device.emplace(std::move(device_io));
+    }
+    else
+    {
+        global_ledger_device.emplace();
+    }
+
+    global_ledger_account.emplace().create_from_device(*global_ledger_device);
+}
+//----------------------------------------------------------------------------------------------------------------------
+const cryptonote::account_keys &get_global_ledger_account()
+{
+    return global_ledger_account->get_keys();
+}
+//----------------------------------------------------------------------------------------------------------------------
+cryptonote::tx_source_entry gen_ringed_tx_source_entry(
+    const rct::xmr_amount amount,
+    const cryptonote::account_public_address &address,
+    const bool is_subaddress,
+    const bool is_ringct,
+    const std::size_t ring_size)
+{
+    cryptonote::tx_source_entry src;
+    src.real_output = crypto::rand_idx(ring_size);
+    src.real_output_in_tx_index = crypto::rand_idx<std::uint64_t>(BULLETPROOF_MAX_OUTPUTS);
+    src.amount = amount;
+    src.rct = is_ringct;
+    for (std::size_t ring_member_idx = 0; ring_member_idx < ring_size; ++ring_member_idx)
+    {
+        auto &output = src.outputs.emplace_back();
+        output.first = ring_member_idx;
+
+        if (ring_member_idx != src.real_output)
+        {
+            // fake output
+            output.second = {rct::pkGen(), rct::pkGen()};
+            continue;
+        }
+
+        // generate ephemeral tx pubkeys
+        crypto::secret_key tx_privkey = rct::rct2sk(rct::skGen());
+        const crypto::public_key base_1 = is_subaddress ? address.m_spend_public_key : crypto::get_G();
+        const crypto::public_key tx_pubkey = rct::rct2pk(rct::scalarmultKey(rct::pk2rct(base_1),
+            rct::sk2rct(tx_privkey)));
+        if (is_subaddress)
+        {
+            src.real_out_additional_tx_keys.resize(src.real_output_in_tx_index + 1);
+            src.real_out_additional_tx_keys.at(src.real_output_in_tx_index) = tx_pubkey;
+            src.real_out_tx_key = rct::rct2pk(rct::pkGen());
+        }
+        else
+        {
+            src.real_out_tx_key = tx_pubkey;
+        }
+
+        // derive ECDH and one-time address
+        crypto::key_derivation kd;
+        assert(crypto::generate_key_derivation(address.m_view_public_key, tx_privkey, kd));
+        crypto::public_key onetime_address;
+        assert(crypto::derive_public_key(kd, src.real_output_in_tx_index,
+            address.m_spend_public_key, onetime_address));
+
+        // calculate amount blinding factor
+        if (is_ringct)
+        {
+            crypto::secret_key sd;
+            crypto::derivation_to_scalar(kd, src.real_output_in_tx_index, sd);
+            src.mask = rct::genCommitmentMask(rct::sk2rct(sd));
+        }
+        else
+        {
+            src.mask = rct::I;
+        }
+
+        // add output
+        const rct::key amount_commitment = rct::commit(amount, src.mask);
+        output.second = {rct::pk2rct(onetime_address), amount_commitment};
+    }
+
+    return src;
+}
+//----------------------------------------------------------------------------------------------------------------------
+} //namespace mock

--- a/tests/ledger/ledger_tests_utils.h
+++ b/tests/ledger/ledger_tests_utils.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "cryptonote_basic/account.h"
+#include "cryptonote_core/cryptonote_tx_utils.h"
+
+//third party headers
+
+//standard headers
+#include <cstddef>
+#include <string>
+
+//forward declarations
+
+namespace mock
+{
+void init_global_ledger_account(bool speculos = true, const std::string &speculos_address = "");
+const cryptonote::account_keys &get_global_ledger_account();
+
+/**
+ * brief: generate fake ring data required to allow holder of address to spend an input of given amount
+ */
+cryptonote::tx_source_entry gen_ringed_tx_source_entry(
+    const rct::xmr_amount amount,
+    const cryptonote::account_public_address &address,
+    const bool is_subaddress,
+    const bool is_ringct = true,
+    const std::size_t ring_size = 16);
+} //namespace mock

--- a/tests/ledger/main.cpp
+++ b/tests/ledger/main.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "common/command_line.h"
+#include "common/util.h"
+#include "ledger_tests_utils.h"
+#include "misc_log_ex.h"
+#include "string_tools.h"
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+//----------------------------------------------------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+    tools::on_startup();
+    epee::string_tools::set_module_name_and_folder(argv[0]);
+    mlog_configure(mlog_get_default_log_path("ledger_tests.log"), true);
+    epee::debug::get_set_enable_assert(true, false);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    po::options_description desc_options("Command line options");
+    const command_line::arg_descriptor<std::string> arg_log_level = { "log-level",  "0-4 or categories", "" };
+    command_line::add_arg(desc_options, arg_log_level);
+
+    po::variables_map vm;
+    bool r = command_line::handle_error_helper(desc_options, [&]()
+    {
+        po::store(po::parse_command_line(argc, argv, desc_options), vm);
+        po::notify(vm);
+        return true;
+    });
+    if (!r)
+        return 1;
+
+    // set the log level
+    if (!command_line::is_arg_defaulted(vm, arg_log_level))
+        mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());
+
+    mock::init_global_ledger_account(/*speculos=*/true, /*speculos_address=*/"");
+
+    return RUN_ALL_TESTS();
+}
+//----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
[Speculos](https://github.com/LedgerHQ/speculos) is an emulator for Ledger hardware devices. This PR adds support for Ledger firmware functional tests through Speculos directly from the C++ codebase.

Steps to get it working:
  - Build and install Speculos on your system, preferably in a Python virtual environment
     * To build Speculos from source, especially on Arch Linux, you may have to use my fork of Speculos here: https://github.com/LedgerHQ/speculos/pull/654
  - Compile the [Monero firmware](https://github.com/LedgerHQ/app-monero)
  - Compile this PR
  - Launch Speculos with the Monero firmware binary, with default ports
  - Run the `ledger.*` unit tests

The tests pass on my system, but I want to add some more, and maybe move it's own directory. This code will be useful for testing Ledger support for FCMP++.

Depends on #10429 