### PR TITLE
wallet: clear offline mode after daemon rebind

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1393,6 +1393,7 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
   bool ret =  m_http_client->set_server(address, get_daemon_login(), std::move(ssl_options));
   if (ret)
   {
+    set_offline(false);
     CRITICAL_REGION_LOCAL(default_daemon_address_lock);
     default_daemon_address = address;
   }


### PR DESCRIPTION
## Summary

- clear wallet offline mode after `wallet2::set_daemon()` successfully accepts a daemon endpoint
- restore the wallet RPC proxy and HTTP client auto-connect state through the existing `set_offline(false)` helper
- keep failed `set_daemon()` behavior unchanged; initial `--offline` startup still applies after wallet initialization

## Tests

- `git diff --check`
- static source assertion that `set_daemon()` clears offline only on the success path and startup `--offline` is still applied after `init()`
- anchored conflict-marker audit on the touched file
- Not run: full C++ build / wallet RPC functional test, because this local machine's Apple Command Line Tools `xcrun` is installed for an incompatible architecture and `cmake` is unavailable
