### PR TITLE
wallet: fix gamma picker boundary lookup

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1091,7 +1091,7 @@ uint64_t gamma_picker::pick()
     return std::numeric_limits<uint64_t>::max(); // bad pick
   output_index = num_rct_outputs - 1 - output_index;
 
-  const uint64_t *it = std::lower_bound(begin, end, output_index);
+  const uint64_t *it = std::upper_bound(begin, end, output_index);
   THROW_WALLET_EXCEPTION_IF(it == end, error::wallet_internal_error, "output_index not found");
   uint64_t index = std::distance(begin, it);
 

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -147,7 +147,7 @@ TEST(select_outputs, density)
     uint64_t o = picker.pick();
     if (o >= n_outs)
       continue;
-    auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
     ASSERT_LT(idx, picks.size());
     ++picks[idx];
@@ -191,7 +191,7 @@ TEST(select_outputs, same_distribution)
     uint64_t o = picker.pick();
     if (o >= n_outs)
       continue;
-    auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
     ASSERT_LT(idx, chain_picks.size());
     ++chain_picks[idx];
@@ -222,9 +222,11 @@ TEST(select_outputs, same_distribution)
 TEST(select_outputs, exact_unlock_block)
 {
   std::vector<uint64_t> offsets;
-  MKOFFSETS(300000, 1 + (crypto::rand<size_t>() & 0x1f));
+  MKOFFSETS(300000, 1);
   tools::gamma_picker picker(offsets);
 
+  // Use one output per block so a cumulative-boundary off-by-one cannot be
+  // hidden by selecting another output from the same block.
   // Calculate output offset ranges for the very first block that is spendable.
   // Since gamma_picker is passed data for EXISTING blocks. The last block it can select outputs
   // from *inclusive* that is allowed by consensus is the


### PR DESCRIPTION
### Overview

Fixes the cumulative-offset boundary lookup used by `gamma_picker::pick()`.

`rct_offsets` stores cumulative output counts. When the selected zero-based `output_index` is exactly equal to a cumulative count, that output is the first output in the next block. The lookup therefore needs `upper_bound` semantics, not `lower_bound`.

### Changes

- use `std::upper_bound` when mapping `output_index` back to an `rct_offsets` block
- update the output selection tests' reverse block mapping to the same cumulative-count semantics
- make `select_outputs.exact_unlock_block` use the one-output-per-block case so this boundary cannot be hidden by multiple outputs in the same block

Refs #10350.

This addresses the cumulative-offset boundary case reported there.

### Validation

- `git diff --check`
- local boundary simulation for one-output-per-block offsets confirming `output_index == offsets[i]` maps to the following block with `upper_bound`

I did not run the full Monero unit test binary locally because this checkout does not have a configured build tree.