### PR TITLE
update rapidjson submodule

### DIFF
--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -42,6 +42,12 @@
 #include "transport.hpp"
 #include "messages/messages-common.pb.h"
 
+// https://github.com/Tencent/rapidjson/issues/1448
+#ifdef _WIN32
+#undef GetObject
+#endif
+#include <rapidjson/document.h>
+
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "device.trezor.transport"
 


### PR DESCRIPTION
Diff: https://github.com/Tencent/rapidjson/compare/129d19ba7f496df5e33658527a7158c79b99c21c...24b5e7a8b27f42fa16b96fc70aade9106cf7102f

Fixes:

```
/distsrc-base/build/distsrc-5904e14da484-arm64-apple-darwin/external/rapidjson/include/rapidjson/document.h:2057:25: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'Member' (aka 'GenericMember<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>') [-Wnontrivial-memcall]
 2057 |             std::memcpy(m, members, count * sizeof(Member));
      |                         ^
```

and related warnings when building with Clang 21+.