### PR TITLE
ci: guix: use mirror

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -98,7 +98,7 @@ jobs:
           source /etc/profile.d/zzz-guix.sh
           /usr/local/bin/guix --version
       - name: build
-        run: ADDITIONAL_GUIX_TIMEMACHINE_FLAGS="--disable-authentication" SUBSTITUTE_URLS='https://bordeaux.guix.gnu.org' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
+        run: ADDITIONAL_GUIX_TIMEMACHINE_FLAGS="--disable-authentication" SUBSTITUTE_URLS='https://bordeaux.guix.gnu.org' GUIX_REPO='https://github.com/monero-project/guix.git' HOSTS="${{ matrix.toolchain.target }}" ./contrib/guix/guix-build
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.toolchain.target }}

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -57,7 +57,7 @@ fi
 # - Check how the update affects our build graph and which packages have been updated.
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://codeberg.org/guix/guix.git \
+    guix time-machine --url=${GUIX_REPO:-https://codeberg.org/guix/guix.git} \
                       --commit=4a507aa8c0a579d150267d81ab4013189a7ec505 \
                       --cores="$JOBS" \
                       --keep-failed \


### PR DESCRIPTION
[Switch back](https://github.com/monero-project/monero/pull/9995) to using our Guix mirror in CI jobs. Codeberg has stopped being reliable in CI: [[1](https://github.com/monero-project/monero/actions/runs/26307311825/job/77447328611)] [[2](https://github.com/monero-project/monero/actions/runs/26126087630/job/77360538400?pr=10620)] [[3](https://github.com/monero-project/monero/actions/runs/26174961187/job/77003753840?pr=10621)] [[4](https://github.com/monero-project/monero/actions/runs/26126087630/job/76993982573?pr=10620)]

It's unclear whether the issue is with codeberg or GitHub's steadily declining infrastructure. I have not been able to reproduce this issue outside of GitHub CI.

For local builds it will still default to the offical repo at codeberg, unless the `GUIX_REPO` environment variable is set.