### PR TITLE
tests: avoid std::terminate in node_server test

### DIFF
--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -1133,6 +1133,10 @@ TEST(node_server, race_condition)
           }
         );
       });
+      struct joiner {
+        worker_t& thread;
+        ~joiner() { if (thread.joinable()) thread.join(); }
+      } join_worker{worker};
       {
         unique_lock_t guard(lock);
         ++counter;
@@ -1148,7 +1152,6 @@ TEST(node_server, race_condition)
         {},
         relay_t::fluff
       );
-      worker.join();
       return {};
     }
     bool init(const options_t &options) { return {}; }


### PR DESCRIPTION
Attempt to fix sporadically failing test.

```
[ RUN      ] node_server.race_condition
terminate called without an active exception
```

Closes #9212