### PR TITLE
daemon: on exit, stop the daemon's blockchain processing protocol asap

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1107,6 +1107,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::send_stop_signal()
   {
+    MDEBUG("[node] stopping server payload handler");
+    m_payload_handler.stop();
     MDEBUG("[node] sending stop signal");
     for (auto& zone : m_network_zones)
     {
@@ -1129,7 +1131,6 @@ namespace nodetool
       zone.second.m_net_server.send_stop_signal(close_all_connections);
     }
     MDEBUG("[node] Stop signal sent");
-    m_payload_handler.stop();
     return true;
   }
   //-----------------------------------------------------------------------------------


### PR DESCRIPTION
#10382 introduced the following flow: wait until all connections complete their termination sequence, and *then* stop the blockchain protocol from continuing to process blocks.

If the server is in the middle of a heavy task like `try_add_next_blocks` that actually may never end until synced, then the user has to sit and wait for that heavy task to finish before all connections can complete the terminate sequence.

This PR ensures the blockchain protocol is canceled as soon as the user stops the server, before waiting for the termination sequence to complete.

____

Note: I think #10488 is a higher priority PR than this one, but I think this is also a necessary fix so connections terminate immediately and avoid that PR's `wait_for` actually waiting until timeout and returning false.