### PR TITLE
trezor: replace use of boost::is_base_of with std::is_base_of_v

### DIFF
--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -34,6 +34,7 @@
 #include <cstddef>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include "device/device.hpp"
 #include "device/device_default.hpp"
 #include "device/device_cold.hpp"
@@ -146,7 +147,7 @@ namespace trezor {
                       bool open_session = false)
       {
         // Require strictly protocol buffers response in the template.
-        BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+        static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
         const bool accepting_base = boost::is_same<google::protobuf::Message, t_message>::value;
         if (resp_types && !accepting_base){
           throw std::invalid_argument("Cannot specify list of accepted types and not using generic response");

--- a/src/device_trezor/trezor/debug_link.hpp
+++ b/src/device_trezor/trezor/debug_link.hpp
@@ -32,6 +32,7 @@
 
 #include "transport.hpp"
 #include "messages/messages-debug.pb.h"
+#include <type_traits>
 
 
 namespace hw {
@@ -60,7 +61,7 @@ namespace trezor {
         const boost::optional<messages::MessageType> &resp_type = boost::none,
         bool no_wait = false)
     {
-      BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+      static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
 
       m_transport->write(req);
       if (no_wait){

--- a/src/device_trezor/trezor/messages_map.hpp
+++ b/src/device_trezor/trezor/messages_map.hpp
@@ -72,14 +72,14 @@ namespace trezor {
 
     template<class t_message=google::protobuf::Message>
     static messages::MessageType get_message_wire_number() {
-      BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+      static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
       return get_message_wire_number(t_message::default_instance().GetDescriptor()->name());
     }
   };
 
   template<class t_message=google::protobuf::Message>
   std::shared_ptr<t_message> message_ptr_retype(std::shared_ptr<google::protobuf::Message> & in){
-    BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+    static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
     if (!in){
       return nullptr;
     }
@@ -89,7 +89,7 @@ namespace trezor {
 
   template<class t_message=google::protobuf::Message>
   std::shared_ptr<t_message> message_ptr_retype_static(std::shared_ptr<google::protobuf::Message> & in){
-    BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+    static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
     if (!in){
       return nullptr;
     }

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -383,7 +383,7 @@ namespace trezor {
                        boost::optional<messages::MessageType> resp_type = boost::none)
   {
     // Require strictly protocol buffers response in the template.
-    BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
+    static_assert(std::is_base_of_v<google::protobuf::Message, t_message>);
 
     // Write the request
     transport.write(req);


### PR DESCRIPTION
Extracted from #10222.

When building with Boost 1.91:

```
In file included from src/device_trezor/trezor/messages_map.cpp:30:
src/device_trezor/trezor/messages_map.hpp: In static member function 'static hw::trezor::messages::MessageType hw::trezor::MessageMapper::get_message_wire_number()':
src/device_trezor/trezor/messages_map.hpp:75:34: error: 'is_base_of' is not a member of 'boost'; did you mean 'std::is_base_of'?
   75 |       BOOST_STATIC_ASSERT(boost::is_base_of<google::protobuf::Message, t_message>::value);
      |                                  ^~~~~~~~~~
```

Missing header include, but we might as well switch to std.

There are no other occurrences of `boost::is_base_of` in the code base.