### PR TITLE
cryptonote_basic: add `calculate_transaction_hash_from_blob()`

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -30,6 +30,10 @@
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
+#include <cstddef>
+#include <limits>
+#include "common/varint.h"
+#include "ringct/rctTypes.h"
 #include "wipeable_string.h"
 #include "string_tools.h"
 #include "string_tools_lexical.h"
@@ -1435,6 +1439,164 @@ namespace cryptonote
   bool get_transaction_hash(const transaction& t, crypto::hash& res, size_t& blob_size)
   {
     return get_transaction_hash(t, res, &blob_size);
+  }
+  //---------------------------------------------------------------
+  bool calculate_transaction_hash_from_blob(const blobdata_ref tx_blob,
+    const crypto::hash &pruned_data_hash, crypto::hash &res)
+  {
+    //! @TODO: update for FCMP++:
+    //!    * Allow rct::RctTypeFcmpPlusPlus
+    //!    * Set output length for txout_to_carrot_v1
+
+    const unsigned char *p = reinterpret_cast<const unsigned char*>(tx_blob.data());
+    const unsigned char *end = reinterpret_cast<const unsigned char*>(tx_blob.data() + tx_blob.size());
+
+    #define READ_VARINT(v) if (tools::read_varint(p, end, v) <= 0) return false
+    #define READ_BYTE(v) if (end <= p ) { return false; } else { v = *p; ++p; }
+    #define SKIP(n) if (end - p < static_cast<std::ptrdiff_t>(n)) { return false; } else { p += (n); }
+
+    // read and validate tx version
+    std::size_t tx_version = 0;
+    READ_VARINT(tx_version);
+    if (tx_version < 1 || tx_version > 2)
+      return false;
+
+    // v1 is simple hash of tx blob
+    if (1 == tx_version)
+    {
+      res = get_blob_hash(tx_blob);
+      return true;
+    }
+
+    // skip unlock_time
+    std::size_t dummy;
+    READ_VARINT(dummy);
+
+    // read number of inputs
+    std::size_t n_inputs = 0;
+    READ_VARINT(n_inputs);
+
+    // skip n_inputs inputs
+    for (std::size_t i = 0; i < n_inputs; ++i)
+    {
+      std::size_t input_tag = 0;
+      READ_BYTE(input_tag);
+      switch (input_tag)
+      {
+      case 0xff: //txin_gen
+        READ_VARINT(dummy); //height
+        break;
+      case 0x02: //txin_to_key
+        READ_VARINT(dummy); //amount
+        READ_VARINT(input_tag); //key_offsets.size()
+        for (;input_tag-->0;)
+          READ_VARINT(dummy);
+        SKIP(32); //k_image
+        break;
+      default:
+        return false;
+      }
+    }
+
+    // read number of outputs
+    std::size_t n_outputs = 0;
+    READ_VARINT(n_outputs);
+
+    // skip n_outputs outputs
+    for (std::size_t i = 0; i < n_outputs; ++i)
+    {
+      READ_VARINT(dummy); //amount
+      std::size_t output_tag = 0;
+      READ_BYTE(output_tag); //target variant tag
+      std::ptrdiff_t output_length = 0;
+      switch (output_tag)
+      {
+      case 0x02: //txout_to_key
+        output_length = 32;
+        break;
+      case 0x03: //txout_to_tagged_key
+        output_length = 32 + 1;
+        break;
+      default:
+        return false;
+      }
+      SKIP(output_length);
+    }
+
+    // read extra length and skip that
+    std::size_t extra_len = 0;
+    READ_VARINT(extra_len);
+    if (extra_len > CRYPTONOTE_MAX_TX_SIZE)
+      return false;
+    SKIP(extra_len);
+
+    // now `p` is at end of tx prefix...
+    const unsigned char * const tx_prefix_end = p;
+
+    // read RingCT type
+    std::uint8_t rct_type = std::numeric_limits<std::uint8_t>::max();
+    READ_BYTE(rct_type);
+    if (rct_type > rct::RCTTypeBulletproofPlus)
+      return false;
+
+    // skip unprunable RingCT fields
+    if (rct_type != rct::RCTTypeNull)
+    {
+      // skip txnFee
+      READ_VARINT(dummy);
+
+      // if RCTTypeSimple, skip pseudoOutputs
+      if (rct_type == rct::RCTTypeSimple)
+      {
+        SKIP(32 * n_inputs);
+      }
+
+      // skip ECDH info and amount commitments
+      const bool short_amount = rct_type >= rct::RCTTypeBulletproof2;
+      const std::ptrdiff_t ecdh_tuple_len = short_amount ? 8 : 64;
+      const std::ptrdiff_t output_stuff_len = n_outputs * (ecdh_tuple_len + 32);
+      SKIP(output_stuff_len);
+    }
+
+    #undef READ_VARINT
+    #undef READ_BYTE
+    #undef SKIP
+
+    // now `p` is at end of unprunable part of v2 tx...
+
+    // check prunable
+    const bool has_prunable_data = end > p;
+    const bool provided_pruned_data_hash = crypto::null_hash != pruned_data_hash;
+    const bool null_rct = rct::RCTTypeNull == rct_type;
+    if (null_rct) //coinbase
+    {
+      if (has_prunable_data || provided_pruned_data_hash)
+        return false;
+    }
+    else //non-coinbase
+    {
+      if (has_prunable_data == provided_pruned_data_hash)
+        return false; 
+    }
+
+    // hash tx prefix
+    crypto::hash tx_subhashes[3] = {};
+    crypto::cn_fast_hash(tx_blob.data(), reinterpret_cast<const char*>(tx_prefix_end) - tx_blob.data(), 
+      tx_subhashes[0]);
+
+    // hash unprunable
+    crypto::cn_fast_hash(tx_prefix_end, p - tx_prefix_end, tx_subhashes[1]);
+
+    // hash prunable
+    if (provided_pruned_data_hash)
+      tx_subhashes[2] = pruned_data_hash;
+    else if (!null_rct)
+      crypto::cn_fast_hash(p, end - p, tx_subhashes[2]);
+
+    // do final hash
+    res = crypto::cn_fast_hash(tx_subhashes, sizeof(tx_subhashes));
+
+    return true;
   }
   //---------------------------------------------------------------
   blobdata get_block_hashing_blob(const block& b)

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -119,6 +119,29 @@ namespace cryptonote
   crypto::hash get_transaction_prunable_hash(const transaction& t, const cryptonote::blobdata_ref *blob = NULL);
   bool calculate_transaction_hash(const transaction& t, crypto::hash& res, size_t* blob_size);
   bool get_pruned_transaction_hash(const transaction& t, const crypto::hash &pruned_data_hash, crypto::hash& res);
+  /**
+   * @brief: calculate a TXID directly from a transaction hash
+   * @param tx_blob transaction blob
+   * @param pruned_data_hash hash of prunable data if applicable, else null (see below)
+   * @param[out] res resultant TXID
+   * @return true on successful TXID calculation, false otherwise
+   *
+   * This function should succeed in all scenarios where
+   * `parse_and_validate_tx_from_blob(tx_blob, tx)` is `true`, and input types are of `txin_gen` or
+   * `txin_to_key`. The converse is not necessarily true: this function MAY succeed when
+   * `parse_and_validate_tx_from_blob(...)` fails. In other words, it should work on ALL valid
+   * Monero transactions, but may also succeed on invalid Monero transactions. However, this
+   * function should always return the same TXID as `calculate_transaction_hash(...)` when they both
+   * return `true`.
+   *
+   * To calculate the TXID of a pruned transaction blob, pass the hash of the pruned data in
+   * `pruned_data_hash`. If this argument is null, and the blob contains a pruned transaction, then
+   * this function will return `false`. Inversely, if this argument is non-null, and the blob
+   * contains a transaction which cannot have a prunable section, or the prunable section is present
+   * in the blob, then this function will return false.
+   */
+  bool calculate_transaction_hash_from_blob(const blobdata_ref tx_blob,
+    const crypto::hash &pruned_data_hash, crypto::hash &res);
 
   blobdata get_block_hashing_blob(const block& b);
   bool calculate_block_hash(const block& b, crypto::hash& res, const blobdata_ref *blob = NULL);

--- a/tests/performance_tests/main.cpp
+++ b/tests/performance_tests/main.cpp
@@ -66,6 +66,7 @@
 #include "multiexp.h"
 #include "sig_mlsag.h"
 #include "sig_clsag.h"
+#include "tx_blob_to_hash.h"
 
 namespace po = boost::program_options;
 
@@ -309,6 +310,47 @@ int main(int argc, char** argv)
   TEST_PERFORMANCE1(filter, p, test_crypto_ops, op_isInMainSubgroup);
   TEST_PERFORMANCE1(filter, p, test_crypto_ops, op_zeroCommitUncached);
   TEST_PERFORMANCE1(filter, p, test_crypto_ops, op_zeroCommitCached);
+
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  1,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  1,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  1,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  1,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  1,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  1,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  1, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  1, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  2,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  2,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  2,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  2,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  2,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  2,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  2, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  2, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  4,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  4,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  4,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  4,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  4,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  4,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  4, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  4, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  8,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  8,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  8,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  8,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  8,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  8,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false,  8, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true,  8, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false, 16,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true, 16,  2);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false, 16,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true, 16,  4);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false, 16,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true, 16,  8);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash, false, 16, 16);
+  TEST_PERFORMANCE3(filter, p, test_bpp_tx_blob_to_hash,  true, 16, 16);
 
   TEST_PERFORMANCE2(filter, p, test_multiexp, multiexp_bos_coster, 2);
   TEST_PERFORMANCE2(filter, p, test_multiexp, multiexp_bos_coster, 4);

--- a/tests/performance_tests/tx_blob_to_hash.h
+++ b/tests/performance_tests/tx_blob_to_hash.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include <cstddef>
+
+#include "crypto/hash.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "ringct/rctOps.h"
+#include "ringct/rctTypes.h"
+
+/**
+ * @brief: Test perf of calculating a transaction hash from a blob on a BP+ tx
+ * @tparam hash_from_blob true for calculate_transaction_hash_from_blob(), otherwise get_transaction_hash()
+ * @tparam n_inputs number of tx inputs
+ * @tparam n_outputs number of tx outputs
+ */
+template<bool hash_from_blob, std::size_t n_inputs, std::size_t n_outputs>
+class test_bpp_tx_blob_to_hash 
+{
+public:
+    static const std::size_t loop_count = 1000;
+
+    static constexpr std::size_t extra_len = 1 + 32 + 1 + 1 + 1 + 8; // main tx pubkey and dummy encrypted payment ID
+    static constexpr std::size_t ring_size = 16;
+
+    bool init()
+    {
+        static const cryptonote::txin_to_key inp{
+            .amount = 0,
+            .key_offsets = {90195203, 6886484, 54104233, 42303, 691774,
+                456173, 1271021, 18026, 333412, 316502, 95847, 61774,
+                3078, 391, 1485, 158},
+            .k_image = {}
+        };
+
+        cryptonote::transaction tx;
+        tx.version = 2;
+        tx.unlock_time = 0;
+        tx.vin.resize(n_inputs, inp);
+        tx.vout.resize(n_outputs,
+            cryptonote::tx_out{.amount = 0, .target = cryptonote::txout_to_tagged_key{}});
+        tx.extra.resize(extra_len);
+
+        tx.rct_signatures.type = rct::RCTTypeBulletproofPlus;
+        tx.rct_signatures.ecdhInfo.resize(n_outputs);
+        tx.rct_signatures.outPk.resize(n_outputs, {{}, rct::I});
+        tx.rct_signatures.txnFee = 122960000;
+
+        std::size_t n_lr = 0;
+        while ((1 << n_lr) < n_outputs) ++n_lr;
+        n_lr += 6;
+        auto &bpp = tx.rct_signatures.p.bulletproofs_plus.emplace_back();
+        bpp.L.resize(n_lr);
+        bpp.R.resize(n_lr);
+        tx.rct_signatures.p.CLSAGs.resize(n_inputs, {
+            .s = rct::keyV(ring_size)
+        });
+        tx.rct_signatures.p.pseudoOuts.resize(n_inputs);
+
+        m_tx_blob = cryptonote::tx_to_blob(tx);
+
+        return true;
+    }
+
+    bool test()
+    {
+        crypto::hash tx_hash;
+        if constexpr (hash_from_blob)
+        {
+            if (!cryptonote::calculate_transaction_hash_from_blob(m_tx_blob, crypto::null_hash, tx_hash))
+                return false;
+        }
+        else // blob -> tx -> hash
+        {
+            cryptonote::transaction tx;
+            if (!cryptonote::parse_and_validate_tx_from_blob(m_tx_blob, tx))
+                return false;
+
+            if (!cryptonote::get_transaction_hash(tx, tx_hash))
+                return false;
+        }
+
+        return true;
+    }
+
+private:
+    cryptonote::blobdata m_tx_blob;
+};

--- a/tests/unit_tests/cryptonote_format_utils.cpp
+++ b/tests/unit_tests/cryptonote_format_utils.cpp
@@ -27,11 +27,22 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gtest/gtest.h"
+#include <boost/filesystem/path.hpp>
+#include <cstdlib>
 
+#include "crypto/crypto.h"
 #include "crypto/generators.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
+#include "crypto/hash.h"
+#include "cryptonote_basic/blobdatatype.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_config.h"
+#include "file_io_utils.h"
+#include "ringct/rctOps.h"
+#include "ringct/rctTypes.h"
 #include "serialization/binary_utils.h"
 #include "serialization/string.h"
+#include "unit_tests_utils.h"
 
 TEST(cn_format_utils, add_extra_nonce_to_tx_extra)
 {
@@ -240,6 +251,347 @@ TEST(cn_format_utils, tx_extra_merge_mining_tag_store_load)
                 ASSERT_EQ(mm_merkle_root, mm_field.merkle_root);
                 ASSERT_EQ(mm_merkle_tree_depth, mm_field.depth);
             }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_real)
+{
+    // load tx from file
+    const boost::filesystem::path tx_path = unit_test::data_dir / "txs" / "bpp_tx_e89415.bin";
+    cryptonote::blobdata tx_blob;
+    ASSERT_TRUE(epee::file_io_utils::load_file_to_string(tx_path.string(), tx_blob));
+    cryptonote::transaction tx;
+    ASSERT_TRUE(cryptonote::parse_and_validate_tx_from_blob(tx_blob, tx));
+
+    // hash from tx structure
+    const crypto::hash expected_tx_hash = cryptonote::get_transaction_hash(tx);
+
+    // hash directly from blob
+    crypto::hash tx_hash_from_blob;
+    ASSERT_TRUE(cryptonote::calculate_transaction_hash_from_blob(tx_blob, 
+        crypto::null_hash, tx_hash_from_blob));
+
+    EXPECT_EQ(expected_tx_hash, tx_hash_from_blob);
+}
+
+static const std::vector<std::size_t> n_inputs_vals = {1, 2, 3, 4, 7, 8, 15, 16, 31,
+    32, 63, 64, 127, 128};
+static const std::vector<std::size_t> n_outputs_vals = {0, 1, 2, 3, 4, 7, 8, 15, 16};
+static const std::vector<std::size_t> ring_size_vals = {1, 2, 3, 4, 7, 8, 15, 16};
+static const std::vector<std::size_t> extra_len_vals = {0, 1, 2, 3, 4, 5, 6, 7, 8,
+    9, 10, 127, 128, 512, MAX_TX_EXTRA_SIZE};
+
+/**
+ * @brief: generate a random transaction prefix with the given parameters
+ */
+static void gen_tx_prefix(cryptonote::transaction &tx,
+    const std::size_t tx_version,
+    const std::size_t n_inputs,
+    const std::size_t n_outputs,
+    const std::size_t extra_len,
+    const std::size_t ring_size,
+    const bool use_view_tags)
+{
+    static const std::uint64_t unlock_time = crypto::rand<std::uint64_t>();
+    static const std::uint64_t inp_amount = crypto::rand<std::uint64_t>();
+    static const std::uint64_t key_offset = crypto::rand_idx<std::uint64_t>(CRYPTONOTE_MAX_BLOCK_NUMBER);
+    static const crypto::key_image ki = crypto::rand<crypto::key_image>();
+    static const unsigned char extra_char = crypto::rand<unsigned char>();
+    static const cryptonote::tx_out output_untagged = cryptonote::tx_out{
+        .amount = crypto::rand<std::uint64_t>(),
+        .target = cryptonote::txout_to_key(crypto::rand<crypto::public_key>())
+    };
+    static const cryptonote::tx_out output_tagged = cryptonote::tx_out{
+        .amount = crypto::rand<std::uint64_t>(),
+        .target = cryptonote::txout_to_tagged_key(
+            crypto::rand<crypto::public_key>(), crypto::rand<crypto::view_tag>())
+    };
+
+    tx.invalidate_hashes();
+    tx.unprunable_size = 0;
+    tx.prefix_size = 0;
+    tx.version = tx_version;
+    tx.unlock_time = unlock_time;
+    tx.vin.resize(n_inputs, cryptonote::txin_to_key{.amount = inp_amount,
+        .key_offsets = {},
+        .k_image = ki});
+    for (cryptonote::txin_v &in_v : tx.vin)
+        boost::get<cryptonote::txin_to_key>(in_v).key_offsets.resize(ring_size, key_offset);
+    tx.vout.resize(n_outputs, use_view_tags ? output_tagged : output_untagged);
+    tx.extra.resize(extra_len, extra_char);
+    tx.rct_signatures.type = rct::RCTTypeNull;
+}
+
+/**
+ * @brief: generate random RingCT sig base fields with the given type, and given sizes in the prefix
+ */
+template <std::uint8_t rct_type>
+static void gen_tx_rctsig_base(cryptonote::transaction &tx)
+{
+    const std::size_t n_inputs = tx.vin.size();
+    const std::size_t n_outputs = tx.vout.size();
+
+    static const rct::ecdhTuple ecdh_tuple = crypto::rand<rct::ecdhTuple>();
+    static const rct::key dest = crypto::rand<rct::key>();
+    static const rct::key mask = rct::pkGen();
+    static const rct::ctkey ct = {dest, mask};
+    static const rct::xmr_amount fee = crypto::rand<std::uint64_t>();
+
+    switch (rct_type)
+    {
+    case rct::RCTTypeNull:
+        break;
+    case rct::RCTTypeSimple:
+        tx.rct_signatures.pseudoOuts.resize(n_inputs, dest);
+        [[fallthrough]];
+    case rct::RCTTypeFull:
+    case rct::RCTTypeBulletproof:
+    case rct::RCTTypeBulletproof2:
+    case rct::RCTTypeCLSAG:
+    case rct::RCTTypeBulletproofPlus:
+        tx.rct_signatures.ecdhInfo.resize(n_outputs, ecdh_tuple);
+        tx.rct_signatures.outPk.resize(n_outputs, ct);
+        tx.rct_signatures.txnFee = fee;
+        break;
+    default:
+        throw std::logic_error("Unrecognized RingCT type: " + std::to_string(rct_type));
+    }
+
+    tx.rct_signatures.type = rct_type;
+}
+
+/**
+ * @brief: test that a serialized transaction gets the same TXID from parsing and hashing, as direct hashing from blob
+ */
+static void assert_tx_to_blob_to_hash_from_blob(cryptonote::transaction &tx, cryptonote::blobdata &tx_blob)
+{
+    // do typical blob -> tx -> hash
+    ASSERT_TRUE(cryptonote::tx_to_blob(tx, tx_blob));
+    ASSERT_TRUE(cryptonote::parse_and_validate_tx_from_blob(tx_blob, tx));
+    const crypto::hash expected_tx_hash = cryptonote::get_transaction_hash(tx);
+
+    // do direct blob -> hash
+    crypto::hash tx_hash_from_blob;
+    ASSERT_TRUE(cryptonote::calculate_transaction_hash_from_blob(tx_blob,
+        crypto::null_hash, tx_hash_from_blob));
+
+    // expect equality
+    ASSERT_EQ(expected_tx_hash, tx_hash_from_blob);
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_v1)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_inputs : n_inputs_vals)
+    {
+        for (std::size_t n_outputs : n_outputs_vals)
+        {
+            for (std::size_t ring_size : ring_size_vals)
+            {
+                for (std::size_t extra_len : extra_len_vals)
+                {
+                    // make v1 tx
+                    gen_tx_prefix(tx, 1, n_inputs, n_outputs, extra_len, ring_size, false);
+                    tx.signatures.resize(n_inputs);
+                    for (std::vector<crypto::signature> &sig : tx.signatures)
+                        sig.resize(ring_size);
+
+                    ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+                }
+            }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_RCTTypeFull)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_inputs : n_inputs_vals)
+    {
+        for (std::size_t n_outputs : n_outputs_vals)
+        {
+            for (std::size_t ring_size : ring_size_vals)
+            {
+                for (std::size_t extra_len : extra_len_vals)
+                {
+                    // make RingCT non-simple tx
+                    gen_tx_prefix(tx, 2, n_inputs, n_outputs, extra_len, ring_size, false);
+                    gen_tx_rctsig_base<rct::RCTTypeFull>(tx);
+                    tx.rct_signatures.p.rangeSigs.resize(n_outputs);
+                    tx.rct_signatures.p.MGs = {rct::mgSig{
+                        .ss = rct::keyM(ring_size, rct::keyV(n_inputs + 1, crypto::rand<rct::key>())),
+                        .cc = crypto::rand<rct::key>(),
+                        .II = rct::keyV(n_inputs, crypto::rand<rct::key>())
+                    }};
+
+                    ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+                }
+            }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_RCTTypeSimple)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_inputs : n_inputs_vals)
+    {
+        for (std::size_t n_outputs : n_outputs_vals)
+        {
+            for (std::size_t ring_size : ring_size_vals)
+            {
+                for (std::size_t extra_len : extra_len_vals)
+                {
+                    // make RingCT simple tx, MLSAGs, Borromean, long-amount
+                    gen_tx_prefix(tx, 2, n_inputs, n_outputs, extra_len, ring_size, false);
+                    gen_tx_rctsig_base<rct::RCTTypeSimple>(tx);
+                    tx.rct_signatures.p.rangeSigs.resize(n_outputs);
+                    tx.rct_signatures.p.MGs.resize(n_inputs);
+                    for (rct::mgSig &mlsag : tx.rct_signatures.p.MGs)
+                    {
+                        mlsag.ss.resize(ring_size, rct::keyV(2, crypto::rand<rct::key>()));
+                        mlsag.cc = crypto::rand<rct::key>();
+                        mlsag.II.resize(1, crypto::rand<rct::key>());
+                    };
+
+                    ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+                }
+            }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_RCTTypeBulletproof2)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_inputs : n_inputs_vals)
+    {
+        for (std::size_t n_outputs : n_outputs_vals)
+        {
+            if (n_outputs < 1)
+                continue;
+
+            std::size_t n_lr = 0;
+            while ((1 << n_lr) < n_outputs) { ++n_lr; }
+            n_lr += 6;
+
+            for (std::size_t ring_size : ring_size_vals)
+            {
+                for (std::size_t extra_len : extra_len_vals)
+                {
+                    // make RingCT simple tx, MLSAGs, Bulletproof, short-amount
+                    gen_tx_prefix(tx, 2, n_inputs, n_outputs, extra_len, ring_size, false);
+                    gen_tx_rctsig_base<rct::RCTTypeBulletproof2>(tx);
+                    tx.rct_signatures.p.bulletproofs.resize(1);
+                    tx.rct_signatures.p.bulletproofs.front().L.resize(n_lr);
+                    tx.rct_signatures.p.bulletproofs.front().R.resize(n_lr);
+                    tx.rct_signatures.p.MGs.resize(n_inputs);
+                    for (rct::mgSig &mlsag : tx.rct_signatures.p.MGs)
+                    {
+                        mlsag.ss.resize(ring_size, rct::keyV(2, crypto::rand<rct::key>()));
+                        mlsag.cc = crypto::rand<rct::key>();
+                        mlsag.II.resize(1, crypto::rand<rct::key>());
+                    };
+                    tx.rct_signatures.p.pseudoOuts.resize(n_inputs, crypto::rand<rct::key>());
+
+                    ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+                }
+            }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_RCTTypeBulletproofPlus)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_inputs : n_inputs_vals)
+    {
+        for (std::size_t n_outputs : n_outputs_vals)
+        {
+            if (n_outputs < 1)
+                continue;
+
+            std::size_t n_lr = 0;
+            while ((1 << n_lr) < n_outputs) { ++n_lr; }
+            n_lr += 6;
+
+            for (std::size_t ring_size : ring_size_vals)
+            {
+                for (std::size_t extra_len : extra_len_vals)
+                {
+                    // make RingCT simple tx, CLSAGs, Bulletproof+, short-amount, view tags
+                    gen_tx_prefix(tx, 2, n_inputs, n_outputs, extra_len, ring_size, true);
+                    gen_tx_rctsig_base<rct::RCTTypeBulletproofPlus>(tx);
+                    tx.rct_signatures.p.bulletproofs_plus.resize(1);
+                    tx.rct_signatures.p.bulletproofs_plus.front().L.resize(n_lr);
+                    tx.rct_signatures.p.bulletproofs_plus.front().R.resize(n_lr);
+                    tx.rct_signatures.p.CLSAGs.resize(n_inputs);
+                    for (rct::clsag &cl : tx.rct_signatures.p.CLSAGs)
+                        cl.s.resize(ring_size, crypto::rand<rct::key>());
+                    tx.rct_signatures.p.pseudoOuts.resize(n_inputs, crypto::rand<rct::key>());
+
+                    ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+                }
+            }
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_v1_coinbase)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_outputs = 0; n_outputs <= 128; ++n_outputs)
+    {
+        for (std::size_t extra_len : extra_len_vals)
+        {
+            // make v1 coinbase tx
+            tx.set_null();
+            tx.version = 1;
+            tx.unlock_time = crypto::rand<std::uint64_t>();
+            tx.vin.emplace_back(cryptonote::txin_gen{
+                .height = crypto::rand<std::uint64_t>()
+            });
+            tx.vout.resize(n_outputs, cryptonote::tx_out{
+                .amount = crypto::rand<std::uint64_t>(),
+                .target = cryptonote::txout_to_key(crypto::rand<crypto::public_key>())
+            });
+            tx.extra.resize(extra_len, crypto::rand<unsigned char>());
+
+            ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
+        }
+    }
+}
+
+TEST(cn_format_utils, calculate_transaction_hash_from_blob_v2_coinbase)
+{
+    cryptonote::transaction tx;
+    cryptonote::blobdata tx_blob;
+    for (std::size_t n_outputs = 0; n_outputs <= 128; ++n_outputs)
+    {
+        for (std::size_t extra_len : extra_len_vals)
+        {
+            // make v2 coinbase tx
+            tx.set_null();
+            tx.version = 2;
+            tx.unlock_time = 0;
+            tx.vin.emplace_back(cryptonote::txin_gen{
+                .height = crypto::rand<std::uint64_t>()
+            });
+            tx.vout.resize(n_outputs, cryptonote::tx_out{
+                .amount = crypto::rand<std::uint64_t>(),
+                .target = cryptonote::txout_to_tagged_key(
+                    crypto::rand<crypto::public_key>(), crypto::rand<crypto::view_tag>())
+            });
+            tx.extra.resize(extra_len, crypto::rand<unsigned char>());
+
+            ASSERT_NO_FATAL_FAILURE(assert_tx_to_blob_to_hash_from_blob(tx, tx_blob));
         }
     }
 }


### PR DESCRIPTION
Adds function `calculate_transaction_hash_from_blob()` which can calculate a TXID directly from its blob with zero allocations and zero elliptic curve operations. Part of resolving #10522.

Here is how many times faster this function is (to 2 significant digits) than the traditional method of deserializing, expanding, then hashing (`i.e. parse_and_validate_tx_from_blob()` then `get_transaction_hash()`) when processing a RingCT, CLSAG, BP+, view tagged transaction:

|           | 2-out | 4-out | 8-out | 16-out |
|---------|---------|---------|----------|-----------|
|   1-in |    43.  |     85. |    130 |      200 |
|   2-in |     33. |     64. |    100 |      170 |
|   4-in |     22. |     43. |     73. |      130 |
|   8-in |     13. |     24. |     43. |       84. |
| 16-in |     7.6 |     14. |     25. |       47. |

- [x] Write function
- [ ] Unit tests (unpruned)
  * [x] v1 coinbase
  * [x] v1 non-coinbase
  * [x] v2 coinbase
  * [x] v2 RCTTypeFull
  * [x] v2 RCTTypeSimple
  * [ ] v2 RCTTypeBulletproof
  * [x] v2 RCTTypeBulletproof2
  * [ ] v2 RCTTypeCLSAG
  * [x] v2 RCTTypeBulletproofPlus
  * [x] view tags
- [ ] Unit tests (pruned)
  * [ ] v1 coinbase
  * [ ] v1 non-coinbase
  * [ ] v2 coinbase
  * [ ] v2 RCTTypeFull
  * [ ] v2 RCTTypeSimple
  * [ ] v2 RCTTypeBulletproof
  * [ ] v2 RCTTypeBulletproof2
  * [ ] v2 RCTTypeCLSAG
  * [ ] v2 RCTTypeBulletproofPlus
  * [ ] view tags
- [x] Performance tests