### PR TITLE
common/download.cpp: abort oversized transfers before written to disk

### DIFF
--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -108,6 +108,8 @@ namespace tools
           {
             MINFO("Content-Length: " << length);
             content_length = length;
+            if (control->progress_cb && !control->progress_cb(control->path, control->uri, 0, content_length))
+              return false;
             boost::filesystem::path path(control->path);
             try
             {


### PR DESCRIPTION
commit title is wrong, it would allow that to happen but this is just returning file size earlier, could use some help that

callers can reject oversized downloads

copied from here but total 0 , as soon as we have headers https://github.com/monero-project/monero/blob/fb5b06bd3bf84bb44a3998b6a6def5ce63752903/src/common/download.cpp#L155

although a niche feature : https://github.com/monero-project/monero/issues/10539#issuecomment-4408292045

for dns blocklists that download a file - i would like to implement a safety check against a malicious domain hosting a very large file - without this, we must write the entire thing to disk first. 