### PR TITLE
contrib: fix `bucket_head2` alignment and serialization

### DIFF
--- a/contrib/epee/include/net/levin_base.h
+++ b/contrib/epee/include/net/levin_base.h
@@ -43,23 +43,13 @@ namespace epee
 class byte_slice;
 namespace levin
 {
-#pragma pack(push)
-#pragma pack(1)
-	struct bucket_head
-	{
-		uint64_t m_signature;
-		uint64_t m_cb;
-		uint8_t  m_have_to_return_data;
-		uint32_t m_command;
-		int32_t  m_return_code;
-		uint32_t m_reservedA; //probably some flags in future
-		uint32_t m_reservedB; //probably some check sum in future
-	};
-#pragma pack(pop)
-
-
-#pragma pack(push)
-#pragma pack(1)
+  /**
+   * @brief Data representing a levin v1 header
+   *
+   * In-memory representation is not necessarily the same as on-the-wire representation.
+   * On-the-wire, a levin header has no padding bytes and the integers are in little-endian repr.
+   * See write_header()/read_header() for exactly how the header is {de}serialized.
+  */
   struct bucket_head2
   {
     uint64_t m_signature;
@@ -70,8 +60,8 @@ namespace levin
     uint32_t m_flags;
     uint32_t m_protocol_version;
   };
-#pragma pack(pop)
 
+  static constexpr std::size_t levin_v1_header_size = 33; // bucket_head2's on-the-wire size
 
 constexpr const std::chrono::milliseconds LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED{0};
 #define LEVIN_INITIAL_MAX_PACKET_SIZE  256*1024      // 256 KiB before handshake
@@ -146,7 +136,7 @@ constexpr const std::chrono::milliseconds LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED{0}
     //! \return Size of payload (excludes header size).
     std::size_t payload_size() const noexcept
     {
-      return buffer.size() < sizeof(header) ? 0 : buffer.size() - sizeof(header);
+      return buffer.size() < levin_v1_header_size ? 0 : buffer.size() - levin_v1_header_size;
     }
 
     byte_slice finalize_invoke(uint32_t command) { return finalize(command, LEVIN_PACKET_REQUEST, 0, true); }
@@ -162,6 +152,12 @@ constexpr const std::chrono::milliseconds LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED{0}
 
   //! \return Intialized levin header.
   bucket_head2 make_header(uint32_t command, uint64_t msg_size, uint32_t flags, bool expect_response) noexcept;
+
+  //! \brief Serialize levin header.
+  void write_header(const bucket_head2 &head, unsigned char head_bytes[levin_v1_header_size]) noexcept;
+
+  //! \brief Deserialize levin header.
+  void read_header(const unsigned char head_bytes[levin_v1_header_size], bucket_head2 &head) noexcept;
 
   /*! Generate a dummy levin message.
 

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -136,11 +136,11 @@ class async_protocol_handler
 
   bool send_message(byte_slice message)
   {
-    if (message.size() < sizeof(message_writer::header))
+    if (message.size() < levin_v1_header_size)
       return false;
 
     message_writer::header head;
-    std::memcpy(std::addressof(head), message.data(), sizeof(head));
+    read_header(message.data(), head);
     if(!m_pservice_endpoint->do_send(std::move(message)))
       return false;
 
@@ -462,16 +462,16 @@ public:
             if (!(m_current_head.m_flags & LEVIN_PACKET_END))
               break; // skip to next message
 
-            if (m_fragment_buffer.size() < sizeof(bucket_head2))
+            if (m_fragment_buffer.size() < levin_v1_header_size)
             {
               MERROR(m_connection_context << "Fragmented data too small for levin header");
               return false;
             }
 
             temp.swap(m_fragment_buffer);
-            std::memcpy(std::addressof(m_current_head), std::addressof(temp[0]), sizeof(bucket_head2));
-            const std::uint64_t inner_size = SWAP64LE(m_current_head.m_cb);
-            buff_to_invoke = {reinterpret_cast<const uint8_t*>(temp.data()) + sizeof(bucket_head2), temp.size() - sizeof(bucket_head2)};
+            read_header(reinterpret_cast<const unsigned char*>(temp.data()), m_current_head);
+            const std::uint64_t inner_size = m_current_head.m_cb;
+            buff_to_invoke = {reinterpret_cast<const uint8_t*>(temp.data()) + levin_v1_header_size, temp.size() - levin_v1_header_size};
             if (buff_to_invoke.size() < inner_size)
             {
               MERROR(m_connection_context << "Invalid fragmented buffer size: " << buff_to_invoke.size() << " vs " << inner_size);
@@ -548,36 +548,29 @@ public:
         break;
       case stream_state_head:
         {
-          if(m_cache_in_buffer.size() < sizeof(bucket_head2))
+          if(m_cache_in_buffer.size() < levin_v1_header_size)
           {
-            if(m_cache_in_buffer.size() >= sizeof(uint64_t) && *((uint64_t*)m_cache_in_buffer.span(8).data()) != SWAP64LE(LEVIN_SIGNATURE))
+            if(m_cache_in_buffer.size() >= sizeof(uint64_t))
             {
-              MWARNING(m_connection_context << "Signature mismatch, connection will be closed");
-              return false;
+              uint64_t levin_sig;
+              memcpy(&levin_sig, m_cache_in_buffer.span(sizeof(uint64_t)).data(), sizeof(uint64_t));
+              if (levin_sig != SWAP64LE(LEVIN_SIGNATURE))
+              {
+                MWARNING(m_connection_context << "Signature mismatch, connection will be closed");
+                return false;
+              }
             }
             is_continue = false;
             break;
           }
 
-#if BYTE_ORDER == LITTLE_ENDIAN
-          bucket_head2& phead = *(bucket_head2*)m_cache_in_buffer.span(sizeof(bucket_head2)).data();
-#else
-          bucket_head2 phead = *(bucket_head2*)m_cache_in_buffer.span(sizeof(bucket_head2)).data();
-          phead.m_signature = SWAP64LE(phead.m_signature);
-          phead.m_cb = SWAP64LE(phead.m_cb);
-          phead.m_command = SWAP32LE(phead.m_command);
-          phead.m_return_code = SWAP32LE(phead.m_return_code);
-          phead.m_flags = SWAP32LE(phead.m_flags);
-          phead.m_protocol_version = SWAP32LE(phead.m_protocol_version);
-#endif
-          if(LEVIN_SIGNATURE != phead.m_signature)
+          read_header(m_cache_in_buffer.carve(levin_v1_header_size).data(), m_current_head);
+          if(LEVIN_SIGNATURE != m_current_head.m_signature)
           {
             LOG_ERROR_CC(m_connection_context, "Signature mismatch, connection will be closed");
             return false;
           }
-          m_current_head = phead;
 
-          m_cache_in_buffer.erase(sizeof(bucket_head2));
           m_state = stream_state_body;
           m_oponent_protocol_ver = m_current_head.m_protocol_version;
           const size_t max_bytes = m_connection_context.get_max_bytes(m_current_head.m_command);

--- a/contrib/epee/src/levin_base.cpp
+++ b/contrib/epee/src/levin_base.cpp
@@ -30,6 +30,23 @@
 
 #include "int-util.h"
 
+namespace
+{
+#if BYTE_ORDER != LITTLE_ENDIAN
+epee::levin::bucket_head2 swap_header_endian(const epee::levin::bucket_head2 &head)
+{
+  epee::levin::bucket_head2 little_head = head;
+  little_head.m_signature = SWAP64(little_head.m_signature);
+  little_head.m_cb = SWAP64(little_head.m_cb);
+  little_head.m_command = SWAP32(little_head.m_command);
+  little_head.m_return_code =  SWAP32(little_head.m_return_code);
+  little_head.m_flags = SWAP32(little_head.m_flags);
+  little_head.m_protocol_version = SWAP32(little_head.m_protocol_version);
+  return little_head;
+}
+#endif
+} //anonymous namespace
+
 namespace epee
 {
 namespace levin
@@ -38,32 +55,80 @@ namespace levin
     : buffer()
   {
     buffer.reserve(reserve);
-    buffer.put_n(0, sizeof(header));
+    buffer.put_n(0, levin_v1_header_size);
   }
 
   byte_slice message_writer::finalize(const uint32_t command, const uint32_t flags, const uint32_t return_code, const bool expect_response)
   {
-    if (buffer.size() < sizeof(header))
+    if (buffer.size() < levin_v1_header_size)
       throw std::runtime_error{"levin_writer::finalize already called"};
 
     header head = make_header(command, payload_size(), flags, expect_response);
-    head.m_return_code = SWAP32LE(return_code);
+    head.m_return_code = return_code;
 
-    std::memcpy(buffer.tellp() - buffer.size(), std::addressof(head), sizeof(head));
+    write_header(head, buffer.tellp() - buffer.size());
     return byte_slice{std::move(buffer)};
   }
 
   bucket_head2 make_header(uint32_t command, uint64_t msg_size, uint32_t flags, bool expect_response) noexcept
   {
     bucket_head2 head = {0};
-    head.m_signature = SWAP64LE(LEVIN_SIGNATURE);
+    head.m_signature = LEVIN_SIGNATURE;
     head.m_have_to_return_data = expect_response;
-    head.m_cb = SWAP64LE(msg_size);
+    head.m_cb = msg_size;
 
-    head.m_command = SWAP32LE(command);
-    head.m_protocol_version = SWAP32LE(LEVIN_PROTOCOL_VER_1);
-    head.m_flags = SWAP32LE(flags);
+    head.m_command = command;
+    head.m_protocol_version = LEVIN_PROTOCOL_VER_1;
+    head.m_flags = flags;
     return head;
+  }
+
+  void write_header(const bucket_head2 &head, unsigned char head_bytes[levin_v1_header_size]) noexcept
+  {
+    static constexpr std::size_t w_size = 2 * sizeof(uint64_t);
+    static_assert(offsetof(bucket_head2, m_have_to_return_data) == w_size);
+    static_assert(sizeof(bucket_head2::m_have_to_return_data) == 1);
+    static constexpr std::size_t end_offset = offsetof(bucket_head2, m_protocol_version) + sizeof(bucket_head2::m_protocol_version);
+    static_assert(end_offset - offsetof(bucket_head2, m_command) == w_size);
+    static_assert(2 * w_size + 1 == levin_v1_header_size);
+
+    #if BYTE_ORDER == LITTLE_ENDIAN
+    const bucket_head2 &little_head = head;
+    #else
+    bucket_head2 little_head = swap_header_endian(head);
+    #endif
+
+    unsigned char *pout = reinterpret_cast<unsigned char*>(head_bytes);
+
+    memcpy(pout, &little_head, w_size);
+    pout += w_size;
+    *(pout++) = little_head.m_have_to_return_data;
+    memcpy(pout, &little_head.m_command, w_size);
+    assert(pout + w_size == head_bytes + levin_v1_header_size);
+  }
+
+  void read_header(const unsigned char head_bytes[levin_v1_header_size], bucket_head2 &head) noexcept
+  {
+    static constexpr std::size_t w_size = 2 * sizeof(uint64_t);
+    static_assert(offsetof(bucket_head2, m_have_to_return_data) == w_size);
+    static_assert(sizeof(bucket_head2::m_have_to_return_data) == 1);
+    static constexpr std::size_t end_offset = offsetof(bucket_head2, m_protocol_version) + sizeof(bucket_head2::m_protocol_version);
+    static_assert(end_offset - offsetof(bucket_head2, m_command) == w_size);
+    static_assert(2 * w_size + 1 == levin_v1_header_size);
+
+    head = {};
+
+    const unsigned char *pin = reinterpret_cast<const unsigned char*>(head_bytes);
+  
+    memcpy(&head, pin, w_size);
+    pin += w_size;
+    head.m_have_to_return_data = *(pin++);
+    memcpy(&head.m_command, pin, w_size);
+    assert(pin + w_size == head_bytes + levin_v1_header_size);
+
+    #if BYTE_ORDER != LITTLE_ENDIAN
+    head = swap_header_endian(head);
+    #endif
   }
 
   byte_slice make_noise_notify(const std::size_t noise_bytes)
@@ -71,19 +136,19 @@ namespace levin
     static constexpr const std::uint32_t flags =
         LEVIN_PACKET_BEGIN | LEVIN_PACKET_END;
 
-    if (noise_bytes < sizeof(bucket_head2))
+    if (noise_bytes < levin_v1_header_size)
       return nullptr;
 
-    std::string buffer(noise_bytes, char(0));
-    const bucket_head2 head = make_header(0, noise_bytes - sizeof(bucket_head2), flags, false);
-    std::memcpy(std::addressof(buffer[0]), std::addressof(head), sizeof(head));
+    std::vector<std::uint8_t> buffer(noise_bytes);
+    const bucket_head2 head = make_header(0, noise_bytes - levin_v1_header_size, flags, false);
+    write_header(head, std::addressof(buffer[0]));
 
     return byte_slice{std::move(buffer)};
   }
 
   byte_slice make_fragmented_notify(const std::size_t noise_size, const int command, message_writer message)
   {
-    if (noise_size < sizeof(bucket_head2) * 2)
+    if (noise_size < levin_v1_header_size * 2)
       return nullptr;
 
     if (message.buffer.size() <= noise_size)
@@ -100,14 +165,16 @@ namespace levin
     const byte_slice payload_bytes = message.finalize_notify(command);
     span<const std::uint8_t> payload = to_span(payload_bytes);
 
-    const size_t payload_space = noise_size - sizeof(bucket_head2);
+    const size_t payload_space = noise_size - levin_v1_header_size;
     const size_t expected_fragments = ((payload.size() - 2) / payload_space) + 1;
 
     byte_stream buffer{};
     buffer.reserve(expected_fragments * noise_size);
 
     bucket_head2 head = make_header(0, payload_space, LEVIN_PACKET_BEGIN, false);
-    buffer.write(as_byte_span(head));
+    unsigned char head_bytes[levin_v1_header_size];
+    write_header(head, head_bytes);
+    buffer.write(head_bytes, levin_v1_header_size);
 
     // internal levin header is in payload already
 
@@ -122,11 +189,12 @@ namespace levin
       if (payload.empty())
         head.m_flags = LEVIN_PACKET_END;
 
-      buffer.write(as_byte_span(head));
+      write_header(head, head_bytes);
+      buffer.write(head_bytes, levin_v1_header_size);
       buffer.write(payload.data() - copy_size, copy_size);
     }
 
-    const size_t padding = noise_size - copy_size - sizeof(bucket_head2);
+    const size_t padding = noise_size - copy_size - levin_v1_header_size;
     buffer.put_n(0, padding);
 
     return byte_slice{std::move(buffer)};

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -600,7 +600,7 @@ namespace nodetool
       epee::byte_slice this_noise = nullptr;
       if (proxy.noise)
       {
-        static_assert(sizeof(epee::levin::bucket_head2) < CRYPTONOTE_NOISE_BYTES, "noise bytes too small");
+        static_assert(epee::levin::levin_v1_header_size < CRYPTONOTE_NOISE_BYTES, "noise bytes too small");
         if (noise.empty())
           noise = epee::levin::make_noise_notify(CRYPTONOTE_NOISE_BYTES);
 


### PR DESCRIPTION
Fixes a couple issues:
1. Fix unaligned read 64-bit int from byte pointers in `levin_protocol_handler_async.h` (may crash on 32-bit ARM and RISC platforms)
2. Fixes strict aliasing violation by reading `bucket_head2` from a byte pointer 
3. Unpacks `bucket_head2`  for faster in-memory access

This one is harder to review than #10623, so if review speed ends up being a blocker, I'm fine moving forwards with just #10623