### PR TITLE
depends: zeromq: assume flags available [0.18]

### DIFF
--- a/contrib/depends/packages/zeromq.mk
+++ b/contrib/depends/packages/zeromq.mk
@@ -8,6 +8,15 @@ $(package)_patches=06aba27b04c5822cb88a69677382a0f053367143.patch
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
   $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux+=libzmq_cv_o_cloexec=yes
+  $(package)_config_opts_linux+=libzmq_cv_efd_cloexec=yes
+  $(package)_config_opts_linux+=libzmq_cv_sock_cloexec=yes
+  $(package)_config_opts_linux+=libzmq_cv_so_bindtodevice=yes
+  $(package)_config_opts_linux+=libzmq_cv_so_keepalive=yes
+  $(package)_config_opts_linux+=libzmq_cv_so_priority=yes
+  $(package)_config_opts_linux+=libzmq_cv_tcp_keepcnt=yes
+  $(package)_config_opts_linux+=libzmq_cv_tcp_keepidle=yes
+  $(package)_config_opts_linux+=libzmq_cv_tcp_keepintvl=yes
   $(package)_config_opts_freebsd=--with-pic
   $(package)_cxxflags=-std=c++11
 endef


### PR DESCRIPTION
These are disabled by configure when cross-compiling, but should always be available.

```
# - O_CLOEXEC		(2007, kernel 2.6.23, glibc 2.7)
# - EFD_CLOEXEC		(2008, kernel 2.6.27, glibc 2.9)
# - SOCK_CLOEXEC	(2008, kernel 2.6.27, glibc 2.9)
# - SO_BINDTODEVICE	(2009, kernel 2.6.31)
# - SO_KEEPALIVE	(2009, kernel 2.6.31, glibc 1.x)
# - SO_PRIORITY		(2009, kernel 2.6.31)
# - TCP_KEEPCNT		(pre 2005/2013, pre kernel 2.6.12, glibc 2.18)
# - TCP_KEEPIDLE	(pre 2005/2013, pre kernel 2.6.12, glibc 2.18)
# - TCP_KEEPINTVL	(pre 2005/2013, pre kernel 2.6.12, glibc 2.18)
```