### PR TITLE
rpc: remove unused origin flag (fix warning)

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1259,8 +1259,6 @@ namespace cryptonote
       return ok;
 
     const bool restricted = m_restricted && ctx;
-    const bool request_has_rpc_origin = ctx != NULL;
-
     if (restricted && req.key_images.size() > RESTRICTED_SPENT_KEY_IMAGES_COUNT)
     {
       res.status = "Too many key images queried in restricted mode";


### PR DESCRIPTION
```
/Users/selsta/dev/monero/src/rpc/core_rpc_server.cpp:1262:16: warning: unused variable 'request_has_rpc_origin' [-Wunused-variable]
 1262 |     const bool request_has_rpc_origin = ctx != NULL;
      |                ^~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

`clang-2100.1.1.101`