### PR TITLE
tests: isolate functional monerod config files

### DIFF
--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -52,7 +52,7 @@ WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 FUNCTIONAL_TESTS_DIRECTORY = builddir + "/tests/functional_tests"
 DIFFICULTY = 10
 
-monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1", "--rpc-max-connections-per-private-ip", "100", "--rpc-max-connections", "100"]
+monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--config-file", "monerod_config_file", "--log-level", "1", "--rpc-max-connections-per-private-ip", "100", "--rpc-max-connections", "100"]
 
 monerod_extra = [
   ["--offline"],
@@ -77,8 +77,19 @@ processes = []
 outputs = []
 ports = []
 
+def monerod_data_dir(i):
+  return builddir + "/functional-tests-directory/monerod" + str(i)
+
+def monerod_config_file(i):
+  data_dir = monerod_data_dir(i)
+  os.makedirs(data_dir, exist_ok = True)
+  config_file = data_dir + "/monerod.conf"
+  with open(config_file, 'a'):
+    pass
+  return config_file
+
 for i in range(N_MONERODS):
-  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else "tcp://127.0.0.1:" + str(18480+i) if x == "monerod_zmq_pub" else builddir + "/functional-tests-directory/monerod" + str(i) if x == "monerod_data_dir" else x for x in monerod_base])
+  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else "tcp://127.0.0.1:" + str(18480+i) if x == "monerod_zmq_pub" else monerod_data_dir(i) if x == "monerod_data_dir" else monerod_config_file(i) if x == "monerod_config_file" else x for x in monerod_base])
   if i < len(monerod_extra):
     command_lines[-1] += monerod_extra[i]
   outputs.append(open(FUNCTIONAL_TESTS_DIRECTORY + '/monerod' + str(i) + '.log', 'a+'))


### PR DESCRIPTION
## Summary
- add a test-owned empty `--config-file` per functional daemon in `tests/functional_tests/functional_tests_rpc.py`
- keep each daemon's config under its own `functional-tests-directory/monerodN/monerod.conf`
- prevent `functional_tests` from inheriting the user's default `~/.bitmonero/monerod.conf`

Fixes #9175.

## Validation
- `python3 -m py_compile tests/functional_tests/functional_tests_rpc.py`
- `git diff --check origin/master...HEAD`
