### PR TITLE
tests: remove psutil

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -50,7 +50,7 @@ Functional tests are located under the `tests/functional_tests` directory.
 
 Building all the tests requires installing the following dependencies:
 ```bash
-pip install requests psutil zmq deepdiff
+pip install requests zmq deepdiff
 ```
 
 First, run a regtest daemon in the offline mode and with a fixed difficulty:

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -68,7 +68,7 @@ monero_add_minimal_executable(cpu_power_test cpu_power_test.cpp)
 
 find_package(Python3 REQUIRED)
 
-execute_process(COMMAND ${Python3_EXECUTABLE} "-c" "import requests; import psutil; import zmq; import deepdiff; print('OK')" OUTPUT_VARIABLE REQUESTS_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${Python3_EXECUTABLE} "-c" "import requests; import zmq; import deepdiff; print('OK')" OUTPUT_VARIABLE REQUESTS_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (REQUESTS_OUTPUT STREQUAL "OK")
   add_test(
     NAME    functional_tests_rpc
@@ -77,7 +77,7 @@ if (REQUESTS_OUTPUT STREQUAL "OK")
     NAME    check_missing_rpc_methods
     COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/check_missing_rpc_methods.py" "${CMAKE_SOURCE_DIR}")
 else()
-  message(WARNING "functional_tests_rpc and check_missing_rpc_methods skipped, needs the 'requests', 'psutil', 'zmq', and 'deepdiff' python modules")
+  message(WARNING "functional_tests_rpc and check_missing_rpc_methods skipped, needs the 'requests', 'zmq', and 'deepdiff' python modules")
   set(CTEST_CUSTOM_TESTS_IGNORE ${CTEST_CUSTOM_TESTS_IGNORE} functional_tests_rpc check_missing_rpc_methods)
   if (EXPECT_FUNCTIONAL_TESTS)
     message(FATAL_ERROR "Functional tests are expected")

--- a/tests/functional_tests/mining.py
+++ b/tests/functional_tests/mining.py
@@ -92,7 +92,6 @@ class MiningTest():
             time_pi_single_cpu = self.measure_cpu_power_get_time(cores_mine)
             time_pi_all_cores = self.measure_cpu_power_get_time(cores_init)
         # This is the last measurement, since it takes very little time and can be placed timewise-closer to the mining itself.
-        available_ram = self.get_available_ram() # So far no ideas how to use this var, other than printing it
 
         start = time.monotonic()
         daemon = Daemon()
@@ -220,16 +219,6 @@ class MiningTest():
         time_pi = util_resources.get_time_pi_seconds(cores, build_dir_funcional_tests)
         self.print_mining_info("Time taken to calculate Pi on {} core(s) was {:.2f} s.".format(cores, time_pi))
         return time_pi
-
-    def get_available_ram(self):
-        available_ram = util_resources.available_ram_gb()
-        threshold_ram = 3
-        self.print_mining_info("Available RAM = " + str(round(available_ram, 1)) + " GB")
-        if available_ram < threshold_ram and not self.is_mining_silent():
-            print("Warning! Available RAM =", round(available_ram, 1), 
-                  "GB is less than the reasonable threshold =", threshold_ram,
-                  ". The RX init might exceed the calculated timeout.")
-        return available_ram
 
     def submitblock(self):
         print("Test submitblock")

--- a/tests/functional_tests/util_resources.py
+++ b/tests/functional_tests/util_resources.py
@@ -35,15 +35,8 @@
 """
 
 import subprocess
-import psutil
 import os
 import errno
-
-def available_ram_gb():
-    ram_bytes = psutil.virtual_memory().available
-    kilo = 1024.0
-    ram_gb = ram_bytes / kilo**3
-    return ram_gb
 
 def get_time_pi_seconds(cores, app_dir='.'):
     app_path = '{}/cpu_power_test'.format(app_dir)


### PR DESCRIPTION
This module is only used to print an informational message. A preemptive warning on low memory does not justify dragging in a third-party dependency. Failure to init will result in an error message.