### PR TITLE
fix: warning: old-style function definition

### DIFF
--- a/src/crypto/rx-slow-hash.c
+++ b/src/crypto/rx-slow-hash.c
@@ -504,11 +504,11 @@ void rx_set_miner_thread(uint32_t value, size_t max_dataset_init_threads) {
   CTHR_RWLOCK_UNLOCK_WRITE(main_dataset_lock);
 }
 
-uint32_t rx_get_miner_thread() {
+uint32_t rx_get_miner_thread(void) {
   return miner_thread;
 }
 
-void rx_slow_hash_allocate_state() {}
+void rx_slow_hash_allocate_state(void) {}
 
 static void rx_destroy_vm(randomx_vm** vm) {
   if (*vm) {
@@ -517,7 +517,7 @@ static void rx_destroy_vm(randomx_vm** vm) {
   }
 }
 
-void rx_slow_hash_free_state() {
+void rx_slow_hash_free_state(void) {
   rx_destroy_vm(&main_vm_full);
   rx_destroy_vm(&main_vm_light);
   rx_destroy_vm(&secondary_vm_light);


### PR DESCRIPTION
```
/__w/monero/monero/src/crypto/rx-slow-hash.c: In function ‘rx_get_miner_thread’:
/__w/monero/monero/src/crypto/rx-slow-hash.c:507:10: warning: old-style function definition [-Wold-style-definition]
  507 | uint32_t rx_get_miner_thread() {
      |          ^~~~~~~~~~~~~~~~~~~
/__w/monero/monero/src/crypto/rx-slow-hash.c: In function ‘rx_slow_hash_allocate_state’:
/__w/monero/monero/src/crypto/rx-slow-hash.c:511:6: warning: old-style function definition [-Wold-style-definition]
  511 | void rx_slow_hash_allocate_state() {}
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/monero/monero/src/crypto/rx-slow-hash.c: In function ‘rx_slow_hash_free_state’:
/__w/monero/monero/src/crypto/rx-slow-hash.c:520:6: warning: old-style function definition [-Wold-style-definition]
  520 | void rx_slow_hash_free_state() {
      |      ^~~~~~~~~~~~~~~~~~~~~~~
```