### PR TITLE
cmake: remove obsolete gtest definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -949,7 +949,7 @@ include(CheckTrezor)
   endif()
 
   if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default -DGTEST_HAS_TR1_TUPLE=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default")
     if(ARM)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-aligned-allocation")
     endif()


### PR DESCRIPTION
Not present in our GTest submodule pinned at version 0.15.2.