### PR TITLE
guix: add initial loongarch64 support

### DIFF
--- a/contrib/depends/.gitignore
+++ b/contrib/depends/.gitignore
@@ -9,3 +9,4 @@ mips*
 arm*
 aarch64*
 riscv64*
+loongarch64*

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -163,7 +163,7 @@ if(ARCHITECTURE STREQUAL "riscv64")
 endif()
 if(ARCHITECTURE STREQUAL "loongarch64")
     set(ARCH_ID "loongarch64")
-    set(ARCH "loongarch")
+    set(ARCH "loongarch64")
 endif()
 
 if(ARCHITECTURE STREQUAL "i686")

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -199,6 +199,7 @@ case "$HOST" in
                 aarch64-linux-gnu)     echo /lib/ld-linux-aarch64.so.1 ;;
                 riscv64-linux-gnu)     echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
                 i686-linux-gnu)        echo /lib/ld-linux.so.2 ;;
+                loongarch64-linux-gnu) echo /lib64/ld-linux-loongarch-lp64d.so.1 ;;
                 *)                     exit 1 ;;
             esac
         )

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -276,7 +276,9 @@ chain for " target " development."))
            (list
              gcc-toolchain-14
              (list gcc-toolchain-14 "static")
-             (make-monero-cross-toolchain target)))
+             (if (string-contains target "loongarch64")
+               (make-monero-cross-toolchain target #:base-libc glibc)
+               (make-monero-cross-toolchain target))))
           ((string-contains target "freebsd")
            (list
              xz ; used to unpack freebsd_base


### PR DESCRIPTION
This makes it possible to build for `loongarch64-linux-gnu` using Guix. It is not added as a default target for releases.

`loongarch` isn't a valid arch-type, hence the change to `loongarch64`, see: https://gcc.gnu.org/onlinedocs/gcc/LoongArch-Options.html