### PR TITLE
epee: fix memory leak with readline

### DIFF
--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -2,6 +2,7 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <iostream>
+#include <memory>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/algorithm/string.hpp>
@@ -201,7 +202,7 @@ static void handle_line(char* line)
 static bool same_as_last_line(const std::string& test_line)
 {
   // Note that state->offset == state->length, when a new line was entered.
-  HISTORY_STATE* state = history_get_history_state();
+  auto state = std::unique_ptr<HISTORY_STATE, decltype(free)*>{history_get_history_state(), free};
   return state->length > 0
     && test_line.compare(state->entries[state->length-1]->line) == 0;
 }


### PR DESCRIPTION
`history_get_history_state` returns a `HISTORY_STATE*` that it allocates and expects the user to free.
Free it before leaving the function to avoid leaking it.
Caught with valgrind.