### PR TITLE
zmq: apply restricted-mode privacy filtering to get_transaction_pool

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1548,9 +1548,9 @@ namespace cryptonote
     return m_mempool.get_transactions_and_spent_keys_info(tx_infos, key_image_infos, include_sensitive_data);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const
+  bool core::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos, bool include_sensitive) const
   {
-    return m_mempool.get_pool_for_rpc(tx_infos, key_image_infos);
+    return m_mempool.get_pool_for_rpc(tx_infos, key_image_infos, include_sensitive);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t& current_height) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -556,10 +556,11 @@ namespace cryptonote
 
      /**
       * @copydoc tx_memory_pool::get_pool_for_rpc
+      * @param include_sensitive include node-private fields (timing)
       *
       * @note see tx_memory_pool::get_pool_for_rpc
       */
-     bool get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const;
+     bool get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos, bool include_sensitive) const;
 
      /**
       * @copydoc tx_memory_pool::get_transactions_count

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1241,13 +1241,13 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const
+  bool tx_memory_pool::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos, bool include_sensitive) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
     tx_infos.reserve(m_blockchain.get_txpool_tx_count());
     key_image_infos.reserve(m_blockchain.get_txpool_tx_count());
-    m_blockchain.for_all_txpool_txes([&tx_infos, key_image_infos](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd){
+    m_blockchain.for_all_txpool_txes([&tx_infos, key_image_infos, include_sensitive](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd){
       cryptonote::rpc::tx_in_pool txi;
       txi.tx_hash = txid;
       if (!(meta.pruned ? parse_and_validate_tx_base_from_blob(*bd, txi.tx) : parse_and_validate_tx_from_blob(*bd, txi.tx)))
@@ -1265,9 +1265,11 @@ namespace cryptonote
       txi.max_used_block_hash = meta.max_used_block_id;
       txi.last_failed_block_height = meta.last_failed_height;
       txi.last_failed_block_hash = meta.last_failed_id;
-      txi.receive_time = meta.receive_time;
+      // In restricted mode we do not include this data:
+      txi.receive_time = include_sensitive ? meta.receive_time : 0;
       txi.relayed = meta.relayed;
-      txi.last_relayed_time = meta.dandelionpp_stem ? 0 : meta.last_relayed_time;
+      // In restricted mode we do not include this data:
+      txi.last_relayed_time = (include_sensitive && !meta.dandelionpp_stem) ? meta.last_relayed_time : 0;
       txi.do_not_relay = meta.do_not_relay;
       txi.double_spend_seen = meta.double_spend_seen;
       tx_infos.push_back(txi);

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -323,10 +323,11 @@ namespace cryptonote
      *
      * @param tx_infos [out] the transactions' information
      * @param key_image_infos [out] the spent key images' information
+     * @param include_sensitive include fields that are sensitive to node privacy
      *
      * @return true
      */
-    bool get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const;
+    bool get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos, bool include_sensitive) const;
 
     /**
      * @brief check for presence of key images in the pool

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -756,7 +756,7 @@ namespace rpc
 
   void DaemonHandler::handle(const GetTransactionPool::Request& req, GetTransactionPool::Response& res)
   {
-    bool r = m_core.get_pool_for_rpc(res.transactions, res.key_images);
+    bool r = m_core.get_pool_for_rpc(res.transactions, res.key_images, !m_restricted);
 
     if (!r) res.status = Message::STATUS_FAILED;
     else res.status = Message::STATUS_OK;

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -455,7 +455,7 @@ bool txpool_double_spend_base::check_changed(cryptonote::core& c, const size_t e
   {
     std::vector<cryptonote::rpc::tx_in_pool> infos{};
     cryptonote::rpc::key_images_with_tx_hashes key_images{};
-    if (!c.get_pool_for_rpc(infos, key_images) || infos.size() != m_broadcasted_hashes.size() || key_images.size() != m_broadcasted_hashes.size())
+    if (!c.get_pool_for_rpc(infos, key_images, true) || infos.size() != m_broadcasted_hashes.size() || key_images.size() != m_broadcasted_hashes.size())
     {
       MERROR("Expected broadcasted rpc data to return " << m_broadcasted_hashes.size() << " but got " << infos.size() << " infos and " << key_images.size() << "key images");
       return false;


### PR DESCRIPTION
Refs #10529.

## What

Adds `"get_transaction_pool"` to `blocked_in_restricted_mode` in [src/rpc/zmq_restricted_methods.cpp](../../blob/master/src/rpc/zmq_restricted_methods.cpp).
Restricted ZMQ callers receive `METHOD_NOT_FOUND` for this method.

The HTTP equivalent
([src/rpc/core_rpc_server.cpp:1709-1717](../../blob/master/src/rpc/core_rpc_server.cpp#L1709-L1717)) already zeros `receive_time` / `last_relayed_time` for restricted callers; the ZMQ handler at [src/rpc/daemon_handler.cpp:757-763](../../blob/master/src/rpc/daemon_handler.cpp#L757-L763) returns them verbatim. Both paths already filter to
`relay_category::broadcasted`, so stem-phase txs are not exposed either
way.

## Changes

- `src/rpc/zmq_restricted_methods.cpp` — bump array size 9 → 10, insert   `"get_transaction_pool"` between `get_peer_list` and `mining_status` (alphabetical order preserved so `check_blocked_methods_sorted()` keeps passing).
- `tests/unit_tests/zmq_rpc.cpp` — matching `EXPECT_TRUE` in `ZmqRestrictedMethods.BasicCoverage`.

## Test plan

- [x] `unit_tests` `ZmqRestrictedMethods.BasicCoverage` covers the new entry
- [x] Sort invariant preserved
- [ ] Manual: `monerod --restricted-zmq-rpc` → restricted ZMQ `get_transaction_pool` returns `METHOD_NOT_FOUND`
- [ ] Manual: unrestricted ZMQ port still serves it normally
- [ ] Manual: HTTP behavior unchanged on both ports
