### PR TITLE
add safety for future fork heights

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12798,6 +12798,13 @@ uint64_t wallet2::get_approximate_blockchain_height() const
   const time_t now = time(NULL);
   if (now > fork_time)
     approx_blockchain_height += (now - fork_time) / seconds_per_block;
+  else if (approx_blockchain_height > (fork_time - now) / seconds_per_block)
+    approx_blockchain_height -= (fork_time - now) / seconds_per_block;
+  else
+  {
+    LOG_ERROR("Failed to approximate blockchain height from future fork block: " << approx_blockchain_height);
+    return 0;
+  }
   // testnet and stagenet got some huge rollbacks, so the estimation is way off
   const uint64_t approximate_rolled_back_blocks = m_nettype == TESTNET ? 26600 : m_nettype == STAGENET ? 48600 : 33600;
   if (approx_blockchain_height > approximate_rolled_back_blocks)


### PR DESCRIPTION
More info about deviations between approximated and actual height: #10165 
Downstream PR: https://github.com/seraphis-migration/monero/pull/401


## Current Deviations
|nettype|estimated|actual|deviation|
|-|-|-|-|
|mainnet|3658923|3680572|21649 (~30 days)|
|stagenet|2106034|2125779|19745 (~27 days)|
|testnet|2991627|3008846|17219 (~24 days)|

Reminder: our target is 30 days. So since October 2025 the testnet produced ~6 days worth of blocks less than it should have.
Does anyone think I should adjust/nudge the rollback so the estimation is back to 30 days?