### PR TITLE
epee: skip IPv4 TOS option for non-IPv4 peers

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -960,14 +960,16 @@ namespace net_utils
 
     ec_t ec;
     #if !defined(_WIN32) || !defined(__i686)
-    connection_basic::socket_.next_layer().set_option(
-      boost::asio::detail::socket_option::integer<IPPROTO_IP, IP_TOS>{
-        connection_basic::get_tos_flag()
-      },
-      ec
-    );
-    if (ec.value())
-      return false;
+    if (real_remote->get_type_id() == ipv4_network_address::get_type_id()) {
+      connection_basic::socket_.next_layer().set_option(
+        boost::asio::detail::socket_option::integer<IPPROTO_IP, IP_TOS>{
+          connection_basic::get_tos_flag()
+        },
+        ec
+      );
+      if (ec.value())
+        return false;
+    }
     #endif
     connection_basic::socket_.next_layer().set_option(
       boost::asio::ip::tcp::no_delay{false},


### PR DESCRIPTION
Backport of #10549 for the release-v0.18 branch, as requested.\n\nThis applies the same guard so the IPv4 TOS socket option is only set for IPv4 peers.