### PR TITLE
epee: remove LOCAL_ASSERT

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -124,16 +124,6 @@
 
 #define MLOG_SET_THREAD_NAME(x) el::Helpers::setThreadName(x)
 
-#ifndef LOCAL_ASSERT
-#include <assert.h>
-#if (defined _MSC_VER)
-#define LOCAL_ASSERT(expr) {if(epee::debug::get_set_enable_assert()){_ASSERTE(expr);}}
-#else
-#define LOCAL_ASSERT(expr)
-#endif
-
-#endif
-
 std::string mlog_get_default_log_path(const char *default_filename);
 void mlog_configure(const std::string &filename_base, bool console, const std::size_t max_log_file_size = MAX_LOG_FILE_SIZE, const std::size_t max_log_files = MAX_LOG_FILES);
 void mlog_set_categories(const char *categories);
@@ -143,18 +133,6 @@ void mlog_set_log(const char *log);
 
 namespace epee
 {
-namespace debug
-{
-  inline bool get_set_enable_assert(bool set = false, bool v = false)
-  {
-    static bool e = true;
-    if(set)
-      e = v;
-    return e;
-  }
-}
-
-
 
 #define ENDL std::endl
 
@@ -195,7 +173,7 @@ namespace debug
 
 
 #ifndef CHECK_AND_ASSERT
-#define CHECK_AND_ASSERT(expr, fail_ret_val)   do{if(!(expr)){LOCAL_ASSERT(expr); return fail_ret_val;};}while(0)
+#define CHECK_AND_ASSERT(expr, fail_ret_val)   do{if(!(expr)){return fail_ret_val;};}while(0)
 #endif
 
 #ifndef CHECK_AND_ASSERT_MES
@@ -203,7 +181,7 @@ namespace debug
 #endif
 
 #ifndef CHECK_AND_NO_ASSERT_MES_L
-#define CHECK_AND_NO_ASSERT_MES_L(expr, fail_ret_val, l, message)   do{if(!(expr)) {LOG_PRINT_L##l(message); /*LOCAL_ASSERT(expr);*/ return fail_ret_val;};}while(0)
+#define CHECK_AND_NO_ASSERT_MES_L(expr, fail_ret_val, l, message)   do{if(!(expr)) {LOG_PRINT_L##l(message); return fail_ret_val;};}while(0)
 #endif
 
 #ifndef CHECK_AND_NO_ASSERT_MES

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -243,7 +243,6 @@ bool transactions_flow_test(std::string& working_folder,
       if(!do_send_money(w1, w2, mix_in_factor, amount_to_tx, tx))
       {
         LOG_PRINT_L0( "failed to transfer money, second chance. tx: " << get_transaction_hash(tx) << ", exit" );
-        LOCAL_ASSERT(false);
         return false;
       }
     }
@@ -297,7 +296,6 @@ bool transactions_flow_test(std::string& working_folder,
 
     MERROR("-----------------------FINISHING TRANSACTIONS FLOW TEST FAILED-----------------------" );
     MERROR("income " << print_money(money_2) << " via " << i << " transactions, expected money = " << print_money(transfered_money) );
-    LOCAL_ASSERT(false);
     return false;
   }
 

--- a/tests/net_load_tests/clt.cpp
+++ b/tests/net_load_tests/clt.cpp
@@ -631,7 +631,6 @@ int main(int argc, char** argv)
 {
   TRY_ENTRY();
   tools::on_startup();
-  epee::debug::get_set_enable_assert(true, false);
   //set up logging options
   mlog_configure(mlog_get_default_log_path("net_load_tests_clt.log"), true);
 

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -58,7 +58,6 @@ int main(int argc, char** argv)
   tools::on_startup();
   epee::string_tools::set_module_name_and_folder(argv[0]);
   mlog_configure(mlog_get_default_log_path("unit_tests.log"), true);
-  epee::debug::get_set_enable_assert(true, false);
 
   ::testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
LOCAL_ASSERT was only defined on Windows, only used in the `CHECK_AND_ASSERT` macro, and was disabled in unit tests anyways, but only in the main translation unit, which didn't have local asserts, since get_set_enable_assert was inline, so the disabling didn't even do anything.