### PR TITLE
tests: remove obsolete memwipe optimization override (fix warning)

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -143,8 +143,6 @@ set_property(TARGET unit_tests
   PROPERTY
     COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
 
-SET_PROPERTY(SOURCE memwipe.cpp PROPERTY COMPILE_FLAGS -Ofast)
-
 add_test(
   NAME    unit_tests
   COMMAND unit_tests --data-dir "${TEST_DATA_DIR}")


### PR DESCRIPTION
```
clang++: warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Wdeprecated-ofast]
```

`clang-2100.1.1.101`

See also https://github.com/monero-project/monero/pull/10312