### PR TITLE
crypto: split wire serialization in header

### DIFF
--- a/contrib/epee/include/serialization/wire/traits.h
+++ b/contrib/epee/include/serialization/wire/traits.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 #include <type_traits>
 
 #define WIRE_DECLARE_BLOB_NS(type) \

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -42,7 +42,6 @@
 #include "mlocker.h"
 #include "generic-ops.h"
 #include "hex.h"
-#include "span.h"
 #include "hash.h"
 
 namespace crypto {

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -37,8 +37,6 @@
 #include "common/pod-class.h"
 #include "generic-ops.h"
 #include "hex.h"
-#include "span.h"
-#include "serialization/wire/traits.h"
 
 namespace crypto {
 
@@ -109,9 +107,3 @@ namespace crypto {
 
 CRYPTO_MAKE_HASHABLE(hash)
 CRYPTO_MAKE_COMPARABLE(hash8)
-
-namespace wire
-{
-  WIRE_DECLARE_BLOB_NS(crypto::hash);
-  WIRE_DECLARE_BLOB_NS(crypto::hash8);
-}

--- a/src/crypto/wire.h
+++ b/src/crypto/wire.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include "crypto.h"
+#include "serialization/wire/traits.h"
+
+namespace wire
+{
+  WIRE_DECLARE_BLOB_NS(crypto::hash);
+  WIRE_DECLARE_BLOB_NS(crypto::hash8);
+  WIRE_DECLARE_BLOB_NS(crypto::ec_point);
+}

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -44,6 +44,7 @@ using namespace epee;
 #include "cryptonote_basic/tx_extra.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
+#include "crypto/wire.h"
 #include "ringct/rctSigs.h"
 #include "serialization/wire.h"
 

--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -45,6 +45,7 @@
 
 #include "common/expect.h"
 #include "crypto/crypto.h"
+#include "crypto/wire.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/events.h"
 #include "misc_log_ex.h"


### PR DESCRIPTION
This splits wire serialization off into its own header, to keep crypto.h minimal as possible. Also improves readability, and adds an overload for `crypto::ec_point`, which will be used for the FCMP++ integration. ZMQ/wire changes added in #10241

@vtnerd 