### PR TITLE
epee: avoid memcpy in rolling median move (fix warning)

### DIFF
--- a/contrib/epee/include/rolling_median.h
+++ b/contrib/epee/include/rolling_median.h
@@ -36,6 +36,7 @@
 
 #include "misc_language.h"
 
+#include <type_traits>
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -47,6 +48,9 @@ namespace misc_utils
 template<typename Item>
 struct rolling_median_t
 {
+  static_assert(std::is_trivially_copyable_v<Item>,
+    "rolling_median_t requires trivially copyable Item");
+
 private:
   Item* data;  //circular queue of values
   int*  pos;   //index into `heap` for each value
@@ -124,6 +128,27 @@ private:
      return i == 0;
   }
 
+  void consume_from(rolling_median_t& m) noexcept
+  {
+    data = m.data;
+    pos = m.pos;
+    heap = m.heap;
+    N = m.N;
+    idx = m.idx;
+    minCt = m.minCt;
+    maxCt = m.maxCt;
+    sz = m.sz;
+
+    m.data = nullptr;
+    m.pos = nullptr;
+    m.heap = nullptr;
+    m.N = 0;
+    m.idx = 0;
+    m.minCt = 0;
+    m.maxCt = 0;
+    m.sz = 0;
+  }
+
 protected:
   rolling_median_t &operator=(const rolling_median_t&) = delete;
 
@@ -152,16 +177,19 @@ public:
     sz = other.sz;
   }
 
-  rolling_median_t(rolling_median_t &&m)
+  rolling_median_t(rolling_median_t &&m) noexcept
   {
-    memcpy(this, &m, sizeof(rolling_median_t));
-    m.data = NULL;
+    consume_from(m);
   }
-  rolling_median_t &operator=(rolling_median_t &&m)
+
+  rolling_median_t &operator=(rolling_median_t &&m) noexcept
   {
-    free(data);
-    memcpy(this, &m, sizeof(rolling_median_t));
-    m.data = NULL;
+    if (this != &m)
+    {
+      free(data);
+      consume_from(m);
+    }
+
     return *this;
   }
 


### PR DESCRIPTION
```
In file included from /Users/selsta/dev/monero/src/cryptonote_core/blockchain.cpp:41:
In file included from /Users/selsta/dev/monero/src/cryptonote_core/blockchain.h:53:
/Users/selsta/dev/monero/contrib/epee/include/rolling_median.h:163:12: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'epee::misc_utils::rolling_median_t<unsigned long long>' [-Wnontrivial-memcall]
  163 |     memcpy(this, &m, sizeof(rolling_median_t));
      |            ^
/Users/selsta/dev/monero/src/cryptonote_core/blockchain.cpp:443:52: note: in instantiation of member function 'epee::misc_utils::rolling_median_t<unsigned long long>::operator=' requested here
  443 |     m_long_term_block_weights_cache_rolling_median = epee::misc_utils::rolling_median_t<uint64_t>(m_long_term_block_weights_window);
      |                                                    ^
/Users/selsta/dev/monero/contrib/epee/include/rolling_median.h:163:12: note: explicitly cast the pointer to silence this warning
  163 |     memcpy(this, &m, sizeof(rolling_median_t));
      |            ^
      |            (void*)
1 warning generated.
```

`clang-2100.1.1.101`