### PR TITLE
Fixed dangling iterator in is_remote_host_allowed

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -202,8 +202,8 @@ namespace nodetool
       {
         if (now >= it->second)
         {
-          it = m_blocked_subnets.erase(it);
           MCLOG_CYAN(el::Level::Info, "global", "Subnet " << it->first.host_str() << " unblocked.");
+          it = m_blocked_subnets.erase(it);
           continue;
         }
         if (it->first.matches(ipv4_address))


### PR DESCRIPTION
- m_blocked_subnets.erase(it) either moves it to the next entry, or sets it to m_blocked_subnets.end() in which case the MCLOG_CYAN will access invalid data