### PR TITLE
cryptonote_core: fix GCC bogus stringop-overread warning

### DIFF
--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -84,12 +84,12 @@ namespace cryptonote
     bool operator()(const crypto::hash& a, const crypto::hash& b) const
     {
       // Workaround for a GCC bug causing warnings
-      #if __GNUC__
+      #if defined(__GNUC__) && (__GNUC__ >= 11)
       # pragma GCC diagnostic push
       # pragma GCC diagnostic ignored "-Wstringop-overread"
       #endif
       return memcmp(a.data, b.data, sizeof(crypto::hash)) < 0;
-      #if __GNUC__
+      #if defined(__GNUC__) && (__GNUC__ >= 11)
       # pragma GCC diagnostic pop
       #endif
     }

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -83,7 +83,15 @@ namespace cryptonote
   public:
     bool operator()(const crypto::hash& a, const crypto::hash& b) const
     {
+      // Workaround for a GCC bug causing warnings
+      #if __GNUC__
+      # pragma GCC diagnostic push
+      # pragma GCC diagnostic ignored "-Wstringop-overread"
+      #endif
       return memcmp(a.data, b.data, sizeof(crypto::hash)) < 0;
+      #if __GNUC__
+      # pragma GCC diagnostic pop
+      #endif
     }
   };
 


### PR DESCRIPTION
GCC is throwing a big warning about the `memcmp` here attempting to read 32 bytes into an object that was allocated with a size of 0 bytes.
This doesn't happen at `-O0` or `-O1` and adding an unrelated function call like `puts("");` to the function makes the warning go away so this appears to be a GCC bug.
Silence it for now.
`gcc (GCC) 16.1.1`