### PR TITLE
serialization: avoid blob memcpy of secret_key vector (fix warning)

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <vector>
 #include <deque>
+#include <type_traits>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/contains_fwd.hpp>
 
@@ -114,6 +115,9 @@ namespace epee
     template<class stl_container, class t_storage>
     static bool serialize_stl_container_pod_val_as_blob(const stl_container& container, t_storage& stg, typename t_storage::hsection hparent_section, const char* pname)
     {
+      static_assert(std::is_trivially_copyable_v<typename stl_container::value_type>,
+        "serialize_stl_container_pod_val_as_blob requires trivially copyable value_type");
+
       if(!container.size()) return true;
       std::string mb;
       mb.resize(sizeof(typename stl_container::value_type)*container.size());
@@ -129,6 +133,9 @@ namespace epee
     template<class stl_container, class t_storage>
     static bool unserialize_stl_container_pod_val_as_blob(stl_container& container, t_storage& stg, typename t_storage::hsection hparent_section, const char* pname)
     {
+      static_assert(std::is_trivially_copyable_v<typename stl_container::value_type>,
+        "unserialize_stl_container_pod_val_as_blob requires trivially copyable value_type");
+
       container.clear();
       std::string buff;
       bool res = stg.get_value(pname, buff, hparent_section);

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -50,7 +50,25 @@ namespace cryptonote
       KV_SERIALIZE(m_account_address)
       KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_spend_secret_key)
       KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_view_secret_key)
-      KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_multisig_keys)
+      if constexpr (is_store)
+      {
+        std::vector<crypto::ec_scalar> multisig_keys;
+        multisig_keys.reserve(this_ref.m_multisig_keys.size());
+        for (const crypto::secret_key& key : this_ref.m_multisig_keys)
+          multisig_keys.push_back(unwrap(unwrap(key)));
+        epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(
+          multisig_keys, stg, hparent_section, "m_multisig_keys");
+      }
+      else
+      {
+        std::vector<crypto::ec_scalar> multisig_keys;
+        epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(
+          multisig_keys, stg, hparent_section, "m_multisig_keys");
+        this_ref.m_multisig_keys.clear();
+        this_ref.m_multisig_keys.reserve(multisig_keys.size());
+        for (const crypto::ec_scalar& key : multisig_keys)
+          this_ref.m_multisig_keys.emplace_back(tools::scrubbed<crypto::ec_scalar>{key});
+      }
       const crypto::chacha_iv default_iv{{0, 0, 0, 0, 0, 0, 0, 0}};
       KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(m_encryption_iv, default_iv)
     END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
```
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:147:18: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'epee::mlocked<tools::scrubbed<crypto::ec_scalar>>' [-Wnontrivial-memcall]
  147 |           memcpy(std::addressof(v), pelem, sizeof(v));
      |                  ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:364:37: note: in instantiation of function template specialization 'epee::serialization::unserialize_stl_container_pod_val_as_blob<std::vector<epee::mlocked<tools::scrubbed<crypto::ec_scalar>>>, epee::serialization::portable_storage>' requested here
  364 |         return epee::serialization::unserialize_stl_container_pod_val_as_blob(d, stg, hparent_section, pname);
      |                                     ^
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:53:7: note: in instantiation of function template specialization 'epee::serialization::selector<false>::serialize_stl_container_pod_val_as_blob<std::vector<epee::mlocked<tools::scrubbed<crypto::ec_scalar>>>, epee::serialization::portable_storage>' requested here
   53 |       KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_multisig_keys)
      |       ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:124:59: note: expanded from macro 'KV_SERIALIZE_CONTAINER_POD_AS_BLOB'
  124 | #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
      |                                                           ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:116:44: note: expanded from macro 'KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N'
  116 |   epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(this_ref.varialble, stg, hparent_section, val_name);
      |                                            ^
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:49:5: note: in instantiation of function template specialization 'cryptonote::account_keys::serialize_map<false, epee::serialization::portable_storage>' requested here
   49 |     BEGIN_KV_SERIALIZE_MAP()
      |     ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:55:12: note: expanded from macro 'BEGIN_KV_SERIALIZE_MAP'
   55 |     return serialize_map<false>(stg, hparent_section);\
      |            ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:83:18: note: in instantiation of function template specialization 'cryptonote::account_keys::_load<epee::serialization::portable_storage>' requested here
   83 |       return obj._load(stg, hchild_section);
      |                  ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:273:16: note: in instantiation of function template specialization 'epee::serialization::unserialize_t_obj<cryptonote::account_keys, epee::serialization::portable_storage>' requested here
  273 |         return unserialize_t_obj(d, stg, hparent_section, pname);
      |                ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:383:181: note: (skipping 2 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
  383 |       return kv_serialization_overloads_impl_is_base_serializable_types<boost::mpl::contains<base_serializable_types<t_storage>, typename std::remove_const<t_type>::type>::value>::kv_unserialize(d, stg, hparent_section, pname);
      |                                                                                                                                                                                     ^
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:114:7: note: in instantiation of function template specialization 'epee::serialization::selector<false>::serialize<cryptonote::account_keys, epee::serialization::portable_storage>' requested here
  114 |       KV_SERIALIZE(m_keys)
      |       ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:120:59: note: expanded from macro 'KV_SERIALIZE'
  120 | #define KV_SERIALIZE(varialble)                           KV_SERIALIZE_N(varialble, #varialble)
      |                                                           ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:79:44: note: expanded from macro 'KV_SERIALIZE_N'
   79 |   epee::serialization::selector<is_store>::serialize(this_ref.varialble, stg, hparent_section, val_name);
      |                                            ^
/Users/selsta/dev/monero/src/cryptonote_basic/account.h:113:5: note: in instantiation of function template specialization 'cryptonote::account_base::serialize_map<false, epee::serialization::portable_storage>' requested here
  113 |     BEGIN_KV_SERIALIZE_MAP()
      |     ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization.h:61:12: note: expanded from macro 'BEGIN_KV_SERIALIZE_MAP'
   61 |     return serialize_map<false>(stg, hparent_section);\
      |            ^
/Users/selsta/dev/monero/contrib/epee/include/storages/portable_storage_template_helper.h:98:18: note: in instantiation of function template specialization 'cryptonote::account_base::load<epee::serialization::portable_storage>' requested here
   98 |       return out.load(ps);
      |                  ^
/Users/selsta/dev/monero/contrib/epee/include/storages/portable_storage_template_helper.h:104:14: note: in instantiation of function template specialization 'epee::serialization::load_t_from_binary<cryptonote::account_base>' requested here
  104 |       return load_t_from_binary(out, epee::strspan<uint8_t>(binary_buff));
      |              ^
/Users/selsta/dev/monero/src/wallet/wallet2.cpp:4991:48: note: in instantiation of function template specialization 'epee::serialization::load_t_from_binary<cryptonote::account_base>' requested here
 4991 |     if (try_v0_format && !epee::serialization::load_t_from_binary(account_data_check, account_data))
      |                                                ^
/Users/selsta/dev/monero/contrib/epee/include/serialization/keyvalue_serialization_overloads.h:147:18: note: explicitly cast the pointer to silence this warning
  147 |           memcpy(std::addressof(v), pelem, sizeof(v));
      |                  ^
      |                  (void*)
```

`clang-2100.1.1.101`

Alternatively I could also silence the warning but this seems to be the more correct solution due to added `static_assert` against future misuse.

Needs testing with existing multisig wallet .keys