### PR TITLE
rpc: fix incomplete range check in get_coinbase_tx_sum + update test

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3076,9 +3076,9 @@ namespace cryptonote
   {
     RPC_TRACKER(get_coinbase_tx_sum);
     const uint64_t bc_height = m_core.get_current_blockchain_height();
-    if (req.height >= bc_height || req.count > bc_height)
+    if (req.height >= bc_height || req.count > bc_height - req.height)
     {
-      res.status = "height or count is too large";
+      res.status = "requested range exceeds blockchain height";
       return true;
     }
     CHECK_PAYMENT_MIN1(req, res, COST_PER_COINBASE_TX_SUM_BLOCK * req.count, false);

--- a/tests/functional_tests/blockchain.py
+++ b/tests/functional_tests/blockchain.py
@@ -219,9 +219,12 @@ class BlockchainTest():
         assert res.emission_amount < extrapolated and res.emission_amount > extrapolated - 1e12
         assert res.fee_amount == 0
         sum_blocks_emission = res.emission_amount
-        res = daemon.get_coinbase_tx_sum(1, sum_blocks)
+        res = daemon.get_coinbase_tx_sum(1, sum_blocks - 1)
         assert res.emission_amount == sum_blocks_emission - 17592186044415
         assert res.fee_amount == 0
+        # height + count must not exceed the blockchain height
+        res = daemon.get_coinbase_tx_sum(1, sum_blocks)
+        assert res.status != 'OK'
 
         res = daemon.get_output_distribution([0, 1, 17592186044415], 0, 0)
         assert len(res.distributions) == 3


### PR DESCRIPTION
The `on_get_coinbase_tx_sum` RPC handler validates `req.height` and `req.count` independently against the blockchain height, but does not validate their combined range. This allows requests where `height + count` exceeds the blockchain height to pass validation.

For example, with `bc_height=100`:
- `req.height=90, req.count=20` passes both checks (`90 < 100` and `20 <= 100`)
- But `get_coinbase_tx_sum(90, 20)` computes `end = 90 + 20 - 1 = 109` and calls `for_blocks_range(90, 109)`, reading past the end of the chain

The fix changes the second condition from `req.count > bc_height` to `req.count > bc_height - req.height`. The subtraction is safe from underflow because the first condition (`req.height >= bc_height`) short-circuits via `||`, guaranteeing `bc_height > req.height` when the second condition is evaluated.