### PR TITLE
p2p: download blocklist from quorum'd hash;url

### DIFF
--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -108,6 +108,8 @@ namespace tools
           {
             MINFO("Content-Length: " << length);
             content_length = length;
+            if (control->progress_cb && !control->progress_cb(control->path, control->uri, 0, content_length))
+              return false;
             boost::filesystem::path path(control->path);
             try
             {
@@ -266,6 +268,24 @@ namespace tools
     download_async_handle handle = download_async(path, url, [&success](const std::string&, const std::string&, bool result) {success = result;}, cb);
     download_wait(handle);
     return success;
+  }
+
+  bool download(const std::string &path, const std::string &url, size_t max_size)
+  {
+    const auto size_guard = [max_size](const std::string& /*path*/, const std::string& /*uri*/, size_t bytes_written, ssize_t content_length) {
+      if (max_size > 0 && content_length >= 0 && static_cast<size_t>(content_length) > max_size)
+      {
+        MERROR("Download rejected, file exceeds maximum size");
+        return false;
+      }
+      if (max_size > 0 && bytes_written > max_size)
+      {
+        MERROR("Download rejected, file exceeds maximum size");
+        return false;
+      }
+      return true;
+    };
+    return download(path, url, size_guard);
   }
 
   download_async_handle download_async(const std::string &path, const std::string &url, std::function<void(const std::string&, const std::string&, bool)> result, std::function<bool(const std::string&, const std::string&, size_t, ssize_t)> progress)

--- a/src/common/download.h
+++ b/src/common/download.h
@@ -38,6 +38,7 @@ namespace tools
   typedef std::shared_ptr<download_thread_control> download_async_handle;
 
   bool download(const std::string &path, const std::string &url, std::function<bool(const std::string&, const std::string&, size_t, ssize_t)> progress = NULL);
+  bool download(const std::string &path, const std::string &url, size_t max_size);
   download_async_handle download_async(const std::string &path, const std::string &url, std::function<void(const std::string&, const std::string&, bool)> result, std::function<bool(const std::string&, const std::string&, size_t, ssize_t)> progress = NULL);
   bool download_error(const download_async_handle &h);
   bool download_finished(const download_async_handle &h);

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -214,6 +214,7 @@
 #define RPC_CREDITS_PER_HASH_SCALE ((float)(1<<24))
 
 #define DNS_BLOCKLIST_LIFETIME (86400 * 8)
+#define DNS_BLOCKLIST_MAX_SIZE (1024 * 1024)
 
 //The limit is enough for the mandatory transaction content with 16 outputs (547 bytes),
 //a custom tag (1 byte) and up to 32 bytes of custom data for each recipient.

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -214,7 +214,7 @@
 #define RPC_CREDITS_PER_HASH_SCALE ((float)(1<<24))
 
 #define DNS_BLOCKLIST_LIFETIME (86400 * 8)
-#define DNS_BLOCKLIST_MAX_SIZE (1024 * 1024)
+#define DNS_BLOCKLIST_MAX_SIZE (1024 * 1024 * 10)
 
 //The limit is enough for the mandatory transaction content with 16 outputs (547 bytes),
 //a custom tag (1 byte) and up to 32 bytes of custom data for each recipient.

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -365,7 +365,7 @@ namespace nodetool
     bool do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context, bool just_take_peerlist = false);
     bool do_peer_timed_sync(const epee::net_utils::connection_context_base& context, peerid_type peer_id);
     bool update_dns_blocklist();
-    size_t apply_blocklist_file(const std::string& path, time_t seconds = std::numeric_limits<time_t>::max(), bool add_only = false, std::string *error = nullptr, size_t max_size = DNS_BLOCKLIST_MAX_SIZE);
+    size_t apply_blocklist_file(const std::string& path, time_t seconds = std::numeric_limits<time_t>::max(), bool add_only = false, std::string *error = nullptr);
 
     bool make_new_connection_from_anchor_peerlist(const std::vector<anchor_peerlist_entry>& anchor_peerlist);
     bool make_new_connection_from_peerlist(network_zone& zone, bool use_white_list);

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -365,6 +365,7 @@ namespace nodetool
     bool do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context, bool just_take_peerlist = false);
     bool do_peer_timed_sync(const epee::net_utils::connection_context_base& context, peerid_type peer_id);
     bool update_dns_blocklist();
+    size_t apply_blocklist_file(const std::string& path, time_t seconds = std::numeric_limits<time_t>::max(), bool add_only = false, std::string *error = nullptr);
 
     bool make_new_connection_from_anchor_peerlist(const std::vector<anchor_peerlist_entry>& anchor_peerlist);
     bool make_new_connection_from_peerlist(network_zone& zone, bool use_white_list);

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -365,7 +365,7 @@ namespace nodetool
     bool do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context, bool just_take_peerlist = false);
     bool do_peer_timed_sync(const epee::net_utils::connection_context_base& context, peerid_type peer_id);
     bool update_dns_blocklist();
-    size_t apply_blocklist_file(const std::string& path, time_t seconds = std::numeric_limits<time_t>::max(), bool add_only = false, std::string *error = nullptr);
+    size_t apply_blocklist_file(const std::string& path, time_t seconds = std::numeric_limits<time_t>::max(), bool add_only = false, std::string *error = nullptr, size_t max_size = DNS_BLOCKLIST_MAX_SIZE);
 
     bool make_new_connection_from_anchor_peerlist(const std::vector<anchor_peerlist_entry>& anchor_peerlist);
     bool make_new_connection_from_peerlist(network_zone& zone, bool use_white_list);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -504,8 +504,17 @@ namespace nodetool
 
     if (!command_line::is_arg_defaulted(vm, arg_ban_list))
     {
+      const std::string ban_list_path = command_line::get_arg(vm, arg_ban_list);
       std::string error;
-      apply_blocklist_file(command_line::get_arg(vm, arg_ban_list), std::numeric_limits<time_t>::max(), false, &error);
+      try
+      {
+        apply_blocklist_file(ban_list_path, std::numeric_limits<time_t>::max(), false, &error);
+      }
+      catch (const std::exception& e)
+      {
+        error = "Failed to read ban list file " + ban_list_path;
+        MWARNING(error << ": " << e.what());
+      }
       if (!error.empty())
         throw std::runtime_error(error);
     }
@@ -2136,7 +2145,10 @@ namespace nodetool
     // TXT format <url>;<sha256>
     std::vector<std::string> records;
     if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))
+    {
+      MWARNING("DNS blocklist: no TXT record found");
       return true;
+    }
 
     if (records.empty())
     {
@@ -2175,10 +2187,15 @@ namespace nodetool
     };
 
     crypto::hash cached_hash;
-    const bool cache_ok =
-      epee::file_io_utils::is_file_exist(cache_path.string()) &&
-      tools::sha256sum(cache_path.string(), cached_hash) &&
-      expected_hash == epee::string_tools::pod_to_hex(cached_hash);
+    bool cache_ok = false;
+    try
+    {
+      cache_ok = tools::sha256sum(cache_path.string(), cached_hash) && expected_hash == epee::string_tools::pod_to_hex(cached_hash);
+    }
+    catch (const std::exception& e)
+    {
+      MWARNING("DNS blocklist: failed to read cached file: " << e.what());
+    }
 
     bool rejected_oversize = false;
     const auto size_guard = [&rejected_oversize](const std::string& /*path*/, const std::string& /*uri*/, size_t bytes_written, ssize_t /*content_length*/) {
@@ -2213,9 +2230,18 @@ namespace nodetool
       }
 
       crypto::hash file_hash;
-      if (!tools::sha256sum(tmp_path, file_hash))
+      try
       {
-        MWARNING("DNS blocklist: failed to hash downloaded file from " << url);
+        if (!tools::sha256sum(tmp_path, file_hash))
+        {
+          MWARNING("DNS blocklist: failed to hash downloaded file from " << url);
+          cleanup_tmp(tmp_path);
+          return false;
+        }
+      }
+      catch (const std::exception &e)
+      {
+        MWARNING("DNS blocklist: failed to hash downloaded file from " << url << ": " << e.what());
         cleanup_tmp(tmp_path);
         return false;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -921,7 +921,7 @@ namespace nodetool
         ++good;
         continue;
       }
-      MERROR("Invalid IP address or IPv4 subnet: " << line);
+      MERROR("Invalid IP address or IPv4 subnet: " << line << " - " << parsed_addr.error());
     }
 
     return good;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -506,9 +506,17 @@ namespace nodetool
     {
       const std::string ban_list_path = command_line::get_arg(vm, arg_ban_list);
       std::string error;
+      boost::system::error_code ec{};
+      if (!boost::filesystem::is_regular_file(boost::filesystem::path{ban_list_path}, ec))
+      {
+        error = "Failed to read ban list file " + ban_list_path;
+        MWARNING(error);
+      }
+
       try
       {
-        apply_blocklist_file(ban_list_path, std::numeric_limits<time_t>::max(), false, &error);
+        if (error.empty())
+          apply_blocklist_file(ban_list_path, std::numeric_limits<time_t>::max(), false, &error);
       }
       catch (const std::exception& e)
       {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -871,7 +871,7 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error, size_t max_size)
+  size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error)
   {
     std::ifstream iss{path};
     if (!iss)
@@ -2142,7 +2142,7 @@ namespace nodetool
     , "blocklist-hash.moneropulse.ch"
     };
 
-    // TXT format <url>;<sha256>
+    // TXT format <sha256>;<url>
     std::vector<std::string> records;
     if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))
     {
@@ -2150,37 +2150,29 @@ namespace nodetool
       return true;
     }
 
-    if (records.empty())
-    {
-      MWARNING("DNS blocklist: no TXT record found");
-      return true;
-    }
-
-    std::vector<std::string> fields;
-    std::string record = records[0];
-    boost::split(fields, record, boost::is_any_of(";"));
-    if (fields.size() != 2)
+    const size_t first_delim_pos = records.empty() ? std::string::npos : records[0].find(';');
+    if (first_delim_pos == std::string::npos)
     {
       MWARNING("DNS blocklist: no valid TXT record found");
       return true;
     }
 
-    boost::trim(fields[0]);
-    boost::trim(fields[1]);
-    std::string url = fields[0];
-    std::string expected_hash = fields[1];
+    const std::string& record = records[0];
+    std::string expected_hash = record.substr(0, first_delim_pos);
+    std::string url = record.substr(first_delim_pos + 1, std::string::npos); // url may contain ';'
+    boost::trim(expected_hash);
+    boost::trim(url);
 
-    if (expected_hash.size() != 64)
+    if (expected_hash.size() != 64 || url.empty())
     {
       MWARNING("DNS blocklist: no valid TXT record found");
       return true;
     }
 
     const boost::filesystem::path cache_path = boost::filesystem::path{m_config_folder} / "dns_blocklist.txt";
-    static constexpr size_t max_blocklist_size = DNS_BLOCKLIST_MAX_SIZE;
     std::string error;
     const auto apply_cached_blocklist = [&]() -> bool {
-      const size_t good = apply_blocklist_file(cache_path.string(), DNS_BLOCKLIST_LIFETIME, true, &error, DNS_BLOCKLIST_MAX_SIZE);
+      const size_t good = apply_blocklist_file(cache_path.string(), DNS_BLOCKLIST_LIFETIME, true, &error);
       if (good > 0)
         MINFO(good << " addresses added to the blocklist");
       return good > 0;
@@ -2199,7 +2191,7 @@ namespace nodetool
 
     bool rejected_oversize = false;
     const auto size_guard = [&rejected_oversize](const std::string& /*path*/, const std::string& /*uri*/, size_t bytes_written, ssize_t /*content_length*/) {
-      if (bytes_written > max_blocklist_size)
+      if (bytes_written > DNS_BLOCKLIST_MAX_SIZE)
       {
         rejected_oversize = true;
         MWARNING("DNS blocklist: download rejected, blocklist exceeds maximum size");

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -48,6 +48,7 @@
 #include "version.h"
 #include "string_tools.h"
 #include "common/util.h"
+#include "common/download.h"
 #include "common/dns_utils.h"
 #include "common/pruning.h"
 #include "net/error.h"
@@ -860,7 +861,7 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error)
+  size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error, size_t max_size)
   {
     const boost::filesystem::path blocklist_path(path);
     if (!boost::filesystem::exists(blocklist_path))
@@ -874,7 +875,7 @@ namespace nodetool
     }
 
     std::string banned_ips;
-    if (!epee::file_io_utils::load_file_to_string(path, banned_ips))
+    if (!epee::file_io_utils::load_file_to_string(path, banned_ips, max_size))
     {
       if (error)
       {
@@ -2134,47 +2135,130 @@ namespace nodetool
       return true;
 
     static const std::vector<std::string> dns_urls = {
-      "blocklist.moneropulse.se"
-    , "blocklist.moneropulse.org"
-    , "blocklist.moneropulse.net"
-    , "blocklist.moneropulse.co"
-    , "blocklist.moneropulse.fr"
-    , "blocklist.moneropulse.de"
-    , "blocklist.moneropulse.ch"
+      "blocklist-hash.moneropulse.se"
+    , "blocklist-hash.moneropulse.org"
+    , "blocklist-hash.moneropulse.net"
+    , "blocklist-hash.moneropulse.co"
+    , "blocklist-hash.moneropulse.fr"
+    , "blocklist-hash.moneropulse.de"
+    , "blocklist-hash.moneropulse.ch"
     };
 
+    // TXT format <url>;<sha256>
     std::vector<std::string> records;
     if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))
       return true;
 
-    unsigned good = 0;
-    for (const auto& record : records)
+    if (records.empty())
     {
-      std::vector<std::string> ips;
-      boost::split(ips, record, boost::is_any_of(";"));
-      for (const auto &ip: ips)
-      {
-        if (ip.empty())
-          continue;
-        auto subnet = net::get_ipv4_subnet_address(ip);
-        if (subnet)
-        {
-          block_subnet(*subnet, DNS_BLOCKLIST_LIFETIME);
-          ++good;
-          continue;
-        }
-        const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(ip, 0);
-        if (parsed_addr)
-        {
-          block_host(*parsed_addr, DNS_BLOCKLIST_LIFETIME, true);
-          ++good;
-          continue;
-        }
-        MWARNING("Invalid IP address or subnet from DNS blocklist: " << ip << " - " << parsed_addr.error());
-      }
+      MWARNING("DNS blocklist: no TXT record found");
+      return true;
     }
-    if (good > 0)
-      MINFO(good << " addresses added to the blocklist");
+
+    std::vector<std::string> fields;
+    std::string record = records[0];
+    boost::split(fields, record, boost::is_any_of(";"));
+    if (fields.size() != 2)
+    {
+      MWARNING("DNS blocklist: no valid TXT record found");
+      return true;
+    }
+
+    boost::trim(fields[0]);
+    boost::trim(fields[1]);
+    std::string url = fields[0];
+    std::string expected_hash = fields[1];
+
+    if (expected_hash.size() != 64)
+    {
+      MWARNING("DNS blocklist: no valid TXT record found");
+      return true;
+    }
+
+    const boost::filesystem::path cache_path = boost::filesystem::path{m_config_folder} / "dns_blocklist.txt";
+    static constexpr size_t max_blocklist_size = DNS_BLOCKLIST_MAX_SIZE;
+    std::string error;
+    const auto apply_cached_blocklist = [&]() -> bool {
+      const size_t good = apply_blocklist_file(cache_path.string(), DNS_BLOCKLIST_LIFETIME, true, &error, DNS_BLOCKLIST_MAX_SIZE);
+      if (good > 0)
+        MINFO(good << " addresses added to the blocklist");
+      return good > 0;
+    };
+
+    crypto::hash cached_hash;
+    const bool cache_ok =
+      epee::file_io_utils::is_file_exist(cache_path.string()) &&
+      tools::sha256sum(cache_path.string(), cached_hash) &&
+      expected_hash == epee::string_tools::pod_to_hex(cached_hash);
+
+    bool rejected_oversize = false;
+    const auto size_guard = [&rejected_oversize](const std::string& /*path*/, const std::string& /*uri*/, size_t bytes_written, ssize_t /*content_length*/) {
+      if (bytes_written > max_blocklist_size)
+      {
+        rejected_oversize = true;
+        MWARNING("DNS blocklist: download rejected, blocklist exceeds maximum size");
+        return false;
+      }
+      return true;
+    };
+
+    const auto cleanup_tmp = [](const std::string& tmp_path) {
+      try
+      {
+        boost::filesystem::remove(tmp_path);
+      }
+      catch (const std::exception &e)
+      {
+        MWARNING("DNS blocklist: failed to remove tmp file: " << e.what());
+      }
+    };
+
+    const auto refresh_cache = [&]() -> bool {
+      const std::string tmp_path = cache_path.string() + ".tmp";
+
+      MDEBUG("DNS blocklist: downloading from " << url);
+      if (!tools::download(tmp_path, url, size_guard) || rejected_oversize)
+      {
+        cleanup_tmp(tmp_path);
+        return false;
+      }
+
+      crypto::hash file_hash;
+      if (!tools::sha256sum(tmp_path, file_hash))
+      {
+        MWARNING("DNS blocklist: failed to hash downloaded file from " << url);
+        cleanup_tmp(tmp_path);
+        return false;
+      }
+      if (expected_hash != epee::string_tools::pod_to_hex(file_hash))
+      {
+        MWARNING("DNS blocklist: hash mismatch from " << url);
+        cleanup_tmp(tmp_path);
+        return false;
+      }
+
+      const std::error_code e = tools::replace_file(tmp_path, cache_path.string());
+      if (e)
+      {
+        MWARNING("DNS blocklist: failed to replace cache: " << e.message());
+        cleanup_tmp(tmp_path);
+        return false;
+      }
+
+      return true;
+    };
+
+    if (!cache_ok && !refresh_cache())
+    {
+      MWARNING("DNS blocklist: could not obtain a verified blocklist");
+      MWARNING("DNS blocklist: applying cached blocklist (may be outdated)");
+      if (!apply_cached_blocklist())
+        MWARNING("DNS blocklist: no cached blocklist available");
+      return true;
+    }
+
+    if (!apply_cached_blocklist())
+      MWARNING("DNS blocklist: verified blocklist is missing/unreadable");
     return true;
   }
   //-----------------------------------------------------------------------------------

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2197,17 +2197,6 @@ namespace nodetool
       MWARNING("DNS blocklist: failed to read cached file: " << e.what());
     }
 
-    bool rejected_oversize = false;
-    const auto size_guard = [&rejected_oversize](const std::string& /*path*/, const std::string& /*uri*/, size_t bytes_written, ssize_t /*content_length*/) {
-      if (bytes_written > DNS_BLOCKLIST_MAX_SIZE)
-      {
-        rejected_oversize = true;
-        MWARNING("DNS blocklist: download rejected, blocklist exceeds maximum size");
-        return false;
-      }
-      return true;
-    };
-
     const auto cleanup_tmp = [](const std::string& tmp_path) {
       try
       {
@@ -2223,7 +2212,7 @@ namespace nodetool
       const std::string tmp_path = cache_path.string() + ".tmp";
 
       MDEBUG("DNS blocklist: downloading from " << url);
-      if (!tools::download(tmp_path, url, size_guard) || rejected_oversize)
+      if (!tools::download(tmp_path, url, DNS_BLOCKLIST_MAX_SIZE))
       {
         cleanup_tmp(tmp_path);
         return false;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -502,48 +502,10 @@ namespace nodetool
 
     if (!command_line::is_arg_defaulted(vm, arg_ban_list))
     {
-      const std::string ban_list = command_line::get_arg(vm, arg_ban_list);
-
-      const boost::filesystem::path ban_list_path(ban_list);
-      boost::system::error_code ec;
-      if (!boost::filesystem::exists(ban_list_path, ec))
-      {
-        throw std::runtime_error("Can't find ban list file " + ban_list + " - " + ec.message());
-      }
-
-      std::string banned_ips;
-      if (!epee::file_io_utils::load_file_to_string(ban_list_path.string(), banned_ips))
-      {
-        throw std::runtime_error("Failed to read ban list file " + ban_list);
-      }
-
-      std::istringstream iss(banned_ips);
-      for (std::string line; std::getline(iss, line); )
-      {
-        // ignore comments after '#' character
-        const size_t pound_idx = line.find('#');
-        if (pound_idx != std::string::npos)
-          line.resize(pound_idx);
-
-        // trim whitespace and ignore empty lines
-        boost::trim(line);
-        if (line.empty())
-          continue;
-
-        auto subnet = net::get_ipv4_subnet_address(line);
-        if (subnet)
-        {
-          block_subnet(*subnet, std::numeric_limits<time_t>::max());
-          continue;
-        }
-        const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
-        if (parsed_addr)
-        {
-          block_host(*parsed_addr, std::numeric_limits<time_t>::max());
-          continue;
-        }
-        MERROR("Invalid IP address or IPv4 subnet: " << line);
-      }
+      std::string error;
+      apply_blocklist_file(command_line::get_arg(vm, arg_ban_list), std::numeric_limits<time_t>::max(), false, &error);
+      if (!error.empty())
+        throw std::runtime_error(error);
     }
 
     if(command_line::has_arg(vm, arg_p2p_hide_my_port))
@@ -895,6 +857,67 @@ namespace nodetool
 
     network_zone& public_zone = m_network_zones[epee::net_utils::zone::public_];
     return m_network_zones.emplace_hint(zone_, std::piecewise_construct, std::make_tuple(zone), std::tie(public_zone.m_net_server.get_io_context()))->second;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error)
+  {
+    const boost::filesystem::path blocklist_path(path);
+    if (!boost::filesystem::exists(blocklist_path))
+    {
+      if (error)
+      {
+        *error = "Can't find ban list file " + path;
+        MWARNING(*error);
+      }
+      return 0;
+    }
+
+    std::string banned_ips;
+    if (!epee::file_io_utils::load_file_to_string(path, banned_ips))
+    {
+      if (error)
+      {
+        *error = "Failed to read ban list file " + path;
+        MWARNING(*error);
+      }
+      return 0;
+    }
+
+    std::istringstream iss(banned_ips);
+    unsigned good = 0;
+    for (std::string line; std::getline(iss, line); )
+    {
+      // ignore comments after '#' character
+      const size_t pound_idx = line.find('#');
+      if (pound_idx != std::string::npos)
+        line.resize(pound_idx);
+
+      // trim whitespace and ignore empty lines
+      boost::trim(line);
+      if (line.empty())
+        continue;
+
+      auto subnet = net::get_ipv4_subnet_address(line);
+      if (subnet)
+      {
+        block_subnet(*subnet, seconds);
+        ++good;
+        continue;
+      }
+
+      const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
+
+      if (parsed_addr)
+      {
+        block_host(*parsed_addr, seconds, add_only);
+        ++good;
+        continue;
+      }
+      MERROR("Invalid IP address or IPv4 subnet: " << line);
+    }
+
+    return good;
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -39,6 +39,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/algorithm/string.hpp>
 #include <atomic>
+#include <fstream>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -863,19 +864,8 @@ namespace nodetool
   template<class t_payload_net_handler>
   size_t node_server<t_payload_net_handler>::apply_blocklist_file(const std::string& path, time_t seconds, bool add_only, std::string *error, size_t max_size)
   {
-    const boost::filesystem::path blocklist_path(path);
-    if (!boost::filesystem::exists(blocklist_path))
-    {
-      if (error)
-      {
-        *error = "Can't find ban list file " + path;
-        MWARNING(*error);
-      }
-      return 0;
-    }
-
-    std::string banned_ips;
-    if (!epee::file_io_utils::load_file_to_string(path, banned_ips, max_size))
+    std::ifstream iss{path};
+    if (!iss)
     {
       if (error)
       {
@@ -885,7 +875,6 @@ namespace nodetool
       return 0;
     }
 
-    std::istringstream iss(banned_ips);
     unsigned good = 0;
     for (std::string line; std::getline(iss, line); )
     {


### PR DESCRIPTION
sorry for refactor. here's my case: when switching the dns banlist to parsing/applying a banlist file - it'll be convenient / less duplication but a bug here in the parser could cause a node to crash or ips not actually banned, so its best to have it in one place. 

where dns would call this (to explain `good` being returned) https://github.com/monero-project/monero/blob/master/src/p2p/net_node.inl#L2127-L2156

