### PR TITLE
db_lmdb: fix uninit read in get_tx_amount_output_indices

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3520,14 +3520,17 @@ std::vector<std::vector<uint64_t>> BlockchainLMDB::get_tx_amount_output_indices(
   while (n_txes-- > 0)
   {
     int result = mdb_cursor_get(m_cur_tx_outputs, &k_tx_id, &v, op);
+    op = MDB_NEXT;
     if (result == MDB_NOTFOUND)
+    {
       LOG_PRINT_L0("WARNING: Unexpected: tx has no amount indices stored in "
           "tx_outputs, but it should have an empty entry even if it's a tx without "
           "outputs");
+      amount_output_indices_set.emplace_back();
+      continue;
+    }
     else if (result)
       throw0(DB_ERROR(lmdb_error("DB error attempting to get data for tx_outputs[tx_index]", result).c_str()));
-
-    op = MDB_NEXT;
 
     const uint64_t* indices = (const uint64_t*)v.mv_data;
     size_t num_outputs = v.mv_size / sizeof(uint64_t);

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3521,9 +3521,7 @@ std::vector<std::vector<uint64_t>> BlockchainLMDB::get_tx_amount_output_indices(
   {
     int result = mdb_cursor_get(m_cur_tx_outputs, &k_tx_id, &v, op);
     if (result == MDB_NOTFOUND)
-      LOG_PRINT_L0("WARNING: Unexpected: tx has no amount indices stored in "
-          "tx_outputs, but it should have an empty entry even if it's a tx without "
-          "outputs");
+      throw0(DB_ERROR("Unexpected: tx has no amount indices stored in tx_outputs, but it should have an empty entry even if it's a tx without outputs"));
     else if (result)
       throw0(DB_ERROR(lmdb_error("DB error attempting to get data for tx_outputs[tx_index]", result).c_str()));
 


### PR DESCRIPTION
`mdb_cursor_get` leaves `*data` untouched on `MDB_NOTFOUND` so the existing warn-and-continue reads uninitialized (or stale) `v.mv_data` / `v.mv_size` and returns garbage indices to callers including `remove_output()` during a reorg.

A missing `tx_outputs` entry cannot happen on a consistent DB so throw `DB_ERROR` like every other "Unexpected" state in this file.