### PR TITLE
lmdb: mark Apple text_env section as code

### DIFF
--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -247,7 +247,7 @@ union semun {
 #ifdef __GNUC__
 /** Put infrequently used env functions in separate section */
 # ifdef __APPLE__
-#  define	ESECT	__attribute__ ((section("__TEXT,text_env")))
+#  define	ESECT	__attribute__ ((section("__TEXT,text_env,regular,pure_instructions")))
 # else
 #  define	ESECT	__attribute__ ((section("text_env")))
 # endif


### PR DESCRIPTION
```
ld: warning: symbols in __TEXT,text_env (/Users/selsta/dev/monero/build/Darwin/master/release/external/db_drivers/liblmdb/liblmdb.a[2](mdb.c.o)) have unwind information, but it's not a code section (missing 'regular,pure_instructions' section flag)
```

Fixes this warning on macOS.