### PR TITLE
fix spelling in comments and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ endfunction()
 option(RELINK_TARGETS "Relink targets, when just a dependant .so changed, but not its header?" OFF)
 function (monero_set_target_no_relink target)
   if (RELINK_TARGETS MATCHES OFF)
-    # Will not relink the target, when just its dependant .so has changed, but not it's interface
+    # Will not relink the target, when just its dependent .so has changed, but not its interface
     set_target_properties("${target}" PROPERTIES LINK_DEPENDS_NO_SHARED true)
   endif()
 endfunction()

--- a/CMakeLists_IOS.txt
+++ b/CMakeLists_IOS.txt
@@ -11,11 +11,11 @@
 #   SIMULATOR - used to build for the Simulator platforms, which have an x86 arch.
 #
 # CMAKE_IOS_DEVELOPER_ROOT = automatic(default) or /path/to/platform/Developer folder
-#   By default this location is automatcially chosen based on the IOS_PLATFORM value above.
+#   By default this location is automatically chosen based on the IOS_PLATFORM value above.
 #   If set manually, it will override the default location and force the user of a particular Developer Platform
 #
 # CMAKE_IOS_SDK_ROOT = automatic(default) or /path/to/platform/Developer/SDKs/SDK folder
-#   By default this location is automatcially chosen based on the CMAKE_IOS_DEVELOPER_ROOT value.
+#   By default this location is automatically chosen based on the CMAKE_IOS_DEVELOPER_ROOT value.
 #   In this case it will always be the most up-to-date SDK found in the CMAKE_IOS_DEVELOPER_ROOT path.
 #   If set manually, this will force the use of a specific SDK version
 
@@ -60,7 +60,7 @@ set (CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
 set (CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
 set (CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
 
-# Hidden visibilty is required for cxx on iOS 
+# Hidden visibility is required for cxx on iOS 
 set (CMAKE_C_FLAGS_INIT "")
 set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden")
 

--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -153,7 +153,7 @@ namespace epee
       put_unsafe(ch);
     }
 
-    /*! Copy `ch` to end of stream. Provides rapidjson compatability.
+    /*! Copy `ch` to end of stream. Provides rapidjson compatibility.
         \throw std::range_error if exceeding max `size_t` value.
         \throw std::bad_alloc if allocation fails. */
     void Put(const std::uint8_t ch)
@@ -194,21 +194,21 @@ namespace epee
     byte_buffer take_buffer() noexcept;
   };
 
-  //! Compatability/optimization for rapidjson.
+  //! Compatibility/optimization for rapidjson.
 
   inline void PutReserve(byte_stream& dest, const std::size_t length)
   {
     dest.reserve(length);
   }
 
-  //! Compatability/optimization for rapidjson.
+  //! Compatibility/optimization for rapidjson.
 
   inline void PutUnsafe(byte_stream& dest, const std::uint8_t ch)
   {
     dest.put_unsafe(ch);
   }
 
-  //! Compability/optimization for rapidjson.
+  //! Compatibility/optimization for rapidjson.
   inline void PutN(byte_stream& dest, const std::uint8_t ch, const std::size_t count)
   {
     dest.put_n(ch, count);

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -36,7 +36,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/* rfree: place for hanlers for the non-template base, can be used by connection<> template class in abstract_tcp_server2 file  */
+/* rfree: place for handlers for the non-template base, can be used by connection<> template class in abstract_tcp_server2 file  */
 
 #ifndef INCLUDED_p2p_connection_basic_hpp
 #define INCLUDED_p2p_connection_basic_hpp
@@ -105,7 +105,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
 
 		std::unique_ptr< connection_basic_pimpl > mI; // my Implementation
 
-		// moved here from orginal connecton<> - common member variables that do not depend on template in connection<>
+		// moved here from original connection<> - common member variables that do not depend on template in connection<>
     std::atomic<bool> m_want_close_connection;
     std::atomic<bool> m_was_shutdown;
     critical_section m_send_que_lock;

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -308,7 +308,7 @@ namespace net_utils
 				if (ndel != 0)
 				{
           //some times it could be that before query line cold be few line breaks
-          //so we have to be calm without panic with assers
+          //so we have to be calm without panic with asserts
 					m_newlines += std::string::npos == ndel ? m_cache.size() : ndel;
 					if (m_newlines > HTTP_MAX_STARTING_NEWLINES)
 					{
@@ -467,7 +467,7 @@ namespace net_utils
 		m_cache.erase(0, pos);
 
 		std::string req_command_str = m_query_info.m_full_request_str;
-    //if we have POST or PUT command, it is very possible tha we will get body
+    //if we have POST or PUT command, it is very possible that we will get body
     //but now, we suppose than we have body only in case of we have "ContentLength" 
 		if(m_query_info.m_header_info.m_content_length.size())
 		{

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -77,7 +77,7 @@ namespace epee
       m_net_server.get_config_object().m_phandler = static_cast<t_child_class*>(this);
       m_net_server.get_config_object().rng = std::move(rng);
 
-      //here set folder for hosting reqests
+      //here set folder for hosting requests
       m_net_server.get_config_object().m_folder = "";
 
       //set access control allow origins if configured

--- a/contrib/epee/include/net/levin_base.h
+++ b/contrib/epee/include/net/levin_base.h
@@ -160,7 +160,7 @@ constexpr const std::chrono::milliseconds LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED{0}
     byte_stream buffer;
   };
 
-  //! \return Intialized levin header.
+  //! \return Initialized levin header.
   bucket_head2 make_header(uint32_t command, uint64_t msg_size, uint32_t flags, bool expect_response) noexcept;
 
   /*! Generate a dummy levin message.

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -71,7 +71,7 @@ namespace net_utils
 
   /*!
     \note `verification != disabled && support == disabled` is currently
-      "allowed" via public interface but obviously invalid configuation.
+      "allowed" via public interface but obviously invalid configuration.
    */
   class ssl_options_t
   {

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -277,7 +277,7 @@ namespace net_utils
 		template<typename Type>
 		Type& as_mutable() const
 		{
-			// types `implmentation<Type>` and `implementation<const Type>` are unique
+			// types `implementation<Type>` and `implementation<const Type>` are unique
 			using Type_ = typename std::remove_const<Type>::type;
 			network_address::interface* const self_ = self.get(); // avoid clang warning in typeid
 			if (!self_ || typeid(implementation<Type_>) != typeid(*self_))

--- a/contrib/epee/include/net/network_throttle-detail.hpp
+++ b/contrib/epee/include/net/network_throttle-detail.hpp
@@ -1,6 +1,6 @@
 /// @file
 /// @author rfree (current maintainer in monero.cc project)
-/// @brief implementaion for throttling of connection (count and rate-limit speed etc)
+/// @brief implementation for throttling of connection (count and rate-limit speed etc)
 
 // Copyright (c) 2014-2024, The Monero Project
 // 
@@ -60,7 +60,7 @@ class network_throttle : public i_network_throttle {
 
 		const size_t m_window_size; // the number of samples to average over
 		network_time_seconds m_slot_size; // the size of one slot. TODO: now hardcoded for 1 second e.g. in time_to_slot()
-		// TODO for big window size, for performance better the substract on change of m_last_sample_time instead of recalculating average of eg >100 elements
+		// TODO for big window size, for performance better the subtract on change of m_last_sample_time instead of recalculating average of eg >100 elements
 
 		boost::circular_buffer< packet_info > m_history; // the history of bw usage
 		network_time_seconds m_last_sample_time; // time of last history[0] - so we know when to rotate the buffer

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -92,7 +92,7 @@ typedef calculate_times_struct calculate_times_struct;
 
 
 /*** 
-@brief Access to simple throttles, with singlton to access global network limits
+@brief Access to simple throttles, with singleton to access global network limits
 */
 class network_throttle_manager {
 	// provides global (singleton) in/inreq/out throttle access
@@ -134,7 +134,7 @@ class i_network_throttle {
 		// time calculations:
 		
 		virtual void calculate_times(size_t packet_size, calculate_times_struct &cts, bool dbg, double force_window) const =0; // assuming sending new package (or 0), calculate:
-		// Average, Window, Delay, Recommended data size ; also gets dbg=debug flag, and forced widnow size if >0 or -1 for not forcing window size 
+		// Average, Window, Delay, Recommended data size ; also gets dbg=debug flag, and forced window size if >0 or -1 for not forcing window size
 
 		// Average speed, Window size, recommended Delay to sleep now, Recommended size of data to send now
 

--- a/contrib/epee/include/serialization/wire/field.h
+++ b/contrib/epee/include/serialization/wire/field.h
@@ -58,7 +58,7 @@ namespace wire
     automatically be converted to an optional field iff `value_type` has an
     `empty()` method that returns `true`. The old output engine omitted fields
     when an array was empty, and the standard input macro would ignore the
-    `false` return for the missing field. For compability reasons, the
+    `false` return for the missing field. For compatibility reasons, the
     input/output engine here matches that behavior. See `wrapper/array.h` to
     enforce a required field even when the array is empty or specialize the
     `is_optional_on_empty` trait. Only new fields should use this behavior.

--- a/contrib/epee/src/network_throttle-detail.cpp
+++ b/contrib/epee/src/network_throttle-detail.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @author rfree (current maintainer in monero.cc project)
-/// @brief implementaion for throttling of connection (count and rate-limit speed etc)
+/// @brief implementation for throttling of connection (count and rate-limit speed etc)
 
 // Copyright (c) 2014-2024, The Monero Project
 // 
@@ -64,7 +64,7 @@
 
 // ################################################################################################
 // ################################################################################################
-// the "header part". Not separeted out for .hpp because point of this modification is 
+// the "header part". Not separated out for .hpp because point of this modification is
 // to rebuild just 1 translation unit while working on this code.
 // (But maybe common parts will be separated out later though - if needed)
 // ################################################################################################

--- a/docs/ANONYMITY_NETWORKS.md
+++ b/docs/ANONYMITY_NETWORKS.md
@@ -56,7 +56,7 @@ You can also combine `--proxy` with `--tx-proxy` (see below).
 
 ### Hidden Services
 
-Hidden services - onion and I2P domains - are available to use for transation broadcasts.
+Hidden services - onion and I2P domains - are available to use for transaction broadcasts.
 You may use the below options with or without `--proxy`.
 
 #### Outbound Connections
@@ -318,7 +318,7 @@ persistent public key identity - the creation of a new circuit will generate
 a new public key identity. The lock time on a change address is ~20 minutes, so
 `monerod` will have rotated its selected outgoing connections several times in
 most cases. However, the number of outgoing connections is typically a small
-fixed number, so there is a decent probability of re-use with the same public
+fixed number, so there is a decent probability of reuse with the same public
 key identity.
 
 @secparam ([Twitter](https://twitter.com/secparam/status/1153411968147042304)) recommended changing circuits (Tor) as an additional

--- a/docs/PORTABLE_STORAGE.md
+++ b/docs/PORTABLE_STORAGE.md
@@ -97,7 +97,7 @@ Which is followed by the section's name-value [entries](#Entry) sequentially:
 | Name              | section key           |
 | Type              | byte                  |
 | Count<sup>1</sup> | varint                |
-| Value(s)          | (type dependant data) |
+| Value(s)          | (type-dependent data) |
 
 <sup>1</sup> Note, this is only present if the entry type has the array flag
 (see below).

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -1820,7 +1820,7 @@ class Configurations : public base::utils::RegistryWithPred<Configuration, Confi
   ///
   /// @detail Any existing configuration for specified level will be replaced. Also note that configuration types
   /// ConfigurationType::SubsecondPrecision and ConfigurationType::PerformanceTracking will be ignored if not set for
-  /// Level::Global because these configurations are not dependant on level.
+  /// Level::Global because these configurations are not dependent on level.
   /// @param level Level to set configuration for (el::Level).
   /// @param configurationType Type of configuration (el::ConfigurationType)
   /// @param value A string based value. Regardless of what the data type of configuration is, it will always be string

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -711,7 +711,7 @@ public:
    *
    * @param folder    The path of the folder containing the database file(s) which must not end with slash '/'.
    *
-   * @return          true if the operation is succesfull
+   * @return          true if the operation is successful
    */
   virtual bool remove_data_file(const std::string& folder) const = 0;
 
@@ -939,7 +939,7 @@ public:
   /**
    * @brief fetch a block's cumulative number of rct outputs
    *
-   * The subclass should return the numer of rct outputs in the blockchain
+   * The subclass should return the number of rct outputs in the blockchain
    * up to the block with the given height (inclusive).
    *
    * If the block does not exist, the subclass should throw BLOCK_DNE
@@ -1546,14 +1546,14 @@ public:
   /**
    * @brief remove a txpool transaction
    *
-   * @param txid the transaction id of the transation to remove
+   * @param txid the transaction id of the transaction to remove
    */
   virtual void remove_txpool_tx(const crypto::hash& txid) = 0;
 
   /**
    * @brief get a txpool transaction's metadata
    *
-   * @param txid the transaction id of the transation to lookup
+   * @param txid the transaction id of the transaction to lookup
    * @param meta the metadata to return
    *
    * @return true if the tx meta was found, false otherwise
@@ -1563,7 +1563,7 @@ public:
   /**
    * @brief get a txpool transaction's blob
    *
-   * @param txid the transaction id of the transation to lookup
+   * @param txid the transaction id of the transaction to lookup
    * @param bd the blob to return
    * @param tx_category for filtering out hidden/private txes
    *
@@ -1574,7 +1574,7 @@ public:
   /**
    * @brief get a txpool transaction's blob
    *
-   * @param txid the transaction id of the transation to lookup
+   * @param txid the transaction id of the transaction to lookup
    *
    * @return the blob for that transaction
    */

--- a/src/blockchain_utilities/blockchain-stats-readme.md
+++ b/src/blockchain_utilities/blockchain-stats-readme.md
@@ -1,6 +1,6 @@
 # Monero Blockchain Stats
 
-Monero Blockchain Stats utlity exports daily statistics for the monero blockchain from creation through current state.
+Monero Blockchain Stats utility exports daily statistics for the monero blockchain from creation through current state.
 
 ## Usage:
 

--- a/src/common/expect.h
+++ b/src/common/expect.h
@@ -372,7 +372,7 @@ public:
     //! \return True if `this` is storing an error instead of a value.
     bool has_error() const noexcept { return bool(code_); }
 
-    //! \return Error - alway
+    //! \return Error - always
     std::error_code error() const noexcept { return code_; }
 
     //! \return `error() == rhs.error()`.

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -146,7 +146,7 @@ namespace tools
 
   /*! \brief creates directories for a path
    *
-   *  wrapper around boost::filesyste::create_directories.  
+   *  wrapper around boost::filesystem::create_directories.  
    *  (ensure-directory-exists): greenspun's tenth rule in action!
    */
   bool create_directories_if_necessary(const std::string& path);
@@ -214,7 +214,7 @@ namespace tools
     }
 #endif
 
-    /*! \brief calles m_handler */
+    /*! \brief calls m_handler */
     static void handle_signal(int type)
     {
       static boost::mutex m_mutex;

--- a/src/common/va_args.h
+++ b/src/common/va_args.h
@@ -29,7 +29,7 @@
 #pragma once
 
 // Check for __VA_OPT__ support
-// Apdated from cpplearner's StackOverflow answer: https://stackoverflow.com/a/48045656
+// Adapted from cpplearner's StackOverflow answer: https://stackoverflow.com/a/48045656
 #define PP_THIRD_ARG(a,b,c,...) c
 #define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),true,false,)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)

--- a/src/common/varint.h
+++ b/src/common/varint.h
@@ -39,7 +39,7 @@
  * \brief provides the implementation of varint's
  * 
  * The representation of varints is rather odd. The first bit of each
- * octet is significant, it represents wheter there is another part
+ * octet is significant, it represents whether there is another part
  * waiting to be read. For example 0x8002 would return 0x200, even
  * though 0x02 does not have its msb set. The actual way they are read
  * is as follows: Strip the msb of each byte, then from left to right,
@@ -57,7 +57,7 @@ namespace tools {
   enum {
     /* \brief Represents the overflow error */
     EVARINT_OVERFLOW = -1,
-    /* \brief Represents a non conical represnetation */
+    /* \brief Represents a non-canonical representation */
     EVARINT_REPRESENT = -2,
   };
 

--- a/src/crypto/jh.c
+++ b/src/crypto/jh.c
@@ -242,7 +242,7 @@ static HashReturn Init(hashState *state, int hashbitlen)
       /*initialize the initial hash value of JH*/
       state->hashbitlen = hashbitlen;
 
-      /*load the intital hash value into state*/
+      /*load the initial hash value into state*/
       switch (hashbitlen)
       {
             case 224: memcpy(state->x,JH224_H0,128); break;

--- a/src/crypto/skein_port.h
+++ b/src/crypto/skein_port.h
@@ -76,7 +76,7 @@
                                 multiple of size / 8)
 
     ptr_cast(x,size)            casts a pointer to a pointer to a 
-                                varaiable of length 'size' bits
+                                variable of length 'size' bits
 */
 
 #define ui_type(size)               uint##size##_t

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -123,7 +123,7 @@ namespace cryptonote {
    * The comparison essentially goes from the 31th, 30th, 29th, ..., 0th byte and compares the MSBs
    * to the LSBs in each byte, up to `nbits` bits. If we use up `nbits` bits before finding a
    * difference in the bits between the two hashes, we return 0. If we encounter a zero bit in `ha`
-   * where `hb` has a one in that bit place, then we reutrn -1. If the converse scenario happens,
+   * where `hb` has a one in that bit place, then we return -1. If the converse scenario happens,
    * we return a 1. When `nbits` == 256 (there are 256 bits in `crypto::hash`), calling this is
    * functionally identical to `BlockchainLMDB::compare_hash32`.
    *
@@ -137,7 +137,7 @@ namespace cryptonote {
   /**
    * @brief Make a template which matches `h` in LMDB order up to `nbits` bits, safe for k-anonymous fetching
    *
-   * To be more technical, this function creates a hash which satifies the following property:
+   * To be more technical, this function creates a hash which satisfies the following property:
    *     For all `H_prime` s.t. `0 == compare_hash32_reversed_nbits(real_hash, H_prime, nbits)`,
    *     `1 > compare_hash32_reversed_nbits(real_hash, H_prime, 256)`.
    * In other words, we return the "least" hash nbit-equal to `real_hash`.

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -710,7 +710,7 @@ namespace cryptonote
         // this should take care of the case where mining is started with bg-enabled, 
         // and then the user decides to un-check background mining, and just do
         // regular full-speed mining. I might just be over-doing it and thinking up 
-        // non-existant use-cases, so if the consensus is to simplify, we can remove all this fluff.
+        // non-existent use-cases, so if the consensus is to simplify, we can remove all this fluff.
         /*
         while( !m_is_background_mining_enabled )
         {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -697,7 +697,7 @@ block Blockchain::pop_block_from_blockchain()
       // as a whole. However, if we had mined that block, that might not be always true. Unlikely
       // though, and always relaying these again might cause a spike of traffic as many nodes
       // re-relay all the transactions in a popped block when a reorg happens. You might notice that
-      // we also set the "nic_verified_hf_version" paramater. Since we know we took this transaction
+      // we also set the "nic_verified_hf_version" parameter. Since we know we took this transaction
       // from the mempool earlier in this function call, when the mempool has the same current fork
       // version, we can return it without re-verifying the consensus rules on it.
       const bool r = m_tx_pool.add_tx(tx, tvc, relay_method::block, true, version, version, valid_input_verification_id);
@@ -2313,7 +2313,7 @@ uint64_t Blockchain::get_num_mature_outputs(uint64_t amount) const
 {
   uint64_t num_outs = m_db->get_num_outputs(amount);
   // ensure we don't include outputs that aren't yet eligible to be used
-  // outpouts are sorted by height
+  // outputs are sorted by height
   const uint64_t blockchain_height = m_db->height();
   while (num_outs > 0)
   {
@@ -3836,7 +3836,7 @@ bool Blockchain::check_block_timestamp(std::vector<uint64_t>& timestamps, const 
 //------------------------------------------------------------------
 // This function grabs the timestamps from the most recent <n> blocks,
 // where n = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW.  If there are not those many
-// blocks in the blockchain, the timestap is assumed to be valid.  If there
+// blocks in the blockchain, the timestamp is assumed to be valid.  If there
 // are, this function returns:
 //   true if the block's timestamp is not less than the timestamp of the
 //       median of the selected blocks
@@ -4102,7 +4102,7 @@ leave:
       // as a whole. However, if we had mined that block, that might not be always true. Unlikely
       // though, and always relaying these again might cause a spike of traffic as many nodes
       // re-relay all the transactions in a popped block when a reorg happens. You might notice that
-      // we also set the "nic_verified_hf_version" paramater. Since we know we took this transaction
+      // we also set the "nic_verified_hf_version" parameter. Since we know we took this transaction
       // from the mempool earlier in this function call, when the mempool has the same current fork
       // version, we can return it without re-verifying the consensus rules on it.
       cryptonote::tx_verification_context tvc{};

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -584,7 +584,7 @@ namespace cryptonote
     /**
      * @brief gets per block distribution of outputs of a given amount
      *
-     * @param amount the amount to get a ditribution for
+     * @param amount the amount to get a distribution for
      * @param from_height the height before which we do not care about the data
      * @param to_height the height after which we do not care about the data
      * @param return-by-reference start_height the height of the first rct output
@@ -600,7 +600,7 @@ namespace cryptonote
      * to a specific transaction.
      *
      * @param tx_id the hash of the transaction to fetch indices for
-     * @param indexs return-by-reference the global indices for the transaction's outputs
+     * @param indices return-by-reference the global indices for the transaction's outputs
      * @param n_txes how many txes in a row to get results for
      *
      * @return false if the transaction does not exist, or if no indices are found, otherwise true
@@ -1567,7 +1567,7 @@ namespace cryptonote
      *
      * This function grabs the timestamps from the most recent <n> blocks,
      * where n = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW.  If there are not those many
-     * blocks in the blockchain, the timestap is assumed to be valid.  If there
+     * blocks in the blockchain, the timestamp is assumed to be valid.  If there
      * are, this function returns:
      *   true if the block's timestamp is not less than the timestamp of the
      *       median of the selected blocks

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -479,7 +479,7 @@ namespace cryptonote
      /**
       * @brief set whether or not to enable or disable DNS checkpoints
       *
-      * @param disble whether to disable DNS checkpoints
+      * @param disable whether to disable DNS checkpoints
       */
      void disable_dns_checkpoints(bool disable = true) { m_disable_dns_checkpoints = disable; }
 
@@ -1081,7 +1081,7 @@ namespace cryptonote
 
      epee::critical_section m_incoming_tx_lock; //!< incoming transaction lock
 
-     //m_miner and m_miner_addres are probably temporary here
+     //m_miner and m_miner_address are probably temporary here
      miner m_miner; //!< miner instance
 
      std::string m_config_folder; //!< folder to look in for configs and other files

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -79,7 +79,7 @@ namespace cryptonote
 
         This value was calculated with k=5, ep=0.10, and hop = 175 ms. A
         testrun from a recent Intel laptop took ~80ms to
-        receive+parse+proces+send transaction. At least 50ms will be added to
+        receive+parse+process+send transaction. At least 50ms will be added to
         the latency if crossing an ocean. So 175ms is the fudge factor for
         a single hop with 39s being the embargo timer. */
     constexpr const std::chrono::seconds dandelionpp_embargo_average{CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE};
@@ -1865,7 +1865,7 @@ namespace cryptonote
 
     // Simple system to make sure the list of removed ids does not swell to an unmanageable size: Set
     // an absolute size limit plus delete entries that are x minutes old (which is ok because clients
-    // will sync with sensible time intervalls and should not ask for incremental info e.g. 1 hour back)
+    // will sync with sensible time intervals and should not ask for incremental info e.g. 1 hour back)
     const int MAX_REMOVED = 20000;
     if (m_removed_txs_by_time.size() > MAX_REMOVED)
     {

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -207,7 +207,7 @@ static bool tx_ver_legacy_ring_sigs(transaction& tx, const rct::ctkeyM& mix_ring
         }
     };
 
-    // Multi-thread calls to check_ring_signature_job() for each input if available, else iterate on ths thread
+    // Multi-thread calls to check_ring_signature_job() for each input if available, else iterate on this thread
     tools::threadpool& tpool = tools::threadpool::getInstanceForCompute();
     const int threads = tpool.get_max_concurrency();
     const bool multi_threaded = threads > 1;
@@ -375,7 +375,7 @@ crypto::hash make_input_verification_id(const crypto::hash &tx_hash, const rct::
 {
     std::stringstream ss;
 
-    // Start with domain seperation
+    // Start with domain separation
     ss << config::HASH_KEY_TXHASH_AND_MIXRING;
 
     // Then add TX hash

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -108,7 +108,7 @@ namespace levin
     //! Run the logic for the next epoch immediately. Only use in testing.
     void run_epoch();
 
-    //! Run the logic for the next stem timeout imemdiately. Only use in  testing.
+    //! Run the logic for the next stem timeout immediately. Only use in testing.
     void run_stems();
 
     //! Run the logic for flushing all Dandelion++ fluff queued txs. Only use in testing.

--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -31,7 +31,7 @@ void fork(const std::string & pidfile)
 {
   // If a PID file is specified, we open the file here, because
   // we can't report errors after the fork operation.
-  // When we fork, we close thise file in each of the parent
+  // When we fork, we close this file in each of the parent
   // processes.
   // Only in the final child process do we write the PID to the
   // file (and close it).

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -61,7 +61,7 @@ namespace cryptonote
 
 namespace hw {
     namespace {
-        //device funcion not supported
+        //device function not supported
         #define dfns()  \
            throw std::runtime_error(std::string("device function not supported: ")+ std::string(__FUNCTION__) + \
                                     std::string(" (device.hpp line ")+std::to_string(__LINE__)+std::string(").")); \

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -203,7 +203,7 @@ namespace trezor {
       }
 
       /**
-       * Utility method to set address_n and network type to the message requets.
+       * Utility method to set address_n and network type to the message requests.
        */
       template<class t_message>
       void set_msg_addr(t_message * msg,

--- a/src/device_trezor/trezor/protob/messages-management.proto
+++ b/src/device_trezor/trezor/protob/messages-management.proto
@@ -143,7 +143,7 @@ message SetBusy {
 }
 
 /**
- * Request: end the current sesson. Following actions must call Initialize again.
+ * Request: end the current session. Following actions must call Initialize again.
  * Cache for the current session is discarded, other sessions remain intact.
  * Device is not PIN-locked.
  * @start

--- a/src/lmdb/util.h
+++ b/src/lmdb/util.h
@@ -69,7 +69,7 @@ namespace lmdb
         Get the native type for enums, or return `T` unchanged. Useful for
         merging generated machine code for templated functions that use enums
         with identical size-widths without relying on aggressive identical
-        comdat folding (ICF) support in linker. So with enum defintion
+        comdat folding (ICF) support in linker. So with enum definition
         `enum class enum_foo : unsigned long {};` will always yield
         `assert(&func_foo<unsigned long> == &func_foo<native_type<enum_foo>>)`.
     */

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -81,7 +81,7 @@ namespace
 
   /*!
    * \brief Finds the word list that contains the seed words and puts the indices
-   *        where matches occured in matched_indices.
+   *        where matches occurred in matched_indices.
    * \param  seed            List of words to match.
    * \param  has_checksum    The seed has a checksum word (maybe not checked).
    * \param  matched_indices The indices where the seed words were found are added to this.

--- a/src/multisig/multisig_account.h
+++ b/src/multisig/multisig_account.h
@@ -203,7 +203,7 @@ namespace multisig
     *
     *    - For example, in 2-of-3 escrowed purchasing, the [vendor, arbitrator] pair can boost the second round
     *      of key exchange by calling this function with the 'round 1' messages of each other.
-    *      Then the [buyer] can use the resulting boost messages, in combination with [vender, arbitrator] round 1 messages,
+    *      Then the [buyer] can use the resulting boost messages, in combination with [vendor, arbitrator] round 1 messages,
     *      to complete the address in one step. In other words, call initialize_kex() on the round 1 messages,
     *      then call kex_update() on the round 2 booster messages to finish the multisig key.
     * 

--- a/src/net/i2p_address.cpp
+++ b/src/net/i2p_address.cpp
@@ -127,7 +127,7 @@ namespace net
 
     bool i2p_address::store(epee::serialization::portable_storage& dest, epee::serialization::section* hparent) const
     {
-        // Set port to 1 for backwards compatability; zero is invalid port
+        // Set port to 1 for backwards compatibility; zero is invalid port
         const i2p_serialized out{std::string{host_}, 1};
         return out.store(dest, hparent);
     }

--- a/src/net/zmq.h
+++ b/src/net/zmq.h
@@ -67,7 +67,7 @@ namespace zmq
     //! \return Category for ZMQ errors.
     const std::error_category& error_category() noexcept;
 
-    //! \return `code` (usally from zmq_errno()`) using `net::zmq::error_category()`.
+    //! \return `code` (usually from zmq_errno()`) using `net::zmq::error_category()`.
     inline std::error_code make_error_code(int code) noexcept
     {
         return std::error_code{code, error_category()};
@@ -111,7 +111,7 @@ namespace zmq
       values less than 0 on error.
 
       \param op The ZMQ function to execute + retry
-      \param args Forwarded to `op`. Must be resuable in case of retry.
+      \param args Forwarded to `op`. Must be reusable in case of retry.
       \return All errors except for `EINTR`. */
     template<typename F, typename... T>
     expect<void> retry_op(F op, T&&... args) noexcept(noexcept(op(args...)))
@@ -175,7 +175,7 @@ namespace zmq
         \param socket Handle created with `zmq_socket`.
         \param flags See `zmq_msg_send` for possible flags.
 
-        \post `payload.emtpy()` - ownership is transferred to zmq.
+        \post `payload.empty()` - ownership is transferred to zmq.
         \return `success()` if sent, otherwise ZMQ error. */
     expect<void> send(epee::byte_slice&& payload, void* socket, int flags = 0) noexcept;
 } // zmq

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -98,7 +98,7 @@ namespace nodetool
   boost::optional<std::vector<proxy>> get_proxies(const boost::program_options::variables_map& vm);
   boost::optional<std::vector<anonymous_inbound>> get_anonymous_inbounds(const boost::program_options::variables_map& vm);
 
-  //! \return True if `commnd` is filtered (ignored/dropped) for `address`
+  //! \return True if `command` is filtered (ignored/dropped) for `address`
   bool is_filtered_command(epee::net_utils::network_address const& address, int command);
 
   // hides boost::future and chrono stuff from mondo template file

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1590,7 +1590,7 @@ namespace nodetool
 
     std::set<uint64_t> tried_peers;  // all peers ever tried
 
-    // Outer try loop, with up to 3 attempts to actually connect to a suitable randomly choosen candidate
+    // Outer try loop, with up to 3 attempts to actually connect to a suitable randomly chosen candidate
     size_t outer_loop_count = 0;
     while ((outer_loop_count < 3) && !zone.m_net_server.is_stop_signal_sent())
     {

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -164,7 +164,7 @@ namespace nodetool
     typedef boost::multi_index_container<
       peerlist_entry,
       boost::multi_index::indexed_by<
-      // access by peerlist_entry::net_adress
+      // access by peerlist_entry::net_address
       boost::multi_index::ordered_unique<boost::multi_index::tag<by_addr>, boost::multi_index::member<peerlist_entry,epee::net_utils::network_address,&peerlist_entry::adr> >,
       // sort by peerlist_entry::last_seen<
       boost::multi_index::ordered_non_unique<boost::multi_index::tag<by_time>, boost::multi_index::member<peerlist_entry,int64_t,&peerlist_entry::last_seen> >
@@ -174,7 +174,7 @@ namespace nodetool
     typedef boost::multi_index_container<
       anchor_peerlist_entry,
       boost::multi_index::indexed_by<
-      // access by anchor_peerlist_entry::net_adress
+      // access by anchor_peerlist_entry::net_address
       boost::multi_index::ordered_unique<boost::multi_index::tag<by_addr>, boost::multi_index::member<anchor_peerlist_entry,epee::net_utils::network_address,&anchor_peerlist_entry::adr> >,
       // sort by anchor_peerlist_entry::first_seen
       boost::multi_index::ordered_non_unique<boost::multi_index::tag<by_time>, boost::multi_index::member<anchor_peerlist_entry,int64_t,&anchor_peerlist_entry::first_seen> >

--- a/src/ringct/bulletproofs_plus.cc
+++ b/src/ringct/bulletproofs_plus.cc
@@ -547,7 +547,7 @@ namespace rct
         // This offset is applied to other group elements as well;
         //  it allows us to apply a multiply-by-8 operation in the verifier efficiently
         //  to ensure that the resulting group elements are in the prime-order point subgroup
-        //  and avoid much more constly multiply-by-group-order operations.
+        //  and avoid much more costly multiply-by-group-order operations.
         for (size_t i = 0; i < sv.size(); ++i)
         {
             rct::key gamma8, sv8;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -686,7 +686,7 @@ namespace rct {
     //   the last row is the sum of input commitments from that column - sum output commitments
     //   this shows that sum inputs = sum outputs
     //Ver:    
-    //   verifies the above sig is created corretly
+    //   verifies the above sig is created correctly
     mgSig proveRctMG(const key &message, const ctkeyM & pubs, const ctkeyV & inSk, const ctkeyV &outSk, const ctkeyV & outPk, unsigned int index, const key &txnFeeKey, hw::device &hwdev) {
         //setup vars
         size_t cols = pubs.size();
@@ -801,7 +801,7 @@ namespace rct {
     //   the last row is the sum of input commitments from that column - sum output commitments
     //   this shows that sum inputs = sum outputs
     //Ver:    
-    //   verifies the above sig is created corretly
+    //   verifies the above sig is created correctly
     bool verRctMG(const mgSig &mg, const ctkeyM & pubs, const ctkeyV & outPk, const key &txnFeeKey, const key &message) {
         PERF_TIMER(verRctMG);
         //setup vars

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -99,7 +99,7 @@ namespace rct {
     //   the last row is the sum of input commitments from that column - sum output commitments
     //   this shows that sum inputs = sum outputs
     //Ver:
-    //   verifies the above sig is created corretly
+    //   verifies the above sig is created correctly
     mgSig proveRctMG(const ctkeyM & pubs, const ctkeyV & inSk, const keyV &outMasks, const ctkeyV & outPk, unsigned int index, const key &txnFee, const key &message, hw::device &hwdev);
     mgSig proveRctMGSimple(const key & message, const ctkeyV & pubs, const ctkey & inSk, const key &a , const key &Cout, unsigned int index, hw::device &hwdev);
     bool verRctMG(const mgSig &mg, const ctkeyM & pubs, const ctkeyV & outPk, const key &txnFee, const key &message);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -360,7 +360,7 @@ namespace cryptonote
     if (store_ssl_key)
     {
       // .key files are often given different read permissions as their corresponding .crt files.
-      // Consequently, sometimes the .key file wont't get copied, while the .crt file will.
+      // Consequently, sometimes the .key file won't get copied, while the .crt file will.
       if (ssl_cert_file_exists != ssl_pkey_file_exists)
       {
         MFATAL("Certificate (.crt) and private key (.key) files must both exist or both not exist at path: " << ssl_base_path);

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -56,7 +56,7 @@ DISABLE_VS_WARNINGS(4244)
  * \brief base for the binary archive type
  * 
  * \detailed It isn't used outside of this file, which its only
- * purpse is to define the functions used for the binary_archive. Its
+ * purpose is to define the functions used for the binary_archive. Its
  * a header, basically. I think it was declared simply to save typing...
  */
 template <bool IsSaving>

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -208,7 +208,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", burnt: " << print_money(burnt)
                      << ", raw_output_value: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not syncronized completely
+        // do not signal on received tx if wallet is not synchronized completely
         if (m_listener && m_wallet->synchronized()) {
             m_listener->moneyReceived(tx_hash, amount - burnt);
             m_listener->updated();
@@ -224,7 +224,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not syncronized completely
+        // do not signal on received tx if wallet is not synchronized completely
         if (m_listener && m_wallet->synchronized()) {
             m_listener->unconfirmedMoneyReceived(tx_hash, amount);
             m_listener->updated();
@@ -240,7 +240,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on sent tx if wallet is not syncronized completely
+        // do not signal on sent tx if wallet is not synchronized completely
         if (m_listener && m_wallet->synchronized()) {
             m_listener->moneySpent(tx_hash, amount);
             m_listener->updated();
@@ -1069,7 +1069,7 @@ bool WalletImpl::synchronized() const
 bool WalletImpl::refresh()
 {
     clearStatus();
-    //TODO: make doRefresh return bool to know whether the error occured during refresh or not
+    //TODO: make doRefresh return bool to know whether the error occurred during refresh or not
     //otherwise one may try, say, to send transaction, transfer fails and this method returns false
     doRefresh();
     return status() == Status_Ok;
@@ -1608,7 +1608,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
 }
 
 // TODO:
-// 1 - properly handle payment id (add another menthod with explicit 'payment_id' param)
+// 1 - properly handle payment id (add another method with explicit 'payment_id' param)
 // 2 - check / design how "Transaction" can be single interface
 // (instead of few different data structures within wallet2 implementation:
 //    - pending_tx;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -88,7 +88,7 @@ struct PendingTransaction
     virtual uint64_t fee() const = 0;
     virtual std::vector<std::string> txid() const = 0;
     /*!
-     * \brief txCount - number of transactions current transaction will be splitted to
+     * \brief txCount - number of transactions current transaction will be split into
      * \return
      */
     virtual uint64_t txCount() const = 0;
@@ -143,7 +143,7 @@ struct UnsignedTransaction
     virtual std::vector<std::string> recipientAddress() const = 0;
     virtual uint64_t minMixinCount() const = 0;
     /*!
-     * \brief txCount - number of transactions current transaction will be splitted to
+     * \brief txCount - number of transactions current transaction will be split into
      * \return
      */
     virtual uint64_t txCount() const = 0;
@@ -368,7 +368,7 @@ struct WalletListener
     virtual void newBlock(uint64_t height) = 0;
 
     /**
-     * @brief updated  - generic callback, called when any event (sent/received/block reveived/etc) happened with the wallet;
+     * @brief updated  - generic callback, called when any event (sent/received/block received/etc) happened with the wallet;
      */
     virtual void updated() = 0;
 
@@ -586,8 +586,8 @@ struct Wallet
     /*!
      * \brief setSubaddressLookahead - set size of subaddress lookahead
      *
-     * \param major - size fot the major index
-     * \param minor - size fot the minor index
+     * \param major - size for the major index
+     * \param minor - size for the minor index
      */
     virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
 
@@ -811,7 +811,7 @@ struct Wallet
     virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) = 0;
     /**
      * @brief exportMultisigImages - exports transfers' key images
-     * @param images - output paramter for hex encoded array of images
+     * @param images - output parameter for hex encoded array of images
      * @return true if success
      */
     virtual bool exportMultisigImages(std::string& images) = 0;

--- a/src/wallet/message_store.h
+++ b/src/wallet/message_store.h
@@ -208,7 +208,7 @@ namespace mms
     END_SERIALIZE()
   };
 
-  // Overal .mms file structure, with the "message_store" object serialized to and
+  // Overall .mms file structure, with the "message_store" object serialized to and
   // encrypted in "encrypted_data"
   struct file_data
   {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -988,7 +988,7 @@ bool get_pruned_tx(const cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry &entry,
     }
     else
     {
-      // for v1, we trust the dameon
+      // for v1, we trust the daemon
       CHECK_AND_ASSERT_MES(epee::string_tools::hex_to_pod(entry.tx_hash, tx_hash), false, "Failed to parse tx hash");
     }
     return true;
@@ -2258,7 +2258,7 @@ void wallet2::cache_tx_data(const cryptonote::transaction& tx, const crypto::has
       return;
   }
 
-  // Don't try to extract tx public key if tx has no ouputs
+  // Don't try to extract tx public key if tx has no outputs
   const bool is_miner = tx.vin.size() == 1 && tx.vin[0].type() == typeid(cryptonote::txin_gen);
   if (!is_miner || m_refresh_type != RefreshType::RefreshNoCoinbase)
   {
@@ -2325,7 +2325,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   const std::vector<tx_extra_field> &tx_extra_fields = tx_cache_data.tx_extra_fields.empty() ? local_tx_extra_fields : tx_cache_data.tx_extra_fields;
   crypto::hash payment_id = crypto::null_hash;
 
-  // Don't try to extract tx public key if tx has no ouputs
+  // Don't try to extract tx public key if tx has no outputs
   size_t pk_index = 0;
   std::vector<tx_scan_info_t> tx_scan_info(tx.vout.size());
   std::deque<bool> output_found(tx.vout.size(), false);
@@ -3590,7 +3590,7 @@ void wallet2::remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashe
 
 //----------------------------------------------------------------------------------------------------
 // Code that is common to 'update_pool_state_by_pool_query' and 'update_pool_state_from_pool_data':
-// Check wether a tx in the pool is worthy of processing because we did not see it
+// Check whether a tx in the pool is worthy of processing because we did not see it
 // yet or because it is "interesting" out of special circumstances
 bool wallet2::accept_pool_tx_for_processing(const crypto::hash &txid)
 {
@@ -9883,7 +9883,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
     // note: The oldest unspent owned output's multisig info (in m_transfers) will contain the most recent result of
     //       'import_multisig()', which means only 'fresh' multisig infos (public nonces) will be used to make tx attempts.
     //       - If a signer's info was missing from the latest call to 'import_multisig()', then they won't be able to participate!
-    //       - If a newly-acquired output doesn't have enouch nonces from multisig infos, then it can't be spent!
+    //       - If a newly-acquired output doesn't have enough nonces from multisig infos, then it can't be spent!
     for (const crypto::public_key &signer: m_multisig_signers)
     {
       if (signer == local_signer)
@@ -11045,7 +11045,7 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
     error::wallet_internal_error, "feature subtractfeefrom not supported for split transactions");
 
   // For destinations from where the fee is subtracted, the required amount has to be at least
-  // target amount - (tx fee / num_subtractable + 1). +1 since fee might not be evenly divisble by
+  // target amount - (tx fee / num_subtractable + 1). +1 since fee might not be evenly divisible by
   // the number of subtractble destinations. For non-subtractable destinations, we need at least
   // the target amount.
   const size_t num_subtractable_dests = subtract_fee_from_outputs.size();
@@ -12725,7 +12725,7 @@ bool wallet2::check_reserve_proof(const cryptonote::account_public_address &addr
     THROW_WALLET_EXCEPTION_IF(tx_pub_key == crypto::null_pkey, error::wallet_internal_error, "The tx public key isn't found");
     const std::vector<crypto::public_key> additional_tx_pub_keys = get_additional_tx_pub_keys_from_extra(tx);
 
-    // check singature for shared secret
+    // check signature for shared secret
     ok = crypto::check_tx_proof(prefix_hash, address.m_view_public_key, tx_pub_key, boost::none, proof.shared_secret, proof.shared_secret_sig, version);
     if (!ok && additional_tx_pub_keys.size() == tx.vout.size())
       ok = crypto::check_tx_proof(prefix_hash, address.m_view_public_key, additional_tx_pub_keys[proof.index_in_tx], boost::none, proof.shared_secret, proof.shared_secret_sig, version);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -678,7 +678,7 @@ private:
     };
 
     // The term "Unsigned tx" is not really a tx since it's not signed yet.
-    // It doesnt have tx hash, key and the integrated address is not separated into addr + payment id.
+    // It doesn't have tx hash, key and the integrated address is not separated into addr + payment id.
     struct unsigned_tx_set
     {
       std::vector<tx_construction_data> txes;

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -47,7 +47,7 @@ namespace wallet_args
 
   \return
     pair.first: The list of parsed options, iff there are no errors.
-    pair.second: Should the execution terminate succesfully without actually launching the application
+    pair.second: Should the execution terminate successfully without actually launching the application
   */
   std::pair<boost::optional<boost::program_options::variables_map>, bool> main(
     int argc, char** argv,

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -272,7 +272,7 @@ namespace tools
         if (over_one_refresh_period_passed)
         {
           // auto_refresh_interval_ms of straight-blasting through blocks has elapsed without end.
-          // Let's freee up the network thread for between 200ms to 300ms (non-deterministic) to handle other requests.
+          // Let's free up the network thread for between 200ms to 300ms (non-deterministic) to handle other requests.
           const auto refresh_throttle = auto_refresh_evaluation_ms + std::chrono::milliseconds(100);
           m_last_auto_refresh_time = end - auto_refresh_interval_ms + refresh_throttle;
           LOG_PRINT_L3((boost::format(tr("Temporarily throttling wallet block refresh by around %i ms")) % refresh_throttle.count()).str());

--- a/tests/core_tests/rct.cpp
+++ b/tests/core_tests/rct.cpp
@@ -169,7 +169,7 @@ bool gen_rct_tx_validation_base::generate_with_full(std::vector<test_event_entry
     blk_r = blk_last;
   }
 
-  // create a tx from the requested ouputs
+  // create a tx from the requested outputs
   std::vector<tx_source_entry> sources;
   size_t global_rct_idx = 6; // skip first coinbase (6 outputs)
   size_t rct_idx = 0;

--- a/tests/functional_tests/multisig.py
+++ b/tests/functional_tests/multisig.py
@@ -153,7 +153,7 @@ class MultisigTest():
         addresses.append(res.address)
         next_stage.append(res.multisig_info)
 
-      # Assert multisig paramaters M/N for each wallet
+      # Assert multisig parameters M/N for each wallet
       for i in range(N_total):
         res = wallet[i].is_multisig()
         assert res.multisig == True
@@ -189,7 +189,7 @@ class MultisigTest():
         assert addresses[i] == expected_address, addresses[i]
       wallet_address = expected_address
 
-      # Assert multisig paramaters M/N and "ready" for each wallet
+      # Assert multisig parameters M/N and "ready" for each wallet
       for i in range(N_total):
         res = wallet[i].is_multisig()
         assert res.multisig == True

--- a/tests/functional_tests/p2p.py
+++ b/tests/functional_tests/p2p.py
@@ -129,7 +129,7 @@ class P2PTest():
         assert res.height == height + 3
         assert res.top_block_hash == daemon3_top_block_hash
 
-        # disconect, mine on daemon2 again more than daemon3
+        # disconnect, mine on daemon2 again more than daemon3
         daemon2.out_peers(0)
         daemon3.out_peers(0)
 

--- a/tests/unit_tests/verRctNonSemanticsSimple.cpp
+++ b/tests/unit_tests/verRctNonSemanticsSimple.cpp
@@ -48,7 +48,7 @@ bool expand_transaction_1(transaction &tx, bool base_only);
 namespace
 {
 /**
- * @brief Make rct::ctkey from hex string representation of destionation and mask
+ * @brief Make rct::ctkey from hex string representation of destination and mask
  *
  * @param dest_hex
  * @param mask_hex
@@ -157,7 +157,7 @@ static void expand_transaction_fully(cryptonote::transaction& tx, const rct::ctk
  * .rct_signatures.mixRings fields of the transaction.
  *
  * @param file_name relative file path in unit test data directory
- * @param input_pubkeys manually retrived input pubkey destination / masks for each ring
+ * @param input_pubkeys manually retrieved input pubkey destination / masks for each ring
  * @return cryptonote::transaction the expanded transaction
  */
 static cryptonote::transaction expand_transaction_from_bin_file_and_pubkeys

--- a/utils/health/README.md
+++ b/utils/health/README.md
@@ -11,7 +11,7 @@ Unless it's stated differently, these scripts should be called from a given sour
 ## ClangBuildAnalyzer
 
 `utils/health/clang-build-time-analyzer-run.sh`
-The CBA helps in finding culprints of slow compilation.
+The CBA helps in finding culprits of slow compilation.
 On the first run, the script will complain about the missing ClangBuildAnalyzer binary and will point you to another script, which is able to clone and build the required binary.
 
 ## clang-tidy


### PR DESCRIPTION
Attempts to fix all spelling issues in comments and docs across the codebase

Fixes spelling mistakes in comments and documentation only: no code, variable names, or string literals were touched.

Review takes 3–5 minutes total, 68 files changed