### PR TITLE
zmq: add more missing restricted rpc checks

### DIFF
--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -30,6 +30,7 @@
 #include "rpc/zmq_restricted_methods.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 
@@ -42,6 +43,14 @@
 #include "cryptonote_basic/blobdatatype.h"
 #include "ringct/rctSigs.h"
 #include "version.h"
+
+namespace
+{
+constexpr size_t restricted_max_fake_outs = 5000;
+constexpr auto restricted_histogram_cutoff = std::chrono::hours{3 * 24};
+constexpr size_t restricted_max_txs = 100;
+constexpr size_t restricted_max_key_images = 5000;
+}
 
 namespace cryptonote
 {
@@ -236,6 +245,13 @@ namespace rpc
 
   void DaemonHandler::handle(const GetTransactions::Request& req, GetTransactions::Response& res)
   {
+    if (m_restricted && req.tx_hashes.size() > restricted_max_txs)
+    {
+      res.status = Message::STATUS_FAILED;
+      res.error_details = "Too many transactions requested in restricted mode";
+      return;
+    }
+
     std::vector<cryptonote::transaction> found_txs_vec;
     std::vector<crypto::hash> missed_vec;
 
@@ -301,6 +317,13 @@ namespace rpc
 
   void DaemonHandler::handle(const KeyImagesSpent::Request& req, KeyImagesSpent::Response& res)
   {
+    if (m_restricted && req.key_images.size() > restricted_max_key_images)
+    {
+      res.status = Message::STATUS_FAILED;
+      res.error_details = "Too many key images queried in restricted mode";
+      return;
+    }
+
     res.spent_status.resize(req.key_images.size(), KeyImagesSpent::STATUS::UNSPENT);
 
     std::vector<bool> chain_spent_status;
@@ -791,6 +814,23 @@ namespace rpc
 
   void DaemonHandler::handle(const GetOutputHistogram::Request& req, GetOutputHistogram::Response& res)
   {
+    size_t amounts = req.amounts.size();
+    if (m_restricted && amounts == 0)
+    {
+      res.status = Message::STATUS_FAILED;
+      res.error_details = "Restricted RPC will not serve histograms on the whole blockchain. Use your own node.";
+      return;
+    }
+
+    using clock = std::chrono::system_clock;
+    const clock::time_point cutoff{std::chrono::seconds{req.recent_cutoff}};
+    if (m_restricted && clock::now() - cutoff > restricted_histogram_cutoff)
+    {
+      res.status = Message::STATUS_FAILED;
+      res.error_details = "Recent cutoff is too old";
+      return;
+    }
+
     std::map<uint64_t, std::tuple<uint64_t, uint64_t, uint64_t> > histogram;
     try
     {
@@ -816,6 +856,13 @@ namespace rpc
 
   void DaemonHandler::handle(const GetOutputKeys::Request& req, GetOutputKeys::Response& res)
   {
+    if (m_restricted && req.outputs.size() > restricted_max_fake_outs)
+    {
+      res.status = Message::STATUS_FAILED;
+      res.error_details = "Too many outs requested";
+      return;
+    }
+
     try
     {
       for (const auto& i : req.outputs)


### PR DESCRIPTION
I duplicated the variables from `core_rpc_server.cpp`, which would allow for different limits for HTTP and ZMQ. Alternatively I can move them out into a separate file and avoid duplication.