### PR TITLE
ci: don't save caches for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ runner.os }}-build-${{ github.sha }}
@@ -57,6 +59,12 @@ jobs:
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: /Users/runner/Library/Caches/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   build-windows:
     name: 'Windows (MSYS2)'
@@ -68,7 +76,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: C:\Users\runneradmin\AppData\Local\ccache
           key: ccache-${{ runner.os }}-build-${{ github.sha }}
@@ -76,6 +86,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
+          cache: false
           install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf mingw-w64-x86_64-libusb mingw-w64-x86_64-unbound mingw-w64-x86_64-rust git pkg-config
       - uses: ./.github/actions/set-make-job-count
       - name: build
@@ -84,6 +95,12 @@ jobs:
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: C:\Users\runneradmin\AppData\Local\ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   build-arch:
     name: 'Arch Linux'
@@ -98,7 +115,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: ~/.cache/ccache
           key: ccache-arch-build-${{ github.sha }}
@@ -110,6 +129,12 @@ jobs:
         run: |
           ${{ env.CCACHE_SETTINGS }}
           ${{ env.BUILD_DEFAULT }}
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   build-debian:
     # Oldest supported Debian version
@@ -133,7 +158,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: ~/.cache/ccache
           key: ccache-debian-11-build-${{ github.sha }}
@@ -145,6 +172,12 @@ jobs:
         run: |
           ${{ env.CCACHE_SETTINGS }}
           ${{ env.BUILD_DEFAULT }}
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   build-ubuntu:
     name: ${{ matrix.name }}
@@ -174,7 +207,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: ~/.cache/ccache
           key: ccache-${{ matrix.container }}-build-${{ github.sha }}
@@ -186,6 +221,12 @@ jobs:
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   test-ubuntu:
     name: "${{ matrix.name }} (tests)"
@@ -221,7 +262,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/cache@v5
+      - name: restore ccache
+        uses: actions/cache/restore@v5
+        id: ccache-restore
         with:
           path: ~/.cache/ccache
           key: ccache-${{ matrix.container }}-build-${{ github.sha }}
@@ -238,6 +281,12 @@ jobs:
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
           cmake --build build --target test
+      - name: save ccache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   source-archive:
     name: "source archive"

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -104,21 +104,21 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 # Most volatile cache
-    - name: ccache
-      uses: actions/cache@v5
+    - name: restore ccache
+      uses: actions/cache/restore@v5
+      id: ccache-restore
       with:
         path: ~/.cache/ccache
         key: ccache-${{ matrix.toolchain.host }}-${{ github.sha }}
         restore-keys: ccache-${{ matrix.toolchain.host }}-
 # Less volatile cache
-    - name: depends cache
-      uses: actions/cache@v5
+    - name: restore depends cache
+      uses: actions/cache/restore@v5
+      id: depends-restore
       with:
         path: contrib/depends/built
         key: depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
-        restore-keys: |
-          depends-${{ matrix.toolchain.host }}-${{ hashFiles('contrib/depends/packages/*') }}
-          depends-${{ matrix.toolchain.host }}-
+        restore-keys: depends-${{ matrix.toolchain.host }}-
     - name: prepare w64-mingw32
       if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' }}
       run: |
@@ -129,6 +129,18 @@ jobs:
       run: |
         ${{env.CCACHE_SETTINGS}}
         make depends target=${{ matrix.toolchain.host }} -j${{env.MAKE_JOB_COUNT}}
+    - name: save ccache
+      uses: actions/cache/save@v5
+      if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
+      with:
+        path: ~/.cache/ccache
+        key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+    - name: save depends cache
+      uses: actions/cache/save@v5
+      if: github.event_name != 'pull_request' && steps.depends-restore.outputs.cache-hit != 'true'
+      with:
+        path: contrib/depends/built
+        key: ${{ steps.depends-restore.outputs.cache-primary-key }}
     - uses: actions/upload-artifact@v7
       if: ${{ matrix.toolchain.host == 'x86_64-w64-mingw32' || matrix.toolchain.host == 'x86_64-apple-darwin' || matrix.toolchain.host == 'arm64-apple-darwin' || matrix.toolchain.host == 'x86_64-unknown-linux-gnu' }}
       with:

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -23,15 +23,21 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: depends sources cache
+      - name: restore depends sources cache
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: contrib/depends/sources
           key: sources-${{ hashFiles('contrib/depends/packages/*') }}
       - name: download depends sources
         if: steps.cache.outputs.cache-hit != 'true'
         run: make -C contrib/depends download
+      - name: save depends sources cache
+        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: contrib/depends/sources
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   build-guix:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Replaces #10636 

One issue with the other approach is that it doesn't automatically create new caches on merges, which will eventually cause them to become stale. With this PR, caches are created for every merge and pull requests will use the most recent cache from their respective branch. It also prevents caches from being created on the pull request scope, which is primarily responsible for our cache thrashing problem.

I have looked for a more concise way to implement this, but haven't found it.