### PR TITLE
crypto: implement CTHR_THREAD_CLOSE to avoid leaking memory

### DIFF
--- a/src/crypto/c_threads.h
+++ b/src/crypto/c_threads.h
@@ -65,6 +65,6 @@
 #define CTHR_THREAD_RETURN	return NULL
 #define CTHR_THREAD_CREATE(thr, func, arg)	(pthread_create(&thr, NULL, func, arg) == 0)
 #define CTHR_THREAD_JOIN(thr)			pthread_join(thr, NULL)
-#define CTHR_THREAD_CLOSE(thr)
+#define CTHR_THREAD_CLOSE(thr)			pthread_detach(thr)
 
 #endif


### PR DESCRIPTION
`CTHR_THREAD_CLOSE` had no implementation causing it to never free resources associated with the handle that was opened for the thread.
Free it to avoid leaking memory.
Caught with valgrind.