### PR TITLE
common: remove obsolete glibc warning

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -33,10 +33,6 @@
 #include <wchar.h>
 
 #ifdef __GLIBC__
-#include <gnu/libc-version.h>
-#endif
-
-#ifdef __GLIBC__
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
@@ -546,12 +542,6 @@ namespace tools
     setup_crash_dump();
 
     sanitize_locale();
-
-#ifdef __GLIBC__
-    const char *ver = gnu_get_libc_version();
-    if (!strcmp(ver, "2.25"))
-      MCLOG_RED(el::Level::Warning, "global", "Running with glibc " << ver << ", hangs may occur - change glibc version if possible");
-#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_TEXT)
     SSL_library_init();


### PR DESCRIPTION
No LTS distributions shipped with this [glibc version](https://github.com/monero-project/monero/pull/9171#issue-2133189958). Release binaries support glibc 2.27 and higher.