### PR TITLE
p2p: wait_for on shutdown instead of indefinite wait

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -1155,17 +1155,21 @@ namespace net_utils
     // execute terminate inside m_strand. So we wait for the connection's shutdown sequence to complete before stopping
     // the io_context.
     MDEBUG("Waiting for connection " << m_conn_context.m_connection_id << " to shutdown, current state: " << m_state.status);
-    m_state.condition.wait(
+    const bool shutdown = m_state.condition.wait_for(
       m_state.lock,
+      std::chrono::seconds(5),
       [this]{
         return (
           m_state.status == status_t::TERMINATED || m_state.status == status_t::WASTED
         );
       }
     );
-    MDEBUG("Shut down connection " << m_conn_context.m_connection_id);
+    if (shutdown)
+      MDEBUG("Shut down connection " << m_conn_context.m_connection_id);
+    else
+      MERROR("Connection " << m_conn_context.m_connection_id << " did not shut down");
 
-    return true;
+    return shutdown;
   }
 
   template<typename T>


### PR DESCRIPTION
I noticed with beta stressnet that the node can still sometimes hang on exit because it's waiting indefinitely for a connection to shut down in the newly added `condition.wait` from #10382.

I mentioned [here](https://github.com/monero-project/monero/pull/10382#issuecomment-4185108498) that we can make that `condition.wait` a `condition.wait_for` instead to prevent that potential hang.

I think this `wait_for` is a solid defense measure that should improve the situation of a hanging shutdown (it's allowing for shutdown to execute to completion on my beta stressnet node right now)~~, while investigation continues into what's preventing the connection from shutting down as expected here~~. EDIT: Separately, I've identified the underlying cause of the hang and included a solution for it in #10492, but I still think this PR is a good defense measure worth including, that should help prevent the server from hanging on shut down.