### PR TITLE
src: replace deprecated sprintf calls (fix warning)

### DIFF
--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -272,7 +272,7 @@ plot 'stats.csv' index "DATA" using (timecolumn(1,"%Y-%m-%d")):4 with lines, '' 
     char buf[8];
     unsigned int i;
     for (i=0; i<24; i++) {
-      sprintf(buf, "\t%02u:00", i);
+      snprintf(buf, sizeof(buf), "\t%02u:00", i);
       std::cout << buf;
     }
   }

--- a/src/device/log.cpp
+++ b/src/device/log.cpp
@@ -38,7 +38,7 @@ namespace hw {
   void buffer_to_str(char *to_buff,  size_t to_len, const char *buff, size_t len) {
     CHECK_AND_ASSERT_THROW_MES(to_len > (len*2), "destination buffer too short. At least" << (len*2+1) << " bytes required");
     for (size_t i=0; i<len; i++) {
-      sprintf(to_buff+2*i, "%.02x", (unsigned char)buff[i]);
+      snprintf(to_buff + 2 * i, to_len - 2 * i, "%.02x", (unsigned char)buff[i]);
     }
   }
 


### PR DESCRIPTION
```
/Users/selsta/dev/monero/src/device/log.cpp:41:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
   41 |       sprintf(to_buff+2*i, "%.02x", (unsigned char)buff[i]);
      |       ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:227:48: note: expanded from macro '__deprecated_msg'
  227 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
1 warning generated.
```

`clang-2100.1.1.101`