### PR TITLE
epee: skip IPv4 TOS option for non-IPv4 peers

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -962,14 +962,16 @@ namespace net_utils
 
     ec_t ec;
     #if !defined(_WIN32) || !defined(__i686)
-    connection_basic::socket_.next_layer().set_option(
-      boost::asio::detail::socket_option::integer<IPPROTO_IP, IP_TOS>{
-        connection_basic::get_tos_flag()
-      },
-      ec
-    );
-    if (ec.value())
-      return false;
+    if (real_remote->get_type_id() == ipv4_network_address::get_type_id()) {
+      connection_basic::socket_.next_layer().set_option(
+        boost::asio::detail::socket_option::integer<IPPROTO_IP, IP_TOS>{
+          connection_basic::get_tos_flag()
+        },
+        ec
+      );
+      if (ec.value())
+        return false;
+    }
     #endif
     connection_basic::socket_.next_layer().set_option(
       boost::asio::ip::tcp::no_delay{false},


### PR DESCRIPTION
## Summary

- only apply the `IPPROTO_IP/IP_TOS` socket option when the accepted remote address is IPv4
- let IPv6 RPC connections continue to the existing TCP startup path instead of failing on an IPv4-only socket option
- keep the existing fatal handling for IPv4 `IP_TOS` failures unchanged

Fixes #10307.

## Tests

- `git diff --check`
- Static diff assertion that the IPv4 guard is present and the existing `tcp::no_delay` startup path remains after it
- Not run: full C++ build / syntax-only compile, because this local machine's Apple Command Line Tools `xcrun` is installed for an incompatible architecture and `cmake` is unavailable
