### PR TITLE
common: validate Content-Range before resuming downloads

### DIFF
--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -125,10 +125,9 @@ namespace tools
           {
             // we requested a range, so check if we're getting it, otherwise truncate
             bool got_range = false;
-            const std::string prefix = "bytes=" + std::to_string(offset) + "-";
             for (const auto &kv: headers.m_header_info.m_etc_fields)
             {
-              if (kv.first == "Content-Range" && strncmp(kv.second.c_str(), prefix.c_str(), prefix.size()))
+              if (kv.first == "Content-Range" && tools::content_range_starts_at(kv.second, offset))
               {
                 got_range = true;
                 break;

--- a/src/common/download.h
+++ b/src/common/download.h
@@ -28,6 +28,7 @@
 
 #pragma once 
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <functional>
@@ -36,6 +37,12 @@ namespace tools
 {
   struct download_thread_control;
   typedef std::shared_ptr<download_thread_control> download_async_handle;
+
+  inline bool content_range_starts_at(const std::string &content_range, uint64_t offset)
+  {
+    const std::string prefix = "bytes " + std::to_string(offset) + "-";
+    return content_range.compare(0, prefix.size(), prefix) == 0;
+  }
 
   bool download(const std::string &path, const std::string &url, std::function<bool(const std::string&, const std::string&, size_t, ssize_t)> progress = NULL);
   download_async_handle download_async(const std::string &path, const std::string &url, std::function<void(const std::string&, const std::string&, bool)> result, std::function<bool(const std::string&, const std::string&, size_t, ssize_t)> progress = NULL);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(unit_tests_sources
   device.cpp
   difficulty.cpp
   dns_resolver.cpp
+  download.cpp
   epee_boosted_tcp_server.cpp
   epee_levin_protocol_handler_async.cpp
   epee_http_server.cpp

--- a/tests/unit_tests/download.cpp
+++ b/tests/unit_tests/download.cpp
@@ -1,0 +1,14 @@
+#include "common/download.h"
+
+#include "gtest/gtest.h"
+
+TEST(download, content_range_starts_at)
+{
+  EXPECT_TRUE(tools::content_range_starts_at("bytes 1024-2047/4096", 1024));
+  EXPECT_TRUE(tools::content_range_starts_at("bytes 1024-", 1024));
+
+  EXPECT_FALSE(tools::content_range_starts_at("bytes 0-2047/4096", 1024));
+  EXPECT_FALSE(tools::content_range_starts_at("bytes 10240-20479/40960", 1024));
+  EXPECT_FALSE(tools::content_range_starts_at("bytes=1024-2047/4096", 1024));
+  EXPECT_FALSE(tools::content_range_starts_at("", 1024));
+}


### PR DESCRIPTION
## Summary

- validate that a resumed download's `Content-Range` starts at the requested offset before keeping the partial file
- use the HTTP response format (`bytes <start>-...`) instead of treating any non-matching range header as valid
- add unit coverage for matching, mismatched, ambiguous-prefix, and nonstandard `Content-Range` values

## Tests

- `git diff --check`
- Not run: `unit_tests` (local environment does not have `cmake`, and the macOS command-line compiler toolchain fails before compilation)
