### PR TITLE
guix: update clang to 21.1.8

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -284,7 +284,7 @@ chain for " target " development."))
              xz ; used to unpack freebsd_base
              gcc-toolchain-14
              (list gcc-toolchain-14 "static")
-             clang-toolchain-19
+             clang-toolchain-21
              binutils))
           ((string-contains target "android")
             (list
@@ -294,7 +294,7 @@ chain for " target " development."))
           ((string-contains target "darwin")
            (list
              gcc-toolchain-14
-             clang-toolchain-19
-             lld-19
-             (make-lld-wrapper lld-19 #:lld-as-ld? #t)))
+             clang-toolchain-21
+             lld-21
+             (make-lld-wrapper lld-21 #:lld-as-ld? #t)))
           (else '())))))


### PR DESCRIPTION
RapidJSON produces a lot of warnings. Fixed by #10584