### PR TITLE
cmake: enable linker library de-duplication policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 
+# Let CMake de-duplicate link libraries according to linker/platform capabilities.
+if (POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+endif()
+if (POLICY CMP0179)
+    cmake_policy(SET CMP0179 NEW)
+endif()
+
 if (IOS)
     INCLUDE(CmakeLists_IOS.txt)
 endif()


### PR DESCRIPTION
```
ld: warning: ignoring duplicate libraries: '../../contrib/epee/src/libepee.a', '../libversion.a'
```

`clang-2100.1.1.101`

https://cmake.org/cmake/help/latest/policy/CMP0156.html

https://cmake.org/cmake/help/latest/policy/CMP0179.html