### PR TITLE
cmake: fix Boost thread variable typo

### DIFF
--- a/tests/net_load_tests/CMakeLists.txt
+++ b/tests/net_load_tests/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(net_load_tests_clt
     ${GTEST_LIBRARIES}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBARRY}
+    ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 


### PR DESCRIPTION
Summary:
- Fix the misspelled Boost thread CMake variable used by `net_load_tests_clt`
- Link the target with `${Boost_THREAD_LIBRARY}` instead of the undefined `${Boost_THREAD_LIBARRY}`

Validation:
- `git diff --check`
- Confirmed `tests/net_load_tests/CMakeLists.txt` no longer contains `Boost_THREAD_LIBARRY`
- `cmake` validation was not run locally because `cmake` is not installed in this environment
