### PR TITLE
cmake: require unbound idiomatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,8 @@ if (WIN32)
   list(APPEND OPENSSL_LIBRARIES ws2_32 crypt32)
 endif()
 
+find_package(Unbound REQUIRED)
+
 find_package(HIDAPI)
 
 add_definition_if_library_exists(c memset_s "string.h" HAVE_MEMSET_S)

--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -25,8 +25,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-MESSAGE(STATUS "Looking for libunbound")
-
 FIND_PATH(UNBOUND_INCLUDE_DIR
   NAMES unbound.h
   PATH_SUFFIXES include/ include/unbound/
@@ -38,3 +36,21 @@ FIND_PATH(UNBOUND_INCLUDE_DIR
 )
 
 find_library(UNBOUND_LIBRARIES unbound)
+
+find_package_handle_standard_args(Unbound
+        REQUIRED_VARS
+        UNBOUND_LIBRARIES
+        UNBOUND_INCLUDE_DIR
+)
+
+add_library(unbound UNKNOWN IMPORTED)
+
+set_target_properties(unbound PROPERTIES
+        IMPORTED_LOCATION ${UNBOUND_LIBRARIES}
+        INTERFACE_INCLUDE_DIRECTORIES ${UNBOUND_INCLUDE_DIR}
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+if(MINGW)
+    target_link_libraries(unbound INTERFACE "iphlpapi;ws2_32;crypt32")
+endif()

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -20,9 +20,6 @@ SET(Readline_INCLUDE_DIR @prefix@/include)
 SET(Readline_LIBRARY @prefix@/lib/libreadline.a)
 SET(Terminfo_LIBRARY @prefix@/lib/libtinfo.a)
 
-SET(UNBOUND_INCLUDE_DIR @prefix@/include)
-SET(UNBOUND_LIBRARIES @prefix@/lib/libunbound.a)
-
 SET(LIBUSB-1.0_LIBRARY @prefix@/lib/libusb-1.0.a)
 SET(LIBUDEV_LIBRARY @prefix@/lib/libudev.a)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,19 +28,6 @@
 # 
 # Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-find_package(Unbound)
-
-if(NOT UNBOUND_INCLUDE_DIR)
-  message(FATAL_ERROR "Could not find libunbound")
-else()
-  message(STATUS "Found libunbound include (unbound.h) in ${UNBOUND_INCLUDE_DIR}")
-  if(UNBOUND_LIBRARIES)
-    message(STATUS "Found libunbound library")
-  else()
-    message(FATAL_ERROR "Found libunbound includes, but could not find libunbound library. Please make sure you have installed libunbound or libunbound-dev or the equivalent")
-  endif()
-endif()
-
 add_subdirectory(db_drivers)
 add_subdirectory(easylogging++)
 add_subdirectory(qrcodegen)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -66,7 +66,7 @@ monero_add_library(common
 target_link_libraries(common
   PUBLIC
     cncrypto
-    ${UNBOUND_LIBRARIES}
+    unbound
     ${LIBUNWIND_LIBRARIES}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}


### PR DESCRIPTION
Also:

- Move `find_package` to the main `CMakeLists.txt` like our other dependencies. 
- Explicitly link required Windows libraries. 