### PR TITLE
common/dns_utils: load DNS blocklist in chunks from each domain

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -565,6 +565,39 @@ bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std
   return true;
 }
 
+bool load_chunked_txt_records_from_dns(std::vector<std::string> &good_records, const std::vector<std::string> &dns_urls)
+{
+  if (dns_urls.empty()) return false;
+
+  good_records = {};
+  for (size_t chunk_idx = 0; ; ++chunk_idx)
+  {
+    std::vector<std::string> chunk_urls;
+    chunk_urls.reserve(dns_urls.size());
+    for (const auto &url : dns_urls)
+      chunk_urls.push_back(std::to_string(chunk_idx) + "." + url);
+
+    std::vector<std::string> chunk_records;
+    if (!load_txt_records_from_dns(chunk_records, chunk_urls))
+    {
+      MDEBUG("DNS blocklist: chunk " << chunk_idx << " unavailable or without consensus, stopping after " << chunk_idx << " chunk(s)");
+      break;
+    }
+
+    MDEBUG("Found chunk " << chunk_idx << " with " << chunk_records.size() << " record(s)");
+    for (const auto &s : chunk_records)
+      good_records.push_back(s);
+  }
+
+  if (good_records.empty())
+  {
+    LOG_PRINT_L0("WARNING: no DNS blocklist chunks were successfully fetched");
+    return false;
+  }
+
+  return true;
+}
+
 std::vector<std::string> parse_dns_public(const char *s)
 {
   unsigned ip0, ip1, ip2, ip3;

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -172,6 +172,8 @@ std::string get_account_address_as_str_from_url(const std::string& url, bool& dn
 
 bool load_txt_records_from_dns(std::vector<std::string> &records, const std::vector<std::string> &dns_urls);
 
+bool load_chunked_txt_records_from_dns(std::vector<std::string> &records, const std::vector<std::string> &dns_urls);
+
 std::vector<std::string> parse_dns_public(const char *s);
 
 }  // namespace tools::dns_utils

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2121,7 +2121,7 @@ namespace nodetool
     };
 
     std::vector<std::string> records;
-    if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))
+    if (!tools::dns_utils::load_chunked_txt_records_from_dns(records, dns_urls))
       return true;
 
     unsigned good = 0;


### PR DESCRIPTION
- expects blocklist txt records to be served on numbered subdomains for each dns domain 0.blocklist.. 1.blocklist..
- consensus is required to keep chunk index increasing e.g. if 4/7 domains are offline it will not look upward

for testing i changed `once_a_time_seconds<7000>` to 15 and ran monerod with `DNS_PUBLIC=tcp://127.0.0.1`,  added txt records in `dnsmasq` conf file like this: (due to TTL from the dns provider, or unbound caching, you have to restart monerod to see new updates) *with DNSSEC checks commented out
```
txt-record=0.blocklist.moneropulse.co,"1.2.3.4"
txt-record=0.blocklist.moneropulse.fr,"1.2.3.4"
txt-record=0.blocklist.moneropulse.de,"1.2.3.4"
txt-record=0.blocklist.moneropulse.ch,"1.2.3.4"
txt-record=1.blocklist.moneropulse.co,"5.6.7.8"
txt-record=1.blocklist.moneropulse.fr,"5.6.7.8"
txt-record=1.blocklist.moneropulse.de,"5.6.7.8"
txt-record=1.blocklist.moneropulse.ch,"5.6.7.8"

```