### PR TITLE
Add cbor support to all ZMQ-PUB subscriptions

### DIFF
--- a/contrib/epee/include/serialization/wire/adapted/span.h
+++ b/contrib/epee/include/serialization/wire/adapted/span.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2022-2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,44 +27,37 @@
 
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
-#include <utility>
 
-#include "serialization/wire.h"
+#include "span.h" 
+#include "serialization/wire/traits.h"
 
 namespace wire
 {
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
-  {
-    WIRE_DEFINE_CONVERSIONS()
-
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
-  };
-
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
-  }
-
-  //! Links `value` with `range_`.
+  //! Enable span types for array output
   template<typename T>
-  inline constexpr range_<T> range(T value)
-  {
-    return {std::move(value)};
-  }
-} // wire
+  struct is_array<epee::span<T>>
+    : std::true_type
+  {};
+
+  template<>
+  struct is_array<epee::span<char>>
+    : std::false_type
+  {};
+
+  template<>
+  struct is_array<epee::span<const char>>
+    : std::false_type
+  {};
+
+  template<>
+  struct is_array<epee::span<std::uint8_t>>
+    : std::false_type
+  {};
+
+  template<>
+  struct is_array<epee::span<const std::uint8_t>>
+    : std::false_type
+  {};
+}

--- a/contrib/epee/include/serialization/wire/cbor.h
+++ b/contrib/epee/include/serialization/wire/cbor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,44 +27,22 @@
 
 #pragma once
 
-#include <type_traits>
-#include <utility>
+#include "serialization/wire/cbor/base.h"
+#include "serialization/wire/cbor/error.h"
+#include "serialization/wire/cbor/write.h"
 
-#include "serialization/wire.h"
-
-namespace wire
-{
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
-  {
-    WIRE_DEFINE_CONVERSIONS()
-
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
-  };
-
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
+#define WIRE_CBOR_DEFINE_OBJECT(type, map)                        \
+  void write_bytes(::wire::cbor_writer& dest, const type& source) \
+  {                                                               \
+    map(dest, source);                                            \
   }
 
-  //! Links `value` with `range_`.
-  template<typename T>
-  inline constexpr range_<T> range(T value)
-  {
-    return {std::move(value)};
-  }
-} // wire
+//! Define functions that convert `type` to/from cbor bytes
+#define WIRE_CBOR_DEFINE_CONVERSION(type)                                      \
+  std::error_code convert_to_cbor(epee::byte_stream& dest, const type& source) \
+  { return ::wire_write::to_bytes<::wire::cbor_slice_writer>(dest, source); }
+
+//! Define functions that convert `type::request` and `type::response` to/from cbor bytes
+#define WIRE_CBOR_DEFINE_COMMAND(type)          \
+  WIRE_CBOR_DEFINE_CONVERSION(type::request)    \
+  WIRE_CBOR_DEFINE_CONVERSION(type::response)

--- a/contrib/epee/include/serialization/wire/cbor/base.h
+++ b/contrib/epee/include/serialization/wire/cbor/base.h
@@ -1,0 +1,126 @@
+// Copyright (c) 2026, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <system_error>
+#include <tuple>
+
+#include "byte_slice.h"
+#include "serialization/wire/cbor/fwd.h"
+
+namespace wire
+{
+  struct cbor
+  {
+    using input_type = cbor_reader;
+    using output_type = cbor_slice_writer;
+
+    // Major type defined in RFC
+    enum class major : std::uint8_t
+    {
+      positive_int = 0,
+      negative_int = 1 << 5,
+      bytes = 2 << 5,
+      string = 3 << 5,
+      array = 4 << 5,
+      map = 5 << 5,
+      //tagged = 6 << 5, not supported
+      real_and_special = 7 << 5
+    };
+
+    //! If the unsigned value is less equal than this, store in minor type
+    static constexpr std::uint8_t inline_max() { return 23; }
+
+    template<std::uint8_t M>
+    struct simple
+    {
+      static constexpr std::uint8_t tag() noexcept { return M; }
+      static constexpr std::uint8_t value() noexcept
+      { return std::uint8_t(major::real_and_special) | tag(); }
+    };
+
+    using false_ = simple<20>;
+    using true_ = simple<21>;
+    using null = simple<22>;
+    using undefined = simple<23>;
+    using stop = simple<31>;
+
+    template<typename T, std::uint8_t M>
+    struct minor
+    {
+      using type = T;
+      static constexpr T min() noexcept { return std::numeric_limits<T>::min(); }
+      static constexpr T max() noexcept { return std::numeric_limits<T>::max(); }
+      static constexpr std::uint8_t value() noexcept { return M; }
+    };
+
+    using uint8_t = minor<std::uint8_t, 24>;
+    using uint16_t = minor<std::uint16_t, 25>;
+    using uint32_t = minor<std::uint32_t, 26>;
+    using uint64_t = minor<std::uint64_t, 27>;
+
+    using unsigned_types =
+      std::tuple<cbor::uint8_t, cbor::uint16_t, cbor::uint32_t, cbor::uint64_t>;
+
+    using real16 = minor<std::uint16_t, 25>;
+    using real32 = minor<std::uint32_t, 26>;
+    using real64 = minor<std::uint64_t, 27>;
+
+    //! Only enabled if `T` has templated method `from_bytes`.
+    template<typename T>
+    static auto from_bytes(const epee::span<const char> source, T& dest) -> decltype(dest.template from_bytes<input_type>(source))
+    {
+      return dest.template from_bytes<input_type>(source);
+    }
+
+    //! Only enabled if `T` has templated method `to_bytes`.
+    template<typename T>
+    static auto to_bytes(epee::byte_stream& dest, const T& source) -> decltype(source.template to_bytes<output_type>(dest))
+    {
+      return source.template to_bytes<output_type>(dest);
+    }
+
+
+    // Parameters packs have lower precedence; above functions are preferred.
+
+    template<typename... T>
+    static std::error_code from_bytes(const epee::span<const char> source, T&... dest)
+    {
+      return convert_from_cbor(source, dest...); // ADL (searches every associated namespace)
+    }
+
+    template<typename... T>
+    static std::error_code to_bytes(epee::byte_stream& dest, const T&... source)
+    {
+      return convert_to_cbor(dest, source...); // ADL (searches every associated namespace)
+    }
+  };
+}
+

--- a/contrib/epee/include/serialization/wire/cbor/error.h
+++ b/contrib/epee/include/serialization/wire/cbor/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,44 +27,39 @@
 
 #pragma once
 
+#include <system_error>
 #include <type_traits>
-#include <utility>
-
-#include "serialization/wire.h"
 
 namespace wire
 {
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
+namespace error
+{
+  //! Type wrapper to "grab" cbor errors
+  enum class cbor : int
   {
-    WIRE_DEFINE_CONVERSIONS()
-
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
+    success = 0, // required for `expected<T>`
+    incomplete,
+    integer_encoding
   };
 
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
-  }
+  //! \return Static string describing error `value`.
+  const char* get_string(cbor value) noexcept;
 
-  //! Links `value` with `range_`.
-  template<typename T>
-  inline constexpr range_<T> range(T value)
+  //! \return Category for cbor generated errors.
+  const std::error_category& cbor_category() noexcept;
+
+  //! \return Error code with `value` and `cbor_category()`.
+  inline std::error_code make_error_code(cbor value) noexcept
   {
-    return {std::move(value)};
+    return std::error_code{int(value), cbor_category()};
   }
-} // wire
+}
+}
+
+namespace std
+{
+  template<>
+  struct is_error_code_enum<wire::error::cbor>
+    : true_type
+  {};
+}

--- a/contrib/epee/include/serialization/wire/cbor/fwd.h
+++ b/contrib/epee/include/serialization/wire/cbor/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,44 +27,20 @@
 
 #pragma once
 
-#include <type_traits>
-#include <utility>
+#define WIRE_CBOR_DECLARE_ENUM(type)            \
+  const char* get_string(type) noexcept;        \
+  void read_bytes(::wire::cbor_reader&, type&); \
+  void write_bytes(::wire::cbor_writer&, type)
 
-#include "serialization/wire.h"
+#define WIRE_CBOR_DECLARE_OBJECT(type)                \
+  void read_bytes(::wire::cbor_reader&, type&);       \
+  void write_bytes(::wire::cbor_writer&, const type&)
 
 namespace wire
 {
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
-  {
-    WIRE_DEFINE_CONVERSIONS()
+  struct cbor;
+  class cbor_reader;
+  struct cbor_slice_writer;
+  class cbor_writer;
+}
 
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
-  };
-
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
-  }
-
-  //! Links `value` with `range_`.
-  template<typename T>
-  inline constexpr range_<T> range(T value)
-  {
-    return {std::move(value)};
-  }
-} // wire

--- a/contrib/epee/include/serialization/wire/cbor/write.h
+++ b/contrib/epee/include/serialization/wire/cbor/write.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "byte_stream.h"
+#include "span.h"
+
+#include "serialization/wire/cbor/base.h"
+#include "serialization/wire/write.h"
+
+namespace wire
+{
+  //! Writes CBOR tokens one-at-a-time for DOMless output.
+  class cbor_writer : public writer
+  {
+    epee::byte_stream bytes_;
+    std::size_t expected_; //! Tracks number of expected elements remaining
+
+    void do_unsigned_integer(cbor::major major, std::uintmax_t);
+
+  protected:
+    cbor_writer(epee::byte_stream&& sink)
+      : writer(), bytes_(std::move(sink)), expected_(1)
+    {}
+
+    //! \throw std::logic_error if tree was not completed
+    void check_complete();
+
+    //! \throw std::logic_error if incomplete cbor tree. \return cbor bytes
+    epee::byte_stream take_cbor();
+
+  public:
+    cbor_writer(const cbor_writer&) = delete;
+    virtual ~cbor_writer() noexcept;
+    cbor_writer& operator=(const cbor_writer&) = delete;
+
+    void boolean(const bool value) override final
+    {
+      if (value)
+        bytes_.put(cbor::true_::value());
+      else
+        bytes_.put(cbor::false_::value());
+      --expected_;
+    }
+
+    void integer(const std::intmax_t value) override final;
+    void unsigned_integer(const std::uintmax_t value) override final;
+
+    void real(double) override final;
+
+    void string(std::string_view source) override final;
+    void binary(epee::span<const std::uint8_t> source) override final;
+
+    void start_array(std::size_t items) override final;
+    void end_array() override final { --expected_; }
+
+    void start_object(std::size_t items) override final;
+    void key(const std::string_view key) override final { string(key); }
+    void binary_key(const epee::span<const std::uint8_t> key) override final { binary(key); }
+    void end_object() override final { --expected_; }
+  };
+
+  //! Buffers entire cbor message in memory
+  struct cbor_slice_writer final : cbor_writer
+  {
+    explicit cbor_slice_writer(epee::byte_stream&& sink)
+      : cbor_writer(std::move(sink))
+    {}
+
+    explicit cbor_slice_writer()
+      : cbor_slice_writer(epee::byte_stream{})
+    {}
+
+    //! \throw std::logic_error if incomplete tree \return cbor bytes
+    epee::byte_stream take_buffer()
+    {
+      return cbor_writer::take_cbor();
+    }
+  };
+}

--- a/contrib/epee/include/serialization/wire/wrapper/variant.h
+++ b/contrib/epee/include/serialization/wire/wrapper/variant.h
@@ -1,0 +1,206 @@
+// Copyright (c) 2022, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/variant/get.hpp>
+#include <boost/variant/variant_fwd.hpp>
+#include <functional>
+#include <utility>
+
+#include "serialization/wire/error.h" // monero/contrib/epee/include
+#include "serialization/wire/fwd.h"   // monero/contrib/epee/include
+#include "serialization/wire/field.h" // monero/contrib/epee/include
+#include "serialization/wire/write.h" // monero/contrib/epee/include
+
+#define WIRE_OPTION(name, type, cpp_name)                               \
+  wire::optional_field(name, wire::option<type>(std::ref(cpp_name)))
+
+namespace wire
+{
+  [[noreturn]] void throw_variant_exception(error::schema type, const char* variant_name);
+
+  /*! Wrapper for any C++ variant type that tracks if a `read_bytes` call has
+    completed on wrapped `value`. This wrapper is not needed if the variant is
+    being used for writes only - see `wire::option_` below for more information.
+
+    `variant_type` is `T` with optional `std::reference_wrapper` removed. See
+    `option_` for concept requirements of `variant_type`.
+
+    Example usage:
+    ```
+    template<typename F, typename T>
+    void type_map(F& format, T& self)
+    {
+      auto variant = wire::variant(std::ref(self.field3));
+      wire::object(format,
+        ...
+        WIRE_OPTION("type1", type1, variant),
+        WIRE_OPTION("type2", type2, variant)
+      );
+    }
+    ``` */
+  template<typename T>
+  struct variant_
+  {
+    using variant_type = unwrap_reference_t<T>;
+
+    //! \throw wire::exception with `type` and mangled C++ name of `variant_type`.
+    [[noreturn]] static void throw_exception(const error::schema type)
+    { throw_variant_exception(type, typeid(variant_type).name()); }
+
+    constexpr variant_(T&& value)
+      : value(std::move(value)), read(false)
+    {}
+
+    T value;
+    bool read;
+
+    constexpr const variant_type& get_variant() const noexcept { return value; }
+    variant_type& get_variant() noexcept { return value; }
+
+    //! Makes `variant_` compatible with `emplace()` in `option_`.
+    template<typename U>
+    variant_& operator=(U&& rhs)
+    {
+      get_variant() = std::forward<U>(rhs);
+      return *this;
+    }
+  };
+
+  template<typename T>
+  inline constexpr variant_<T> variant(T value)
+  { return {std::move(value)}; }
+
+  namespace adapt
+  {
+    template<typename T>
+    inline void throw_if_not_read(const T&)
+    { throw_variant_exception(error::schema::missing_key, typeid(T).name()); }
+
+    template<typename T>
+    inline void throw_if_not_read(const variant_<T>& value)
+    {
+      if (!value.read)
+        value.throw_exception(error::schema::missing_key);
+    }
+
+
+    // other variant overloads can be added here as needed
+
+    template<typename U, typename... T>
+    inline const U* get_if(const boost::variant<T...>& value)
+    { return boost::get<U>(std::addressof(value)); }
+
+    template<typename U, typename T>
+    inline const U* get_if(const variant_<T>& value)
+    { return adapt::get_if<U>(value.get_variant()); }
+  }
+
+  /*! Wrapper that makes a variant compatible with `wire::optional_field`.
+    Currently `wire::variant_` and `boost::variant` are valid variant types
+    for writing, and only `wire::variant_` is valid for reading.
+
+   `variant_type` is `T` with optional `std::reference_wrapper` removed.
+   `variant_type` concept requirements:
+     * must have two overloads for `get<U>` function in `adapt` namespace - one
+       `const` and one non-`const` that returns `const U&` and `U&` respectively
+       iff `variant_type` is storing type `U`. Otherwise, the function should
+       throw an exception.
+     * must have overload for `get_if<U>` function in `adapt` namespace that
+       returns `const U*` when `variant_type` is storing type `U`. Otherwise, the
+       function should return `nullptr`.
+     * must have a member function `operator=(U&&)` that changes the stored type
+       to `U` (`get<U>` and `get_if<U>` will return `U` after `operator=`
+       completion).
+
+   The `wire::variant(std::ref(self.field3))` step in the example above can be
+   omitted if only writing is needed. The `boost::variant` value should be
+   given directly to `wire::option<U>(...)` or `WIRE_OPTION` macro - only one
+   type is active so `wire::optional_field` will omit all other types/fields. */
+  template<typename T, typename U>
+  struct option_
+  {
+    using variant_type = unwrap_reference_t<T>;
+    using option_type = U;
+
+    T value;
+
+    constexpr const variant_type& get_variant() const noexcept { return value; }
+    variant_type& get_variant() noexcept { return value; }
+
+    //! \return `true` iff `U` is active type in variant.
+    bool is_active() const { return adapt::get_if<U>(get_variant()) != nullptr; }
+
+
+    // concept requirements for optional fields
+
+    explicit operator bool() const { return is_active(); }
+    void emplace() { get_variant() = U{}; }
+
+    const option_& operator*() const { return *this; }
+    option_& operator*() { return *this; }
+
+    //! \throw wire::exception iff no variant type was read.
+    void reset() { adapt::throw_if_not_read(get_variant()); }
+  };
+
+  template<typename U, typename T>
+  inline constexpr option_<T, U> option(T value)
+  { return {std::move(value)}; }
+
+  namespace adapt
+  {
+    // other variant overloads can be added here as needed
+
+    template<typename U, typename... T>
+    inline U& get(boost::variant<T...>& value)
+    { return boost::get<U>(value); }
+
+    template<typename U, typename... T>
+    inline const U& get(const boost::variant<T...>& value)
+    { return boost::get<U>(value); }
+
+    template<typename U, typename T>
+    inline const U& get(const variant_<T>& value)
+    { return adapt::get<U>(value.get_variant()); }
+  }
+
+  //! \throw wire::exception if `dest.get_variant()` has already been used in `read_bytes`.
+  template<typename R, typename T, typename U>
+  inline void read_bytes(R& source, option_<std::reference_wrapper<variant_<T>>, U> dest)
+  {
+    if (dest.get_variant().read)
+      dest.get_variant().throw_exception(error::schema::invalid_key);
+    wire_read::bytes(source, adapt::get<U>(dest.get_variant().get_variant()));
+    dest.get_variant().read = true;
+  }
+
+  template<typename W, typename T, typename U>
+  inline void write_bytes(W& dest, const option_<T, U>& source)
+  { wire_write::bytes(dest, adapt::get<U>(source.get_variant())); }
+}

--- a/contrib/epee/include/serialization/wire/write.h
+++ b/contrib/epee/include/serialization/wire/write.h
@@ -289,6 +289,6 @@ namespace wire
   template<typename W, typename... T>
   inline void object_fwd(const std::false_type /* is_read */, W& dest, T... fields)
   {
-    wire::object(dest, std::move(fields)...);
+    wire_write::object(dest, std::move(fields)...);
   }
 }

--- a/contrib/epee/include/span.h
+++ b/contrib/epee/include/span.h
@@ -182,3 +182,4 @@ namespace epee
     return {reinterpret_cast<const T*>(s.data()), s.size()};
   }
 }
+

--- a/contrib/epee/src/wire/CMakeLists.txt
+++ b/contrib/epee/src/wire/CMakeLists.txt
@@ -31,4 +31,6 @@ set(wire_sources error.cpp write.cpp)
 add_library(wire ${wire_sources})
 target_link_libraries(wire epee)
 
+add_subdirectory(cbor)
 add_subdirectory(json)
+add_subdirectory(wrapper)

--- a/contrib/epee/src/wire/cbor/CMakeLists.txt
+++ b/contrib/epee/src/wire/cbor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2024, The Monero Project
+# Copyright (c) 2023-2026, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,51 +26,5 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(ringct_basic_sources
-  rctOps.cpp
-  rctTypes.cpp
-  rctCryptoOps.c
-  multiexp.cc
-  bulletproofs.cc
-  bulletproofs_plus.cc)
-
-monero_find_all_headers(ringct_basic_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
-
-monero_private_headers(ringct_basic
-  ${crypto_private_headers})
-monero_add_library(ringct_basic
-  ${ringct_basic_sources}
-  ${ringct_basic_private_headers})
-target_link_libraries(ringct_basic
-  PUBLIC
-    common
-    cncrypto
-    wire
-  PRIVATE
-    ${OPENSSL_LIBRARIES}
-    ${EXTRA_LIBRARIES})
-
-set(ringct_sources
-  rctSigs.cpp
-)
-
-set(ringct_headers)
-
-set(ringct_private_headers
-  rctSigs.h
-)
-
-monero_private_headers(ringct
-  ${crypto_private_headers})
-monero_add_library(ringct
-  ${ringct_sources}
-  ${ringct_headers}
-  ${ringct_private_headers})
-target_link_libraries(ringct
-  PUBLIC
-    common
-    cncrypto
-    device
-  PRIVATE
-    ${OPENSSL_LIBRARIES}
-    ${EXTRA_LIBRARIES})
+add_library(wire-cbor error.cpp write.cpp)
+target_link_libraries(wire-cbor wire)

--- a/contrib/epee/src/wire/cbor/error.cpp
+++ b/contrib/epee/src/wire/cbor/error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -25,46 +25,43 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
-
-#include <type_traits>
-#include <utility>
-
-#include "serialization/wire.h"
+#include "serialization/wire/cbor/error.h"
 
 namespace wire
 {
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
+namespace error
+{
+  const char* get_string(const cbor value) noexcept
   {
-    WIRE_DEFINE_CONVERSIONS()
+    switch (value)
+    {
+      default:
+        break;
+      case cbor::incomplete:
+        return "Incomplete cbor tree structure";
+      case cbor::integer_encoding:
+        return "Unable to encode integer in cbor";
+    }
 
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
-  };
-
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
+    return "Unknown cbor error";
   }
 
-  //! Links `value` with `range_`.
-  template<typename T>
-  inline constexpr range_<T> range(T value)
+  const std::error_category& cbor_category() noexcept
   {
-    return {std::move(value)};
+    struct category final : std::error_category
+    {
+      virtual const char* name() const noexcept override final
+      {
+        return "wire::error::cbor_category()";
+      }
+
+      virtual std::string message(int value) const override final
+      {
+        return get_string(cbor(value));
+      }
+    };
+    static const category instance{};
+    return instance;
   }
+} // error
 } // wire

--- a/contrib/epee/src/wire/cbor/write.cpp
+++ b/contrib/epee/src/wire/cbor/write.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2026, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "serialization/wire/cbor/write.h"
+
+#include <boost/endian/buffers.hpp>
+#include <boost/fusion/include/any.hpp>
+#include <boost/fusion/include/std_tuple.hpp>
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+#include <type_traits>
+
+#include "serialization/wire/error.h"
+#include "serialization/wire/cbor/error.h"
+
+namespace
+{
+  template<typename T, std::uint8_t M>
+  void write_endian(epee::byte_stream& bytes, const std::uintmax_t value, const wire::cbor::major major, const wire::cbor::minor<T, M> minor)
+  {
+    assert(value <= minor.max());
+
+    static constexpr const std::size_t bits = 8 * sizeof(T);
+    using buffer_type =
+      boost::endian::endian_buffer<boost::endian::order::big, T, bits>;
+    const buffer_type buffer(value);
+
+    bytes.put(std::uint8_t(major) | minor.value());
+    bytes.write(buffer.data(), sizeof(buffer));
+  }
+}
+
+namespace wire
+{
+  void cbor_writer::do_unsigned_integer(const cbor::major major, const std::uintmax_t value)
+  {
+    if (value <= cbor::inline_max())
+        bytes_.put(std::uint8_t(major) | std::uint8_t(value));
+    else
+    {
+      const auto match_size = [this, major, value] (const auto minor) -> bool
+      {
+        if (minor.max() < value)
+          return false;
+        write_endian(bytes_, value, major, minor);
+        return true;
+      };
+      if (!boost::fusion::any(cbor::unsigned_types{}, match_size))
+        WIRE_DLOG_THROW_(error::cbor::integer_encoding);
+    }
+
+    --expected_;
+  }
+
+  void cbor_writer::check_complete()
+  {
+    if (expected_)
+      throw std::logic_error{"cbor_writer::take_cbor() failed with incomplete tree"};
+  }
+  epee::byte_stream cbor_writer::take_cbor()
+  {
+    check_complete();
+    epee::byte_stream out{std::move(bytes_)};
+    bytes_.clear();
+    return out;
+  }
+
+  cbor_writer::~cbor_writer() noexcept
+  {}
+
+  void cbor_writer::integer(const std::intmax_t value)
+  {
+    if (0 <= value)
+      unsigned_integer(std::uintmax_t(value));
+    else
+      do_unsigned_integer(cbor::major::negative_int, std::uintmax_t(-std::intmax_t(value + 1)));
+  }
+
+  void cbor_writer::unsigned_integer(const std::uintmax_t value)
+  { do_unsigned_integer(cbor::major::positive_int, value); }
+
+  void cbor_writer::real(const double source)
+  {
+    static_assert(std::numeric_limits<double>::is_iec559);
+    static_assert(sizeof(double) == sizeof(std::uint64_t));
+
+    std::uint64_t buf;
+    std::memcpy(&buf, &source, sizeof(buf));
+    write_endian(bytes_, buf, cbor::major::real_and_special, cbor::real64{}); 
+    --expected_;
+  }
+
+  void cbor_writer::string(const std::string_view source)
+  {
+    do_unsigned_integer(cbor::major::string, source.size());
+    bytes_.write(source.data(), source.size());
+  }
+  void cbor_writer::binary(epee::span<const std::uint8_t> source)
+  {
+    do_unsigned_integer(cbor::major::bytes, source.size());
+    bytes_.write(source);
+  }
+
+  void cbor_writer::start_array(const std::size_t items)
+  {
+    do_unsigned_integer(cbor::major::array, items);
+    expected_ += items + 1;
+  }
+
+  void cbor_writer::start_object(const std::size_t items)
+  {
+    do_unsigned_integer(cbor::major::map, items);
+    expected_ += items * 2 + 1;
+  }
+}

--- a/contrib/epee/src/wire/wrapper/CMakeLists.txt
+++ b/contrib/epee/src/wire/wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2024, The Monero Project
+# Copyright (c) 2026, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,51 +26,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(ringct_basic_sources
-  rctOps.cpp
-  rctTypes.cpp
-  rctCryptoOps.c
-  multiexp.cc
-  bulletproofs.cc
-  bulletproofs_plus.cc)
+add_library(wire-wrapper variant.cpp)
+target_link_libraries(wire-wrapper wire)
 
-monero_find_all_headers(ringct_basic_private_headers "${CMAKE_CURRENT_SOURCE_DIR}")
-
-monero_private_headers(ringct_basic
-  ${crypto_private_headers})
-monero_add_library(ringct_basic
-  ${ringct_basic_sources}
-  ${ringct_basic_private_headers})
-target_link_libraries(ringct_basic
-  PUBLIC
-    common
-    cncrypto
-    wire
-  PRIVATE
-    ${OPENSSL_LIBRARIES}
-    ${EXTRA_LIBRARIES})
-
-set(ringct_sources
-  rctSigs.cpp
-)
-
-set(ringct_headers)
-
-set(ringct_private_headers
-  rctSigs.h
-)
-
-monero_private_headers(ringct
-  ${crypto_private_headers})
-monero_add_library(ringct
-  ${ringct_sources}
-  ${ringct_headers}
-  ${ringct_private_headers})
-target_link_libraries(ringct
-  PUBLIC
-    common
-    cncrypto
-    device
-  PRIVATE
-    ${OPENSSL_LIBRARIES}
-    ${EXTRA_LIBRARIES})

--- a/contrib/epee/src/wire/wrapper/variant.cpp
+++ b/contrib/epee/src/wire/wrapper/variant.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2022, The Monero Project
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -25,46 +26,14 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#include "serialization/wire/wrapper/variant.h"
 
-#include <type_traits>
-#include <utility>
-
-#include "serialization/wire.h"
+#include <boost/core/demangle.hpp>
 
 namespace wire
 {
-  //! A wrapper that tells `wire::writer`s to write the inner type as an array.
-  template<typename U>
-  struct range_
+  [[noreturn]] void throw_variant_exception(wire::error::schema type, const char* variant_name)
   {
-    WIRE_DEFINE_CONVERSIONS()
-
-    using value_type = unwrap_reference_t<U>;
-
-    U value;
-
-    constexpr const value_type& get_value() const noexcept { return value; }
-    value_type& get_value() noexcept { return value; }
-
-    // concept requirements for `is_optional_on_empty`    
-    bool empty() const { return get_value().empty(); }
-
-    // concept requirements for `optional_field`.
-    explicit operator bool() const noexcept { return !empty(); }
-    range_ operator*() const noexcept { return *this; }
-  };
-
-  template<typename F, typename T>
-  void write_bytes(F& format, const range_<T> self)
-  {
-    wire_write::array(format, self.get_value());
+    WIRE_DLOG_THROW(type, "error with variant type: " << boost::core::demangle(variant_name));
   }
-
-  //! Links `value` with `range_`.
-  template<typename T>
-  inline constexpr range_<T> range(T value)
-  {
-    return {std::move(value)};
-  }
-} // wire
+}

--- a/src/crypto/wire.h
+++ b/src/crypto/wire.h
@@ -35,7 +35,14 @@
 
 namespace wire
 {
+  WIRE_DECLARE_BLOB_NS(crypto::ec_point);
+  WIRE_DECLARE_BLOB_NS(crypto::ec_scalar);
   WIRE_DECLARE_BLOB_NS(crypto::hash);
   WIRE_DECLARE_BLOB_NS(crypto::hash8);
-  WIRE_DECLARE_BLOB_NS(crypto::ec_point);
+  WIRE_DECLARE_BLOB_NS(crypto::key_derivation);
+  WIRE_DECLARE_BLOB_NS(crypto::key_image);
+  WIRE_DECLARE_BLOB_NS(crypto::public_key);
+  WIRE_DECLARE_BLOB_NS(crypto::signature);
+  WIRE_DECLARE_BLOB_NS(crypto::view_tag);
 }
+

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(cryptonote_format_utils_basic
 set(cryptonote_basic_sources
   account.cpp
   connection_context.cpp
+  cryptonote_basic.cpp
   cryptonote_basic_impl.cpp
   cryptonote_format_utils.cpp
   difficulty.cpp
@@ -72,6 +73,8 @@ target_link_libraries(cryptonote_basic
     cryptonote_format_utils_basic
     device
     ringct_basic
+    wire
+    wire-wrapper
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}

--- a/src/cryptonote_basic/cryptonote_basic.cpp
+++ b/src/cryptonote_basic/cryptonote_basic.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2022-2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "cryptonote_basic.h"
+
+#include "cryptonote_basic_impl.h"
+#include "crypto/wire.h"
+#include "serialization/wire.h"
+#include "serialization/wire/adapted/vector.h"
+#include "serialization/wire/wrapper/range.h"
+#include "serialization/wire/wrapper/variant.h"
+
+namespace cryptonote
+{
+  namespace
+  {
+    template<typename F, typename T>
+    void txin_gen_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(height));
+    }
+
+    template<typename F, typename T>
+    void txin_to_script_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(prev), WIRE_FIELD(prevout), WIRE_FIELD(sigset));
+    }
+
+    template<typename F, typename T>
+    void txin_to_scripthash_map(F& format, T& self)
+    {
+      wire::object(format,
+        WIRE_FIELD(prev),
+        WIRE_FIELD(prevout),
+        WIRE_FIELD(script),
+        WIRE_FIELD(sigset)
+      );
+    }
+
+    template<typename F, typename T>
+    void txin_to_key_map(F& format, T& self)
+    {
+      wire::object(format,
+        WIRE_FIELD(amount),
+        WIRE_FIELD(key_offsets),
+        wire::field("key_image", std::ref(self.k_image))
+      );
+    }
+
+    template<typename F, typename T>
+    void txin_v_map(F& format, T& self)
+    {
+      auto variant = wire::variant(std::ref(self));
+      wire::object(format,
+        WIRE_OPTION("gen",           txin_gen,           variant),
+        WIRE_OPTION("to_script",     txin_to_script,     variant),
+        WIRE_OPTION("to_scripthash", txin_to_scripthash, variant),
+        WIRE_OPTION("to_key",        txin_to_key,        variant)
+      );
+    }
+  } // anonymous
+  WIRE_DEFINE_OBJECT(txin_gen, txin_gen_map)
+  WIRE_DEFINE_OBJECT(txin_to_script, txin_to_script_map)
+  WIRE_DEFINE_OBJECT(txin_to_scripthash, txin_to_scripthash_map)
+  WIRE_DEFINE_OBJECT(txin_to_key, txin_to_key_map)
+  WIRE_DEFINE_OBJECT(txin_v, txin_v_map)
+
+  namespace
+  {
+    template<typename F, typename T>
+    void txout_to_script_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(keys), WIRE_FIELD(script));
+    }
+
+    template<typename F, typename T>
+    void txout_to_scripthash_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(hash));
+    }
+
+    template<typename F, typename T>
+    void txout_to_key_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(key));
+    }
+
+    template<typename F, typename T>
+    void txout_to_tagged_key_map(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD(key), WIRE_FIELD(view_tag));
+    }
+
+    template<typename F, typename T>
+    void tx_out_map(F& format, T& self)
+    {
+      auto variant = wire::variant(std::ref(self.target));
+      wire::object(format,
+        WIRE_FIELD(amount),
+        WIRE_OPTION("to_script",     txout_to_script,     variant),
+        WIRE_OPTION("to_scripthash", txout_to_scripthash, variant),
+        WIRE_OPTION("to_key",        txout_to_key,        variant),
+        WIRE_OPTION("to_tagged_key", txout_to_tagged_key, variant)
+      );
+    }
+  } // anonymous
+  WIRE_DEFINE_OBJECT(txout_to_script, txout_to_script_map)
+  WIRE_DEFINE_OBJECT(txout_to_scripthash, txout_to_scripthash_map)
+  WIRE_DEFINE_OBJECT(txout_to_key, txout_to_key_map)
+  WIRE_DEFINE_OBJECT(txout_to_tagged_key, txout_to_tagged_key_map)
+  WIRE_DEFINE_OBJECT(tx_out, tx_out_map)
+
+  namespace
+  {
+    template<typename F, typename T>
+    void tx_map(F& format, T& self)
+    {
+      boost::optional<const std::vector<std::vector<crypto::signature>>&> signatures;
+      if (!self.pruned)
+        signatures.emplace(self.signatures);
+
+      // make input/output arrays required for ZMQ backwards compatability
+      wire::object(format,
+        WIRE_FIELD(version),
+        WIRE_FIELD(unlock_time),
+        wire::field("inputs", wire::range(std::ref(self.vin))),
+        wire::field("outputs", wire::range(std::ref(self.vout))),
+        WIRE_FIELD(extra),
+        wire::optional_field("signatures", signatures),
+        wire::field("ringct", prune_wrapper(std::ref(self.rct_signatures), self.pruned))
+      );
+    }
+
+    template<typename F, typename T>
+    void block_map(F& format, T& self)
+    {
+      // make all arrays required for ZMQ backwards compatability
+      wire::object(format,
+        WIRE_FIELD(major_version),
+        WIRE_FIELD(minor_version),
+        WIRE_FIELD(timestamp),
+        WIRE_FIELD(prev_id),
+        WIRE_FIELD(nonce),
+        WIRE_FIELD(miner_tx),
+        wire::field("tx_hashes", wire::range(std::ref(self.tx_hashes)))
+      );
+    }
+  } // anonymous
+
+  void write_bytes(wire::writer& dest, const transaction& source)
+  { tx_map(dest, source); }
+
+  void write_bytes(wire::writer& dest, const block& source)
+  { block_map(dest, source); }
+} // cryptonote

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -43,6 +43,7 @@
 #include "serialization/debug_archive.h"
 #include "serialization/crypto.h"
 #include "serialization/keyvalue_serialization.h" // eepe named serialization
+#include "serialization/wire/fwd.h"
 #include "cryptonote_config.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
@@ -345,6 +346,7 @@ namespace cryptonote
   private:
     static size_t get_signature_size(const txin_v& tx_in);
   };
+  WIRE_DECLARE_OBJECT(transaction);
 
   inline transaction::transaction(const transaction &t):
     transaction_prefix(t),
@@ -572,6 +574,7 @@ namespace cryptonote
         return false;
     END_SERIALIZE()
   };
+  WIRE_DECLARE_OBJECT(block);
 
 
   /************************************************************************/

--- a/src/ringct/rctTypes.cpp
+++ b/src/ringct/rctTypes.cpp
@@ -32,6 +32,12 @@
 #include "cryptonote_config.h"
 #include "rctTypes.h"
 #include "int-util.h"
+#include "serialization/wire.h"
+#include "serialization/wire/adapted/span.h"
+#include "serialization/wire/adapted/vector.h"
+#include "serialization/wire/wrapper/range.h"
+#include "serialization/wire/wrapper/variant.h"
+
 using namespace crypto;
 using namespace std;
 
@@ -339,4 +345,155 @@ namespace rct {
         return n;
     }
 
+    namespace
+    {
+        template<typename F, typename T>
+        void ecdh_tuple_map(F& format, T& self)
+        {
+            wire::object(format, WIRE_FIELD(mask), WIRE_FIELD(amount));
+        }
+
+        template<typename F, typename T, typename U>
+        void boro_sig_map(F& format, T& self, U&& s0, U&& s1)
+        {
+            wire::object(format, WIRE_FIELD(ee), wire::field("s0", std::ref(s0)), wire::field("s1", std::ref(s1)));
+        }
+
+        template<typename F, typename T, typename U>
+        void range_sig_map(F& format, T& self, U&& Ci)
+        {
+          wire::object(format, WIRE_FIELD(asig), wire::field("Ci", std::ref(Ci)));
+        }
+
+        template<typename F, typename T>
+        void bulletproof_map(F& format, T& self)
+        {
+            wire::object(format,
+                WIRE_FIELD(V),
+                WIRE_FIELD(A),
+                WIRE_FIELD(S),
+                WIRE_FIELD(T1),
+                WIRE_FIELD(T2),
+                WIRE_FIELD(taux),
+                WIRE_FIELD(mu),
+                WIRE_FIELD(L),
+                WIRE_FIELD(R),
+                WIRE_FIELD(a),
+                WIRE_FIELD(b),
+                WIRE_FIELD(t)
+            );
+        }
+
+        template<typename F, typename T>
+        void bulletproof_plus_map(F& format, T& self)
+        {
+            wire::object(format,
+                WIRE_FIELD(V),
+                WIRE_FIELD(A),
+                WIRE_FIELD(A1),
+                WIRE_FIELD(B),
+                WIRE_FIELD(r1),
+                WIRE_FIELD(s1),
+                WIRE_FIELD(d1),
+                WIRE_FIELD(L),
+                WIRE_FIELD(R)
+            );
+        }
+
+        template<typename F, typename T>
+        void mg_sig_map(F& format, T& self)
+        {
+            wire::object(format,
+                wire::field("ss", wire::range(std::ref(self.ss))),
+                WIRE_FIELD(cc)
+            );
+        }
+
+        template<typename F, typename T>
+        void clsag_map(F& format, T& self)
+        {
+          wire::object(format, WIRE_FIELD(s), WIRE_FIELD(c1), WIRE_FIELD(D));
+        }
+
+        template<typename F, typename T>
+        void rct_sig_prunable_map(F& format, T& self)
+        {
+            // make all arrays required for ZMQ backwards compatability
+            wire::object(format,
+                wire::field("range_proofs", wire::range(std::ref(self.p.rangeSigs))),
+                wire::field("bulletproofs", wire::range(std::ref(self.p.bulletproofs))),
+                wire::field("bulletproofs_plus", wire::range(std::ref(self.p.bulletproofs_plus))),
+                wire::field("mlsags", wire::range(std::ref(self.p.MGs))),
+                wire::field("clsags", wire::range(std::ref(self.p.CLSAGs))),
+                wire::field("pseudo_outs", wire::range(std::ref(self.pseudo_outs)))
+            );
+        }
+
+        struct prunable_read
+        {
+            keyV pseudo_outs;
+            rctSigPrunable p;
+        };
+
+        struct prunable_write
+        {
+            const keyV& pseudo_outs;
+            const rctSigPrunable& p;
+
+            prunable_write(const keyV& pseudo_outs, const rctSigPrunable& p)
+                : pseudo_outs(pseudo_outs), p(p)
+            {}
+        };
+        void write_bytes(wire::writer& dest, const prunable_write source)
+        {
+            rct_sig_prunable_map(dest, source);
+        }
+
+        template<typename F, typename T, typename U, typename V>
+        void rct_sig_map(F& format, const prune_wrapper_<T> self, boost::optional<U>& fee, boost::optional<V>& prunable)
+        {
+            if (self.p.get().type != rct::RCTTypeNull && (self.p.get().ecdhInfo.empty() || self.p.get().outPk.empty() || !fee))
+              WIRE_DLOG_THROW(wire::error::schema::missing_key, "Missing critical fields");
+
+            wire::object(format,
+                wire::field("type", std::ref(self.p.get().type)),
+                wire::optional_field("encrypted", wire::range(std::ref(self.p.get().ecdhInfo))),
+                wire::optional_field("commitments", wire::range(std::ref(self.p.get().outPk))),
+                wire::optional_field("fee", std::ref(fee)),
+                wire::optional_field("prunable", std::ref(prunable))
+            );
+        }
+    } // anonymous
+    void write_bytes(wire::writer& dest, const ctkey& source)
+    {
+        wire_write::bytes(dest, source.mask);
+    }
+    WIRE_DEFINE_OBJECT(ecdhTuple, ecdh_tuple_map)
+    static void write_bytes(wire::writer& dest, const rct::boroSig& source)
+    {
+        using key_span = epee::span<const rct::key>;
+        boro_sig_map(dest, source, key_span{source.s0}, key_span{source.s1});
+    }
+    static void write_bytes(wire::writer& dest, const rct::rangeSig& source)
+    {
+        range_sig_map(dest, source, epee::span<const rct::key>{source.Ci});
+    }
+    WIRE_DEFINE_OBJECT(Bulletproof, bulletproof_map)
+    WIRE_DEFINE_OBJECT(BulletproofPlus, bulletproof_plus_map)
+    WIRE_DEFINE_OBJECT(mgSig, mg_sig_map)
+    WIRE_DEFINE_OBJECT(clsag, clsag_map);
+    void write_bytes(wire::writer& dest, const prune_wrapper_<const rctSig> source)
+    {
+        boost::optional<rct::xmr_amount> fee;
+        boost::optional<prunable_write> prunable;
+
+        if (source.p.get().type != rct::RCTTypeNull)
+            fee.emplace(source.p.get().txnFee);
+
+        if (!source.prune && (!source.p.get().p.MGs.empty() || !source.p.get().p.CLSAGs.empty() || !source.p.get().p.bulletproofs.empty() || !source.p.get().p.bulletproofs_plus.empty() || !source.p.get().p.rangeSigs.empty() || !source.p.get().get_pseudo_outs().empty()))
+            prunable.emplace(source.p.get().get_pseudo_outs(), source.p.get().p);
+
+        rct_sig_map(dest, source, fee, prunable);
+    }
 }
+

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -33,6 +33,7 @@
 #define RCT_TYPES_H
 
 #include <cstddef>
+#include <functional>
 #include <vector>
 #include <iostream>
 #include <cinttypes>
@@ -53,7 +54,8 @@ extern "C" {
 #include "serialization/debug_archive.h"
 #include "serialization/binary_archive.h"
 #include "serialization/json_archive.h"
-
+#include "serialization/wire/fwd.h"
+#include "serialization/wire/traits.h"
 
 //Define this flag when debugging to get additional info on the console
 #ifdef DBG
@@ -630,6 +632,19 @@ namespace rct {
         END_SERIALIZE()
     };
 
+    template<typename T>
+    struct prune_wrapper_
+    {
+      std::reference_wrapper<T> p;
+      bool prune;
+    };
+
+    template<typename T>
+    prune_wrapper_<T> prune_wrapper(std::reference_wrapper<T> p, const bool prune)
+    { return {std::move(p), prune}; }
+
+    void write_bytes(wire::writer&, prune_wrapper_<const rctSig>);
+
     //other basepoint H = toPoint(cn_fast_hash(G)), G the basepoint
     static const key H = { {0x8b, 0x65, 0x59, 0x70, 0x15, 0x37, 0x99, 0xaf, 0x2a, 0xea, 0xdc, 0x9f, 0xf1, 0xad, 0xd0, 0xea, 0x6c, 0x72, 0x51, 0xd5, 0x41, 0x54, 0xcf, 0xa9, 0x2c, 0x17, 0x3a, 0x0d, 0xd3, 0x9c, 0x1f, 0x94} };
 
@@ -768,6 +783,8 @@ namespace std
 {
   template<> struct hash<rct::key> { std::size_t operator()(const rct::key &k) const { return reinterpret_cast<const std::size_t&>(k); } };
 }
+
+WIRE_DECLARE_BLOB(rct::key);
 
 BLOB_SERIALIZER(rct::key);
 BLOB_SERIALIZER(rct::key64);

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -145,6 +145,7 @@ target_link_libraries(rpc_pub
     cryptonote_basic
     cryptonote_core
     serialization
+    wire-cbor
     wire-json
     ${Boost_THREAD_LIBRARY})
 
@@ -165,6 +166,7 @@ target_link_libraries(daemon_rpc_server
     version
     daemon_messages
     serialization
+    wire-cbor
     wire-json
     ${Boost_REGEX_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -54,6 +54,7 @@ using namespace epee;
 #include "crypto/hash.h"
 #include "rpc/rpc_args.h"
 #include "rpc/rpc_handler.h"
+#include "rpc/zmq_pub.h"
 #include "core_rpc_server_error_codes.h"
 #include "p2p/net_node.h"
 #include "version.h"
@@ -496,6 +497,7 @@ namespace cryptonote
     res.synchronized = check_core_ready();
     res.busy_syncing = m_p2p.get_payload_object().is_busy_syncing();
     res.restricted = restricted;
+    res.zmq_pub_filters = listener::zmq_pub::get_all_filters();
 
     res.status = CORE_RPC_STATUS_OK;
     return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -724,6 +724,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint64_t free_space;
       bool offline;
       std::string bootstrap_daemon_address;
+      std::vector<std::string> zmq_pub_filters;
       uint64_t height_without_bootstrap;
       bool was_bootstrap_ever_used;
       uint64_t database_size;
@@ -766,6 +767,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(free_space)
         KV_SERIALIZE(offline)
         KV_SERIALIZE(bootstrap_daemon_address)
+        KV_SERIALIZE(zmq_pub_filters)
         KV_SERIALIZE(height_without_bootstrap)
         KV_SERIALIZE(was_bootstrap_ever_used)
         KV_SERIALIZE(database_size)

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -42,6 +42,7 @@
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/blobdatatype.h"
 #include "ringct/rctSigs.h"
+#include "rpc/zmq_pub.h"
 #include "version.h"
 
 namespace
@@ -580,6 +581,7 @@ namespace rpc
     res.info.adjusted_time = m_core.get_blockchain_storage().get_adjusted_time(res.info.height);
     res.info.start_time = m_restricted ? 0 : (uint64_t)m_core.get_start_time();
     res.info.version = m_restricted ? "" : MONERO_VERSION;
+    res.info.pub_filters = listener::zmq_pub::get_all_filters();
 
     res.status = Message::STATUS_OK;
     res.error_details = "";

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -34,6 +34,7 @@
 #include "ringct/rctSigs.h"
 #include "rpc/rpc_handler.h"
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -201,6 +202,7 @@ namespace rpc
     uint64_t block_weight_median;
     uint64_t start_time;
     std::string version;
+    std::vector<std::string> pub_filters;
   };
 
   struct output_distribution

--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -54,6 +54,7 @@
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "serialization/wire.h"
 #include "serialization/wire/adapted/vector.h"
+#include "serialization/wire/cbor.h"
 #include "serialization/wire/json.h"
 #include "serialization/wire/wrapper/range.h"
 
@@ -221,7 +222,7 @@ namespace
       wire::field("difficulty", cryptonote::hex(self.diff)),
       WIRE_FIELD_COPY(median_weight),
       WIRE_FIELD_COPY(already_generated_coins),
-      WIRE_FIELD(tx_backlog)
+      wire::field("tx_backlog", wire::range(std::cref(self.tx_backlog))) // always output
     );
   }
 
@@ -246,9 +247,10 @@ namespace
     );
   }
 
-  std::error_code json_full_chain(epee::byte_stream& buf, const std::uint64_t height, const epee::span<const cryptonote::block> blocks)
+  template<typename F>
+  std::error_code full_chain_format(epee::byte_stream& buf, const std::uint64_t height, const epee::span<const cryptonote::block> blocks)
   {
-    return json_pub(buf, blocks);
+    return F::to_bytes(buf, wire::range(blocks));
   }
 
   template<typename F>
@@ -266,14 +268,15 @@ namespace
   // boost::adaptors are in place "views" - no copy/move takes place
   // moving transactions (via sort, etc.), is expensive!
 
-  std::error_code json_full_txpool(epee::byte_stream& buf, epee::span<const cryptonote::txpool_event> txes)
+  template<typename F>
+  std::error_code full_txpool_format(epee::byte_stream& buf, epee::span<const cryptonote::txpool_event> txes)
   {
     namespace adapt = boost::adaptors;
     const auto to_full_tx = [](const cryptonote::txpool_event& event)
     {
       return event.tx;
     };
-    return json_pub(buf, (txes | adapt::filtered(is_valid{}) | adapt::transformed(to_full_tx)));
+    return F::to_bytes(buf, wire::range(txes | adapt::filtered(is_valid{}) | adapt::transformed(to_full_tx)));
   }
 
   template<typename F>
@@ -288,20 +291,25 @@ namespace
     return F::to_bytes(buf, wire::range(txes | adapt::filtered(is_valid{}) | adapt::transformed(to_minimal_tx)));
   }
 
-  constexpr const std::array<context<chain_writer>, 2> chain_contexts =
+  constexpr const std::array<context<chain_writer>, 4> chain_contexts =
   {{
-    {u8"json-full-chain_main", json_full_chain},
+    {u8"cbor-full-chain_main", full_chain_format<wire::cbor>},
+    {u8"cbor-minimal-chain_main", minimal_chain_format<wire::cbor>},
+    {u8"json-full-chain_main", full_chain_format<wire::json>},
     {u8"json-minimal-chain_main", minimal_chain_format<wire::json>}
   }};
 
-  constexpr const std::array<context<miner_writer>, 1> miner_contexts =
+  constexpr const std::array<context<miner_writer>, 2> miner_contexts =
   {{
+    {u8"cbor-full-miner_data", miner_data_format<wire::cbor>},
     {u8"json-full-miner_data", miner_data_format<wire::json>}
   }};
 
-  constexpr const std::array<context<txpool_writer>, 2> txpool_contexts =
+  constexpr const std::array<context<txpool_writer>, 4> txpool_contexts =
   {{
-    {u8"json-full-txpool_add", json_full_txpool},
+    {u8"cbor-full-txpool_add", full_txpool_format<wire::cbor>},
+    {u8"cbor-minimal-txpool_add", minimal_txpool_format<wire::cbor>},
+    {u8"json-full-txpool_add", full_txpool_format<wire::json>},
     {u8"json-minimal-txpool_add", minimal_txpool_format<wire::json>}
   }};
 
@@ -423,6 +431,22 @@ namespace
 
 namespace cryptonote { namespace listener
 {
+std::vector<std::string> zmq_pub::get_all_filters()
+{
+  std::vector<std::string> out;
+  const auto add = [&] (const auto& list)
+  {
+    for (const auto& elem : list)
+      out.push_back(elem.name);
+  };
+
+  add(chain_contexts);
+  add(miner_contexts);
+  add(txpool_contexts);
+
+  std::sort(out.begin(), out.end());
+  return out;
+}
 
 zmq_pub::zmq_pub(void* context)
   : relay_(),
@@ -497,7 +521,7 @@ bool zmq_pub::relay_to_pub(void* const relay, void* const pub)
 
   if (!*relayed)
   {
-    std::array<std::size_t, 2> subs;
+    std::array<std::size_t, 4> subs;
     std::vector<cryptonote::txpool_event> events;
     {
       const boost::lock_guard<boost::mutex> lock{sync_};

--- a/src/rpc/zmq_pub.h
+++ b/src/rpc/zmq_pub.h
@@ -59,14 +59,17 @@ class zmq_pub
 
     net::zmq::socket relay_;
     std::deque<std::vector<txpool_event>> txes_;
-    std::array<std::size_t, 2> chain_subs_;
-    std::array<std::size_t, 1> miner_subs_;
-    std::array<std::size_t, 2> txpool_subs_;
+    std::array<std::size_t, 4> chain_subs_;
+    std::array<std::size_t, 2> miner_subs_;
+    std::array<std::size_t, 4> txpool_subs_;
     boost::mutex sync_; //!< Synchronizes counts in `*_subs_` arrays.
 
   public:
     //! \return Name of ZMQ_PAIR endpoint for pub notifications
     static constexpr const char* relay_endpoint() noexcept { return "inproc://pub_relay"; }
+
+    //! \return List of all available PUB filters
+    static std::vector<std::string> get_all_filters();
 
     explicit zmq_pub(void* context);
 

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -1456,6 +1456,7 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::r
   INSERT_INTO_JSON_OBJECT(dest, adjusted_time, info.adjusted_time);
   INSERT_INTO_JSON_OBJECT(dest, start_time, info.start_time);
   INSERT_INTO_JSON_OBJECT(dest, version, info.version);
+  INSERT_INTO_JSON_OBJECT(dest, pub_filters, info.pub_filters);
 
   dest.EndObject();
 }
@@ -1497,6 +1498,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::DaemonInfo& inf
   GET_FROM_JSON_OBJECT(val, info.adjusted_time, adjusted_time);
   GET_FROM_JSON_OBJECT(val, info.start_time, start_time);
   GET_FROM_JSON_OBJECT(val, info.version, version);
+  GET_FROM_JSON_OBJECT(val, info.pub_filters, pub_filters);
 
   info.wide_difficulty = difficulty_top64;
   info.wide_difficulty <<= 64;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -105,6 +105,7 @@ set(unit_tests_sources
   is_hdd.cpp
   aligned.cpp
   rpc_version_str.cpp
+  wire.cpp
   zmq_rpc.cpp)
 
 set(unit_tests_headers
@@ -126,6 +127,7 @@ target_link_libraries(unit_tests
     net
     serialization
     wallet
+    wire-cbor
     p2p
     version
     ${Boost_CHRONO_LIBRARY}

--- a/tests/unit_tests/wire.cpp
+++ b/tests/unit_tests/wire.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2023-2026, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <boost/core/demangle.hpp>
+#include <boost/range/algorithm/equal.hpp>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <type_traits>
+
+#include "serialization/wire/adapted/vector.h"
+#include "serialization/wire/cbor.h"
+#include "serialization/wire/field.h"
+#include "serialization/wire/traits.h"
+
+#include "hex.h"
+#include <iostream>
+
+namespace wire
+{
+  struct small_blob { std::uint8_t data[4]; };
+  WIRE_DECLARE_BLOB_NS(small_blob);
+}
+
+namespace
+{
+  template<typename T>
+  using limits = std::numeric_limits<T>;
+
+  constexpr const char basic_string[] = u8"my_string_data";
+  constexpr const wire::small_blob basic_blob{{0x00, 0xff, 0x22, 0x11}};
+
+  //  u8"{\"utf8\":\"my_string_data\",\"vec\":[0,127],\"data\":\"00ff2211\",\"integer\":-2,\"real\":3.5,\"choice\":true}";
+  constexpr const std::uint8_t basic_cbor[] = {
+    0xa6, 0x64, 0x75, 0x74, 0x66, 0x38, 0x6e, 0x6d, 0x79, 0x5f, 0x73, 0x74,
+    0x72, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x61, 0x74, 0x61, 0x63, 0x76, 0x65,
+    0x63, 0x82, 0x00, 0x18, 0x7f, 0x64, 0x64, 0x61, 0x74, 0x61, 0x44, 0x00,
+    0xff, 0x22, 0x11, 0x67, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x21,
+    0x64, 0x72, 0x65, 0x61, 0x6c, 0xfb, 0x40, 0x0c, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x66, 0x63, 0x68, 0x6f, 0x69, 0x63, 0x65, 0xf5
+  };
+
+  template<typename T>
+  struct integer { T val; };
+
+  template<typename T>
+  struct object
+  {
+    std::string utf8;
+    std::vector<T> vec;
+    wire::small_blob data;
+    std::int32_t integer;
+    double real;
+    bool choice;
+  };
+
+  template<typename F, typename T>
+  void object_map(F& format, T& self)
+  {
+    wire::object(format,
+      WIRE_FIELD(utf8),
+      WIRE_FIELD(vec),
+      WIRE_FIELD(data),
+      WIRE_FIELD(integer),
+      WIRE_FIELD(real),
+      WIRE_FIELD(choice)
+    );
+  }
+
+  template<typename T>
+  void write_bytes(wire::writer& dest, const object<T>& src)
+  {
+    object_map(dest, src);
+  }
+
+  template<typename T>
+  void write_bytes(wire::writer& dest, const integer<T>& src)
+  {
+    write_bytes(dest, src.val);
+  }
+
+  template<typename T>
+  std::error_code convert_to_cbor(epee::byte_stream& dest, const T& src)
+  {
+    return wire_write::to_bytes<wire::cbor_slice_writer>(dest, src);
+  }
+
+  template<typename T>
+  bool test_writing()
+  {
+    const object<T> val{basic_string, std::vector<T>{0, 127}, basic_blob, -2, 3.5, true};   
+    epee::byte_stream result{};
+    const std::error_code error = wire::cbor::to_bytes(result, val);
+    return !error && boost::range::equal(epee::byte_slice{std::move(result)}, epee::byte_slice{basic_cbor});
+  }
+
+  template<typename T>
+  bool test_integer(const T val, const epee::span<const std::uint8_t> expected)
+  {
+    epee::byte_stream result{};
+    const std::error_code error = wire::cbor::to_bytes(result, integer<T>{val});
+    return !error && boost::range::equal(epee::byte_slice{std::move(result)}, expected);
+  }
+}
+
+TEST(wire, cbor_writer_object)
+{
+  EXPECT_TRUE(test_writing<std::int16_t>());
+  EXPECT_TRUE(test_writing<std::int32_t>());
+  EXPECT_TRUE(test_writing<std::int64_t>());
+  EXPECT_TRUE(test_writing<std::intmax_t>());
+  EXPECT_TRUE(test_writing<std::uint16_t>());
+  EXPECT_TRUE(test_writing<std::uint32_t>());
+  EXPECT_TRUE(test_writing<std::uint64_t>());
+  EXPECT_TRUE(test_writing<std::uintmax_t>());
+}
+
+TEST(wire, cbor_writer_integers)
+{
+  const std::uint8_t v_0[] = {0x00};
+  const std::uint8_t v_23[] = {23};
+  const std::uint8_t v_24[] = {24, 24};
+  const std::uint8_t v_uint8[] = {24, 0xff};
+  const std::uint8_t v_uint16[] = {25, 0xff, 0xff};
+  const std::uint8_t v_uint32[] = {26, 0xff, 0xff, 0xff, 0xff};
+  const std::uint8_t v_uint64[] = {27, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+  const std::uint8_t v_n1[] = {0x20};
+  const std::uint8_t v_n24[] = {0x20 | 23};
+  const std::uint8_t v_n25[] = {0x20 | 24, 24};
+  const std::uint8_t v_int8[] = {0x20 | 24, 0x7f};
+  const std::uint8_t v_int16[] = {0x20 | 25, 0x7f, 0xff};
+  const std::uint8_t v_int32[] = {0x20 | 26, 0x7f, 0xff, 0xff, 0xff};
+  const std::uint8_t v_int64[] = {0x20 | 27, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+
+  EXPECT_TRUE(test_integer(0, v_0));
+  EXPECT_TRUE(test_integer(23, v_23));
+  EXPECT_TRUE(test_integer(24, v_24));
+  EXPECT_TRUE(test_integer(limits<std::uint8_t>::max(), v_uint8));
+  EXPECT_TRUE(test_integer(limits<std::uint16_t>::max(), v_uint16));
+  EXPECT_TRUE(test_integer(limits<std::uint32_t>::max(), v_uint32));
+  EXPECT_TRUE(test_integer(limits<std::uint64_t>::max(), v_uint64));
+  EXPECT_TRUE(test_integer(-1, v_n1));
+  EXPECT_TRUE(test_integer(-24, v_n24));
+  EXPECT_TRUE(test_integer(-25, v_n25));
+  EXPECT_TRUE(test_integer(limits<std::int8_t>::min(), v_int8));
+  EXPECT_TRUE(test_integer(limits<std::int16_t>::min(), v_int16));
+  EXPECT_TRUE(test_integer(limits<std::int32_t>::min(), v_int32));
+  EXPECT_TRUE(test_integer(limits<std::int64_t>::min(), v_int64));
+}

--- a/tests/unit_tests/zmq_rpc.cpp
+++ b/tests/unit_tests/zmq_rpc.cpp
@@ -27,11 +27,13 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <boost/endian/conversion.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 #include <rapidjson/ostreamwrapper.h>
-#include <rapidjson/prettywriter.h> 
+#include <rapidjson/prettywriter.h>
+#include <vector>
 
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -45,6 +47,8 @@
 #include "rpc/zmq_restricted_methods.h"
 #include "rpc/zmq_server.h"
 #include "serialization/json_object.h"
+#include "serialization/wire/json.h"
+#include "serialization/wire/cbor.h"
 
 #define MASSERT(...)                                                      \
   if (!(__VA_ARGS__))                                                     \
@@ -103,9 +107,131 @@ TEST(ZmqRestrictedMethods, BasicCoverage)
 
 namespace
 {
+  using published_bytes = std::pair<std::string, std::string>;
   using published_json = std::pair<std::string, rapidjson::Document>;
 
   constexpr const char inproc_pub[] = "inproc://dummy_pub";
+
+  std::string cbor_to_json(epee::span<const std::uint8_t> bytes)
+  {
+    const auto multibyte = [&bytes] (const auto minor)
+    {
+      using minor_type = decltype(minor);
+      using payload_type = typename minor_type::type;
+      if (bytes.size() < sizeof(payload_type))
+        throw std::logic_error{"Invalid cbor - expected more bytes for size"};
+
+      payload_type buf;
+      std::memcpy(&buf, bytes.data(), sizeof(buf));
+      bytes.remove_prefix(sizeof(buf));
+      return boost::endian::big_to_native(buf);
+    };
+
+    std::vector<std::pair<std::uint64_t, wire::cbor::major>> stack{};
+    wire::json_string_writer dest{};
+    while (!bytes.empty())
+    {
+      const std::uint8_t tag = bytes[0];
+      bytes.remove_prefix(1);
+      const auto major = wire::cbor::major(tag & 0xE0);
+      const std::uint8_t minor = tag & 0x1F;
+
+      std::uint64_t size = minor;
+      switch (minor)
+      {
+        default:
+          break;
+        case wire::cbor::uint8_t::value():
+          size = multibyte(wire::cbor::uint8_t{});
+          break;
+        case wire::cbor::uint16_t::value():
+          size = multibyte(wire::cbor::uint16_t{});
+          break;
+        case wire::cbor::uint32_t::value():
+          size = multibyte(wire::cbor::uint32_t{});
+          break;
+        case wire::cbor::uint64_t::value():
+          size = multibyte(wire::cbor::uint64_t{});
+          break;
+      }
+
+      switch (major)
+      {
+        default:
+          throw std::logic_error{"cbor conversion not supported for this major type"};
+        case wire::cbor::major::positive_int:
+          dest.unsigned_integer(size);
+          break;
+        case wire::cbor::major::negative_int:
+          if (std::numeric_limits<std::intmax_t>::max() < size)
+            throw std::logic_error{"cbor exceeded implementation signed limits"};
+          dest.integer((-std::intmax_t(size)) - 1);
+          break;
+        case wire::cbor::major::bytes:
+          if (bytes.size() < size)
+            throw std::logic_error{"cbor missing bytes"};
+          dest.binary({bytes.data(), size});
+          bytes.remove_prefix(size);
+          break;
+        case wire::cbor::major::string:
+          if (bytes.size() < size)
+            throw std::logic_error{"cbor missing string"};
+          if (!stack.empty() && stack.back().second == wire::cbor::major::map && stack.back().first % 2 == 0)
+            dest.key({reinterpret_cast<const char*>(bytes.data()), size});
+          else
+            dest.string({reinterpret_cast<const char*>(bytes.data()), size});
+          bytes.remove_prefix(size);
+          break;
+        case wire::cbor::major::array:
+          dest.start_array(size);
+          stack.push_back({size + 1, wire::cbor::major::array});
+          break;
+        case wire::cbor::major::map:
+          dest.start_object(size);
+          stack.push_back({size * 2 + 1, wire::cbor::major::map});
+          break;
+        case wire::cbor::major::real_and_special:
+          switch (minor)
+          {
+            default:
+              throw std::logic_error{"cbor conversion not supported for this major/minor type"};
+            case wire::cbor::real64::value():
+              double real;
+              static_assert(sizeof(real) == sizeof(size));
+              std::memcpy(&real, &size, sizeof(real));
+              dest.real(real);
+              break;
+            case wire::cbor::true_::tag():
+              dest.boolean(true);
+              break;
+            case wire::cbor::false_::tag():
+              dest.boolean(false);
+              break;
+          }
+      };
+
+      while (!stack.empty() && !--stack.back().first)
+      {
+        switch (stack.back().second)
+        {
+          default:
+            break;
+          case wire::cbor::major::array:
+            dest.end_array();
+            break;
+          case wire::cbor::major::map:
+            dest.end_object();
+            break;
+        }
+        stack.pop_back();
+      }
+    }
+
+    if (!stack.empty())
+      throw std::logic_error{"cbor expected more elements"};
+
+    return dest.take_buffer();
+  }
 
   net::zmq::socket create_socket(void* ctx, const char* address)
   {
@@ -130,9 +256,9 @@ namespace
     return out;
   }
 
-  std::vector<published_json> get_published(void* socket, int count = -1)
+  std::vector<published_bytes> get_published(void* socket, int count = -1)
   {
-    std::vector<published_json> out;
+    std::vector<published_bytes> out;
 
     const auto messages = get_messages(socket, count);
     out.reserve(messages.size());
@@ -143,10 +269,40 @@ namespace
       if (!split)
         throw std::runtime_error{"Invalid ZMQ/Pub message"};
 
-      out.emplace_back();
-      out.back().first = {message.c_str(), split};
-      if (out.back().second.Parse(split + 1).HasParseError())
+      out.emplace_back(
+        std::string{message.data(), split},
+        std::string{split + 1, message.c_str() + message.size()}
+      );
+    }
+
+    return out;
+  }
+
+  std::vector<published_json> to_published_json(const std::vector<published_bytes>& messages)
+  {
+    std::vector<published_json> out;
+    out.reserve(messages.size());
+
+    for (const published_bytes& message : messages)
+    {
+      out.emplace_back(message.first, rapidjson::Document{});
+      if (out.back().second.Parse(message.second.c_str()).HasParseError())
         throw std::runtime_error{"Failed to parse ZMQ/Pub message"};
+    }
+
+    return out;
+  }
+
+  std::vector<published_bytes> published_cbor_to_json(const std::vector<published_bytes>& messages)
+  {
+    std::vector<published_bytes> out;
+    out.reserve(messages.size());
+
+    for (const published_bytes& message : messages)
+    {
+      if (message.first.substr(0, 5) != "cbor-")
+        throw std::logic_error{"expected cbor prefix"};
+      out.emplace_back("json-" + message.first.substr(5), cbor_to_json(epee::strspan<std::uint8_t>(message.second)));
     }
 
     return out;
@@ -166,6 +322,7 @@ namespace
   {
     MASSERT(pub.first == "json-full-txpool_add");
     MASSERT(pub.second.IsArray());
+    MASSERT(1 <= pub.second.Size());
     MASSERT(pub.second.Size() <= events.size());
 
     std::size_t i = 0;
@@ -191,6 +348,7 @@ namespace
   {
     MASSERT(pub.first == "json-minimal-txpool_add");
     MASSERT(pub.second.IsArray());
+    MASSERT(1 <= pub.second.Size());
     MASSERT(pub.second.Size() <= events.size());
 
     std::size_t i = 0;
@@ -295,7 +453,11 @@ namespace
     {
       cryptonote::account_base temp_account;
       temp_account.generate();
-      return make_transaction({temp_account.get_keys().m_account_address});
+
+      cryptonote::account_base temp_account2;
+      temp_account2.generate();
+ 
+      return make_transaction({temp_account.get_keys().m_account_address, temp_account2.get_keys().m_account_address});
     }
 
     cryptonote::block make_block()
@@ -434,13 +596,13 @@ TEST_F(zmq_pub, JsonFullTxpool)
 
   std::vector<cryptonote::txpool_event> events
   {
-   {make_transaction(), {}, true}, {make_transaction(), {}, true}
+    {make_transaction(), {}, {}, {}, true}, {make_transaction(), {}, {}, {}, true}
   };
 
   EXPECT_NO_THROW(pub->send_txpool_add(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  auto pubs = get_published(dummy_client.get());
+  auto pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -448,7 +610,7 @@ TEST_F(zmq_pub, JsonFullTxpool)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -457,7 +619,7 @@ TEST_F(zmq_pub, JsonFullTxpool)
   EXPECT_EQ(1u, pub->send_txpool_add(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -466,11 +628,58 @@ TEST_F(zmq_pub, JsonFullTxpool)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
 }
+
+TEST_F(zmq_pub, CborFullTxpool)
+{
+  static constexpr const char topic[] = "\1cbor-full-txpool_add";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  std::vector<cryptonote::txpool_event> events
+  {
+    {make_transaction(), {}, {}, {}, true}, {make_transaction(), {}, {}, {}, true}
+  };
+
+  EXPECT_NO_THROW(pub->send_txpool_add(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+  events.at(0).res = false;
+  EXPECT_EQ(1u, pub->send_txpool_add(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+  events.at(0).res = false;
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+}
+
 
 TEST_F(zmq_pub, JsonMinimalTxpool)
 {
@@ -478,15 +687,25 @@ TEST_F(zmq_pub, JsonMinimalTxpool)
 
   ASSERT_TRUE(sub_request(topic));
 
+  const auto tx1 = make_transaction();
+  const auto tx2 = make_transaction();
+  std::size_t size1 = 0;
+  std::size_t size2 = 0;
+  crypto::hash id1{};
+  crypto::hash id2{};
+
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
   std::vector<cryptonote::txpool_event> events
   {
-   {make_transaction(), {}, true}, {make_transaction(), {}, true}
+    {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
   };
 
   EXPECT_NO_THROW(pub->send_txpool_add(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  auto pubs = get_published(dummy_client.get());
+  auto pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -494,7 +713,7 @@ TEST_F(zmq_pub, JsonMinimalTxpool)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -503,7 +722,7 @@ TEST_F(zmq_pub, JsonMinimalTxpool)
   EXPECT_EQ(1u, pub->send_txpool_add(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -512,7 +731,63 @@ TEST_F(zmq_pub, JsonMinimalTxpool)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+}
+
+TEST_F(zmq_pub, CborMinimalTxpool)
+{
+  static constexpr const char topic[] = "\1cbor-minimal-txpool_add";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  const auto tx1 = make_transaction();
+  const auto tx2 = make_transaction();
+  std::size_t size1 = 0;
+  std::size_t size2 = 0;
+  crypto::hash id1{};
+  crypto::hash id2{};
+
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
+  std::vector<cryptonote::txpool_event> events
+  {
+    {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
+  };
+
+  EXPECT_NO_THROW(pub->send_txpool_add(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+  events.at(0).res = false;
+  EXPECT_EQ(1u, pub->send_txpool_add(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+  events.at(0).res = false;
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -529,7 +804,7 @@ TEST_F(zmq_pub, JsonFullChain)
   EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  auto pubs = get_published(dummy_client.get());
+  auto pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
@@ -537,7 +812,32 @@ TEST_F(zmq_pub, JsonFullChain)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+}
+
+TEST_F(zmq_pub, CborFullChain)
+{
+  static constexpr const char topic[] = "\1cbor-full-chain_main";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  const std::array<cryptonote::block, 2> blocks{{make_block(), make_block()}};
+
+  EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
@@ -545,20 +845,9 @@ TEST_F(zmq_pub, JsonFullChain)
 
 TEST_F(zmq_pub, JsonFullMinerData)
 {
-/*  uint8_t major_version;
-    uint64_t height;
-    const crypto::hash& prev_id;
-    const crypto::hash& seed_hash;
-    cryptonote::difficulty_type diff;
-    uint64_t median_weight;
-    uint64_t already_generated_coins;
-    const std::vector<cryptonote::tx_block_template_backlog_entry>& tx_backlog ; */
-
   static constexpr const char topic[] = "\1json-full-miner_data";
   ASSERT_TRUE(sub_request(topic));
 
-    //std::size_t send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog);
-  
   const auto hash = crypto::rand<crypto::hash>();
   const auto seed = crypto::rand<crypto::hash>();
   const cryptonote::difficulty_type difficulty = 500;
@@ -590,18 +879,65 @@ TEST_F(zmq_pub, JsonFullMinerData)
   EXPECT_EQ(1u, pub->send_miner_data(100, 200, hash, seed, difficulty, 400, 10000, txs));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  auto pubs = get_published(dummy_client.get());
+  auto pubs = to_published_json(get_published(dummy_client.get()));
   ASSERT_EQ(1u, pubs.size());
   EXPECT_TRUE(compare_miner_data(expected, pubs.front()));
 
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::miner_data{pub}(100, 200, hash, seed, difficulty, 400, 10000, txs));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
   ASSERT_EQ(1u, pubs.size());
   EXPECT_TRUE(compare_miner_data(expected, pubs.front()));
 }
 
+TEST_F(zmq_pub, CborFullMinerData)
+{
+  static constexpr const char topic[] = "\1cbor-full-miner_data";
+  ASSERT_TRUE(sub_request(topic));
+
+  const auto hash = crypto::rand<crypto::hash>();
+  const auto seed = crypto::rand<crypto::hash>();
+  const cryptonote::difficulty_type difficulty = 500;
+  const std::vector<cryptonote::tx_block_template_backlog_entry> txs = {
+    {crypto::rand<crypto::hash>(), 7545, 455},
+    {crypto::rand<crypto::hash>(), 755, 34545}
+  };
+  const std::string expected =
+    R"({
+      "major_version": 100,
+      "height": 200,
+      "prev_id": ")" + epee::to_hex::string(epee::as_byte_span(hash)) + R"(",
+      "seed_hash": ")" + epee::to_hex::string(epee::as_byte_span(seed)) + R"(",
+      "difficulty": ")" + cryptonote::hex(difficulty) + R"(",
+      "median_weight": 400,
+      "already_generated_coins": 10000,
+      "tx_backlog": [
+        {
+          "id": ")" + epee::to_hex::string(epee::as_byte_span(txs.at(0).id)) + R"(",
+          "weight": 7545,
+          "fee": 455
+        },{
+          "id": ")" + epee::to_hex::string(epee::as_byte_span(txs.at(1).id)) + R"(",
+          "weight": 755,
+          "fee": 34545
+        }
+      ]
+    })";
+  EXPECT_EQ(1u, pub->send_miner_data(100, 200, hash, seed, difficulty, 400, 10000, txs));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  ASSERT_EQ(1u, pubs.size());
+  EXPECT_TRUE(compare_miner_data(expected, pubs.front()));
+
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::miner_data{pub}(100, 200, hash, seed, difficulty, 400, 10000, txs));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  ASSERT_EQ(1u, pubs.size());
+  EXPECT_TRUE(compare_miner_data(expected, pubs.front()));
+}
 
 TEST_F(zmq_pub, JsonMinimalChain)
 {
@@ -614,7 +950,7 @@ TEST_F(zmq_pub, JsonMinimalChain)
   EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  auto pubs = get_published(dummy_client.get());
+  auto pubs = to_published_json(get_published(dummy_client.get()));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_block(100, epee::to_span(blocks), pubs.front()));
@@ -622,7 +958,32 @@ TEST_F(zmq_pub, JsonMinimalChain)
   EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
   EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-  pubs = get_published(dummy_client.get());
+  pubs = to_published_json(get_published(dummy_client.get()));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_block(533, epee::to_span(blocks), pubs.front()));
+}
+
+TEST_F(zmq_pub, CborMinimalChain)
+{
+  static constexpr const char topic[] = "\1cbor-minimal-chain_main";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  const std::array<cryptonote::block, 2> blocks{{make_block(), make_block()}};
+
+  EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+  EXPECT_EQ(1u, pubs.size());
+  ASSERT_LE(1u, pubs.size());
+  EXPECT_TRUE(compare_minimal_block(100, epee::to_span(blocks), pubs.front()));
+
+  EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
+  EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+  pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
   EXPECT_EQ(1u, pubs.size());
   ASSERT_LE(1u, pubs.size());
   EXPECT_TRUE(compare_minimal_block(533, epee::to_span(blocks), pubs.front()));
@@ -634,15 +995,25 @@ TEST_F(zmq_pub, JsonFullAll)
 
   ASSERT_TRUE(sub_request(topic));
   {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
     std::vector<cryptonote::txpool_event> events
     {
-     {make_transaction(), {}, true}, {make_transaction(), {}, true}
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
     };
 
     EXPECT_EQ(1u, pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -650,7 +1021,7 @@ TEST_F(zmq_pub, JsonFullAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -659,7 +1030,7 @@ TEST_F(zmq_pub, JsonFullAll)
     EXPECT_NO_THROW(pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -668,7 +1039,7 @@ TEST_F(zmq_pub, JsonFullAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -679,7 +1050,8 @@ TEST_F(zmq_pub, JsonFullAll)
     EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()))
+    ;
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
@@ -687,12 +1059,90 @@ TEST_F(zmq_pub, JsonFullAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
   }
 }
+
+TEST_F(zmq_pub, CborFullAll)
+{
+  static constexpr const char topic[] = "\1cbor-full";
+
+  ASSERT_TRUE(sub_request(topic));
+  {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
+    std::vector<cryptonote::txpool_event> events
+    {
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
+    };
+
+    EXPECT_EQ(1u, pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+    events.at(0).res = false;
+    EXPECT_NO_THROW(pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+
+    events.at(0).res = false;
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+  }
+  {
+    const std::array<cryptonote::block, 2> blocks{{make_block(), make_block()}};
+
+    EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())))
+    ;
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+  }
+}
+
 
 TEST_F(zmq_pub, JsonMinimalAll)
 {
@@ -701,15 +1151,25 @@ TEST_F(zmq_pub, JsonMinimalAll)
   ASSERT_TRUE(sub_request(topic));
 
   {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
     std::vector<cryptonote::txpool_event> events
     {
-     {make_transaction(), {}, true}, {make_transaction(), {}, true}
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
     };
 
     EXPECT_EQ(1u, pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -717,7 +1177,7 @@ TEST_F(zmq_pub, JsonMinimalAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -726,7 +1186,7 @@ TEST_F(zmq_pub, JsonMinimalAll)
     EXPECT_NO_THROW(pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -735,7 +1195,7 @@ TEST_F(zmq_pub, JsonMinimalAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
@@ -746,7 +1206,7 @@ TEST_F(zmq_pub, JsonMinimalAll)
     EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_block(100, epee::to_span(blocks), pubs.front()));
@@ -754,7 +1214,84 @@ TEST_F(zmq_pub, JsonMinimalAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_block(533, epee::to_span(blocks), pubs.front()));
+  }
+}
+
+TEST_F(zmq_pub, CborMinimalAll)
+{
+  static constexpr const char topic[] = "\1cbor-minimal";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
+    std::vector<cryptonote::txpool_event> events
+    {
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
+    };
+
+    EXPECT_EQ(1u, pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+    events.at(0).res = false;
+    EXPECT_NO_THROW(pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+
+    events.at(0).res = false;
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+  }
+  {
+    const std::array<cryptonote::block, 2> blocks{{make_block(), make_block()}};
+
+    EXPECT_EQ(1u, pub->send_chain_main(100, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(1u, pubs.size());
+    ASSERT_LE(1u, pubs.size());
+    EXPECT_TRUE(compare_minimal_block(100, epee::to_span(blocks), pubs.front()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
     EXPECT_EQ(1u, pubs.size());
     ASSERT_LE(1u, pubs.size());
     EXPECT_TRUE(compare_minimal_block(533, epee::to_span(blocks), pubs.front()));
@@ -768,15 +1305,25 @@ TEST_F(zmq_pub, JsonAll)
   ASSERT_TRUE(sub_request(topic));
 
   {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
     std::vector<cryptonote::txpool_event> events
     {
-     {make_transaction(), {}, true}, {make_transaction(), {}, true}
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
     };
 
     EXPECT_EQ(1u, pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -785,7 +1332,7 @@ TEST_F(zmq_pub, JsonAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -795,7 +1342,7 @@ TEST_F(zmq_pub, JsonAll)
     EXPECT_EQ(1u, pub->send_txpool_add(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -805,7 +1352,7 @@ TEST_F(zmq_pub, JsonAll)
     EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
@@ -818,7 +1365,7 @@ TEST_F(zmq_pub, JsonAll)
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    auto pubs = get_published(dummy_client.get());
+    auto pubs = to_published_json(get_published(dummy_client.get()));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
@@ -828,7 +1375,92 @@ TEST_F(zmq_pub, JsonAll)
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
     EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
 
-    pubs = get_published(dummy_client.get());
+    pubs = to_published_json(get_published(dummy_client.get()));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+    EXPECT_TRUE(compare_minimal_block(533, epee::to_span(blocks), pubs.back()));
+  }
+}
+
+TEST_F(zmq_pub, CborAll)
+{
+  static constexpr const char topic[] = "\1cbor";
+
+  ASSERT_TRUE(sub_request(topic));
+
+  {
+    const auto tx1 = make_transaction();
+    const auto tx2 = make_transaction();
+    std::size_t size1 = 0;
+    std::size_t size2 = 0;
+    crypto::hash id1{};
+    crypto::hash id2{};
+
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+    EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
+    std::vector<cryptonote::txpool_event> events
+    {
+      {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
+    };
+
+    EXPECT_EQ(1u, pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.back()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.back()));
+
+    events.at(0).res = false;
+    EXPECT_EQ(1u, pub->send_txpool_add(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.back()));
+
+    events.at(0).res = false;
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::txpool_add{pub}(events));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_txpool(epee::to_span(events), pubs.front()));
+    EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.back()));
+  }
+  {
+    const std::array<cryptonote::block, 1> blocks{{make_block()}};
+
+    EXPECT_EQ(2u, pub->send_chain_main(100, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    auto pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
+    EXPECT_EQ(2u, pubs.size());
+    ASSERT_LE(2u, pubs.size());
+    EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
+    EXPECT_TRUE(compare_minimal_block(100, epee::to_span(blocks), pubs.back()));
+
+    EXPECT_NO_THROW(cryptonote::listener::zmq_pub::chain_main{pub}(533, epee::to_span(blocks)));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+    EXPECT_TRUE(pub->relay_to_pub(relay.get(), dummy_pub.get()));
+
+    pubs = to_published_json(published_cbor_to_json(get_published(dummy_client.get())));
     EXPECT_EQ(2u, pubs.size());
     ASSERT_LE(2u, pubs.size());
     EXPECT_TRUE(compare_full_block(epee::to_span(blocks), pubs.front()));
@@ -856,7 +1488,7 @@ TEST_F(zmq_pub, JsonTxpoolWeakPtrSkip)
 
   std::vector<cryptonote::txpool_event> events
   {
-    {make_transaction(), {}, true}, {make_transaction(), {}, true}
+    {make_transaction(), {}, {}, {}, true}, {make_transaction(), {}, {}, {}, true}
   };
 
   pub.reset();
@@ -867,9 +1499,19 @@ TEST_F(zmq_server, pub)
 {
   subscribe("json-minimal");
 
+  const auto tx1 = make_transaction();
+  const auto tx2 = make_transaction();
+  std::size_t size1 = 0;
+  std::size_t size2 = 0;
+  crypto::hash id1{};
+  crypto::hash id2{};
+
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
   std::vector<cryptonote::txpool_event> events
   {
-   {make_transaction(), {}, true}, {make_transaction(), {}, true}
+    {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
   };
 
   const std::array<cryptonote::block, 1> blocks{{make_block()}};
@@ -877,7 +1519,38 @@ TEST_F(zmq_server, pub)
   ASSERT_EQ(1u, pub->send_txpool_add(events));
   ASSERT_EQ(1u, pub->send_chain_main(200, epee::to_span(blocks)));
 
-  auto pubs = get_published(sub.get(), 2);
+  auto pubs = to_published_json(get_published(sub.get(), 2));
+  EXPECT_EQ(2u, pubs.size());
+  ASSERT_LE(2u, pubs.size());
+  EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));
+  EXPECT_TRUE(compare_minimal_block(200, epee::to_span(blocks), pubs.back()));
+}
+
+TEST_F(zmq_server, pub_cbor)
+{
+  subscribe("cbor-minimal");
+
+  const auto tx1 = make_transaction();
+  const auto tx2 = make_transaction();
+  std::size_t size1 = 0;
+  std::size_t size2 = 0;
+  crypto::hash id1{};
+  crypto::hash id2{};
+
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx1, id1, size1));
+  EXPECT_TRUE(cryptonote::get_transaction_hash(tx2, id2, size2));
+
+  std::vector<cryptonote::txpool_event> events
+  {
+    {tx1, id1, size1, {}, true}, {tx2, id2, size2, {}, true}
+  };
+
+  const std::array<cryptonote::block, 1> blocks{{make_block()}};
+
+  ASSERT_EQ(1u, pub->send_txpool_add(events));
+  ASSERT_EQ(1u, pub->send_chain_main(200, epee::to_span(blocks)));
+
+  auto pubs = to_published_json(published_cbor_to_json(get_published(sub.get(), 2)));
   EXPECT_EQ(2u, pubs.size());
   ASSERT_LE(2u, pubs.size());
   EXPECT_TRUE(compare_minimal_txpool(epee::to_span(events), pubs.front()));


### PR DESCRIPTION
### Marking as draft for now. This PR:

  * Adds cbor output (writer) to the `::wire` serialization system
  * Adds block+transaction output support to the `::wire` serialization system
  * Switches all `ZMQ-PUB `output to use `::wire` serialization system (instead of just select few)
  * Adds cbor output to all existing `ZMQ-PUB` subscription options

### Needs (before marking ready):
  * A system to signal which subscription types are supported