### PR TITLE
depends: support building without readline packages

### DIFF
--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -12,6 +12,7 @@ C_STANDARD ?= c11
 CXX_STANDARD ?= c++17
 
 NO_WALLET ?=
+NO_READLINE ?=
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)
@@ -115,10 +116,12 @@ build_id_string:=$(realpath $(GUIX_ENVIRONMENT))
 $(host_arch)_$(host_os)_id_string:=$(realpath $(GUIX_ENVIRONMENT))
 endif
 
+readline_packages_$(NO_READLINE) = $(readline_packages)
+
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 wallet_native_packages_$(NO_WALLET) = $(wallet_native_packages)
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(wallet_packages_)
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(wallet_packages_) $(readline_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages) $(wallet_native_packages_)
 
 all_packages = $(packages) $(native_packages)

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -2,7 +2,7 @@ native_packages :=
 packages := boost openssl zeromq unbound sodium
 
 ifneq ($(host_os),mingw32)
-packages += ncurses readline
+readline_packages += ncurses readline
 endif
 
 wallet_native_packages := native_protobuf


### PR DESCRIPTION
Extracted from #10208.

Faster builds and leaner binary for non-interactive environments.