### PR TITLE
ci: guix: use https for substitute server

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -82,7 +82,7 @@ jobs:
           sudo aa-enforce guix || true
           sudo apt purge apparmor
       - name: build
-        run: ADDITIONAL_GUIX_TIMEMACHINE_FLAGS="--disable-authentication" SUBSTITUTE_URLS='http://bordeaux.guix.gnu.org' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
+        run: ADDITIONAL_GUIX_TIMEMACHINE_FLAGS="--disable-authentication" SUBSTITUTE_URLS='https://bordeaux.guix.gnu.org' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.toolchain.target }}


### PR DESCRIPTION
Should fix CI. E.g. https://github.com/monero-project/monero/actions/runs/26126087630/job/77038340846?pr=10620