### PR TITLE
p2p: initialize m_fallback_seed_nodes_added before first use

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -465,7 +465,7 @@ namespace nodetool
 
     std::list<epee::net_utils::network_address>   m_priority_peers;
     std::vector<epee::net_utils::network_address> m_exclusive_peers;
-    std::atomic_flag m_fallback_seed_nodes_added;
+    std::atomic_flag m_fallback_seed_nodes_added = ATOMIC_FLAG_INIT;
     std::vector<nodetool::peerlist_entry> m_command_line_peers;
     uint64_t m_peer_livetime;
     //keep connections to initiate some interactions


### PR DESCRIPTION
`m_fallback_seed_nodes_added` wasn't being initialized before it was used in `net_node.inl`, properly initialize it.
Caught with valgrind.