### PR TITLE
tests: avoid braced scalar init in expect macros (fix warning)

### DIFF
--- a/tests/unit_tests/expect.cpp
+++ b/tests/unit_tests/expect.cpp
@@ -818,27 +818,15 @@ TEST(Expect, EqualNoCopies)
 
 TEST(Expect, Macros) {
     EXPECT_TRUE(
-        [] () -> ::common_error {
-            MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidErrorCode
-    );
-    EXPECT_TRUE(
-        [] () -> ::common_error {
-            MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
-        } () == common_error::kInvalidArgument
-    );
-    EXPECT_TRUE(
         [] () -> std::error_code {
             MONERO_PRECOND(true);
-            return {common_error::kInvalidErrorCode};
+            return common_error::kInvalidErrorCode;
         } () == common_error::kInvalidErrorCode
     );
     EXPECT_TRUE(
         [] () -> std::error_code {
             MONERO_PRECOND(false);
-            return {common_error::kInvalidErrorCode};
+            return common_error::kInvalidErrorCode;
         } () == common_error::kInvalidArgument
     );
     EXPECT_TRUE(


### PR DESCRIPTION
```
/Users/selsta/dev/monero/tests/unit_tests/expect.cpp:822:13: warning: braces around scalar initializer [-Wbraced-scalar-init]
  822 |             MONERO_PRECOND(true);
      |             ^~~~~~~~~~~~~~~~~~~~
/Users/selsta/dev/monero/src/common/expect.h:44:20: note: expanded from macro 'MONERO_PRECOND'
   44 |             return {::common_error::kInvalidArgument}; \
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/selsta/dev/monero/external/gtest/googletest/include/gtest/gtest.h:1823:50: note: expanded from macro 'EXPECT_TRUE'
 1823 | #define EXPECT_TRUE(condition) GTEST_EXPECT_TRUE(condition)
      |                                                  ^~~~~~~~~
/Users/selsta/dev/monero/external/gtest/googletest/include/gtest/gtest.h:1808:23: note: expanded from macro 'GTEST_EXPECT_TRUE'
 1808 |   GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
      |                       ^~~~~~~~~
/Users/selsta/dev/monero/external/gtest/googletest/include/gtest/internal/gtest-internal.h:1453:38: note: expanded from macro 'GTEST_TEST_BOOLEAN_'
 1453 |           ::testing::AssertionResult(expression))                     \
      |                                      ^~~~~~~~~~
```

`clang-2100.1.1.101`