### PR TITLE
p2p: cleaner connection close()

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -1140,7 +1140,9 @@ namespace net_utils
   bool connection<T>::close(const bool wait_for_shutdown)
   {
     std::lock_guard<std::mutex> guard(m_state.lock);
-    if (m_state.status != status_t::RUNNING)
+    if (m_state.status == status_t::TERMINATED || m_state.status == status_t::WASTED)
+      return true;
+    if (!wait_for_shutdown && m_state.status != status_t::RUNNING)
       return false;
     terminate_async();
 


### PR DESCRIPTION
This cleans up expectations for this connection `close` operation introduced in #10382. If the caller wants to wait for shutdown and the connection is not already shutdown, then the function *should* wait for shutdown.

We don't want the problem of #10382 to resurface where the io context is stopped on server exit before the termination sequence can execute to completion in the strand. Without this PR, that can happen if this `close()` gets called more than once (e.g. user sends multiple stop signals to daemon).