### PR TITLE
Remove obsolete test-drop-download debug options

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -135,16 +135,6 @@ namespace cryptonote
     "sync-pruned-blocks"
   , "Allow syncing from nodes with only pruned blocks"
   };
-
-  static const command_line::arg_descriptor<bool> arg_test_drop_download = {
-    "test-drop-download"
-  , "For net tests: in download, discard ALL blocks instead checking/saving them (very fast)"
-  };
-  static const command_line::arg_descriptor<uint64_t> arg_test_drop_download_height = {
-    "test-drop-download-height"
-  , "Like test-drop-download but discards only after around certain height"
-  , 0
-  };
   static const command_line::arg_descriptor<int> arg_test_dbg_lock_sleep = {
     "test-dbg-lock-sleep"
   , "Sleep time in ms, defaults to 0 (off), used to debug before/after locking mutex. Values 100 to 1000 are good for tests."
@@ -322,9 +312,6 @@ namespace cryptonote
   {
     command_line::add_arg(desc, arg_data_dir);
 
-    command_line::add_arg(desc, arg_test_drop_download);
-    command_line::add_arg(desc, arg_test_drop_download_height);
-
     command_line::add_arg(desc, arg_testnet_on);
     command_line::add_arg(desc, arg_stagenet_on);
     command_line::add_arg(desc, arg_regtest_on);
@@ -392,12 +379,8 @@ namespace cryptonote
 
 
     set_enforce_dns_checkpoints(command_line::get_arg(vm, arg_dns_checkpoints));
-    test_drop_download_height(command_line::get_arg(vm, arg_test_drop_download_height));
     m_offline = get_arg(vm, arg_offline);
     m_disable_dns_checkpoints = get_arg(vm, arg_disable_dns_checkpoints);
-
-    if (command_line::get_arg(vm, arg_test_drop_download) == true)
-      test_drop_download();
 
     epee::debug::g_test_dbg_lock_sleep() = command_line::get_arg(vm, arg_test_dbg_lock_sleep);
 
@@ -793,32 +776,6 @@ namespace cryptonote
     m_mempool.deinit();
     m_blockchain_storage.deinit();
     return true;
-  }
-  //-----------------------------------------------------------------------------------------------
-  void core::test_drop_download()
-  {
-    m_test_drop_download = false;
-  }
-  //-----------------------------------------------------------------------------------------------
-  void core::test_drop_download_height(uint64_t height)
-  {
-    m_test_drop_download_height = height;
-  }
-  //-----------------------------------------------------------------------------------------------
-  bool core::get_test_drop_download() const
-  {
-    return m_test_drop_download;
-  }
-  //-----------------------------------------------------------------------------------------------
-  bool core::get_test_drop_download_height() const
-  {
-    if (m_test_drop_download_height == 0)
-      return true;
-
-    if (get_blockchain_storage().get_current_blockchain_height() <= m_test_drop_download_height)
-      return true;
-
-    return false;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, relay_method tx_relay, bool relayed)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -317,35 +317,6 @@ namespace cryptonote
      bool deinit();
 
      /**
-      * @brief sets to drop blocks downloaded (for testing)
-      */
-     void test_drop_download();
-
-     /**
-      * @brief sets to drop blocks downloaded below a certain height
-      *
-      * @param height height below which to drop blocks
-      */
-     void test_drop_download_height(uint64_t height);
-
-     /**
-      * @brief gets whether or not to drop blocks (for testing)
-      *
-      * @return whether or not to drop blocks
-      */
-     bool get_test_drop_download() const;
-
-     /**
-      * @brief gets whether or not to drop blocks
-      *
-      * If the current blockchain height <= our block drop threshold
-      * and test drop blocks is set, return true
-      *
-      * @return see above
-      */
-     bool get_test_drop_download_height() const;
-
-     /**
       * @copydoc Blockchain::get_current_blockchain_height
       *
       * @note see Blockchain::get_current_blockchain_height()
@@ -1068,10 +1039,6 @@ namespace cryptonote
       * @return true
       */
      bool recalculate_difficulties();
-
-     bool m_test_drop_download = true; //!< whether or not to drop incoming blocks (for testing)
-
-     uint64_t m_test_drop_download_height = 0; //!< height under which to drop incoming blocks, if doing so
 
      BlockchainAndPool m_bap; //! Contains owned instances of Blockchain and tx_memory_pool
      tx_memory_pool& m_mempool; //!< ref to transaction pool instance in m_bap

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1281,10 +1281,6 @@ namespace cryptonote
 
       const crypto::hash last_block_hash = cryptonote::get_block_hash(b);
       context.m_last_known_hash = last_block_hash;
-
-      if (!m_core.get_test_drop_download() || !m_core.get_test_drop_download_height()) { // DISCARD BLOCKS for testing
-        return 1;
-      }
     }
 
     try_add_next_blocks(context);

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -86,8 +86,6 @@ public:
   bool find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp){return true;}
   bool handle_get_objects(cryptonote::NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote::NOTIFY_RESPONSE_GET_OBJECTS::request& rsp, cryptonote::cryptonote_connection_context& context){return true;}
   cryptonote::blockchain_storage &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class test_core."); }
-  bool get_test_drop_download() const {return true;}
-  bool get_test_drop_download_height() const {return true;}
   bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks) { return true; }
   bool cleanup_handle_incoming_blocks(bool force_sync = false) { return true; }
   bool check_incoming_block_size(const cryptonote::blobdata& block_blob) const { return true; }

--- a/utils/fish/monerod.fish
+++ b/utils/fish/monerod.fish
@@ -19,8 +19,6 @@ complete -c monerod -l zmq-rpc-bind-port -r -d "Port for ZMQ RPC server to liste
 complete -c monerod -l zmq-pub -r -d "Address for ZMQ pub - tcp://ip:port or ipc://path "
 complete -c monerod -l no-zmq -d "Disable ZMQ RPC server [114/349]"
 complete -c monerod -l data-dir -x -a "(__fish_complete_directories)" -d "Specify data directory"
-complete -c monerod -l test-drop-download -d "For net tests: in download, discard ALL blocks instead checking/saving them (very fast)"
-complete -c monerod -l test-drop-download-height -r -d "Like test-drop-download but discards only after around certain height. Default: 0"
 complete -c monerod -l testnet -d "Run on testnet. The wallet must be launched with --testnet flag."
 complete -c monerod -l stagenet -d "Run on stagenet. The wallet must be launched with --stagenet flag."
 complete -c monerod -l regtest -d "Run in a regression testing mode."


### PR DESCRIPTION
These options were introduced in 2015 as manual debug helpers for network-limit testing. They are not used by the current test suite.

If someone uses this, or has used it somewhat recently I'm fine with closing this PR.