### PR TITLE
src: replace deprecated strand wrap (fix warning)

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -29,6 +29,7 @@
 
 #include <string.h>
 #include <thread>
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -615,7 +616,7 @@ bool ssl_options_t::handshake(
         socket.async_handshake(
           type,
           boost::asio::buffer(buffer),
-          strand.wrap(on_handshake)
+          boost::asio::bind_executor(strand, on_handshake)
         );
       }
     );

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -28,6 +28,7 @@
 
 #include "levin_notify.h"
 
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -354,7 +355,9 @@ namespace levin
         detail::zone& this_zone = *zone;
         ++this_zone.flush_callbacks;
         this_zone.flush_txs.expires_at(flush_time);
-        this_zone.flush_txs.async_wait(this_zone.strand.wrap(fluff_flush{std::move(zone)}));
+        this_zone.flush_txs.async_wait(
+          boost::asio::bind_executor(this_zone.strand, fluff_flush{std::move(zone)})
+        );
       }
 
       void operator()(const boost::system::error_code error)
@@ -629,7 +632,7 @@ namespace levin
         noise_channel& channel = zone->channels.at(index);
         channel.next_noise.expires_at(start + noise_min_delay + random_duration(noise_delay_range));
         channel.next_noise.async_wait(
-          channel.strand.wrap(send_noise{std::move(zone), index, core})
+          boost::asio::bind_executor(channel.strand, send_noise{std::move(zone), index, core})
         );
       }
 


### PR DESCRIPTION
```
/Users/selsta/dev/monero/src/cryptonote_protocol/levin_notify.cpp:357:57: warning: 'wrap' is deprecated: Use boost::asio::bind_executor() [-Wdeprecated-declarations]
  357 |         this_zone.flush_txs.async_wait(this_zone.strand.wrap(fluff_flush{std::move(zone)}));
      |                                                         ^
/opt/homebrew/include/boost/asio/io_context_strand.hpp:246:3: note: 'wrap' has been explicitly marked deprecated here
  246 |   wrap(Handler handler)
      |   ^
/Users/selsta/dev/monero/src/cryptonote_protocol/levin_notify.cpp:357:57: warning: 'wrap<cryptonote::levin::(anonymous namespace)::fluff_flush>' is deprecated: Use boost::asio::bind_executor() [-Wdeprecated-declarations]
  357 |         this_zone.flush_txs.async_wait(this_zone.strand.wrap(fluff_flush{std::move(zone)}));
      |                                                         ^
/opt/homebrew/include/boost/asio/io_context_strand.hpp:240:3: note: 'wrap<cryptonote::levin::(anonymous namespace)::fluff_flush>' has been explicitly marked deprecated here
```

`clang-2100.1.1.101`